### PR TITLE
fix: ResultScreen z-index level

### DIFF
--- a/src/pages/Typing/components/ResultScreen/index.tsx
+++ b/src/pages/Typing/components/ResultScreen/index.tsx
@@ -169,7 +169,7 @@ const ResultScreen = () => {
   )
 
   return (
-    <div className="fixed inset-0 z-10 overflow-y-auto">
+    <div className="fixed inset-0 z-30 overflow-y-auto">
       <div className="absolute inset-0 bg-gray-300 opacity-80 dark:bg-gray-600"></div>
       <Transition
         show={true}


### PR DESCRIPTION
 resultScreen z-index hierarchy issue fixes

![image](https://github.com/RealKai42/qwerty-learner/assets/49627376/ac1884eb-9210-4bb9-89ee-37be316ac32a)
