### PR TITLE
fix: ListTooltip z-index level

### DIFF
--- a/src/pages/Typing/components/WordList/index.tsx
+++ b/src/pages/Typing/components/WordList/index.tsx
@@ -32,7 +32,7 @@ export default function WordList() {
 
   return (
     <>
-      <Tooltip content="List" placement="top" className="!absolute left-5 top-[50%]">
+      <Tooltip content="List" placement="top" className="!absolute left-5 top-[50%] z-20">
         <button
           type="button"
           onClick={openModal}


### PR DESCRIPTION
ListTooltip z-index level issue fixes

<img width="1470" alt="截屏2023-12-17 15 51 02" src="https://github.com/RealKai42/qwerty-learner/assets/49627376/32991716-ef2e-4c61-afff-876f13c46e5a">
