### PR TITLE
fix: update id for frequently used words in dictionary

### DIFF
--- a/src/resources/dictionary.ts
+++ b/src/resources/dictionary.ts
@@ -546,7 +546,7 @@ const chinaExam: DictionaryResource[] = [
   },
 
   {
-    id: 'frequently_used_words03',
+    id: 'frequently_used_words02',
     name: '超频单词level 2',
     description: '超频单词level 2',
     category: '中国考试',


### PR DESCRIPTION
Problem:
The id field was being used as the React key in the gallery component, but it wasn’t guaranteed to be unique across tags. This caused React to reuse elements incorrectly, which triggered the non-clickable dictionary bug when switching between tags.

Solution:
Updated the id to be unique, preventing conflicts during re-render.

Fixes: #1018 