### PR TITLE
fix mobilePage carousel animation bug

### DIFF
--- a/src/pages/Mobile/index.tsx
+++ b/src/pages/Mobile/index.tsx
@@ -53,13 +53,13 @@ const MobilePage: React.FC = () => {
       const slideWidth = container.offsetWidth
 
       if (currentSlide === 0) {
-        container.style.transition = 'none'
-        container.style.transform = `translateX(0)`
+        container.style.transform = `translateX(-${totalSlides * slideWidth}px)`
         setTimeout(() => {
-          container.style.transition = 'transform 0.5s ease'
-          container.style.transform = `translateX(-${slideWidth}px)`
-        }, 50)
+          container.style.transition = 'none'
+          container.style.transform = `translateX(0)`
+        }, 500)
       } else {
+        container.style.transition = 'transform 0.5s ease'
         container.style.transform = `translateX(-${currentSlide * slideWidth}px)`
       }
     }


### PR DESCRIPTION
On the mobile page, the hot image in the carousel will flash quickly.