### PR TITLE
fix(error_book): correct WordPronunciationIcon props for pronunciation functionality

### DIFF
--- a/src/pages/ErrorBook/RowDetail/index.tsx
+++ b/src/pages/ErrorBook/RowDetail/index.tsx
@@ -79,7 +79,8 @@ const RowDetail: React.FC<RowDetailProps> = ({ currentRowDetail, allRecords }) =
             {word ? <Phonetic word={word} /> : <LoadingWordUI isLoading={isLoading} hasError={hasError} />}
             {word && (
               <WordPronunciationIcon
-                word={word.name}
+                lang={dictInfo.language}
+                word={word}
                 className="absolute -right-7 top-1/2 h-5 w-5 -translate-y-1/2 transform "
                 ref={wordPronunciationIconRef}
               />


### PR DESCRIPTION
## What is this Pull-Request?
This Pull Request addresses an issue in the ErrorBook `RowDetail` component where the `WordPronunciationIcon` was not receiving the correct props, resulting in an "undefined" sound being played for all words.

<img width="1443" alt="스크린샷 2024-07-30 22 43 01" src="https://github.com/user-attachments/assets/7e9002d5-7331-4b50-bb6b-1f970b19c9a8">

## Changes Made
- Added the missing `lang` prop to the `WordPronunciationIcon` component, ensuring that the correct language is used for pronunciation.
- Corrected the `word` prop type to match the expected structure in `WordPronunciationIcon`.
- Verified that the pronunciation feature now functions correctly, playing the appropriate sound for the selected word.
