### PR TITLE
更换 link 为 audio 防止触发下载事件

### DIFF
--- a/src/hooks/usePronunciation.ts
+++ b/src/hooks/usePronunciation.ts
@@ -76,13 +76,18 @@ export function usePrefetchPronunciationSound(word: string | undefined) {
     const isPrefetch = (Array.from(head.querySelectorAll('link[href]')) as HTMLLinkElement[]).some((el) => el.href === soundUrl)
 
     if (!isPrefetch) {
-      const link = document.createElement('link')
-      link.rel = 'prefetch'
-      link.href = soundUrl
-      head.appendChild(link)
+      const audio = new Audio()
+      audio.src = soundUrl
+      audio.preload = 'auto'
+
+      // gpt 说这这两行能尽可能规避下载插件被触发问题。 本地测试不加也可以，考虑到别的插件可能有问题，所以加上保险
+      audio.crossOrigin = 'anonymous'
+      audio.style.display = 'none'
+
+      head.appendChild(audio)
 
       return () => {
-        head.removeChild(link)
+        head.removeChild(audio)
       }
     }
   }, [pronunciationConfig.type, word])


### PR DESCRIPTION
**问题描述：**

一直困扰了好久，自动播放声音时，总会自动误触发下载插件：

**环境：**
- Windows 10
- chrome 
- 浏览器 Edge （版本 122.0.2365.92 (正式版本) (64 位)）
- FireFox 124.0.1 (64 位)

会误触发的下载插件有
NeatDownloadManager （1.4.24） [https://www.neatdownloadmanager.com/index.php/en/](url) 
Internet Download Manager （6.24） [https://www.internetdownloadmanager.com/?v=642b7](url)

相关issues:
#577 



**修改内容：**

1. 修改   link 标签为  audio 标签
2. 设置属性 尽可能避免误触发下载插件（软件） （GPT 说的）

    audio.crossOrigin = 'anonymous'
    audio.style.display = 'none'


**修改后测试**
| 软件名称               | 触发情况     |
|-----------------------|--------------|
| NeatDownloadManager   | 正常无误触发 |
| Internet Download Manager | 正常无误触发 |
| Edge                  | 正常无误触发 |
| FireFox               | 正常无误触发 |
| 迅雷                   | 正常无误触发 |
|Chrome | 正常无误触发|

**以上环境回归无引入新问题，声音播放正常**


