### PR TITLE
feat: add sound hotkey tooltip

### DIFF
--- a/src/pages/Typing/components/WordPanel/components/Word/index.tsx
+++ b/src/pages/Typing/components/WordPanel/components/Word/index.tsx
@@ -6,6 +6,7 @@ import { TipAlert } from './TipAlert'
 import style from './index.module.css'
 import { initialWordState } from './type'
 import type { WordState } from './type'
+import Tooltip from '@/components/Tooltip'
 import type { WordPronunciationIconRef } from '@/components/WordPronunciationIcon'
 import { WordPronunciationIcon } from '@/components/WordPronunciationIcon'
 import { EXPLICIT_SPACE } from '@/constants'
@@ -21,7 +22,7 @@ import {
   wordDictationConfigAtom,
 } from '@/store'
 import type { Word } from '@/typings'
-import { getUtcStringForMixpanel, useMixPanelWordLogUploader } from '@/utils'
+import { CTRL, getUtcStringForMixpanel, useMixPanelWordLogUploader } from '@/utils'
 import { useSaveWordRecord } from '@/utils/db'
 import { useAtomValue } from 'jotai'
 import { useCallback, useContext, useEffect, useRef, useState } from 'react'
@@ -297,11 +298,11 @@ export default function WordComponent({ word, onFinish }: { word: Word; onFinish
             })}
           </div>
           {pronunciationIsOpen && (
-            <WordPronunciationIcon
-              word={word.name}
-              ref={wordPronunciationIconRef}
-              className="absolute -right-12 top-1/2 h-9 w-9 -translate-y-1/2 transform "
-            />
+            <div className="absolute -right-12 top-1/2 h-9 w-9 -translate-y-1/2 transform ">
+              <Tooltip content={`快捷键${CTRL} + J`}>
+                <WordPronunciationIcon word={word.name} ref={wordPronunciationIconRef} className="h-full w-full" />
+              </Tooltip>
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
现有的tips位置，新用户可能不知道是在选择美英发音菜单里面。导致不知道支持快捷键朗读
![image](https://github.com/RealKai42/qwerty-learner/assets/56671014/e82c8cb5-49b7-489e-a776-f6b4484ea408)
