### PR TITLE
Add SAT 1700 2025 dictionary

### DIFF
--- a/public/dicts/SAT_1700_2025_Day_Grouped.json
+++ b/public/dicts/SAT_1700_2025_Day_Grouped.json
@@ -1,0 +1,10202 @@
+[
+  {
+    "name": "abrupt",
+    "trans": [
+      "Day 1 | adj. | English: speaking or acting in a way that seems unfriendly and rude | Example: On painter William H. Johnson's return to the United States in 1938 after a decade in Europe, his style underwent an abrupt transformation."
+    ]
+  },
+  {
+    "name": "absurd",
+    "trans": [
+      "Day 1 | adj. | English: completely ridiculous | Example: So as long as a listener's interpretation isn't willfully absurd or the result of inattention, it is difficult to justify the claim that the listener has misunderstood the piece."
+    ]
+  },
+  {
+    "name": "abyssal",
+    "trans": [
+      "Day 1 | adj. | English: relating to the bottom of the ocean, especially to depths of between 3 000 and 6 000 metres | Example: The Clarion-Clipperton Zone (CCZ) is an expanse of abyssal plain and seamounts (underwater mountains) between Hawai'i and Mexico in which mining is permitted."
+    ]
+  },
+  {
+    "name": "accentuate",
+    "trans": [
+      "Day 1 | v. | English: to emphasize sth or make it more noticeable | Example: The realists’ emphasis on accurately portraying the experiences of average working people was largely a rejection of the romantic style evident in many paintings by Jérome-Martin Langlois, which instead accentuate their subjects’ beauty or heroism while hiding all imperfection."
+    ]
+  },
+  {
+    "name": "accessible",
+    "trans": [
+      "Day 1 | adj. | English: that can be reached, entered, used, seen, etc. | Example: It identifies a writer whose work is regarded as difficult to read, brings up two admirers of that writer's work, and gives information that may make the writer's work more accessible to new readers."
+    ]
+  },
+  {
+    "name": "accessory",
+    "trans": [
+      "Day 1 | adj. | English: adj. not the most important when compared to others; n. an extra piece of equipment that is useful but not essential or that can be added to sth else as a decoration | Example: [1] Within baleen species, some individuals developed accessory spleen. 2] | tend to pay careful attention to a character's accessories like gloves, hats, and jackets. These elements help communicate information about how this person would have fit into society at the time."
+    ]
+  },
+  {
+    "name": "acclaim",
+    "trans": [
+      "Day 1 | v. | English: v. to praise or welcome sb/sth publicly n. praise and approval for sb/sth, especially an artistic achievement | Example: [1] In a variety of ways, Samuel Kamakau, Kristiana Kahakauwila, and other acclaimed writers have drawn on these stories to craft a rich portrait of the Hawaiian Islands and their people. 2] These works are widely praised, meaning that Edwards receives substantial acclaim as an artist."
+    ]
+  },
+  {
+    "name": "acclaimed",
+    "trans": [
+      "Day 1 | adj. | English: attracting public approval and praise | Example: Her acclaimed 2019 novel Empire of Wild is set in a Métis community in southern Canada."
+    ]
+  },
+  {
+    "name": "accommodate",
+    "trans": [
+      "Day 1 | v. | English: to provide enough space for sb/sth | Example: The Al-Fattah Al-Aleem Mosque in the New Administrative Capital, Egypt, is a massive mosque that can accommodate approximately 17,000 people at once."
+    ]
+  },
+  {
+    "name": "accompaniment",
+    "trans": [
+      "Day 1 | n. | English: something that happens at the same time as another thing In his solitary retreat on the shore of the sea, whose mobile surface was visible through the open windows, extending outward until it mingled with the horizon, Padre Florentino was relieving the monotony by playing on his harmonium sad and melancholy tunes, to which the sonorous roar of the surf and the sighing of the treetops of the neighboring wood served as accompaniments."
+    ]
+  },
+  {
+    "name": "account",
+    "trans": [
+      "Day 1 | n. | English: n. an explanation or a description of an idea, a theory or a process; n. a written or spoken description of sth that has happened | Example: [1] And as Jane X. Luu et al. point out, the singular nature of impact ejection makes it untenable as an account of multiple loss episodes of similar duration over several years. 2] It discusses a physical process, evaluates possible causes of that process, and then states that a persuasive account of the process has yet to be put forward."
+    ]
+  },
+  {
+    "name": "account for",
+    "trans": [
+      "Day 1 | v. | English: If you can account for something, you can explain it or give the necessary information about it. | Example: It accounts for a writer's lack of popular appeal, cites a literary figure who appreciates that writer, and summarizes the qualities that make the writer's work unique."
+    ]
+  },
+  {
+    "name": "accrue",
+    "trans": [
+      "Day 1 | v. | English: to increase over a period of time | Example: It is a remarkable story that happened to an unremarkable person, though one could plausibly argue that because the story is valuable, some of its value accrues to the person at its center. accustomed to ta 322 FX: familiar with sth and accepting it as normal or usual The pattern of brain activity that long-headed dogs showed when hearing the scrambled recording was different from the pattern of brain activity that short headed dogs showed when hearing the language they were accustomed to."
+    ]
+  },
+  {
+    "name": "accustomed to",
+    "trans": [
+      "Day 1 | English: familiar with sth and accepting it as normal or usual | Example: The pattern of brain activity that long-headed dogs showed when hearing the scrambled recording was different from the pattern of brain activity that short headed dogs showed when hearing the language they were accustomed to."
+    ]
+  },
+  {
+    "name": "acidify",
+    "trans": [
+      "Day 1 | v. | English: to become or make sth become an acid | Example: In 2015 Filipa Faleiro and colleagues published a study concluding that ocean acidification has a strong effect on the behavior of Hippocampus guttulatus, a species of fish."
+    ]
+  },
+  {
+    "name": "acoustic",
+    "trans": [
+      "Day 1 | adj. | English: related to sound or to the sense of hearing | Example: Nicholas T. Homziak et al. investigated the acoustic properties of moths’ ultrasonic responses to audio of bat echolocation and then assessed the palatability of the ultrasound- producing moths."
+    ]
+  },
+  {
+    "name": "acquaintance",
+    "trans": [
+      "Day 1 | n. | English: n.a person that you know but who is not a close friend; n. knowledge of sth | Example: [1] People tend to fixate more often than they should on whether their acquaintances think highly of them. 2] a book printed is a record, remaining in every man’s possession, always ready to renew its acquaintance with his memory"
+    ]
+  },
+  {
+    "name": "acquainted",
+    "trans": [
+      "Day 1 | adj. | English: familiar with sth, having read, seen or experienced it | Example: The untaught peasant beheld the elements around him and was acquainted with their practical uses."
+    ]
+  },
+  {
+    "name": "act",
+    "trans": [
+      "Day 1 | n. | English: one of the main divisions of a play, an opera , etc. | Example: There are persons who go to the theater like the contestants in a mule-race: the last one in, wins, and we know very sensible men who would ascend the scaffold rather than enter a theater before the first act."
+    ]
+  },
+  {
+    "name": "adapt",
+    "trans": [
+      "Day 1 | v. | English: to change a book or play so that it can be made into a play, film/movie, television programme, etc. | Example: It offers information about how Yamauchi adapted her short story into a play."
+    ]
+  },
+  {
+    "name": "adept",
+    "trans": [
+      "Day 1 | adj. | English: good at doing sth that is quite difficult | Example: There is no doubt that Irving Langmuir must have proved himself to be extraordinarily adept at understanding some of the most advanced concepts in the field of chemistry"
+    ]
+  },
+  {
+    "name": "adhere",
+    "trans": [
+      "Day 1 | v. | English: to behave according to a particular law, rule, set of instructions, etc; to follow a particular set of beliefs or a fixed way of doing sth | Example: | aim to create a clear sense of the character and the world they inhabit. Sometimes this means adhering to the historical period's style, but frequently, as in stagings of A Midsummer Night's Dream, some flexibility is required to communicate an idea to the audience."
+    ]
+  },
+  {
+    "name": "adjective",
+    "trans": [
+      "Day 1 | n. | English: a word that describes a person or thing | Example: If one has a supposition that the word “own” has a high incidence in English, for example, an analysis of a corpus can support that hypothesis by showing that “own” is the eighth most commonly used adjective."
+    ]
+  },
+  {
+    "name": "adore",
+    "trans": [
+      "Day 1 | v. | English: to love sb very much | Example: It's obvious that she adores him."
+    ]
+  },
+  {
+    "name": "adroit",
+    "trans": [
+      "Day 1 | adj. | English: skilful and clever, especially in dealing with people | Example: In his afterword to Crowley's book Little, Big, Bloom argues that the novel adroitly blends what playwright Friedrich Schiller termed the naive and sentimental modes."
+    ]
+  },
+  {
+    "name": "advance",
+    "trans": [
+      "Day 1 | v. | English: v. to help sth to succeed; v. to suggest an idea, a theory, or a plan for other people to discuss | Example: [1] Studying for new qualifications is one way of advancing your career. 2] It introduces a trait shared by certain animals in order to contextualize a hypothesis about the origin of that trait that is advanced later in the text."
+    ]
+  },
+  {
+    "name": "adventure",
+    "trans": [
+      "Day 1 | n. | English: an unusual, exciting or dangerous experience, journey or series of events | Example: Audiences of the time considered Clancy of the Mounted to belong to a genre other than the northern adventure genre."
+    ]
+  },
+  {
+    "name": "adverse",
+    "trans": [
+      "Day 1 | adj. | English: negative and unpleasant; not likely to produce a good result | Example: CLPs primarily transmitted by ingestion were less dependent on host species adversely affected by warming temperatures than were CLPs that use other transmission strategies."
+    ]
+  },
+  {
+    "name": "adversity",
+    "trans": [
+      "Day 1 | n. | English: a difficult or unpleasant situation | Example: She went through the crucible of unprecedented adversities and trials of life and came out one of the rare shining lights that beautify the New England sky."
+    ]
+  },
+  {
+    "name": "advocate",
+    "trans": [
+      "Day 1 | v. | English: to support sth publicly | Example: Thus, Enke et al. suggest that although the behavior of high-income earners who advocate for higher taxes may seem counterintuitive, such people likely do so because they feel enabled by their economic security to take a stance they think is morally correct."
+    ]
+  },
+  {
+    "name": "aerial",
+    "trans": [
+      "Day 1 | adj. | English: You talk about aerial attacks and aerial photographs to indicate that people or things on the ground are attacked or photographed by people in aeroplanes. | Example: Maryam Hosseini and her team found that a computer program trained to identify sidewalks in aerial images of Boston could also accurately identify sidewalks in aerial images of Chicago and even distinguished between brick and asphalt."
+    ]
+  },
+  {
+    "name": "affecting",
+    "trans": [
+      "Day 1 | adj. | English: producing strong feelings of sadness and sympathy | Example: The Roc-aux-Sorciers frieze—a group of relief carvings of animals found in what is now France and dating from around 14,000 years ago—is sometimes said to be emotionally powerful despite its age, but in fact the frieze is affecting precisely because of its age."
+    ]
+  },
+  {
+    "name": "affection",
+    "trans": [
+      "Day 1 | n. | English: the feeling of liking or loving sb/sth very much and caring about them | Example: This was the case for both separation problems and dog rivalry but was especially pronounced for attachment and attention-seeking, which can be seen when a dog solicits affection or attention."
+    ]
+  },
+  {
+    "name": "affiliate",
+    "trans": [
+      "Day 1 | n. | English: acompany, an organization, etc. that is connected with or controlled by another larger one | Example: To conclude that this approach accounts for the ethereal qualities now synonymous with the Highwaymen aesthetic is tempting but inaccurate, as Hair's methods weren't universally practiced by his affiliates: Roy McLendon, for example, painted with greater deliberateness but achieved the same effects."
+    ]
+  },
+  {
+    "name": "affinity",
+    "trans": [
+      "Day 1 | n. | English: a strong feeling that you understand sb/sth and like them or it | Example: Sam was born in the country and had a deep affinity with nature."
+    ]
+  },
+  {
+    "name": "agglomeration",
+    "trans": [
+      "Day 1 | n. | English: a group of things put together in no particular order or arrangement | Example: It is tempting to treat the clustering of information technology firms in Northern California as representative of industrial agglomeration generally."
+    ]
+  },
+  {
+    "name": "aggregate",
+    "trans": [
+      "Day 1 | adj. | English: made up of several amounts that are added together to form a total number | Example: ighteenth-century economist Adam Smith is famed for his metaphor of the invisible hand, which he putatively used to illustrate a robust model of how individuals produce aggregate benefits by pursuing their own economic interests."
+    ]
+  },
+  {
+    "name": "agreeable",
+    "trans": [
+      "Day 1 | adj. | English: pleasant and easy to like | Example: And by his brother clergy he was regarded as a discreet and agreeable fellow."
+    ]
+  },
+  {
+    "name": "air",
+    "trans": [
+      "Day 1 | n. | English: the particular feeling or impression that is given by sb/sth; the way sb does sth | Example: She had the air of a queen and gazed disdainfully at the whole house."
+    ]
+  },
+  {
+    "name": "akin",
+    "trans": [
+      "Day 1 | adj. | English: similar to | Example: The question of whether the people of the time understood the paintings as something akin to art in your modern sense or in some other way entirely is irresolvable: we will never be able to answer it."
+    ]
+  },
+  {
+    "name": "algorithm",
+    "trans": [
+      "Day 1 | n. | English: a set of rules that must be followed when solving a particular problem | Example: How we define a neighborhood and its boundaries is subjective, so the team used a clustering algorithm to locate dense groupings of amenities that represent human-identified neighborhoods like Boston's Central Square."
+    ]
+  },
+  {
+    "name": "align with",
+    "trans": [
+      "Day 1 | English: to change sth slightly so that it is in the correct relationship to sth else | Example: It presents the natural world as aligning with the experience of the speaker and her friend."
+    ]
+  },
+  {
+    "name": "alignment",
+    "trans": [
+      "Day 1 | n. | English: arrangement in a straight line | Example: Political blogs with conspicuous ideological alignments became an integral component of US media in the early 2000s."
+    ]
+  },
+  {
+    "name": "allegedly",
+    "trans": [
+      "Day 1 | adv. | English: used when reporting something that people say is true, although it has not been proved | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+    ]
+  },
+  {
+    "name": "allegory",
+    "trans": [
+      "Day 1 | n. | English: astory, play, picture, etc. in which each character or event is a symbol representing an idea or a quality, such as truth, evil, death, etc The Great Wave off Kanagawa employs visual allegory to convey its deeper thematic meaning to viewers."
+    ]
+  },
+  {
+    "name": "alleviate",
+    "trans": [
+      "Day 1 | v. | English: to make sth less severe | Example: Many experts, like lawyer and cycling advocate Ernesto Hernandez-Lopez, have proposed bike travel as one possible way to alleviate congestion on the busy roadways of Los Angeles County, California."
+    ]
+  },
+  {
+    "name": "alliance",
+    "trans": [
+      "Day 1 | n. | English: a group of people, political parties, etc. who work together in order to achieve sth that they all want | Example: Argyroxiphium sandwicense is a species in a family of plants known collectively as the silversword alliance, all of which grow only on the Hawaiian Islands. Members of this alliance exhibit an extraordinary range of phenotypes, with some species maturing into vines and others into shrubs and trees."
+    ]
+  },
+  {
+    "name": "allocate",
+    "trans": [
+      "Day 1 | v. | English: to give sth officially to sb/sth for a particular purpose | Example: In the 1960s, Greece, Malta, and dozens of other countries were allocated unique country dialing codes to route international calls."
+    ]
+  },
+  {
+    "name": "allude",
+    "trans": [
+      "Day 1 | v. | English: to mention sth in an indirect way | Example: It stresses the discrepancy between Mr. Ely's public and private conduct and then alludes to his motivation for hiding his true personality."
+    ]
+  },
+  {
+    "name": "alphabetical",
+    "trans": [
+      "Day 1 | adj. | English: according to the correct order of the letters of the alphabet | Example: She was reading a book a day in alphabetical order and not skipping the dry ones."
+    ]
+  },
+  {
+    "name": "alteration",
+    "trans": [
+      "Day 2 | n. | English: an alteration is a change in or to something | Example: To evaluate the responses of local waterbird species, including the osprey, to landscape alterations, the researchers utilized the Index of Waterbird Community Integrity (IWCl), on which a low score Acorresponds to low community integrity."
+    ]
+  },
+  {
+    "name": "amass",
+    "trans": [
+      "Day 2 | v. | English: to collect sth, especially in large quantities | Example: Agglomeration economies arise when multiple firms in related industries amass in an area, as with leather production firms and footwear manufacturers in Glasgow, UK."
+    ]
+  },
+  {
+    "name": "amateur",
+    "trans": [
+      "Day 2 | n. | English: a person who takes part in a sport or other activity for enjoyment, not as a job | Example: Community science, which involves professional scientists collaborating with amateur science enthusiasts to study a topic, is often an effective and engaging way to conduct research."
+    ]
+  },
+  {
+    "name": "ambient",
+    "trans": [
+      "Day 2 | adj. | English: relating to the surrounding area; on all sides | Example: Water temperatures at this site—named the Octopus Garden—climb as high as 11°C, much warmer than the ambient 1.6°C typical at this depth."
+    ]
+  },
+  {
+    "name": "ambiguity",
+    "trans": [
+      "Day 2 | n. | English: the state of being difficult to understand or explain because of involving many different aspects Detailed statistical analysis helped preclude claims of the event's ambiguity, confirming the signal at a confidence level of over 99%."
+    ]
+  },
+  {
+    "name": "ambiguous",
+    "trans": [
+      "Day 2 | adj. | English: having different meanings | Example: It is also unclear whether categorizing music by genre is useful, since genre categories are ambiguous, subjective, and simplistic."
+    ]
+  },
+  {
+    "name": "ambivalence",
+    "trans": [
+      "Day 2 | n. | English: the simultaneous existence of two opposed and conflicting attitudes, emotions, etc | Example: \"Poetry\" is a 1919 poem by Marianne Moore. The poem highlights an ambivalence toward poetry as the speaker acknowledges its merits while also expressing a sense of displeasure."
+    ]
+  },
+  {
+    "name": "ambivalent",
+    "trans": [
+      "Day 2 | adj. | English: having or showing both good and bad feelings about sb/sth | Example: ‘She seems to feel ambivalent about her new job."
+    ]
+  },
+  {
+    "name": "ameliorate",
+    "trans": [
+      "Day 2 | v. | English: to make sth better | Example: Researchers would later ameliorate this shortcoming after gaining new access to administrative records located in nations in Africa, such as Ivory Coast, and Eastern Europe,"
+    ]
+  },
+  {
+    "name": "amenity",
+    "trans": [
+      "Day 2 | n. | English: a feature that makes a place pleasant, comfortable or easy to live in | Example: As urbanist Mariela Alfonzo argues, our understanding of individuals’ decision-making about whether to walk is insufficiently robust: some studies emphasize the role of climate conditions, others the role of recreational amenities, and so on, but walking decisions are made in complex contexts in which multiple conditions and needs inform individuals’ choices."
+    ]
+  },
+  {
+    "name": "amorphous",
+    "trans": [
+      "Day 2 | adj. | English: having no definite shape, form or structure | Example: Writer Lydia Davis observed that while traditional literary forms, such as the novel, are recognizable as such even as they evolve, there are more amorphous forms that might, for example, borrow elements from both fables and realist narratives to make something unconventional."
+    ]
+  },
+  {
+    "name": "ample",
+    "trans": [
+      "Day 2 | adj. | English: enough or more than enough | Example: Having an ample reserve of stored energy can mitigate the effects of fluctuations in solar energy collection caused by unpredictable shifts in cloud cover and haze."
+    ]
+  },
+  {
+    "name": "amplify",
+    "trans": [
+      "Day 2 | v. | English: to increase sth in strength, especially sound | Example: Remarkable for anticipating and amplifying cultural perceptions of Florida that became pervasive in the public consciousness, paintings by the Highwaymen are readily identifiable by the natural iconography—placid inland rivers, windswept palm trees—that McLendon and colleagues perpetually revisited."
+    ]
+  },
+  {
+    "name": "amusing",
+    "trans": [
+      "Day 2 | adj. | English: funny and enjoyable | Example: If newcomers to the little provincial city of S. complained that life there was monotonous and dull, its inhabitants would answer that, on the contrary, S. was a very amusing place."
+    ]
+  },
+  {
+    "name": "analogical",
+    "trans": [
+      "Day 2 | adj. | English: of, relating to, or based on analogy | Example: Analogical method was applied for the evaluation."
+    ]
+  },
+  {
+    "name": "analogous",
+    "trans": [
+      "Day 2 | adj. | English: similar in some way to another thing or situation and therefore able to be compared with it | Example: The knowledge, communicated by the historian and biographer, is analogous to that which we acquire of a country by the map, —minute, perhaps, and accurate, and available for all necessary purposes, but cold and naked, and wholly destitute of the mimic charm produced by landscape painting."
+    ]
+  },
+  {
+    "name": "analogue",
+    "trans": [
+      "Day 2 | n. | English: a thing that is similar to another thing | Example: The novel is largely pure invention, and readers who neglect this fact and instead try to identify more and more real-life analogues thus risk positing unsupportable connections between Heartburn and Ephron's life."
+    ]
+  },
+  {
+    "name": "anatomical",
+    "trans": [
+      "Day 2 | adj. | English: relating to the structure of the bodies of people and animals The team concluded that differences in dogs' anatomical features may affect their ability to distinguish speech from nonspeech."
+    ]
+  },
+  {
+    "name": "anatomize",
+    "trans": [
+      "Day 2 | vt. | English: If you anatomise a subject or an issue, you examine it in great detail. | Example: _He might dissect, anatomize, and give names; but, not to speak of a final cause, causes in their secondary and tertiary grades were utterly unknown to him."
+    ]
+  },
+  {
+    "name": "annotate",
+    "trans": [
+      "Day 2 | v. | English: to add notes to a book or text, giving explanations or comments | Example: Historians annotate, check and interpret the diary selections."
+    ]
+  },
+  {
+    "name": "antagonistic",
+    "trans": [
+      "Day 2 | adj. | English: showing or feeling opposition | Example: It can also be antagonistic, such as when a political candidate turns toward their competitor during a debate and makes eye contact that signals hostility."
+    ]
+  },
+  {
+    "name": "antennae",
+    "trans": [
+      "Day 2 | n. | English: The antennae of something such as an insect or crustacean are the two long, thin parts attached to its head that it uses to feel things with | Example: At the TIGER-Unwin observatory site in New Zealand, radars point their antennae to the sky to track geomagnetic storms and other geospace phenomena."
+    ]
+  },
+  {
+    "name": "antibiotic",
+    "trans": [
+      "Day 2 | n. | English: a substance, for example penicillin , that can destroy or prevent the growth of bacteria and cure infections | Example: The process can have the effect of increasing bacterial resistance to antibiotics."
+    ]
+  },
+  {
+    "name": "anticipate",
+    "trans": [
+      "Day 2 | v. | English: to expect sth | Example: As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot."
+    ]
+  },
+  {
+    "name": "anvil",
+    "trans": [
+      "Day 2 | n. | English: an iron block on which a blacksmith puts hot pieces of metal before shaping them with a hammer | Example: He told me how calm his soul was laid / By the lack of anvil and strife."
+    ]
+  },
+  {
+    "name": "apathy",
+    "trans": [
+      "Day 2 | n. | English: the feeling of not being interested in or enthusiastic about anything | Example: There is widespread apathy among the electorate."
+    ]
+  },
+  {
+    "name": "aperture",
+    "trans": [
+      "Day 2 | n. | English: an opening that allows light to reach a lens , especially in cameras | Example: A telescope allows us to see very faint objects mostly due to the large size of the opening that light passes through, known as the aperture."
+    ]
+  },
+  {
+    "name": "apostle",
+    "trans": [
+      "Day 2 | n. | English: a person who strongly believes in a policy or an idea and tries to make other people believe in it | Example: The men of culture are the true apostles of equality."
+    ]
+  },
+  {
+    "name": "apostrophize",
+    "trans": [
+      "Day 2 | v. | English: to address what you are saying, or a poem, a speech in a play, etc. to a particular person | Example: Then Clarence was wildly apostrophized, and a torrent of tears relieved the overcharged, aching heart."
+    ]
+  },
+  {
+    "name": "apparel",
+    "trans": [
+      "Day 2 | n. | English: clothing, when it is being sold in shops/stores | Example: A survey found that in April 2022, 7.6 percent of subscribers to fashion and apparel services canceled their subscriptions."
+    ]
+  },
+  {
+    "name": "appeal",
+    "trans": [
+      "Day 2 | v. | English: v. to attract or interest sb; n. a quality that makes sb/sth attractive or interesting | Example: [1] The Aztecs would have disputed the idea that the morality of an individual's actions can be assessed by appealing to standards of behavior that are independent of the individual's social circumstances. 2] Although the literary works of David Malo and Lee Cataluna have universal appeal, they are also inextricable from the Hawaiian literary tradition in which both authors work and that stretches back to the traditional stories of the Kanaka Maoli, the Native Hawaiian people."
+    ]
+  },
+  {
+    "name": "appealing",
+    "trans": [
+      "Day 2 | adj. | English: attractive or interesting | Example: The new skin-care product is less appealing to college students than other similar products on the market are."
+    ]
+  },
+  {
+    "name": "appease",
+    "trans": [
+      "Day 2 | v. | English: to make sb calmer or less angry by giving them what they want | Example: The move was widely seen as an attempt to appease critics of the regime."
+    ]
+  },
+  {
+    "name": "applaud",
+    "trans": [
+      "Day 2 | v. | English: to express praise for sb/sth because you approve of them or it | Example: The reception of Ji-li Jiang's book Red Kite, Blue Kite has been very good. Many reviewers have applauded the book, and it won the Asian/Pacific American Award for Literature."
+    ]
+  },
+  {
+    "name": "applicable",
+    "trans": [
+      "Day 2 | adj. | English: that can be said to be true in the case of sb/sth | Example: It has some evidential support, but it should not be regarded as universally applicable."
+    ]
+  },
+  {
+    "name": "appraise",
+    "trans": [
+      "Day 2 | v. | English: If you appraise something or someone, you consider them carefully and form an opinion about them. | Example: This prompted many employers to appraise their selection and recruitment policies."
+    ]
+  },
+  {
+    "name": "apprehension",
+    "trans": [
+      "Day 2 | n. | English: worry or fear that sth unpleasant may happen | Example: The narrator contrasts his feelings of apprehension with the apparent tranquility of the river as the boat enters the countryside."
+    ]
+  },
+  {
+    "name": "apprehensive",
+    "trans": [
+      "Day 2 | adj. | English: worried or frightened that sth unpleasant may happen | Example: They convey Caravan's growing apprehensiveness about having failed to complete an important work task for the first time in his long career."
+    ]
+  },
+  {
+    "name": "apprise",
+    "trans": [
+      "Day 2 | v. | English: to tell or inform sb of sth | Example: We must apprise them of the dangers that may be involved."
+    ]
+  },
+  {
+    "name": "approach",
+    "trans": [
+      "Day 2 | v. | English: to start dealing with a problem, task, etc. in a particular way | Example: In the United States, historians of the American Revolution once had a tendency to approach their subject with reverence."
+    ]
+  },
+  {
+    "name": "appropriate",
+    "trans": [
+      "Day 2 | adj. | English: suitable, acceptable or correct for the particular circumstances | Example: They have been furnished with the intention of maintaining a sense of appropriateness."
+    ]
+  },
+  {
+    "name": "arbiter",
+    "trans": [
+      "Day 2 | n. | English: a person with the power or influence to make judgements and decide what will be done or accepted | Example: Today, the Michelin Guide is widely known as the arbiter of fine dining, with its coveted 3-star rating being awarded to top restaurants like Xin Rong Ji in Beijing."
+    ]
+  },
+  {
+    "name": "arbitrary",
+    "trans": [
+      "Day 2 | adj. | English: not seeming to be based on a reason, system or plan and sometimes seeming unfair Rather than being an arbitrary stylistic choice, hyperpop's persistent modification of the voice functions as a commentary on how digital technology mediates human experience today."
+    ]
+  },
+  {
+    "name": "arcane",
+    "trans": [
+      "Day 2 | adj. | English: secret and mysterious and therefore difficult to understand | Example: Until a few months ago few people outside the arcane world of contemporary music had heard of Gorecki."
+    ]
+  },
+  {
+    "name": "archaea",
+    "trans": [
+      "Day 2 | n. | English: micro-organisms which are similar to bacteria in size and simplicity of structure but radically different in molecular organization. They are now believed to constitute an ancient group which is intermediate between the bacteria and eukaryotes. | Example: The researchers studied two wooden shipwrecks in the Gulf of Mexico by placing pieces of pine and oak between zero and 200 meters away from each shipwreck to collect samples of three kinds of microbes: bacteria, archaea, and fungi."
+    ]
+  },
+  {
+    "name": "archival",
+    "trans": [
+      "Day 2 | adj. | English: Archival means belonging or relating to archives. | Example: One reason for this discrepancy is that historians of capitalism tend to focus on longitudinal economic data drawn from archival records, which do not exist for much of precolonial Africa."
+    ]
+  },
+  {
+    "name": "arduous",
+    "trans": [
+      "Day 2 | adj. | English: involving a lot of effort and energy, especially over a period of time | Example: The creation of Lotte Reiniger's 1926 animated film The Adventures of Prince Achmed was an arduous process."
+    ]
+  },
+  {
+    "name": "arguably",
+    "trans": [
+      "Day 2 | adv. | English: used, often before a comparative or superlative adjective, when you are stating an opinion which you believe you could give reasons to support But Nixon’s legacy is complex: he has been praised for his role in affirming the sovereignty of tribal nations, and he once made an attempt at reforming United States health care policy that is arguably a precursor to the Affordable Care Act, which became law during the Barack Obama administration."
+    ]
+  },
+  {
+    "name": "arid",
+    "trans": [
+      "Day 2 | adj. | English: having little or no rain; very dry | Example: Some paleontologists thought that a sudden shift toward an arid climate on the Australian continent may have brought about the rapid extinction of several species of large kangaroos around 200,000 years ago."
+    ]
+  },
+  {
+    "name": "articulate",
+    "trans": [
+      "Day 2 | v. | English: to express or explain your thoughts or feelings clearly in word | Example: To emphasize the extent of individuals’ struggles to articulate thoughts on art"
+    ]
+  },
+  {
+    "name": "artificial",
+    "trans": [
+      "Day 3 | adj. | English: created by people | Example: Artificial leaves are a developing renewable energy technology that mimics the process of photosynthesis in plants."
+    ]
+  },
+  {
+    "name": "ascertain",
+    "trans": [
+      "Day 3 | v. | English: to find out the true or correct information about sth | Example: Geochemists analyzing a given rock formation can ascertain that an igneous intrusion that bisects a layer of 393.3-million-year-old Eifelian rock but not the 254.1-million-year-old Changhsingian rock above it is younger than the former but older than the latter."
+    ]
+  },
+  {
+    "name": "asphalt",
+    "trans": [
+      "Day 3 | n. | English: a thick black sticky substance used especially for making the surface of roads | Example: Maryam Hosseini and her team found that a computer program trained to identify sidewalks in aerial images of Boston could also accurately identify sidewalks in aerial images of Chicago and even distinguished between brick and asphalt."
+    ]
+  },
+  {
+    "name": "assemble",
+    "trans": [
+      "Day 3 | v. | English: to come together as a group; to bring people or things together as a group | Example: Linda Lomahaftewa often assembles compositions out of motifs common in the ceramics and other traditional arts of the Hopi Tribe."
+    ]
+  },
+  {
+    "name": "assent",
+    "trans": [
+      "Day 3 | v. | English: to agree to a request, an idea or a suggestion | Example: Nobody would assent to the terms they proposed."
+    ]
+  },
+  {
+    "name": "assert",
+    "trans": [
+      "Day 3 | v. | English: to make other people recognize your right or authority to do sth, by behaving firmly and confidently | Example: Whether the reign of a French monarch such as Louis XII or Louis IV was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy and therefore cannot be understood without a corollary understanding of the factors that allowed the monarch to assert his right to hold the throne successfully."
+    ]
+  },
+  {
+    "name": "assertive",
+    "trans": [
+      "Day 3 | adj. | English: expressing opinions or desires strongly and with confidence, so that people take notice | Example: You should try and be more assertive."
+    ]
+  },
+  {
+    "name": "assess",
+    "trans": [
+      "Day 3 | v. | English: to make a judgement about the nature or quality of sb/sth | Example: One way to assess the importance of a scholar's research is to track how often other scholars refer to that research."
+    ]
+  },
+  {
+    "name": "asset",
+    "trans": [
+      "Day 3 | n. | English: a thing of value, especially property, that a person or company owns, which can be used or sold to pay debts | Example: Companies involved in petroleum extraction include drilling equipment among their assets."
+    ]
+  },
+  {
+    "name": "assign",
+    "trans": [
+      "Day 3 | v. | English: to say that sth has a particular value or function, or happens at a particular time or place | Example: Based on the text, which choice best explains why it is challenging to confidently assign authorship of the essay \"The Senate\"?"
+    ]
+  },
+  {
+    "name": "associative",
+    "trans": [
+      "Day 3 | adj. | English: Associative thoughts are things that you think of because you see, hear, or think of something that reminds you of those things or which you associate with those things. | Example: The associative guilt was ingrained in his soul."
+    ]
+  },
+  {
+    "name": "assuage",
+    "trans": [
+      "Day 3 | v. | English: to make an unpleasant feeling less severe | Example: Knowing this can assuage potential investors' worries about bureaucratic minutiae and thereby allow them to instead focus on identifying sound business opportunities."
+    ]
+  },
+  {
+    "name": "asteroid",
+    "trans": [
+      "Day 3 | n. | English: any one of the many small planets which go around the sun | Example: Asteroid 6478 Gault has experienced intermittent mass loss since at least 2013, but in contrast to some other asteroids with repeated mass-loss episodes, 6478 Gault has not lost mass at its perihelion (the closest point of its orbit to the Sun), and thus the loss is not attributable to solar energy—driven ice vaporization."
+    ]
+  },
+  {
+    "name": "astronomical",
+    "trans": [
+      "Day 3 | adj. | English: connected with astronomy | Example: It describes an astronomical finding, discusses competing theories about that finding that the author regards as flawed, and then describes new evidence that supports an alternative theory."
+    ]
+  },
+  {
+    "name": "asymmetrical",
+    "trans": [
+      "Day 3 | adj. | English: Something that is asymmetrical has two sides or halves that are different in shape, size, or style. | Example: Many plants have leaves that are larger on one side of their long central axis than the other, a phenomenon known as asymmetrical orientation."
+    ]
+  },
+  {
+    "name": "asymmetry",
+    "trans": [
+      "Day 3 | n. | English: lack of symmetry | Example: The way in which individual elements are balanced within a photographic image tends to affect how viewers perceive it: symmetry tends to give the elements equal importance, asymmetry emphasizes differences, and radial balance (organizing the elements around a central point) emphasizes the center over the periphery."
+    ]
+  },
+  {
+    "name": "atrocious",
+    "trans": [
+      "Day 3 | adj. | English: very bad or unpleasant | Example: Asa result, this lovely region is atrociously poor and its few scattered farms provide just the requisite number of red roofs to set off the velvety green of the woods."
+    ]
+  },
+  {
+    "name": "attachment",
+    "trans": [
+      "Day 3 | n. | English: strong feeling of affection for sb/sth | Example: She presents herself as having a strong emotional attachment to the surrounding forests."
+    ]
+  },
+  {
+    "name": "attendee",
+    "trans": [
+      "Day 3 | n. | English: a person who attends a meeting, etc Each is contemptuous of the other attendees but strives to impress them."
+    ]
+  },
+  {
+    "name": "attic",
+    "trans": [
+      "Day 3 | n. | English: a room or space just below the roof of a house, often used for storing things | Example: They usually spent the entire day in the attic, playing dolls and giggling."
+    ]
+  },
+  {
+    "name": "attire",
+    "trans": [
+      "Day 3 | n. | English: clothes But there were vacant seats here and there, and into one of them she was ushered, between brilliantly dressed women who had gone there to kill time and eat candy and display their gaudy attire."
+    ]
+  },
+  {
+    "name": "attributable",
+    "trans": [
+      "Day 3 | adj. | English: probably caused by the thing mentioned | Example: Asteroid 6478 Gault has experienced intermittent mass loss since at least 2013, but in contrast to some other asteroids with repeated mass-loss episodes, 6478 Gault has not lost mass at its perihelion (the closest point of its orbit to the Sun), and thus the loss is not attributable to solar energy—driven ice vaporization."
+    ]
+  },
+  {
+    "name": "attribute to",
+    "trans": [
+      "Day 3 | English: to say or believe that sth is the result of a particular thing | Example: While there are several possible reasons for this, one is that practitioners may overlook confounding variables that account for the results they attribute to the interventions in question."
+    ]
+  },
+  {
+    "name": "atypical",
+    "trans": [
+      "Day 3 | adj. | English: not typical or usual | Example: Contrary to the belief that they evolved from early ancestors with the bilateral form typical of many other animals, sea stars instead originated with an atypical body layout that was neither bilaterally nor radially symmetrical."
+    ]
+  },
+  {
+    "name": "augment",
+    "trans": [
+      "Day 3 | v. | English: to increase the amount, value, size, etc. of sth | Example: While searching for a way to augment the family income, she began making dolls."
+    ]
+  },
+  {
+    "name": "authentic",
+    "trans": [
+      "Day 3 | adj. | English: known to be real and genuine and not a copy | Example: Siemowit appears in the Gesta principum Polonorum, an authentic chronicle of medieval Polish history written in the 12th century."
+    ]
+  },
+  {
+    "name": "authenticate",
+    "trans": [
+      "Day 3 | v. | English: to prove that sth is genuine, real or true | Example: Multiple sculptures dating to the period have been alleged to be the reported bust, but none have been authenticated as Desiderio's depiction of Strozzi."
+    ]
+  },
+  {
+    "name": "authenticity",
+    "trans": [
+      "Day 3 | n. | English: the quality of being authentic | Example: Nicholas Galanin is known for using video and photography to explore questions of authenticity in the identification and presentation of Native art."
+    ]
+  },
+  {
+    "name": "authoritative",
+    "trans": [
+      "Day 3 | adj. | English: showing that you expect people to obey and respect you | Example: Despite the education specialist's hesitancy about her expertise on the subject in general, she found that she could speak authoritatively about the works of author Mildred Pitts Walter, particularly Justin and the Best Biscuits in the World, which she had used effectively in classroom instruction for many years."
+    ]
+  },
+  {
+    "name": "automate",
+    "trans": [
+      "Day 3 | v. | English: to use machines and computers instead of people to do a job or task | Example: Attempts to automate classification of music into genres have not been very successful, and we may be at the limit of what is technologically possible."
+    ]
+  },
+  {
+    "name": "automatic",
+    "trans": [
+      "Day 3 | adj. | English: having controls that work without needing a person to operate them | Example: The author of Text 1 states that the benefits are automatic, while the author of Text 2 states that effort is required to fully achieve the benefits."
+    ]
+  },
+  {
+    "name": "aviation",
+    "trans": [
+      "Day 3 | n. | English: the designing, building and flying of aircraft | Example: To assist with the development of new water-repellant materials for aviation and other applications, a team including both engineers and entomologists conducted a study of the water-repellant properties of cicada wings."
+    ]
+  },
+  {
+    "name": "awry",
+    "trans": [
+      "Day 3 | adj. | English: if sth goes awry , it does not happen in the way that was planned One person after another rose, and, as with an ill-balanced axe, attempted to hew out his conception of art a little more clearly, and sat down with the feeling that, for some reason which he could not grasp, his strokes had gone awry."
+    ]
+  },
+  {
+    "name": "axe",
+    "trans": [
+      "Day 3 | n. | English: a tool with a wooden handle and a heavy metal blade, used for chopping wood, cutting down trees, etc. | Example: One person after another rose, and, as with an ill-balanced axe, attempted to hew out his conception of art a little more clearly, and sat down with the feeling that, for some reason which he could not grasp, his strokes had gone awry."
+    ]
+  },
+  {
+    "name": "bald",
+    "trans": [
+      "Day 3 | adj. | English: having little or no hair on the head | Example: All day long [the soldiers] rode through the canyon, up and down the steep, round hills, dirty and bald as a man’s head, hill after hill in endless succession."
+    ]
+  },
+  {
+    "name": "banal",
+    "trans": [
+      "Day 3 | adj. | English: very ordinary and containing nothing that is interesting or important | Example: The lyrics of the song are embarrassingly banal."
+    ]
+  },
+  {
+    "name": "barring",
+    "trans": [
+      "Day 3 | prep. | English: except for; unless there is/are | Example: Barring major archaeological discoveries, we are unlikely to ever have an exhaustive account of ancient Egypt under the female pharaoh Hatshepsut, as much of the evidence of her reign was deliberately destroyed by her successors."
+    ]
+  },
+  {
+    "name": "base",
+    "trans": [
+      "Day 3 | adj. | English: not having moral principles or rules | Example: Vanya says to himself, \"| was proud of [Professor Serebrakoff] and of his learning; | received all his words and writings as inspired and now? Now he has retired, and what is the total of his life? A blank! He is absolutely unknown, and his fame has burst like a soap-bubble. | have been deceived; | see that now, basely deceived.\""
+    ]
+  },
+  {
+    "name": "be descended from",
+    "trans": [
+      "Day 3 | English: to be related to sb who lived a long time ago Domesticated thousands of years ago by Indigenous people in South America, the tomatillo deviates structurally from the wild plant it is descended from."
+    ]
+  },
+  {
+    "name": "bear out",
+    "trans": [
+      "Day 3 | English: If someone or something bears a person out or bears out what that person is saying, they support what that person is saying. | Example: Those who have had the rare privilege of reading her stirring biography, will, | am sure, bear me out in this statement."
+    ]
+  },
+  {
+    "name": "bearing",
+    "trans": [
+      "Day 3 | n. | English: n. the way in which sth is related to sth or influences it; n. the way in which you stand, walk or behave | Example: [1] It has no direct bearing on whether the claim is true. 2]Her stockings and boots and well-fitting gloves had worked marvels in her bearing—had given her a feeling of assurance, a sense of belonging to the well-dressed multitude."
+    ]
+  },
+  {
+    "name": "becoming",
+    "trans": [
+      "Day 3 | adj. | English: suitable or appropriate for sb or their situation | Example: But culture indefatigably tries, not to make what each raw person may like, the rule by which he fashions himself; but to draw ever nearer to a sense of what is indeed beautiful, graceful, and becoming, and to get the raw person to like that."
+    ]
+  },
+  {
+    "name": "behold",
+    "trans": [
+      "Day 3 | v. | English: to look at or see sb/sth | Example: [1] Do | behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more deep seclusion; and connect / The landscape with the quiet of the sky. 2] The Istiqlal Mosque in Jakarta, Indonesia, is a massive mosque that can accommodate approximately 200,000 people at once, making it an imposing sight to behold."
+    ]
+  },
+  {
+    "name": "belie",
+    "trans": [
+      "Day 3 | v. | English: to give a false impression of sb/sth | Example: Her energy and youthful good looks belie her 65 years."
+    ]
+  },
+  {
+    "name": "bemoan",
+    "trans": [
+      "Day 3 | v. | English: to complain or say that you are not happy about sth | Example: In “Things That Have Lost Their Power,” which appears in her tenth-century account or Japanese courtly life, Pillow Book, she bemoans boats run aground, toppled trees, and defeated wrestlers."
+    ]
+  },
+  {
+    "name": "bend",
+    "trans": [
+      "Day 3 | v. | English: if you bend your arm, leg, etc. or if it bends, you move it so that it is no longer straight | Example: The little fern-leaf, bending / Upon the brink, its green reflection greets, / And kisses soft the shadow that it meets / With touch so fine, / The border line / The keenest vision can't define; / So perfect is the blending. From early morn to the fall of the afternoon he would go from fountain to fountain and from portal to portal his lean body so accustomed to bending that he never thought of straightening it, his head bowed as if in prayer."
+    ]
+  },
+  {
+    "name": "benevolent",
+    "trans": [
+      "Day 3 | adj. | English: kind, helpful and generous | Example: The company has proved to be a most benevolent employer."
+    ]
+  },
+  {
+    "name": "bestow",
+    "trans": [
+      "Day 3 | v. | English: to give sth to sb, especially to show how much they are respected | Example: Helical swimming, widely understood to confer stability and efficiency in the locomotion of a variety of microscopic organisms—including bacteria, eukaryotic algae, and ciliates—bestows similar advantages, albeit via different propulsive modes, to larger oceanic macroplanktons, such as salps."
+    ]
+  },
+  {
+    "name": "betray",
+    "trans": [
+      "Day 3 | v. | English: to tell sb or make them aware of a piece of information, a feeling, etc., usually without meaning to | Example: Miranda's reminiscences about her early childhood have a melancholy quality that betrays her discontented view of her current circumstances."
+    ]
+  },
+  {
+    "name": "bilateral",
+    "trans": [
+      "Day 3 | adj. | English: involving both of two parts or sides of the body or brain | Example: The morphological novelty of echinoderms marine—invertebrates with radial symmetry, usually starlike, around a central point—impedes comparisons with most other animals, in which bilateral symmetry on an anterior-posterior (head to tail) axis through a trunk is typical."
+    ]
+  },
+  {
+    "name": "biome",
+    "trans": [
+      "Day 4 | n. | English: the characteristic plants and animals that exist in a particular type of environment, for example in a forest or desert | Example: Diadromous fish migrate between freshwater and marine biomes during their life cycle."
+    ]
+  },
+  {
+    "name": "bipedal",
+    "trans": [
+      "Day 4 | adj. | English: using only two legs for walking Some robots such as Salvius (developed in 2008) and REEM-C (developed in 2013) feature humanoid characteristics like bipedal locomotion so that people will find it easier to interact with them."
+    ]
+  },
+  {
+    "name": "bleak",
+    "trans": [
+      "Day 4 | adj. | English: exposed, empty, or with no pleasant features | Example: The bleak fields are asleep, / My heart alone wakes;"
+    ]
+  },
+  {
+    "name": "blend",
+    "trans": [
+      "Day 4 | v. | English: to combine with sth in an attractive or effective way | Example: Similarly, Wayuu singer-songwriter Lido Pimienta blended Afro-Indigenous music from Colombia with Latin pop on her album Miss Colombia."
+    ]
+  },
+  {
+    "name": "block",
+    "trans": [
+      "Day 4 | v. | English: to stop sb from going somewhere or seeing sth by standing in front of them or in their way | Example: Is there an available barrier material that can block roots and liquids while allowing fungal strands through?"
+    ]
+  },
+  {
+    "name": "blossom",
+    "trans": [
+      "Day 4 | v. | English: to produce blossom | Example: Night, guardian of dreams, / Now wanders through the land; / The moon, a lily white, / Blossoms within her hand."
+    ]
+  },
+  {
+    "name": "bolster",
+    "trans": [
+      "Day 4 | v. | English: to improve sth or make it stronger | Example: Reducing this kind of subscriber turnover is especially challenging for subscription sellers: customers’ initial enthusiasm for a subscription is often quick to subside, and sellers must thus devise other incentives to bolster retention."
+    ]
+  },
+  {
+    "name": "boorish",
+    "trans": [
+      "Day 4 | adj. | English: very unpleasant and rude | Example: Socrates, a sophist, says to a new customer \"I have not seen any man so boorish, nor so impracticable, nor so stupid, nor so forgetful; who, while learning some little petty quibbles, forgets them before he has learned them.”"
+    ]
+  },
+  {
+    "name": "boost",
+    "trans": [
+      "Day 4 | v. | English: v. to make sth increase, or become better or more successful; n. an increase in sth | Example: [1] In the 1990s, conservationists began planting more than 500,000 native trees in the habitat of the Azores bullfinch to boost the bird's numbers. 2] It's obvious that the selection of Buenaventura by UNESCO has brought awareness to local recipes, cooking practices, and chefs and has provided a boost to the city’s tourism industry."
+    ]
+  },
+  {
+    "name": "bough",
+    "trans": [
+      "Day 4 | n. | English: a large branch of a tree | Example: Adry ravine emerged under boughs / Into the pasture."
+    ]
+  },
+  {
+    "name": "bounded",
+    "trans": [
+      "Day 4 | adj. | English: (of a set) having a bound, esp where a measure is defined in terms of which all the elements of the set, or the differences between all pairs of members, are less than some value, or else all its members lie within some other well-defined set | Example: and leave thou (inexpressibly to unravel) / thou life, with its immensity and fear, / so that, now bounded, now immeasurable, / it is alternately stone in thy and star."
+    ]
+  },
+  {
+    "name": "bouquet",
+    "trans": [
+      "Day 4 | n. | English: a bunch of flowers arranged in an attractive way so that it can be carried in a ceremony or presented as a gift | Example: [May] dropped her eyes to the immense bouquet of lilies-of-the-valley on her knee, and Newland Archer saw her white-gloved finger-tips touch the flowers softly."
+    ]
+  },
+  {
+    "name": "branch",
+    "trans": [
+      "Day 4 | n. | English: a part of a tree that grows out from the main stem and on which leaves, flowers and fruit grow | Example: Canopy soil is formed in a tree's branches (its canopy) when dead leaves and other falling things collect."
+    ]
+  },
+  {
+    "name": "branch off",
+    "trans": [
+      "Day 4 | English: to be joined to another road or river but lead in a different direction | Example: The Chao Phraya River delta is a constantly changing landform made up of a network of distributaries, small channels that branch off from the main river."
+    ]
+  },
+  {
+    "name": "breach",
+    "trans": [
+      "Day 4 | v. | English: If someone or something breaches a barrier, they make an opening in it, usually leaving it weakened or destroyed. | Example: Moreover, the team was surprised to discover that even when the periostracum is breached, pteropods can still mitigate damage by rebuilding the inner shell wall."
+    ]
+  },
+  {
+    "name": "breadth",
+    "trans": [
+      "Day 4 | n. | English: a wide range (of knowledge, interests, etc.) | Example: The breadth of public art on display in the city can thus satisfy any art lover."
+    ]
+  },
+  {
+    "name": "breast",
+    "trans": [
+      "Day 4 | n. | English: the top part of the front of your body, below your neck | Example: | rest me deep within the wood, / Drawn by its silent call, / Far from the throbbing crowd of men, / On nature's breast | fall."
+    ]
+  },
+  {
+    "name": "breathtaking",
+    "trans": [
+      "Day 4 | adj. | English: very exciting or impressive (usually in a pleasant way); very surprising | Example: Giant stone slabs formed the remains of what must once have been a breathtaking structure."
+    ]
+  },
+  {
+    "name": "bribery",
+    "trans": [
+      "Day 4 | n. | English: the giving or taking of bribes | Example: In particular, he thinks oligarchies are particularly susceptible to corruption through bribery."
+    ]
+  },
+  {
+    "name": "brick",
+    "trans": [
+      "Day 4 | n. | English: baked clay used for building walls, houses and other buildings; an individual block of this | Example: Maryam Hosseini and her team found that a computer program trained to identify sidewalks in aerial images of Boston could also accurately identify sidewalks in aerial images of Chicago and even distinguished between brick and asphalt."
+    ]
+  },
+  {
+    "name": "bride",
+    "trans": [
+      "Day 4 | n. | English: a woman on her wedding day, or just before or just after it | Example: The sierra is clad in gala colors. Over its inaccessible peaks the opalescent fog settles like a snowy veil on the forehead of a bride."
+    ]
+  },
+  {
+    "name": "brink",
+    "trans": [
+      "Day 4 | n. | English: the extreme edge of land, for example at the top of a cliff or by a river | Example: The little fern-leaf, bending / Upon the brink, its green reflection greets, / And kisses soft the shadow that it meets / With touch so fine, / The border line / The keenest vision can't define; / So perfect is the blending. broodon fre, WE CARR. BURP RAS) Z232FEX: to think a lot about sth that makes you annoyed, anxious or upset You're not still brooding over what he said, are you?"
+    ]
+  },
+  {
+    "name": "brood",
+    "trans": [
+      "Day 4 | English: to think a lot about sth that makes you annoyed, anxious or upset | Example: You're not still brooding over what he said, are you?"
+    ]
+  },
+  {
+    "name": "brusque",
+    "trans": [
+      "Day 4 | adj. | English: If you describe a person or their behaviour as brusque, you mean that they deal with things, or say things, quickly and shortly, so that they seem to be rude. | Example: There is no denying that, since he was rather brusque in his ways, he never spared the young authors who asked his advice and read him their productions, but criticized vigorously, even to the verge of insult."
+    ]
+  },
+  {
+    "name": "bud",
+    "trans": [
+      "Day 4 | n. | English: a-small lump that grows on a plant and from which a flower, leaf or stem develops | Example: | walked slowly beneath the young leaves, drinking in the air, fragrant with the odor of young buds and sap."
+    ]
+  },
+  {
+    "name": "buoy up",
+    "trans": [
+      "Day 4 | English: to keep sb/sth floating on water | Example: We are poor plants buoyed up by the air-vessels of our own conceit: alas for us, if we get a few pinches that empty us of that windy self-subsistence! The very capacity for good would go out of us."
+    ]
+  },
+  {
+    "name": "bureaucratic",
+    "trans": [
+      "Day 4 | adj. | English: connected with a bureaucracy or bureaucrats and involving complicated official rules which may seem unnecessary | Example: Knowing this can assuage potential investors' worries about bureaucratic minutiae and thereby allow them to instead focus on identifying sound business opportunities."
+    ]
+  },
+  {
+    "name": "burst",
+    "trans": [
+      "Day 4 | n. | English: n.a short period of a particular activity or strong emotion that often starts suddenly; v. to break open or apart, especially because of pressure from inside; to make sth break in this way [1] Bursts caused by neutron mergers typically last fewer than 2 seconds. | Example: 2] All these things awoke in [Don Custodio] the farther he got from Europe, like the life-giving sap within the sown seed prevented from bursting out by the thick husk."
+    ]
+  },
+  {
+    "name": "bust",
+    "trans": [
+      "Day 4 | v. | English: Vv. to break sth; n. a stone or metal model of a person's head, shoulders and chest | Example: [1] Elephants and other animals, though, have busted the myth that tool use requires hands. 2] According to historical documents, Marietta Strozzi—a young woman who was prominent in fifteenth-century Florentine culture—inspired several artworks, including a portrait bust sculpted by Desiderio da Settignano."
+    ]
+  },
+  {
+    "name": "bustling",
+    "trans": [
+      "Day 4 | adj. | English: full of people moving about in a busy way | Example: When they debuted in April 1983 as part of the exhibit Children's Art: Identity: New Work from Youth Education Program, the artworks brought vibrant visual texture to the bustling terminals of San Francisco International Airport."
+    ]
+  },
+  {
+    "name": "buttress",
+    "trans": [
+      "Day 4 | v. | English: to support or give strength to sb/sth | Example: To that end, certain features such as the ability to respond to voice commands can help to buttress people's feelings of comfort"
+    ]
+  },
+  {
+    "name": "bypass",
+    "trans": [
+      "Day 4 | v. | English: to go around or avoid a place | Example: Anew road now bypasses the town."
+    ]
+  },
+  {
+    "name": "calibration",
+    "trans": [
+      "Day 4 | n. | English: the act of checking or adjusting (by comparison with a standard) the accuracy of a measuring instrument | Example: The use of OHD requires careful calibration based on a sample's climatic context."
+    ]
+  },
+  {
+    "name": "candor",
+    "trans": [
+      "Day 4 | n. | English: the quality of saying what you think openly and honestly | Example: ‘I don't trust him,’ he said, in a rare moment of candour."
+    ]
+  },
+  {
+    "name": "canoe",
+    "trans": [
+      "Day 4 | n. | English: a light narrow boat which you move along in the water with a paddle | Example: Thy warm and land-locked waters swell with an easy motion, / And gently glides the light"
+    ]
+  },
+  {
+    "name": "canon",
+    "trans": [
+      "Day 4 | n. | English: alist of the books or other works that are generally accepted as the genuine work of a particular writer or as being important | Example: Works from this period make up an outsized proportion of what is considered the canon of Mexican literature, but nineteenth-century writers like Justo Sierra O'Reilly should be considered just as integral to the Mexican literary canon."
+    ]
+  },
+  {
+    "name": "canonical",
+    "trans": [
+      "Day 4 | adj. | English: included in a list of holy books that are accepted as genuine; connected with works of literature that are highly respected | Example: The fact that there is no contemporary evidence that the first audience of Arrival of the Train was alarmed has not stopped the story from becoming canonical, even among film historians."
+    ]
+  },
+  {
+    "name": "canopy",
+    "trans": [
+      "Day 4 | n. | English: a cover that is fixed or hangs above a bed, seat, etc. as a shelter or decoration | Example: Canopy soil is formed in a tree's branches (its canopy) when dead leaves and other falling things collect."
+    ]
+  },
+  {
+    "name": "canvas",
+    "trans": [
+      "Day 4 | n. | English: a piece of canvas used for painting on; a painting done on a piece of canvas , using oil paints | Example: Hunting Expedition is an important work of Nihonga, or classical Japanese painting. Unlike Wada Eisaku, who adopted traditional European methods such as painting with oil on canvas, Domoto Insh6 embraced traditional Japanese approaches."
+    ]
+  },
+  {
+    "name": "canyon",
+    "trans": [
+      "Day 4 | n. | English: a deep valley with steep sides of rock | Example: All day long [the soldiers] rode through the canyon, up and down the steep, round hills, dirty and bald as a man’s head, hill after hill in endless succession."
+    ]
+  },
+  {
+    "name": "capitalism",
+    "trans": [
+      "Day 4 | n. | English: an economic system in which a country's businesses and industry are controlled and run for profit by private owners rather than by the government Fernand Braudel and other historians of capitalism rarely discuss domestic capitalism in Africa before the period of European colonization, implicitly presenting capitalism as external to and imposed on Africa."
+    ]
+  },
+  {
+    "name": "capitalize",
+    "trans": [
+      "Day 4 | v. | English: to gain a further advantage for yourself from a situation | Example: The team failed to capitalize on their early lead."
+    ]
+  },
+  {
+    "name": "captivate",
+    "trans": [
+      "Day 4 | v. | English: to keep sb's attention by being interesting, attractive, etc. | Example: Utilizing vivid pastel colors, overexposed tones, and mirrorlike symmetry to evoke a Socialist- era aesthetic, her photos captivated viewers from Spain to Taiwan."
+    ]
+  },
+  {
+    "name": "captive",
+    "trans": [
+      "Day 4 | adj. | English: kept as a prisoner or in a confined space; unable to escape | Example: They found for tucos that daytime is the most active period for wild individuals but not for captive individuals."
+    ]
+  },
+  {
+    "name": "capture",
+    "trans": [
+      "Day 4 | v. | English: to catch a person or an animal and keep them as a prisoner or in a confined space | Example: In 2016, Gabriela Gonzalez and team announced that a chirping sound captured by Laser Interferometer Gravitational-Wave Observatory antennas was direct evidence of gravitational waves."
+    ]
+  },
+  {
+    "name": "carnival",
+    "trans": [
+      "Day 4 | n. | English: a public festival, usually one that happens at a regular time each year, that involves music and dancing in the streets, for which people wear brightly coloured clothes | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+    ]
+  },
+  {
+    "name": "carnivorous",
+    "trans": [
+      "Day 4 | adj. | English: (of an animal) feeding on other animals. | Example: Oyster mushrooms typically get their nutrients from the damp logs on which they grow, but the fungi are also carnivorous, with the ability to kill and consume microscopic worms known as nematodes."
+    ]
+  },
+  {
+    "name": "carpet",
+    "trans": [
+      "Day 4 | n. | English: a thick woven material made of wool, etc. for covering floors or stairs | Example: Agleaming carpet was springing up everywhere."
+    ]
+  },
+  {
+    "name": "carve",
+    "trans": [
+      "Day 4 | v. | English: to make objects, patterns, etc. by cutting away material from wood or stone | Example: Carbon dating at the discovery site revealed that the stone was likely carved between 1 and 250 CE."
+    ]
+  },
+  {
+    "name": "cast-iron",
+    "trans": [
+      "Day 4 | adj. | English: very strong or certain; that cannot be broken or fail | Example: George, on the other hand, ridiculed the idea of Harris’s having done anything more than eat and sleep, and had a cast-iron opinion that it was he—George himself—who had done all the labour worth speaking of."
+    ]
+  },
+  {
+    "name": "casual",
+    "trans": [
+      "Day 5 | adj. | English: not showing much care or thought; seeming not to be worried; not wanting to show that sth is important to you | Example: A casual description of Scherezade Garcia's 2019 mural Blame It on the Bean: The Power of Coffee can make the work seem unassuming."
+    ]
+  },
+  {
+    "name": "catalogue",
+    "trans": [
+      "Day 5 | v. | English: to give a list of things connected with a particular person, event, etc. | Example: Researchers catalogued plant seeds found in fecal samples from non-native birds."
+    ]
+  },
+  {
+    "name": "catalyst",
+    "trans": [
+      "Day 5 | n. | English: a substance that makes a chemical reaction happen faster without being changed itself | Example: These devices are silicon-based solar cells coated in chemical catalysts that activate reactions that split water molecules into hydrogen and oxygen gas."
+    ]
+  },
+  {
+    "name": "cataract",
+    "trans": [
+      "Day 5 | n. | English: amedical condition that affects the lens of the eye and causes a gradual loss of sight | Example: Students in a biology class investigated why individual house mice (Mus musculus) can differ from one another in their susceptibility to cataracts in old age."
+    ]
+  },
+  {
+    "name": "categorical",
+    "trans": [
+      "Day 5 | adj. | English: expressed clearly and in a way that shows that you are very sure about what you are saying | Example: Categorical claims about the original function and significance of the Urfa Man—a statue of a human figure found in what is now Turkey and dating from around 11,000 years ago—should be treated skeptically."
+    ]
+  },
+  {
+    "name": "causal",
+    "trans": [
+      "Day 5 | adj. | English: connected with the relationship between two things, where one causes the other to happen | Example: The work of Tobias Gerstenberg et al. on tracking eye movements supports a theory that people engage in counterfactual thinking when making causal judgments."
+    ]
+  },
+  {
+    "name": "cautious",
+    "trans": [
+      "Day 5 | adj. | English: being careful about what you say or do, especially to avoid danger or mistakes | Example: Then the banker cautiously broke the seals off the door and put the key in the keyhole."
+    ]
+  },
+  {
+    "name": "cease",
+    "trans": [
+      "Day 5 | v. | English: to stop happening or existing; to stop sth from happening or existing | Example: Whether resigned or not to the verdict of the public, he ceased to write plays and assumed instead the nobler réle of patron to unrecognized authors and artists and to ruined managers."
+    ]
+  },
+  {
+    "name": "celebrated",
+    "trans": [
+      "Day 5 | adj. | English: famous for having good qualities | Example: The following text is adapted from Virginia Woolf's 1919 novel Night and Day. Katharine is the granddaughter of a celebrated poet."
+    ]
+  },
+  {
+    "name": "celestial",
+    "trans": [
+      "Day 5 | adj. | English: of the sky or of heaven | Example: Socrates, a sophist, explains why he studies astronomy while sitting in a basket hanging a few feet off the ground, saying, \"| should not have rightly discovered things celestial if | had not suspended the intellect, and mixed the thought in a subtle form with its kindred air.\""
+    ]
+  },
+  {
+    "name": "census",
+    "trans": [
+      "Day 5 | n. | English: the process of officially counting sth, especially a country's population, and recording various facts | Example: Central Vermont's Orange County is among the most rural counties in the United States: the US Census Bureau classified it as 97.2% rural in 2010."
+    ]
+  },
+  {
+    "name": "ceremonious",
+    "trans": [
+      "Day 5 | adj. | English: behaving or performed in an extremely formal way | Example: The attorney general made a more ceremonious show of lenity in this particular case."
+    ]
+  },
+  {
+    "name": "chafe",
+    "trans": [
+      "Day 5 | v. | English: to feel annoyed and impatient about sth, especially because it limits what you can do | Example: The little conductor stood on tiptoe in an effort to keep one hand on the signal rope, craning his neck in a vain and dissatisfied endeavor to pierce the miasma of the fog. The motorman chafed in his box, thinking of the drudging lot of the laboring man. He registered discontent."
+    ]
+  },
+  {
+    "name": "chamber",
+    "trans": [
+      "Day 5 | n. | English: space in the body, in a plant or in a machine, which is separated from the rest | Example: The scientists put bacteria in petri dishes with two chambers."
+    ]
+  },
+  {
+    "name": "channel",
+    "trans": [
+      "Day 5 | n. | English: a deep passage of water in a river or near the coast that can be used as route for ships | Example: As with other river deltas, the Krishna River delta is dynamic: it is a constantly evolving network of channels and strips of land that change in size and shape as the river deposits new sedimentary particles where the river meets the waters of the Bay of Bengal."
+    ]
+  },
+  {
+    "name": "chant",
+    "trans": [
+      "Day 5 | v. | English: to sing or shout the same words or phrases many times | Example: It's hard to describe Farsi chanting: the way Mom drew her voice out like the notes of a cello as she recited poems by Rumi or Hafez."
+    ]
+  },
+  {
+    "name": "chariot",
+    "trans": [
+      "Day 5 | n. | English: an open vehicle with two wheels, pulled by horses, used in ancient times in battle and for racing | Example: There is no Frigate like a Book / To take us Lands away / Nor any Coursers like a Page / Of prancing Poetry— / This Traverse may the poorest take / Without oppress of Toll— / How frugal is the Chariot / That bears the Human soul."
+    ]
+  },
+  {
+    "name": "chief",
+    "trans": [
+      "Day 5 | n. | English: aleader or ruler of a people or community | Example: lam Ojistoh, | am she, the wife / Of him whose name breathes bravery and life / And courage to the tribe who calls him chief. / | am Ojistoh, his white star, and he / Is land, and lake, and sky—and soul to me."
+    ]
+  },
+  {
+    "name": "chin",
+    "trans": [
+      "Day 5 | n. | English: the part of the face below the mouth and above the neck | Example: [Jim’s father] was shaving this lawn as if it were a priest's chin."
+    ]
+  },
+  {
+    "name": "chip away",
+    "trans": [
+      "Day 5 | English: to keep breaking small pieces off sth | Example: When constructing his argument regarding the characteristics of a well-functioning government, Aristotle asserts thar 'Transgression creeps in unperceived and at last ruins the state,’ illustrating this idea with a comparison to frequent small expenditures slowly and almost imperceptibly chipping away at a fortune until it is ultimately depleted."
+    ]
+  },
+  {
+    "name": "chorus",
+    "trans": [
+      "Day 5 | n. | English: a piece of music, usually part of a larger work, that is written for a choir (= a group of singers) | Example: The sonorous, joyful bells rang again. From within the church, the honeyed voices of a female chorus rose melancholy and grave."
+    ]
+  },
+  {
+    "name": "chromosome",
+    "trans": [
+      "Day 5 | n. | English: one of the very small structures like threads in the nuclei (= central parts) of animal and plant cells, that carry the genes | Example: Drosophila (fruit files) have generation times of 10-12 days, so seasonal changes in humidity and other environmental conditions can drive seasonal fluctuations in chromosome rearrangements in species such as D. persimilis and D. subobscura."
+    ]
+  },
+  {
+    "name": "chronicle",
+    "trans": [
+      "Day 5 | n. | English: a written record of events in the order in which they happened | Example: Siemowit appears in the Gesta principum Polonorum, an authentic chronicle of medieval Polish history written in the 12th century."
+    ]
+  },
+  {
+    "name": "circuit",
+    "trans": [
+      "Day 5 | n. | English: The invention in 1958 of the integrated circuit (or microchip) radically altered the semiconductor industry. | Example: The invention in 1958 of the integrated circuit (or microchip) radically altered the semiconductor industry."
+    ]
+  },
+  {
+    "name": "circulate",
+    "trans": [
+      "Day 5 | v. | English: ifa story, an idea, information, etc. circulates or if you circulate it, it spreads or it is passed from one person to another | Example: Although the government of the Soviet Union attempted to suppress Georgi Viadimov's novel Faithful Ruslan, copies of the book circulated in secret among readers in several parts of the country."
+    ]
+  },
+  {
+    "name": "circumscribe",
+    "trans": [
+      "Day 5 | v. | English: to limit sb/sth's freedom, rights, power, etc. | Example: and leave thou (inexpressibly to unravel) / thou life, with its immensity and fear, / so that, now circumscribed, now immeasurable, / it is alternately stone in thy and star."
+    ]
+  },
+  {
+    "name": "circumvent",
+    "trans": [
+      "Day 5 | v. | English: circumvent sth to find a way of avoiding a difficulty or a rule | Example: They found a way of circumventing the law."
+    ]
+  },
+  {
+    "name": "citadel",
+    "trans": [
+      "Day 5 | n. | English: a place or situation in which an idea, principle, system etc that you think is important is kept safe | Example: I had gazed upon the fortifications and impediments that seemed to keep human beings from entering the citadel of nature, and rashly and ignorantly | had repined."
+    ]
+  },
+  {
+    "name": "citation",
+    "trans": [
+      "Day 5 | n. | English: words or lines taken from a book or a speech For example, a count of other scholars’ citations shows that Boston University economist Marianne Baxter, who studies international finance, is referenced frequently, indicating that her work has been significant in the field."
+    ]
+  },
+  {
+    "name": "citizenry",
+    "trans": [
+      "Day 5 | n. | English: all the citizens of a particular town, country, etc. | Example: Some social scientists say that while a desire for cooperation rather than conflict is key to democracy, public understanding of economics is also central to public comprehension of state politics, and if a citizenry is to function, economic issues cannot remain the domain only of experts."
+    ]
+  },
+  {
+    "name": "clad",
+    "trans": [
+      "Day 5 | adj. | English: covered in a particular thing | Example: The sierra is clad in gala colors. Over its inaccessible peaks the opalescent fog settles like a snowy veil on the forehead of a bride."
+    ]
+  },
+  {
+    "name": "clade",
+    "trans": [
+      "Day 5 | n. | English: a group of organisms considered as having evolved from a common ancestor | Example: Some researchers have characterized the flora and fauna of the South Pacific island of Grande Terre as members of clades that inhabited nearby islands before Grande Terre completely emerged 37 million years ago."
+    ]
+  },
+  {
+    "name": "clash",
+    "trans": [
+      "Day 5 | v. | English: to be very different and opposed to each other | Example: A two-dimensional photograph, however, cannot capture how a building interacts with its surroundings, whether by complementing, blending in with, or perhaps even clashing with sights and activities nearby."
+    ]
+  },
+  {
+    "name": "classifiable",
+    "trans": [
+      "Day 5 | adj. | English: that you can or should classify | Example: Writer Lydia Davis observed that while traditional literary forms, such as the novel, are recognizable as such even as they evolve, there are rarer “intergeneric” forms that might, for example, use elements of both fiction and essays to create something unclassifiable."
+    ]
+  },
+  {
+    "name": "clay",
+    "trans": [
+      "Day 5 | n. | English: a type of heavy, sticky earth that becomes hard when it is baked and is used to make things such as pots and bricks | Example: Using a mechanical spear-thrower, he launched spears with Clovis points into mounds of clay—substitutes for the animals’ large bodies."
+    ]
+  },
+  {
+    "name": "clergy",
+    "trans": [
+      "Day 5 | n. | English: the priests or ministers of a religion, especially of the Christian Church | Example: And by his brother clergy he was regarded as a discreet and agreeable fellow."
+    ]
+  },
+  {
+    "name": "clerical",
+    "trans": [
+      "Day 5 | adj. | English: connected with the clergy (= priests) | Example: Colours might have been better chosen and lights more perfectly diffused; but perhaps in doing so the thorough clerical aspect of the whole might have been somewhat marred."
+    ]
+  },
+  {
+    "name": "cliff",
+    "trans": [
+      "Day 5 | n. | English: a high area of rock with a very steep side, often at the edge of the sea or ocean | Example: Do I behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more deep seclusion; and connect / The landscape with the quiet of the sky."
+    ]
+  },
+  {
+    "name": "cling",
+    "trans": [
+      "Day 5 | v. | English: to stick to sth | Example: Among the wild rice in the still lagoon. / In monotone the lizard shrills his tune. / The wild goose, homing, seeks a sheltering, / Where rushes grow, and oozing lichens cling."
+    ]
+  },
+  {
+    "name": "clinical trial",
+    "trans": [
+      "Day 5 | English: When a new type of drug or medical treatment undergoes clinical trials, it is tested directly on patients to see if it is effective. | Example: The results of randomized clinical trials testing the efficacy of common medical interventions sometimes fail to corroborate conclusions that practitioners reach based on their real-world observations of patients."
+    ]
+  },
+  {
+    "name": "clipping",
+    "trans": [
+      "Day 5 | n. | English: a piece cut off sth | Example: Although it seems ridiculous and useless to study old newspaper clippings and candy wrappers, these old newspapers, advertising leaflets, posters, and candy wrappers are actually able to evince the shifts in people’s behavior and values in the past and are therefore very valuable for this study."
+    ]
+  },
+  {
+    "name": "clique",
+    "trans": [
+      "Day 5 | n. | English: asmall group of people who spend their time together and do not allow others to join them The great men of culture are those who have had a passion for diffusing, for making prevail, for carrying from one end of society to the other, the best knowledge, the best ideas of their time; who have labored to divest knowledge of all that was harsh, uncouth, difficult, abstract, professional, exclusive; to humanise it, to make it efficient outside the clique of the cultivated and learned, yet still remaining the best knowledge and thought of the time, and a true source, therefore, of sweetness and light."
+    ]
+  },
+  {
+    "name": "clumsy",
+    "trans": [
+      "Day 5 | adj. | English: moving or doing things in a very awkward way | Example: His clumsy fingers couldn't untie the knot."
+    ]
+  },
+  {
+    "name": "cluster",
+    "trans": [
+      "Day 5 | v. | English: to come together in a small group or groups | Example: It is tempting to treat the clustering of information technology firms in Northern California as representative of industrial agglomeration generally."
+    ]
+  },
+  {
+    "name": "coalesce",
+    "trans": [
+      "Day 5 | v. | English: to come together to form one larger group, substance, etc. | Example: One popular theory of the origin of the Moon, the \"big whack,\" posits that a protoplanet called Theia collided with Earth, flinging debris into orbit that eventually coalesced into the Moon."
+    ]
+  },
+  {
+    "name": "coalition",
+    "trans": [
+      "Day 5 | n. | English: the act of two or more groups joining together | Example: \"Coalition\" is the term for a group of male lions, and across the Greater Kruger National Park in South Africa, many coalitions vie for territory."
+    ]
+  },
+  {
+    "name": "coarse",
+    "trans": [
+      "Day 5 | adj. | English: consisting of relatively large pieces | Example: To characterize the nature of the depositional environment, Frances Rivera-Hernandez et al. analyzed the grain size of Murray Formation sediment, finding that although there are intervals of coarse grains, most of the sediment consists of fine grains that show signs of cracking due to episodic desiccation."
+    ]
+  },
+  {
+    "name": "coherence",
+    "trans": [
+      "Day 5 | n. | English: the situation in which all the parts of sth fit together well | Example: For too long, scholars have focused on narrative fragmentation versus coherence, inhibiting inquiry into other points of stylistic correspondence among works that would enrich our understanding of the modernist canon."
+    ]
+  },
+  {
+    "name": "coherent",
+    "trans": [
+      "Day 5 | adj. | English: logical and well organized; easy to understand and clear | Example: Each fails at presenting a wholly coherent vision of art but does not understand why."
+    ]
+  },
+  {
+    "name": "coincide",
+    "trans": [
+      "Day 5 | adj. | English: (Of two or more event ) to take place at the same time | Example: Radiocarbon dating can help scientists determine whether the extinction of the giant short- faced bear around 8000 BCE coincided with the arrival of humans in the same region of the Americas."
+    ]
+  },
+  {
+    "name": "collaborate",
+    "trans": [
+      "Day 6 | v. | English: to work together with sb in order to produce or achieve sth | Example: Known for the albums Quiet Nights and Milestones, jazz trumpeter Miles Davis collaborated several times with pianist Gil Evans."
+    ]
+  },
+  {
+    "name": "collaboration",
+    "trans": [
+      "Day 6 | n. | English: the act of working with another person or group of people to create or produce sth | Example: It describes the development of a type of scientific collaboration, shows how that type of collaboration has been used in a particular field of study, and then suggests future collaborative projects."
+    ]
+  },
+  {
+    "name": "collaborative",
+    "trans": [
+      "Day 6 | adj. | English: involving, or done by, several people or groups of people working together | Example: Itis most likely that \"The Senate\" was the product of a collaborative effort between Hamilton and Madison."
+    ]
+  },
+  {
+    "name": "collapse",
+    "trans": [
+      "Day 6 | n. | English: the action of a building suddenly falling | Example: Like many other genera of wild bees, bumblebees have in recent decades experienced population collapse caused by, among other factors, habitat destruction and climate variation."
+    ]
+  },
+  {
+    "name": "collide",
+    "trans": [
+      "Day 6 | v. | English: if two people, vehicles, etc. collide , they crash into each other | Example: When subjects were asked to look at two colliding billiard balls and judge whether one caused or prevented the other's movement through a gate, their eyes looked at where the target ball would have gone if the ball that altered its path did not exist."
+    ]
+  },
+  {
+    "name": "collocation",
+    "trans": [
+      "Day 6 | n. | English: the act or result of placing or arranging together | Example: The potential for knowledge spillovers, a dominant driver of collocation in this industry, was largely absent from the paint manufacturing industry."
+    ]
+  },
+  {
+    "name": "colonialism",
+    "trans": [
+      "Day 6 | n. | English: the practice by which a powerful country controls another country or other countries | Example: In fact the work is a complex, dynamic meditation on gender and the legacy of colonialism that demands serious attention."
+    ]
+  },
+  {
+    "name": "comet",
+    "trans": [
+      "Day 6 | n. | English: amass of ice and dust that moves around the sun and looks like a bright star with a tail | Example: The team suggests that scientists have ignored the possibility that something other than a comet fragment could have made the crater."
+    ]
+  },
+  {
+    "name": "comfort",
+    "trans": [
+      "Day 6 | n. | English: n. the state of being physically relaxed and free from pain; the state of having a pleasant life, with everything that you need v. to make sb who is worried or unhappy feel better by being kind and sympathetic towards them | Example: To that end, certain features such as the ability to respond to voice commands can help to buttress people's feelings of comfort."
+    ]
+  },
+  {
+    "name": "comforting",
+    "trans": [
+      "Day 6 | adj. | English: making you feel calmer and less worried or unhappy | Example: To this end, certain features such as the ability to respond to voice commands can help to create the comforting semblance of humanity, but a robot that appears too similar to humans can make people feel more unsettled than soothed."
+    ]
+  },
+  {
+    "name": "commend",
+    "trans": [
+      "Day 6 | v. | English: to praise sb/sth, especially publicly | Example: Ina 2018 article celebrating films depicting the Black experience, critics for the New York Times commended William Greaves's 1968 film Symbiopsychotaxiplasm, Take One and Spike Lee's 1992 film Malcolm X, praising the former as \"a vital artifact of its time\" and the latter as \"electrifying.\""
+    ]
+  },
+  {
+    "name": "commentator",
+    "trans": [
+      "Day 6 | n. | English: a person who is an expert on a particular subject and talks or writes about it on television or radio, or in a newspaper | Example: While some commentators lauded this development, asserting that such blogs had a welcome transparency missing from traditional news, less sanguine observers countered that such blogs tended to ideological extremes that exacerbated political polarization to problematic levels."
+    ]
+  },
+  {
+    "name": "commercially",
+    "trans": [
+      "Day 6 | adv. | English: considering whether a business or product is making a profit | Example: Though John Crowley, author of Flint and Mirror, is perhaps not as well-known as the most commercially successful American writers of the past fifty years, influential figures have championed his work, including the poet John Hollander and the literary critic Harold Bloom."
+    ]
+  },
+  {
+    "name": "commission",
+    "trans": [
+      "Day 6 | v. | English: to officially ask sb to write, make or create sth or to do a task for you | Example: The first public library became available in Rome in 28 BCE and was soon followed by one commissioned by Emperor Augustus."
+    ]
+  },
+  {
+    "name": "commitment",
+    "trans": [
+      "Day 6 | n. | English: the willingness to work hard and give your energy and time to a job or an activity | Example: To portray Louis Pipestone's strong commitment to collecting signatures for the petition."
+    ]
+  },
+  {
+    "name": "commonplace",
+    "trans": [
+      "Day 6 | adj. | English: done very often, or existing in many places, and therefore not unusual | Example: Nowadays, the design is commonplace, found in everything from Eiffel Tower replicas like the one in Rio de Janeiro, Brazil, to structures like the Copenhagen Zoo Tower in Copenhagen, Denmark."
+    ]
+  },
+  {
+    "name": "compelling",
+    "trans": [
+      "Day 6 | adj. | English: that makes you think it is true | Example: He and colleagues’ study was not designed in a way that would allow it to produce compelling"
+    ]
+  },
+  {
+    "name": "compensate",
+    "trans": [
+      "Day 6 | v. | English: to provide sth good to balance or reduce the bad effects of damage, loss, etc | Example: The international Slow Food movement, founded in 1989, promotes universal access to healthy, high-quality food that is produced sustainably by workers who are treated and compensated fairly."
+    ]
+  },
+  {
+    "name": "competent",
+    "trans": [
+      "Day 6 | adj. | English: of a good standard but not very good | Example: Cuttlefish appear to be surprisingly competent at exercising self-control: in a 2021 study conducted by behavioral ecologist Alexandra Schnell, these cephalopods routinely demonstrated restraint by delaying gratification, waiting for a favorite treat instead of instantly devouring a readily available meal."
+    ]
+  },
+  {
+    "name": "complement",
+    "trans": [
+      "Day 6 | v. | English: to add to sth in a way that improves it or makes it more attractive | Example: The colors in an Impressionist painting were often chosen to complement the colors of the frame it would be placed in."
+    ]
+  },
+  {
+    "name": "compliance",
+    "trans": [
+      "Day 6 | n. | English: the practice of obeying rules or requests made by people in authority | Example: While bioaccumulation of manufactured nanoparticles may be inherently worrisome, it has been hypothesized that CeO2-NP bioaccumulation in invertebrates like D. polymorpha could serve a valuable proxy role, obviating the need for manufacturers to conduct costly and intrusive sampling of vertebrate species—such as rainbow trout (Oncorhynchus mykiss), commonly used in regulatory compliance testing—for nanoparticle bioaccumulation, as environmental protection laws currently require."
+    ]
+  },
+  {
+    "name": "compliment",
+    "trans": [
+      "Day 6 | v. | English: a remark that expresses praise or admiration of sb | Example: Though few critics consider Vasily Grossman's novel Stalingrad—which focuses on the experience of the Soviet Union in the early years of World War —to be as well written as his later book Everything Flows, some compliment it despite the damage wrought by Soviet censors."
+    ]
+  },
+  {
+    "name": "component",
+    "trans": [
+      "Day 6 | n. | English: one of several parts of which sth is made | Example: Political blogs with conspicuous ideological alignments became an integral component of US"
+    ]
+  },
+  {
+    "name": "composite",
+    "trans": [
+      "Day 6 | n. | English: something made by putting together different parts or materials | Example: Aerospace composites containing the nitrogen-treated SiC fiber may have the ability to withstand mechanical stress for a longer period of time than can aerospace composites containing either of the two polymer-derived SiC fibers."
+    ]
+  },
+  {
+    "name": "composition",
+    "trans": [
+      "Day 6 | n. | English: n.a piece of music or art, or a poem; n. the different parts which sth is made of; the way in which the different parts are organized | Example: [1] The compositions of Delia Derbyshire can yield as many different interpretations as there are people to listen to them. 2] To explain an important study of differences in the composition of Martian soil and the"
+    ]
+  },
+  {
+    "name": "compound",
+    "trans": [
+      "Day 6 | v. | English: v. to make sth bad become even worse by causing further damage or problems n. a thing consisting of two or more separate things combined together | Example: [1] The problems were compounded by severe food shortages. 2] Freezers and other cooling technologies use chemical compounds called refrigerants to absorb heat and release cold air."
+    ]
+  },
+  {
+    "name": "comprehension",
+    "trans": [
+      "Day 6 | n. | English: the ability to understand | Example: Some social scientists say that while a desire for cooperation rather than conflict is key to democracy, public understanding of economics is also central to public comprehension of state politics, and if a citizenry is to function, economic issues cannot remain the domain only of experts."
+    ]
+  },
+  {
+    "name": "comprehensive",
+    "trans": [
+      "Day 6 | adj. | English: including all, or almost all, the items, details, facts, information, etc., that may be concerned | Example: Therefore, if those involved in such efforts want to ensure that a comprehensive range of information is secured, they must incorporate the preservation of songs into their broader efforts to protect Indigenous languages."
+    ]
+  },
+  {
+    "name": "comprise",
+    "trans": [
+      "Day 6 | v. | English: to have sb/sth as parts or members | Example: It clarified that microorganism activity levels in the plant-soil cores varied depending on which microorganism comprised the community."
+    ]
+  },
+  {
+    "name": "compulsory",
+    "trans": [
+      "Day 6 | adj. | English: that must be done because of a law or a rule | Example: It is compulsory for all motorcyclists to wear helmets."
+    ]
+  },
+  {
+    "name": "comrade",
+    "trans": [
+      "Day 6 | n. | English: a friend or other person that you work with, especially as soldiers during a war | Example: _He was daring, without being rash: prompt, but not thoughtless; firm, without being harsh. Kind and devoted to the company he drilled, he soon won the respect of his superior officers and the love of his comrades."
+    ]
+  },
+  {
+    "name": "conceal",
+    "trans": [
+      "Day 6 | v. | English: to hide sb/sth | Example: The paintings were concealed beneath a thick layer of plaster."
+    ]
+  },
+  {
+    "name": "concede",
+    "trans": [
+      "Day 6 | v. | English: to admit that sth is true, logical, etc. | Example: It concedes that a finding may not appear to support the main view that the text advances."
+    ]
+  },
+  {
+    "name": "conceit",
+    "trans": [
+      "Day 6 | n. | English: too much pride in yourself and what you do | Example: We are poor plants buoyed up by the air-vessels of our own conceit: alas for us, if we get a few pinches that empty us of that windy self-subsistence! The very capacity for good would go out of us."
+    ]
+  },
+  {
+    "name": "conceivable",
+    "trans": [
+      "Day 6 | adj. | English: that you can imagine or believe | Example: It seemed as if nature had determined to throw every conceivable obstacle in the way of those who should seek to join the two great oceans of the world."
+    ]
+  },
+  {
+    "name": "conception",
+    "trans": [
+      "Day 6 | n. | English: the process of forming an idea or a plan | Example: One person after another rose, and, as with an ill-balanced axe, attempted to hew out his conception of art a little more clearly, and sat down with the feeling that, for some reason which he could not grasp, his strokes had gone awry."
+    ]
+  },
+  {
+    "name": "conceptualize",
+    "trans": [
+      "Day 6 | v. | English: to form an idea of sth in your mind Rafael Nufiez and colleagues studied how members of the Yupno, an Indigenous group in Papua New Guinea, conceptualize time."
+    ]
+  },
+  {
+    "name": "concern oneself with",
+    "trans": [
+      "Day 6 | English: to take an interest in sth | Example: | did not concern myself with those things."
+    ]
+  },
+  {
+    "name": "concerning",
+    "trans": [
+      "Day 6 | adj. | English: If something is concerning, it causes you to feel concerned about it. | Example: However, measurements taken in 2023 showed that the tower was rotating in a concerning way."
+    ]
+  },
+  {
+    "name": "concrete",
+    "trans": [
+      "Day 6 | adj. | English: adj. based on facts, not on ideas or guesses n. building material that is made by mixing together cement , sand, small stones and water | Example: [1] Itis easier to think in concrete terms rather than in the abstract. 2] When it was tested on images of Brooklyn, it reliably identified sidewalks in the vast majority of cases and even whether sidewalks were concrete or cobblestone."
+    ]
+  },
+  {
+    "name": "concur",
+    "trans": [
+      "Day 6 | v. | English: to agree | Example: Historians have concurred with each other in this view."
+    ]
+  },
+  {
+    "name": "concurrent",
+    "trans": [
+      "Day 6 | adj. | English: existing or happening at the same time | Example: Archaeological evidence of significant increases in clam size and abundance in that area concurrent with the documented past implementation of the method described in the songs supports the conclusion."
+    ]
+  },
+  {
+    "name": "condemn",
+    "trans": [
+      "Day 6 | v. | English: to force sb to accept a difficult or unpleasant situation | Example: Now | suddenly find myself plunged into this wilderness [the estate], condemned to see the same stupid people from morning till night and listen to their futile conversations."
+    ]
+  },
+  {
+    "name": "conduct",
+    "trans": [
+      "Day 6 | n. | English: a person's behaviour in a particular place or in a particular situation | Example: It stresses the discrepancy between Mr. Ely's public and private conduct and then alludes to his motivation for hiding his true personality."
+    ]
+  },
+  {
+    "name": "confer",
+    "trans": [
+      "Day 6 | v. | English: to officially give someone a title etc. | Example: Aany advantages that the transmission strategy used by three-host CLPs may have conferred did not completely offset the negative effects of other temperature driven factors on CLP abundance."
+    ]
+  },
+  {
+    "name": "confess",
+    "trans": [
+      "Day 6 | v. | English: to admit sth that you feel ashamed or embarrassed about | Example: And having cleared the ramparts | had to confess the sky was clearing, prior to its winding in the other shroud, night."
+    ]
+  },
+  {
+    "name": "confidence level",
+    "trans": [
+      "Day 6 | n. | English: ameasure of the reliability of a result. A confidence level of 95 per cent or 0.95 means that there is a probability of at least 95 per cent that the result is reliable | Example: Detailed statistical analysis helped preclude claims of the event's ambiguity, confirming the signal at a confidence level of over 99%."
+    ]
+  },
+  {
+    "name": "configure",
+    "trans": [
+      "Day 6 | v. | English: to arrange sth in a particular way, especially computer equipment; to make equipment or software work in the way that the user prefers | Example: he researchers have concluded that these settlements were culturally linked to Izapa because each of the settlements is the same age and configured in the same manner as Izapa, with a pyramid to the north and a plaza to the south."
+    ]
+  },
+  {
+    "name": "confine",
+    "trans": [
+      "Day 6 | v. | English: to keep sb/sth inside the limits of a particular activity, subject, area, etc. | Example: Several advantages—the ability to react strongly with chip components, to avoid interference from other waves, and to be confined within tiny circuits—have positioned acoustic waves as a promising alternative to electrical waves for transmitting data on computer chips."
+    ]
+  },
+  {
+    "name": "confined",
+    "trans": [
+      "Day 6 | adj. | English: small and surrounded by walls or sides | Example: The waters of the Seine are more confined and rough in Paris than they are in the countryside."
+    ]
+  },
+  {
+    "name": "conflagration",
+    "trans": [
+      "Day 7 | n. | English: a very large fire that destroys a lot of land or buildings | Example: You are cultured and intelligent, [Vanya], and you surely understand that the world is not destroyed by villains and conflagrations, but by hate and malice and all this spiteful tattling."
+    ]
+  },
+  {
+    "name": "conflate",
+    "trans": [
+      "Day 7 | v. | English: to put two or more things together to make one new thing | Example: Her letters conflate past and present."
+    ]
+  },
+  {
+    "name": "conform to",
+    "trans": [
+      "Day 7 | v. | English: to agree with or match sth | Example: The reasons for this characterization may seem irrefutable, but linking Unamuno with the Generation of '98 risks disregarding the subtleties in his style that do not neatly conform to the conventions of this literary movement."
+    ]
+  },
+  {
+    "name": "confound",
+    "trans": [
+      "Day 7 | v. | English: to confuse and surprise sb | Example: [1] While there are several possible reasons for this, one is that practitioners may overlook confounding variables that account for the results they attribute to the interventions in question. 2] Posed in 1970, McMullen's g-conjecture many mathematicians before yielding to the efforts of Karim Adiprasito, who presented a proof of it in 2018."
+    ]
+  },
+  {
+    "name": "congestion",
+    "trans": [
+      "Day 7 | n. | English: the state of being crowded and full of traffic | Example: Building additional road capacity may seem like an obvious solution to traffic congestion, but numerous studies have cast doubt on the efficacy of that approach."
+    ]
+  },
+  {
+    "name": "conjecture",
+    "trans": [
+      "Day 7 | n. | English: an opinion or idea that is not based on definite knowledge and is formed by guessing | Example: Before the Mariner 2 mission completed a successful flyby of Venus in 1962, astronomers’ ideas about the planet were little more than conjectures."
+    ]
+  },
+  {
+    "name": "consecutive",
+    "trans": [
+      "Day 7 | adj. | English: following one after another in a series, without interruption | Example: The time between consecutive pulses of an RRAT is referred to as a period."
+    ]
+  },
+  {
+    "name": "consensus",
+    "trans": [
+      "Day 7 | n. | English: an opinion that all members of a group agree with | Example: Given how little consensus there is among scientists regarding the scope of these categories, this discrepancy shouldn't be surprising: forest researchers regularly dispute one another's classifications."
+    ]
+  },
+  {
+    "name": "consequential",
+    "trans": [
+      "Day 7 | adj. | English: important; that will have important results | Example: Whether the reign of a French monarch such as Louis VII or Henry V was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy and therefore cannot be understood without a corollary understanding of the characteristics without which the monarch would have been forced to abandon the throne."
+    ]
+  },
+  {
+    "name": "conservationist",
+    "trans": [
+      "Day 7 | n. | English: a person who takes an active part in the protection of the environment | Example: In the 1990s, conservationists began planting more than 500,000 native trees in the habitat of the Azores bullfinch to boost the bird's numbers."
+    ]
+  },
+  {
+    "name": "considerable",
+    "trans": [
+      "Day 7 | adj. | English: great in amount, size, importance, etc. | Example: Although Hawaiian literature is highly heterogeneous in many ways, it is also characterized by considerable thematic continuity."
+    ]
+  },
+  {
+    "name": "console",
+    "trans": [
+      "Day 7 | n. | English: a flat surface which contains all the controls and switches for a machine, a piece of electronic equipment, etc. | Example: Portable video game consoles and fitness trackers tend to contain batteries that can't be easily replaced."
+    ]
+  },
+  {
+    "name": "conspicuous",
+    "trans": [
+      "Day 7 | adj. | English: easy to see or notice | Example: Political blogs with conspicuous ideological alignments became an integral component of US"
+    ]
+  },
+  {
+    "name": "constellation",
+    "trans": [
+      "Day 7 | n. | English: n.a group of related ideas; n. a group of stars that forms a shape in the sky and has a name [1] President Richard Nixon is most famous for his participation in the 1970s Watergate political scandal, a convoluted tale of criminality and eroded ethics involving a constellation of associates such as security operative Jack Caulfield and Attorney General John Mitchell. | Example: 2] Quasars—such as APM 08279+5255, located in the Lynx constellation—are extremely luminous galactic nuclei powered by supermassive black holes."
+    ]
+  },
+  {
+    "name": "consternation",
+    "trans": [
+      "Day 7 | n. | English: aworried, sad feeling after you have received an unpleasant surprise | Example: When she entered [the restaurant] her appearance created no surprise, no consternation, as she had half feared it might."
+    ]
+  },
+  {
+    "name": "constitute",
+    "trans": [
+      "Day 7 | v. | English: to be considered to be sth | Example: It notes why the two architectural projects described in the text constitute major departures from Barragan's typical style."
+    ]
+  },
+  {
+    "name": "constrain",
+    "trans": [
+      "Day 7 | v. | English: to restrict or limit sb/sth | Example: Although income of course constrained fuel choice, several factors, including the type of dwelling a household occupies, influenced decisions."
+    ]
+  },
+  {
+    "name": "constrained",
+    "trans": [
+      "Day 7 | adj. | English: not natural; forced or too controlled But the quality of a more constrained investigation, such as a transportation study seeking only to yield the average number of people per day who use a city's public transportation system, is much less dependent on high levels of funding because such studies are not trying to identify trends over time."
+    ]
+  },
+  {
+    "name": "constraint",
+    "trans": [
+      "Day 7 | n. | English: a thing that limits or restricts sth, or your freedom to do sth | Example: The work is manifestly a commentary on constraint, but many critics focus on Valdez and the social constraints women faced at the time, which is understandable but Leaves the presence of Valdez's male collaborator Sandoval unexplained."
+    ]
+  },
+  {
+    "name": "constrict",
+    "trans": [
+      "Day 7 | v. | English: to limit or restrict what sb is able to do Film-makers of the time were constricted by the censors."
+    ]
+  },
+  {
+    "name": "consult",
+    "trans": [
+      "Day 7 | v. | English: to go to sb for information or advice | Example: One no longer widely read edition is the 1984 \"critical and synoptic edition\" edited by Hans Walter Gabler, which followed French and German editorial theories rather than editorial traditions of the United States and United Kingdom and which was later found to have introduced errors due to Gabler's choice to consult facsimile manuscripts rather than using only originals."
+    ]
+  },
+  {
+    "name": "contemplate",
+    "trans": [
+      "Day 7 | v. | English: to think about whether you should do sth, or how you should do sth | Example: Architects dedicated to this approach carefully contemplate every aspect of their projects from location characteristics and initial materials selection to ultimate interior design choices and building installation."
+    ]
+  },
+  {
+    "name": "contemporaneous",
+    "trans": [
+      "Day 7 | adj. | English: happening or existing at the same time | Example: Mantle-derived rocks younger than 3.2 billion years contain some material that is not found in older mantle-derived rocks but is found in older and contemporaneous lithospheric rocks."
+    ]
+  },
+  {
+    "name": "contemporary",
+    "trans": [
+      "Day 7 | n. | English: a person who lives or lived at the same time as sb else, especially sb who is about the same ag | Example: It explains why the architectural project discussed later in the sentence was highly regarded by Barragan's contemporaries."
+    ]
+  },
+  {
+    "name": "contempt",
+    "trans": [
+      "Day 7 | n. | English: the feeling that sb/sth is without value and deserves no respect at all | Example: Reading [poetry], however, with a perfect contempt for it, one discovers that there is in / it after all, a place for the genuine."
+    ]
+  },
+  {
+    "name": "contemptuous",
+    "trans": [
+      "Day 7 | adj. | English: feeling or showing that you have no respect for sb/sth | Example: Each is contemptuous of the other attendees but strives to impress them."
+    ]
+  },
+  {
+    "name": "contend",
+    "trans": [
+      "Day 7 | v. | English: to say that sth is true, especially in an argument | Example: Ghisbain therefore contends that because the responses of bumblebees and other wild bees to environmental threats are not always comparable, researchers need to exercise caution when extrapolating information about wild-bee population declines from bumblebees."
+    ]
+  },
+  {
+    "name": "contender",
+    "trans": [
+      "Day 7 | n. | English: a person who takes part in a competition or tries to win sth | Example: A student claims that opening weekend earnings can reliably predict whether a film will be nominated for an Oscar: films that draw large audiences at the beginning of their release are the most likely contenders to earn these coveted award nominations."
+    ]
+  },
+  {
+    "name": "content",
+    "trans": [
+      "Day 7 | adj. | English: adj. willing to do sth n. the amount of a substance that is contained in sth else | Example: [1] Though there was already talk...of a new Opera House which should compete in costliness and splendour with those of the great European capitals, the world of fashion was still content to reassemble every winter in the shabby red and gold boxes of the sociable old"
+    ]
+  },
+  {
+    "name": "contentious",
+    "trans": [
+      "Day 7 | adj. | English: likely to cause disagreement between people | Example: Sanctions are expected to be among the most contentious issues."
+    ]
+  },
+  {
+    "name": "contestant",
+    "trans": [
+      "Day 7 | n. | English: a person who takes part in a contes | Example: There are persons who go to the theater like the contestants in a mule-race: the last one in, wins, and we know very sensible men who would ascend the scaffold rather than enter a theater before the first act."
+    ]
+  },
+  {
+    "name": "contextualize",
+    "trans": [
+      "Day 7 | v. | English: to consider sth in relation to the situation in which it happens or exists | Example: It introduces a trait shared by certain animals in order to contextualize a hypothesis about the origin of that trait that is advanced later in the text."
+    ]
+  },
+  {
+    "name": "continent",
+    "trans": [
+      "Day 7 | n. | English: one of the large land masses of the earth such as Europe, Asia or Africa | Example: Some paleontologists thought that a sudden shift toward an arid climate on the Australian continent may have brought about the rapid extinction of several species of large kangaroos around 200,000 years ago."
+    ]
+  },
+  {
+    "name": "contingent",
+    "trans": [
+      "Day 7 | adj. | English: depending on sth that may or may not happen | Example: What a photograph conveys is therefore largely contingent on how it is balanced."
+    ]
+  },
+  {
+    "name": "contract",
+    "trans": [
+      "Day 7 | v. | English: v. to get an illness; to become less or smaller; v. to become less or smaller; to make sth become less or smaller n. an official written agreement | Example: Itisn't to the fair | came myself, but up to the Five Acre Meadow I'm going, where | have a contract for the hay. We'll get a share of it into tramps [drying stacks] to-day."
+    ]
+  },
+  {
+    "name": "controversial",
+    "trans": [
+      "Day 7 | adj. | English: causing a lot of angry public discussion and disagreement | Example: The experimental group spent a few minutes writing about one of their personal values before they had a group discussion on a controversial topic."
+    ]
+  },
+  {
+    "name": "controversy",
+    "trans": [
+      "Day 7 | n. | English: public discussion and argument about sth that many people strongly disagree about, disapprove of, or are shocked by | Example: It describes an intensely debated scientific controversy that Victor dedicated his life to resolving."
+    ]
+  },
+  {
+    "name": "convene",
+    "trans": [
+      "Day 7 | v. | English: to arrange for people to come together for a formal meeting | Example: A Board of Inquiry was convened immediately after the accident."
+    ]
+  },
+  {
+    "name": "convention",
+    "trans": [
+      "Day 7 | n. | English: the way in which sth is done that most people in a society expect and consider to be polite or the right way to do it | Example: The reasons for this characterization may seem irrefutable, but linking Unamuno with the Generation of '98 risks disregarding the subtleties in his style that do not neatly conform to the conventions of this literary movement."
+    ]
+  },
+  {
+    "name": "converge",
+    "trans": [
+      "Day 7 | v. | English: to move towards a place from different directions and meet | Example: Thousands of supporters converged on London for the rally."
+    ]
+  },
+  {
+    "name": "convergence",
+    "trans": [
+      "Day 7 | n. | English: the process or state of converging | Example: These early quasars developed partly as a result of rare convergences of gases in space."
+    ]
+  },
+  {
+    "name": "convergent",
+    "trans": [
+      "Day 7 | adj. | English: to come from different directions and meet at the same point to become one thing | Example: Meredith E. Protas and colleagues have explored how convergent evolution—a phenomenon that occurs when the same trait evolves independently in two reproductively separate lineages—can result from a genetic mechanism shared by both lineages."
+    ]
+  },
+  {
+    "name": "conversely",
+    "trans": [
+      "Day 7 | adv. | English: ina way that is the opposite or reverse of sth | Example: Conversely, Mulvey proposes that conspicuous editing or an absence of point-of-view shots would induce a more critical stance toward a protagonist."
+    ]
+  },
+  {
+    "name": "convert",
+    "trans": [
+      "Day 7 | v. | English: to change or make sth change from one form, purpose, system, etc. to another | Example: Automated genre classification systems typically struggle to draw distinctions in situations like this, but Yandre Cossa and colleagues solved that problem by converting sound to images and having computers compare features of those images, an approach that demonstrates how much innovation is possible in this field."
+    ]
+  },
+  {
+    "name": "convey",
+    "trans": [
+      "Day 7 | v. | English: to make ideas, feelings, etc. known to sb The Great Wave off Kanagawa's deeper thematic meaning is conveyed to viewers through visual allegory."
+    ]
+  },
+  {
+    "name": "convoluted",
+    "trans": [
+      "Day 7 | adj. | English: extremely complicated and difficult to follow | Example: President Richard Nixon is most famous for his participation in the 1970s Watergate political scandal, a convoluted tale of criminality and eroded ethics involving a constellation of associates such as security operative Jack Caulfield and Attorney General John Mitchell."
+    ]
+  },
+  {
+    "name": "coordinate",
+    "trans": [
+      "Day 7 | v. | English: to organize the different parts of an activity and the people involved in it so that it works well | Example: Maryland should coordinate with other states to protect their native species from invasive species."
+    ]
+  },
+  {
+    "name": "coordination",
+    "trans": [
+      "Day 7 | n. | English: the act of making parts of sth, groups of people, etc. work together in an efficient and organized way | Example: Urban planning expert Francisco Lara-Valencia and colleagues have argued that managing environmental matters along the US-Mexico border requires coordination between the two countries' governments."
+    ]
+  },
+  {
+    "name": "copious",
+    "trans": [
+      "Day 7 | adj. | English: in large amounts | Example: New and interesting research conducted by Suleiman A. Al-Sweedan and Moath Alhai is inspired by their observation that though there have been copious studies of the effect of high altitude on blood chemistry, there is a paucity of studies of the effect on blood chemistry of living in locations below sea level, such as the California towns of Salton City and Seeley."
+    ]
+  },
+  {
+    "name": "corner",
+    "trans": [
+      "Day 7 | v. | English: to get a person or an animal into a place or situation from which they cannot escape | Example: Louis Pipestone tended the petition like a garden. He kept it with him at all times. In town, his eyes sharpened when he noticed a tribal member who hadn't yet signed. Wherever they were—at the gas pump, mercantile [general store], at Henry's [Café], on the road, or outside the clinic and hospital—Louis cornered them."
+    ]
+  },
+  {
+    "name": "corollary",
+    "trans": [
+      "Day 8 | n. | English: a situation, an argument or a fact that is the natural and direct result of another one | Example: Whether the reign of a French monarch such as Louis VII or Henry V was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy and therefore cannot be understood without a corollary understanding of the characteristics without which the monarch would have been forced to abandon the throne."
+    ]
+  },
+  {
+    "name": "corpora",
+    "trans": [
+      "Day 8 | n. | English: a collection of written or spoken texts | Example: Text corpora such as the British National Corpus are enormous collections of electronically stored texts that can be used for empirical testing of hypotheses regarding the frequency of typical word usage."
+    ]
+  },
+  {
+    "name": "corpus",
+    "trans": [
+      "Day 8 | English: a collection of written or spoken texts | Example: If one has a supposition that the word “own” has a high incidence in English, for example, an analysis of a corpus can support that hypothesis by showing that “own” is the eighth most commonly used adjective."
+    ]
+  },
+  {
+    "name": "correlate",
+    "trans": [
+      "Day 8 | v. | English: if two or more facts, figures, etc. correlate or if a fact, figure, etc. correlates with another, the facts are closely connected and affect or depend on each other | Example: Economists have assumed that companies cluster for the same reasons, but Giulia Faggio et al. found that factors driving agglomeration in some cases are only weakly correlated with agglomeration in others."
+    ]
+  },
+  {
+    "name": "correspondence",
+    "trans": [
+      "Day 8 | n. | English: a connection between two things; the fact of two things being similar | Example: For too long, scholars have focused on experimental versus conventional poetic forms, inhibiting inquiry into other points of stylistic correspondence among poems that would enrich our understanding of the modernist canon."
+    ]
+  },
+  {
+    "name": "corroborate",
+    "trans": [
+      "Day 8 | v. | English: to provide evidence or information that supports a statement, theory, etc. | Example: The results of randomized clinical trials testing the efficacy of common medical interventions sometimes fail to corroborate conclusions that practitioners reach based on their real-world observations of patients."
+    ]
+  },
+  {
+    "name": "countenance",
+    "trans": [
+      "Day 8 | n. | English: a person's face or their expression | Example: After some trouble [Jim’s father] found the subject of the incident, the broken flower. Turning then, he saw the child lurking at the rear and scanning his countenance."
+    ]
+  },
+  {
+    "name": "counter",
+    "trans": [
+      "Day 8 | v. | English: to reply to sb by trying to prove that what they said is not true | Example: While some commentators lauded this development, asserting that such blogs had a welcome transparency missing from traditional news, less sanguine observers countered that such blogs tended to ideological extremes that exacerbated political polarization to problematic levels."
+    ]
+  },
+  {
+    "name": "counteract",
+    "trans": [
+      "Day 8 | v. | English: to do sth to reduce or prevent the bad or harmful effects of sth | Example: The emphasis on accurately representing the experiences of average working people that is characteristic of the realist style can be seen in The Gleaners, painted by Jean-Francois Millet, which depicts peasants picking stray wheat from a field after the harvest. This style can thus be seen as an effort to counteract what were regarded as the excesses of the romantic style evident in many paintings by Horace Vernet, which instead exaggerated their subjects’ beauty or heroism while hiding all imperfection."
+    ]
+  },
+  {
+    "name": "counterbalance",
+    "trans": [
+      "Day 8 | v. | English: to have an equal but opposite effect to sth else | Example: Parents’ natural desire to protect their children should be counterbalanced by the child's need for independence."
+    ]
+  },
+  {
+    "name": "counterfactual",
+    "trans": [
+      "Day 8 | adj. | English: relating to or expressing what has not happened or is not the case | Example: The work of Tobias Gerstenberg et al. on tracking eye movements supports a theory that people engage in counterfactual thinking when making causal judgments."
+    ]
+  },
+  {
+    "name": "counterintuitive",
+    "trans": [
+      "Day 8 | adj. | English: seemingly contrary to common sense | Example: In the 2010s, the price of vintage Teenage Mutant Ninja Turtles action figures rose dramatically, which had the counterintuitive effect of engendering demand."
+    ]
+  },
+  {
+    "name": "counterpart",
+    "trans": [
+      "Day 8 | n. | English: a person or thing that has the same position or function as sb/sth else in a different place or situation | Example: The real-world counterparts of other characters in This Side of Paradise are hard to identify."
+    ]
+  },
+  {
+    "name": "counterproductive",
+    "trans": [
+      "Day 8 | adj. | English: having the opposite effect to the one which was intended | Example: In practice, however, such an attitude is counterproductive."
+    ]
+  },
+  {
+    "name": "course",
+    "trans": [
+      "Day 8 | n. | English: the direction a river moves in | Example: The bald cypresses spread themselves along the water courses while the willows wept as they always did."
+    ]
+  },
+  {
+    "name": "courser",
+    "trans": [
+      "Day 8 | n. | English: a swift horse; steed | Example: There is no Frigate like a Book / To take us Lands away / Nor any Coursers like a Page / Of prancing Poetry—/ This Traverse may the poorest take / Without oppress of Toll— / How frugal is the Chariot / That bears the Human soul."
+    ]
+  },
+  {
+    "name": "coveted",
+    "trans": [
+      "Day 8 | adj. | English: You use coveted to describe something that very many people would like to have. | Example: A student claims that opening weekend earnings can reliably predict whether a film will be nominated for an Oscar: films that draw large audiences at the beginning of their release are the most likely contenders to earn these coveted award nominations."
+    ]
+  },
+  {
+    "name": "craft",
+    "trans": [
+      "Day 8 | v. | English: to make sth using special skills, especially with your hands | Example: Ina variety of ways, Samuel Kamakau, Kristiana Kahakauwila, and other acclaimed writers have drawn on these stories to craft a rich portrait of the Hawaiian Islands and their people."
+    ]
+  },
+  {
+    "name": "crane",
+    "trans": [
+      "Day 8 | v. | English: to lean or stretch over sth in order to see sth better; to stretch your neck | Example: The little conductor stood on tiptoe in an effort to keep one hand on the signal rope, craning his neck in a vain and dissatisfied endeavor to pierce the miasma of the fog."
+    ]
+  },
+  {
+    "name": "crater",
+    "trans": [
+      "Day 8 | n. | English: a large hole in the ground caused by the explosion of a bomb or by sth large hitting it | Example: Others disagree, partly because there is no known crater from such an impact that dates to the beginning of the period."
+    ]
+  },
+  {
+    "name": "credential",
+    "trans": [
+      "Day 8 | v. | English: to provide sb with credentials | Example: Conventional theories of rhetoric hold that presenting information as coming from credentialed experts increases that information's credibility."
+    ]
+  },
+  {
+    "name": "credibility",
+    "trans": [
+      "Day 8 | n. | English: the quality that sb/sth has that makes people believe or trust them | Example: Conventional theories of rhetoric hold that presenting information as coming from credentialed experts increases that information’s credibility."
+    ]
+  },
+  {
+    "name": "credible",
+    "trans": [
+      "Day 8 | adj. | English: that can be believed or trusted | Example: It presents a scientific observation, describes a contrast between that observation and other observations, and then explains why those other observations should not be considered credible."
+    ]
+  },
+  {
+    "name": "credit",
+    "trans": [
+      "Day 8 | n. | English: n. praise or approval because you are responsible for sth good that has happened; v. to believe that sb/sth is of a particular type or quality | Example: [1] Many people worked together to help Buenaventura be recognized by UNESCO, but chefs deserve the most credit for Buenaventura’s selection as a City of Gastronomy. 2] The 2000 production of The Green Bird was the first Broadway show for which Constance Hoffman was credited as a costume designer."
+    ]
+  },
+  {
+    "name": "creep",
+    "trans": [
+      "Day 8 | v. | English: to move or develop very slowly | Example: Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow's o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+    ]
+  },
+  {
+    "name": "creep into",
+    "trans": [
+      "Day 8 | English: to begin to happen or affect sth | Example: Politicians routinely claim that journalists are biased but while it's true that some journalists allow their own views to creep into their reporting more than others do, most journalists make a good faith effort to be neutral in their reporting."
+    ]
+  },
+  {
+    "name": "crew",
+    "trans": [
+      "Day 8 | n. | English: all the people working on a ship, plane etc. except the officers who are in charge | Example: All ships with at least 98 cannons had a crew of at least 850 people."
+    ]
+  },
+  {
+    "name": "criteria",
+    "trans": [
+      "Day 8 | n. | English: a standard or principle by which sth is judged, or with the help of which a decision is made | Example: This new measure establishes global criteria used to define three types of settlements (cities, towns, and rural areas) and allows researchers to better understand global urbanization rates."
+    ]
+  },
+  {
+    "name": "critique",
+    "trans": [
+      "Day 8 | n. | English: n.a piece of written criticism of a set of ideas, a work of art, etc.; v. to write or give your opinion of, or reaction to, a set of ideas, a work of art, etc. | Example: [1] Smith's metaphor of the invisible hand has been interpreted as a model of how individuals acting in their own interest produce aggregate benefits, but it was intended as a subtle critique of the economic theory of mercantilism. 2] Asimov is critiqued for his style, but it is wrong to fault a writer for failing to do what he never intended to do."
+    ]
+  },
+  {
+    "name": "crucible",
+    "trans": [
+      "Day 8 | n. | English: a place or situation in which people or ideas are tested severely, often creating sth new or exciting in the process | Example: She went through the crucible of unprecedented adversities and trials of life and came out one of the rare shining lights that beautify the New England sky."
+    ]
+  },
+  {
+    "name": "crude",
+    "trans": [
+      "Day 8 | adj. | English: in its natural state, before it has been treated with chemicals | Example: The [train] engines of this valley have a whistle, the echoes of which sound like iterated gasps and sobs. | always think of them as crude music."
+    ]
+  },
+  {
+    "name": "crust",
+    "trans": [
+      "Day 8 | n. | English: a hard layer or surface, especially above or around sth soft or liquid | Example: As the process continues, water from the food's center moves to the crust as long as the crust remains permeable."
+    ]
+  },
+  {
+    "name": "cryptology",
+    "trans": [
+      "Day 8 | n. | English: the science or study of analysing and deciphering codes, ciphers, etc; cryptanalysis | Example: Women like Juanita Moody made important early contributions to the history of US cryptology, a field concerned with secure data communication and storage."
+    ]
+  },
+  {
+    "name": "culprit",
+    "trans": [
+      "Day 8 | n. | English: a person who has done sth wrong or against the law | Example: Every morning, after buying his penny paper at the corner of the Faubourg Saint Honore, he bought two rolls, and then went to his office, like a culprit who is giving himself up to justice."
+    ]
+  },
+  {
+    "name": "cultivate",
+    "trans": [
+      "Day 8 | v. | English: to grow plants or crops For thousands of years, O'odham farmers in the Sonoran desert of the southwestern US and northern Mexico have cultivated elderberries and chia seeds"
+    ]
+  },
+  {
+    "name": "cultivated",
+    "trans": [
+      "Day 8 | adj. | English: adj. used to grow crops; adj. having a high level of education and showing good manners [1] As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot. | Example: 2] The great men of culture are those who have had a passion for diffusing, for making prevail, for carrying from one end of society to the other, the best knowledge, the best ideas of their time; who have labored to divest knowledge of all that was harsh, uncouth, difficult, abstract, professional, exclusive; to humanise it, to make it efficient outside the clique of the cultivated and learned, yet still remaining the best knowledge and thought of the time, and a true source, therefore, of sweetness and light."
+    ]
+  },
+  {
+    "name": "curator",
+    "trans": [
+      "Day 8 | n. | English: a person whose job is to be in charge of the objects or works of art in a museum or art gallery | Example: To encourage that sense of connection, the museum's curators recommend nearby hiking trails and outdoor activities."
+    ]
+  },
+  {
+    "name": "currency",
+    "trans": [
+      "Day 8 | n. | English: the system of money that a country uses | Example: Because coins with a silver content below 80% were widely considered unsuitable for trade, Elayi et al. speculate that a crisis in confidence in the currency occurred in Sidon around 367 BCE."
+    ]
+  },
+  {
+    "name": "current",
+    "trans": [
+      "Day 8 | n. | English: the movement of water in the sea or a river; the movement of air in a particular direction | Example: Ocean currents can be powerful and rough, making it difficult for animals to find safe places to hide from predators. The underwater forests slow down the currents."
+    ]
+  },
+  {
+    "name": "curtain",
+    "trans": [
+      "Day 8 | n. | English: a thing that covers, hides or protects sth | Example: She has a thick curtain of long, curly hair that practically engulfs her."
+    ]
+  },
+  {
+    "name": "customary",
+    "trans": [
+      "Day 8 | adj. | English: if sth is customary , it is what people usually do in a particular place or situation Intergenerational Bulgarian female choir group Bistritsa Babi has been working to save customary songs and dances from the Shopluk region of the country since 1939."
+    ]
+  },
+  {
+    "name": "cutlery",
+    "trans": [
+      "Day 8 | n. | English: knives, forks and spoons, used for eating and serving food | Example: Guojun He and colleagues studied a food-delivery phone app that is popular in China. The researchers found that having \"no cutlery\" automatically selected influences whether customers request disposable plastic utensils with their food orders."
+    ]
+  },
+  {
+    "name": "cynical",
+    "trans": [
+      "Day 8 | adj. | English: believing that people only do things to help themselves rather than for good or honest reasons | Example: She wanted him to stop being so cool, so detached, so cynical."
+    ]
+  },
+  {
+    "name": "daring",
+    "trans": [
+      "Day 8 | adj. | English: willing to do dangerous or unusual things; involving danger or taking risks | Example: He was daring, without being rash: prompt, but not thoughtless; firm, without being harsh."
+    ]
+  },
+  {
+    "name": "dart",
+    "trans": [
+      "Day 8 | v. | English: to move suddenly and quickly in a particular direction | Example: The sun, already down, was manifest in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+    ]
+  },
+  {
+    "name": "daze",
+    "trans": [
+      "Day 8 | adj. | English: unable to think clearly, especially because of a shock or because you have been hit on the head The Mole is dazed after briefly meeting a stranger while traveling with a friend."
+    ]
+  },
+  {
+    "name": "dazzle",
+    "trans": [
+      "Day 8 | v. | English: to impress sb a lot with your beauty, skill, etc. | Example: There is often a kind of [deceptive] light, playing around such [famous] names, calculated to dazzle and mislead, by their false lustre, until the eye can no longer receive the pure light of Truth, or the mind appreciate real excellence, or intrinsic worth."
+    ]
+  },
+  {
+    "name": "debatable",
+    "trans": [
+      "Day 8 | adj. | English: not certain because people can have different ideas and opinions about the thing being discussed | Example: Mr. French, the senior partner, who sat opposite Kirby, was an older man—a safe guess would have placed him somewhere in the debatable ground between forty and fifty."
+    ]
+  },
+  {
+    "name": "debris",
+    "trans": [
+      "Day 8 | n. | English: Debris is pieces from something that has been destroyed or pieces of rubbish or unwanted material that are spread around | Example: One popular theory of the origin of the Moon, the \"big whack,\" posits that a protoplanet called Theia collided with Earth, flinging debris into orbit that eventually coalesced into the Moon."
+    ]
+  },
+  {
+    "name": "decidedly",
+    "trans": [
+      "Day 8 | adv. | English: definitely and in an obvious way | Example: Ancient Greek and Roman sculpture is sometimes characterized as idealizing human subjects, but in fact there are many Greco-Roman sculptures that depict people in decidedly unflattering ways."
+    ]
+  },
+  {
+    "name": "decisive",
+    "trans": [
+      "Day 9 | adj. | English: able to decide sth quickly and with confidence | Example: Individuals tend to be more decisive if the information flow between the regions is intensified, whereas they make choices more slowly when information flow is reduced."
+    ]
+  },
+  {
+    "name": "dedication",
+    "trans": [
+      "Day 9 | n. | English: the hard work and effort that sb puts into an activity or purpose because they think it is important | Example: It emphasizes a character's dedication to her career."
+    ]
+  },
+  {
+    "name": "default",
+    "trans": [
+      "Day 9 | v. | English: v. to fail to do sth that you legally have to do, especially by not paying a debt; n. failure to do sth that must be done by law, especially paying a deb | Example: [1] Although the government regularly defaulted on debt, it ran an even larger overall surplus than did the government of eighteenth-century Britain, which historians consider a model of fiscal virtue. 2] But Drelichman and Voth's unique contribution is their reconstruction of the earliest extant set of annual fiscal records for any sovereign state, which demonstrate that Philip's defaults were caused by short-term liquidity crises, not long-term unsustainable debts."
+    ]
+  },
+  {
+    "name": "deference",
+    "trans": [
+      "Day 9 | n. | English: behaviour that shows that you respect sb/sth | Example: The women wore veils in deference to the customs of the country."
+    ]
+  },
+  {
+    "name": "define",
+    "trans": [
+      "Day 9 | v. | English: to describe or show sth accurately | Example: The little fern-leaf, bending / Upon the brink, its green reflection greets, / And kisses soft the shadow that it meets / With touch so fine, / The border line / The keenest vision can't define; / So perfect is the blending."
+    ]
+  },
+  {
+    "name": "defunct",
+    "trans": [
+      "Day 9 | adj. | English: If something is defunct, it no longer exists or has stopped functioning or operating. | Example: As discussed by scholar Anna Mladentseva, many artworks produced in the mid-1990s to the early 2000s exclusively for exhibition on the internet, such as Sinae Kim's Genesis (2001), have become inaccessible because viewing them requires the use of defunct software (most notably Adobe Flash, discontinued in 2021)."
+    ]
+  },
+  {
+    "name": "defy",
+    "trans": [
+      "Day 9 | v. | English: to refuse to obey or show respect for sb in authority, a law, a rule, etc. | Example: Reading is a way of defying the modern world's emphasis on money."
+    ]
+  },
+  {
+    "name": "deliberate",
+    "trans": [
+      "Day 9 | adj. | English: done on purpose rather than by accident | Example: A city that UNESCO officially names as a City of Gastronomy should still make deliberate efforts to attract visitors to promote its tourism."
+    ]
+  },
+  {
+    "name": "deliberately",
+    "trans": [
+      "Day 9 | adv. | English: done in a way that was planned, not by chance | Example: Barring major archaeological discoveries, we are unlikely to ever have an exhaustive account of ancient Egypt under the female pharaoh Hatshepsut, as much of the evidence of her reign was deliberately destroyed by her successors."
+    ]
+  },
+  {
+    "name": "deliberation",
+    "trans": [
+      "Day 9 | n. | English: the process of carefully considering or discussing sth | Example: In the story, Mrs. Sommers is depicted as sometimes making decision without conscious deliberation."
+    ]
+  },
+  {
+    "name": "delicate",
+    "trans": [
+      "Day 9 | adj. | English: easily damaged or broken | Example: Agleaming carpet was springing up everywhere, that looked too delicate to be trodden upon by rough feet."
+    ]
+  },
+  {
+    "name": "delight",
+    "trans": [
+      "Day 9 | v. | English: 0 enjoy doing sth very much, especially sth that makes other people feel embarrassed, uncomfortable, etc. | Example: Each delights in speaking publicly about abstract subjects but detests speaking privately about them."
+    ]
+  },
+  {
+    "name": "demarcate",
+    "trans": [
+      "Day 9 | v. | English: to mark or establish the limits of sth | Example: The migration's obligate nature is why diadromous fish can be demarcated from those that are merely euryhaline (able to tolerate high salinity)."
+    ]
+  },
+  {
+    "name": "demeanor",
+    "trans": [
+      "Day 9 | n. | English: the way that sb looks or behaves | Example: “The father reflected. After a time he said, ‘Jimmie, come here.’ With an infinite modesty of demeanor the child came forward.”"
+    ]
+  },
+  {
+    "name": "democracy",
+    "trans": [
+      "Day 9 | n. | English: a system of government in which all the people of a country can vote to elect their representatives | Example: Some social scientists say that while a desire for cooperation rather than conflict is key to democracy, public understanding of economics is also central to public comprehension of state politics, and if a citizenry is to function, economic issues cannot remain the domain only of experts."
+    ]
+  },
+  {
+    "name": "denigrate",
+    "trans": [
+      "Day 9 | v. | English: to criticize sb/sth unfairly; to say sb/sth does not have any value or is not important | Example: | didn't intend to denigrate her achievements."
+    ]
+  },
+  {
+    "name": "denote",
+    "trans": [
+      "Day 9 | v. | English: to mean sth | Example: High-entropy alloys (HEAs) have been observed to vary considerably in their resistance to crack propagation, a quality denoted as fracture toughness."
+    ]
+  },
+  {
+    "name": "denounce",
+    "trans": [
+      "Day 9 | v. | English: to strongly criticize sb/sth that you think is wrong, illegal, etc. | Example: She publicly denounced the government's handling of the crisis."
+    ]
+  },
+  {
+    "name": "depart",
+    "trans": [
+      "Day 9 | v. | English: to leave a place, especially to start a trip | Example: Tia Ana had already come into the room several times to see if these guests had departed yet."
+    ]
+  },
+  {
+    "name": "departure",
+    "trans": [
+      "Day 9 | n. | English: an action that is different from what is usual or expected | Example: It notes why the two architectural projects described in the text constitute major departures from Barragan's typical style."
+    ]
+  },
+  {
+    "name": "deplete",
+    "trans": [
+      "Day 9 | v. | English: to reduce sth by a large amount so that there is not enough left | Example: When constructing his argument regarding the characteristics of a well-functioning government, Aristotle asserts thar ‘Transgression creeps in unperceived and at last ruins the state,’ illustrating this idea with a comparison to frequent small expenditures slowly and almost imperceptibly chipping away at a fortune until it is ultimately depleted."
+    ]
+  },
+  {
+    "name": "deploy",
+    "trans": [
+      "Day 9 | v. | English: v. to use sth effectively; n. a layer of a substance that has formed naturally underground | Example: Smith deploys this metaphor only once in his economic writings—to make a narrow point about the then-dominant economic theory of mercantilism—and it was largely ignored until some twentieth-century economists eager to secure an intellectual pedigree for their views elevated it to a fully-fledged paradigm."
+    ]
+  },
+  {
+    "name": "deposit",
+    "trans": [
+      "Day 9 | v. | English: to leave a layer of sth on the surface of sth, especially gradually and over a period of time | Example: [1] As with other river deltas, the Krishna River delta is dynamic: it is a constantly evolving network of channels and strips of land that change in size and shape as the river deposits new sedimentary particles where the river meets the waters of the Bay of Bengal. 2] Deposits of valuable objects, called hoards, have been unearthed in many different parts of Ireland and Northern Ireland."
+    ]
+  },
+  {
+    "name": "deposition",
+    "trans": [
+      "Day 9 | n. | English: the natural process of leaving a layer of a substance on rocks or soil; a substance left in this way | Example: The Nile River delta system is located in Northern Egypt, where the river drains into the Mediterranean Sea, and is shaped by interdependent factors: for example, the geography of the coastline influences sedimentary deposition, which over time alters coastal geography."
+    ]
+  },
+  {
+    "name": "depressing",
+    "trans": [
+      "Day 9 | adj. | English: making you feel very sad and without enthusiasm | Example: Perhaps it is a little depressing to inherit not lands but an example of intellectual virtue."
+    ]
+  },
+  {
+    "name": "depression",
+    "trans": [
+      "Day 9 | n. | English: a part of a surface that is lower than the parts around it | Example: Both carbonate dissolution and subsurface salt withdrawal can cause craterlike depressions without the need for a high-velocity impact."
+    ]
+  },
+  {
+    "name": "derive",
+    "trans": [
+      "Day 9 | v. | English: to come or develop from sth | Example: Itis hardly an exaggeration to characterize modern Hawaiian literature as having derived from the traditional stories of the Kanaka Maoli, the Native Hawaiian people."
+    ]
+  },
+  {
+    "name": "descendant",
+    "trans": [
+      "Day 9 | n. | English: a person's descendants are their children, their children's children, and all the people who live after them who are related to them | Example: The tarweed's descendants diversifed into distinct species as they adapted to live in the wide variety of habitats found on the Hawaiian Islands."
+    ]
+  },
+  {
+    "name": "descent",
+    "trans": [
+      "Day 9 | n. | English: a person's family origins | Example: [Katharine's] descent from [a celebrated poet] was no surprise to her."
+    ]
+  },
+  {
+    "name": "deserted",
+    "trans": [
+      "Day 9 | adj. | English: left by a person or people who do not intend to return | Example: We [people] are creatures of the sun. We love light and life. That is why we crowd into the towns and cities, and the country grows more and more deserted every year."
+    ]
+  },
+  {
+    "name": "deserving",
+    "trans": [
+      "Day 9 | adj. | English: that deserves help, praise, a reward, etc. | Example: Daisy Ashford's novels, which she published as a child, were widely read by contemporaries and are therefore deserving of closer attention."
+    ]
+  },
+  {
+    "name": "desiccation",
+    "trans": [
+      "Day 9 | n. | English: the process of becoming completely dry | Example: To characterize the nature of the depositional environment, Frances Rivera-Hernandez et al. analyzed the grain size of Murray Formation sediment, finding that although there are intervals of coarse grains, most of the sediment consists of fine grains that show signs of cracking due to episodic desiccation."
+    ]
+  },
+  {
+    "name": "designate",
+    "trans": [
+      "Day 9 | v. | English: to say officially that sth has a particular character or name | Example: In countries with right-hand traffic, drivers who want to make a left turn at a traffic intersection with stoplights have to wait for either a gap in oncoming traffic or a designated left-turn signal to turn green."
+    ]
+  },
+  {
+    "name": "designation",
+    "trans": [
+      "Day 9 | n. | English: the action of choosing a person or thing for a particular purpose, or of giving them or it a particular status | Example: The country’s designation of the spiraling whitefly as invasive may be appropriate now but not in the future."
+    ]
+  },
+  {
+    "name": "destitute",
+    "trans": [
+      "Day 9 | adj. | English: lacking sth | Example: The knowledge, communicated by the historian and biographer, is analogous to that which we acquire of a country by the map, —minute, perhaps, and accurate, and available for all necessary purposes, but cold and naked, and wholly destitute of the mimic charm produced by landscape painting."
+    ]
+  },
+  {
+    "name": "desultory",
+    "trans": [
+      "Day 9 | adj. | English: going from one thing to another, without a definite plan and without enthusiasm | Example: | wandered about in a desultory fashion."
+    ]
+  },
+  {
+    "name": "detect",
+    "trans": [
+      "Day 9 | v. | English: to discover or notice sth, especially sth that is not easy to see, hear, etc | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+    ]
+  },
+  {
+    "name": "detection",
+    "trans": [
+      "Day 9 | n. | English: the process of detecting sth; the fact of being detected | Example: In 2016, Gabriela Gonzalez and team announced that a chirping sound captured by Laser Interferometer Gravitational-Wave Observatory antennas was direct evidence of gravitational waves, which skeptics had argued would be too faint for detection."
+    ]
+  },
+  {
+    "name": "deterioration",
+    "trans": [
+      "Day 9 | n. | English: becoming worse | Example: An image of the Forbidden City thusc onceals the subtle deterioration of the building's materials."
+    ]
+  },
+  {
+    "name": "detest",
+    "trans": [
+      "Day 9 | v. | English: to hate sb/sth very much | Example: Each delights in speaking publicly about abstract subjects but detests speaking privately about them."
+    ]
+  },
+  {
+    "name": "detractor",
+    "trans": [
+      "Day 9 | n. | English: a person who tries to make sb/sth seem less good or valuable by criticizing it | Example: Although Alfred E. Green's 1950 film The Jackie Robinson Story and Ossie Davis's 1970 film Cotton Comes to Harlem may have had some detractors at the time of their initial release, their place in critics' estimations is now more secure. In 2018, for example, critics for the New York Times described the former as \"irresistible\" and the latter as \"especially pointed.\""
+    ]
+  },
+  {
+    "name": "detrimental",
+    "trans": [
+      "Day 9 | adj. | English: harmful | Example: Relevant traits or behaviors of the animals were observably different between the exposed group and the otherwise similar but unexposed group, regardless of whether that difference was beneficial or detrimental for the exposed group."
+    ]
+  },
+  {
+    "name": "deviate",
+    "trans": [
+      "Day 9 | v. | English: depart from an established course | Example: Domesticated thousands of years ago by Indigenous people in South America, the tomatillo deviates structurally from the wild plant it is descended from."
+    ]
+  },
+  {
+    "name": "devise",
+    "trans": [
+      "Day 9 | v. | English: to invent sth new or a new way of doing sth | Example: Customers’ initial enthusiasm for a subscription is often quick to subside, and sellers must thus devise other incentives to bolster retention. devoteto MAF: MAF: SbF ZR 3CFEMX: to give most of your time, energy, attention, etc. to sb/sth More recently founded US-based institutions devoted to Latino cultures include the Latino Cultural Center."
+    ]
+  },
+  {
+    "name": "devote to",
+    "trans": [
+      "Day 9 | English: to give most of your time, energy, attention, etc. to sb/sth | Example: More recently founded US-based institutions devoted to Latino cultures include the Latino Cultural Center."
+    ]
+  },
+  {
+    "name": "devour",
+    "trans": [
+      "Day 9 | v. | English: v. to eat all of sth quickly, especially because you are very hungry; v. to destroy sb/sth | Example: [1] Cuttlefish appear to be surprisingly competent at exercising self-control: in a 2021 study conducted by behavioral ecologist Alexandra Schnell, these cephalopods routinely demonstrated restraint by delaying gratification, waiting for a favorite treat instead of instantly devouring a readily available meal. 2] Green meadows make rifts in [the woods] here and there, so do little patches of cultivation. But these do not amount to much, for the magnificent woods devour everything."
+    ]
+  },
+  {
+    "name": "diabolical",
+    "trans": [
+      "Day 9 | adj. | English: extremely bad or annoying | Example: How [the sailor] haunted my dreams, | need scarcely tell you. On stormy nights, when the wind shook the four corners of the house and the surf roared along the cove and up the cliffs, | would see him in a thousand forms, and with a thousand diabolical expressions."
+    ]
+  },
+  {
+    "name": "dialect",
+    "trans": [
+      "Day 9 | n. | English: the form of a language that is spoken in one area with grammar, words and pronunciation that may be different from other forms of the same language | Example: A unique dialect, or regional variety, of Spanish is spoken in Puerto Rico."
+    ]
+  },
+  {
+    "name": "diffraction",
+    "trans": [
+      "Day 9 | n. | English: In physics, diffraction is a change in the direction of a sound wave or a light wave caused by the presence of an obstacle in its path | Example: All light passing through the hole can only arrive at a single destination, eliminating diffraction and ensuring a clear image."
+    ]
+  },
+  {
+    "name": "dim",
+    "trans": [
+      "Day 9 | adj. | English: that you cannot remember or imagine clearly [The] Mole stood still a moment, held in thought. As one wakened suddenly from a beautiful dream, who struggles to recall it, and can re-capture nothing but a dim sense of the beauty of it, the beauty!"
+    ]
+  },
+  {
+    "name": "diminish",
+    "trans": [
+      "Day 10 | v. | English: to become or to make sth become smaller, weaker, etc. | Example: One way to diminish the importance of a scholar’s research is to track how often other scholars refer to that research."
+    ]
+  },
+  {
+    "name": "disastrous",
+    "trans": [
+      "Day 10 | adj. | English: very bad, harmful or unsuccessful | Example: Lowering interest rates could have disastrous consequences for the economy."
+    ]
+  },
+  {
+    "name": "discard",
+    "trans": [
+      "Day 10 | v. | English: to get rid of sth that you no longer want or need | Example: Cut, bent, and welded from discarded metal materials, the sculptures of London-based Nigerian artist Sokari Douglas Camp are meant to challenge viewers to consider their own relationships to material waste."
+    ]
+  },
+  {
+    "name": "discern",
+    "trans": [
+      "Day 10 | v. | English: to know, recognize or understand sth, especially sth that is not obvious | Example: The fossil remains of the individual known as Oase 1, discovered in Romania in 2002, can help paleoanthropologists not only discern steps in the evolution of hominids but also illuminate the Pleistocene epoch generally, revealing important details about the time in which Oase 1 lived."
+    ]
+  },
+  {
+    "name": "discipline",
+    "trans": [
+      "Day 10 | n. | English: a subject that people study or are taught, especially in a university | Example: The team explained that the collaboration between experts in these two disciplines resulted in a more comprehensive approach than independent efforts by experts in either discipline could have achieved."
+    ]
+  },
+  {
+    "name": "disclosure",
+    "trans": [
+      "Day 10 | n. | English: the act of making sth known or public that was previously secret or private | Example: In response to concerns that some recent financial crises were exacerbated by consumers misunderstanding risks associated with credit cards, loans, and other financial products, policymakers in many countries have instituted risk-disclosure requirements on sellers of those products."
+    ]
+  },
+  {
+    "name": "discontent",
+    "trans": [
+      "Day 10 | n. | English: a feeling of being unhappy because you are not satisfied with a particular situation; sth that makes you have this feeling | Example: To draw attention to individuals’ discontent with the group's conversation about art"
+    ]
+  },
+  {
+    "name": "discontented",
+    "trans": [
+      "Day 10 | adj. | English: unhappy because you are not satisfied with your situation | Example: Miranda's reminiscences about her early childhood have a melancholy quality that betrays her discontented view of her current circumstances."
+    ]
+  },
+  {
+    "name": "discontinue",
+    "trans": [
+      "Day 10 | v. | English: Ifa product is discontinued, the manufacturer stops making it. | Example: Studying wrappers from discontinued candies, menus from nineteenth-century restaurants, and flyers promoting long-forgotten sporting events may seem like a frivolous pursuit, but ephemeral objects like these are useful as markers of cultural change."
+    ]
+  },
+  {
+    "name": "discontinued",
+    "trans": [
+      "Day 10 | adj. | English: Ifa product is discontinued, the manufacturer stops making it. | Example: As discussed by scholar Anna Mladentseva, many artworks produced in the mid-1990s to the early 2000s exclusively for exhibition on the internet have become inaccessible because viewing them requires the use of defunct software (most notably Adobe Flash, discontinued in 2021)."
+    ]
+  },
+  {
+    "name": "discount",
+    "trans": [
+      "Day 10 | v. | English: to think or say that sth is not important or not true | Example: The tendency to group authors together into distinct literary movements often encourages literary scholars to discount subtleties in an author's style."
+    ]
+  },
+  {
+    "name": "discourse",
+    "trans": [
+      "Day 10 | n. | English: along and serious treatment or discussion of a subject in speech or writing | Example: After traveling to the United States and Europe in the early 1930s and immersing himself in a broader architectural discourse, Barragan shifted his style to incorporate principles of modernism, as seen in the Ortega House."
+    ]
+  },
+  {
+    "name": "discreet",
+    "trans": [
+      "Day 10 | adj. | English: careful in what you say or do, in order to keep sth secret or to avoid causing embarrassment or difficulty for sb | Example: And by his brother clergy he was regarded as a discreet and agreeable fellow."
+    ]
+  },
+  {
+    "name": "discrepancy",
+    "trans": [
+      "Day 10 | n. | English: a difference between two or more things that should be the same | Example: It stresses the discrepancy between Mr. Ely's public and private conduct and then alludes to his motivation for hiding his true personality."
+    ]
+  },
+  {
+    "name": "discrete",
+    "trans": [
+      "Day 10 | adj. | English: independent of other things of the same type | Example: Other critics, however, argue that the books should not be thought of as discrete texts with traditional beginnings and endings but as a single incredibly long work, similar to other multivolume stories, such as John Galsworthy's The Forsyte Saga."
+    ]
+  },
+  {
+    "name": "discretion",
+    "trans": [
+      "Day 10 | n. | English: care in what you say or do, in order to keep sth secret or to avoid causing embarrassment to"
+    ]
+  },
+  {
+    "name": "disdainful",
+    "trans": [
+      "Day 10 | adj. | English: showing disdain | Example: She had the air of a queen and gazed disdainfully at the whole house."
+    ]
+  },
+  {
+    "name": "disengage",
+    "trans": [
+      "Day 10 | v. | English: to free sb/sth from the person or thing that is holding them or it; to become free | Example: They wished to disengage themselves from these policies."
+    ]
+  },
+  {
+    "name": "disguise",
+    "trans": [
+      "Day 10 | v. | English: to change your appearance so that people cannot recognize you | Example: The hijackers were heavily disguised."
+    ]
+  },
+  {
+    "name": "disingenuous",
+    "trans": [
+      "Day 10 | adj. | English: not sincere, especially when you pretend to know less about sth than you really do | Example: It would be disingenuous of me to claim | had never seen it."
+    ]
+  },
+  {
+    "name": "dismiss",
+    "trans": [
+      "Day 10 | v. | English: to decide that sb/sth is not important and not worth thinking or talking about | Example: People sometimes dismiss a claim if it comes from a source they regard as self-interested, but from a strictly logical perspective, the source of a claim is irrelevant."
+    ]
+  },
+  {
+    "name": "dismissal",
+    "trans": [
+      "Day 10 | n. | English: the failure to consider sth as important | Example: Her casual dismissal of the threats seemed irresponsible."
+    ]
+  },
+  {
+    "name": "disparage",
+    "trans": [
+      "Day 10 | v. | English: to suggest that sb/sth is not important or valuable | Example: | don't mean to disparage your achievements."
+    ]
+  },
+  {
+    "name": "disparate",
+    "trans": [
+      "Day 10 | adj. | English: essentially different in kind; not allowing comparison | Example: As disparate as their works may seem, commonalities exist between Antonello da Messina, Italian Renaissance painter of the Venetian School; Adriaen Brouwer, Flemish mannerist painter of the Antwerp School; and Jose Guerrero, American abstract painter of the New York School."
+    ]
+  },
+  {
+    "name": "disparity",
+    "trans": [
+      "Day 10 | n. | English: a difference, especially one connected with unfair treatment | Example: The disparity between these two speeds is not surprising, however, because the features that are most useful for running on land tend to be more limiting on top speeds than the features that are best suited for flying through the air."
+    ]
+  },
+  {
+    "name": "dispassionate",
+    "trans": [
+      "Day 10 | adj. | English: not influenced by emotion | Example: It primarily works to engage audiences in an interrogation of patriarchy and colonialism, which it does by placing audiences at a distance, thereby encouraging them to be dispassionate as they think critically about the social and political questions raised by the play."
+    ]
+  },
+  {
+    "name": "dispersal",
+    "trans": [
+      "Day 10 | English: the process of sending sb/sth in different directions; the process of spreading sth over a wide area | Example: Like many other fruit-eating birds on the Hawaiian island of Oahu, the red-whiskered bulbul helps forest plants spread by dropping seeds from the plants’ fruits in different spots (a"
+    ]
+  },
+  {
+    "name": "disperse",
+    "trans": [
+      "Day 10 | v. | English: to move apart and go away in different directions | Example: She is anxious for the gathering to disperse so that she can ready the space for her own needs."
+    ]
+  },
+  {
+    "name": "dispersed",
+    "trans": [
+      "Day 10 | adj. | English: Things that are dispersed are situated in many different places, a long way apart from each other. | Example: It took some two hours before the crowd was fully dispersed."
+    ]
+  },
+  {
+    "name": "disposable",
+    "trans": [
+      "Day 10 | adj. | English: made to be thrown away after use | Example: Guojun He and colleagues studied a food-delivery phone app that is popular in China. The researchers found that having \"no cutlery\" automatically selected influences whether customers request disposable plastic utensils with their food orders."
+    ]
+  },
+  {
+    "name": "dispose of",
+    "trans": [
+      "Day 10 | English: to get rid of sb/sth that you do not want or cannot keep | Example: Environmental policy researcher Jessika Richter warns that because new batteries can't be put in once the old ones no longer work, the gadgets stop functioning and are usually disposed of as trash."
+    ]
+  },
+  {
+    "name": "disproportionate",
+    "trans": [
+      "Day 10 | adj. | English: too large or too small when compared with sth else | Example: Less populated rural districts with large tracts of land receive a disproportionate number of seats compared to smaller but more populated urban districts."
+    ]
+  },
+  {
+    "name": "dispute",
+    "trans": [
+      "Day 10 | v. | English: to question whether sth is true and valid | Example: Given how little consensus there is among scientists regarding the scope of these categories, this discrepancy shouldn't be surprising: forest researchers regularly dispute one another's classifications."
+    ]
+  },
+  {
+    "name": "disregard",
+    "trans": [
+      "Day 10 | v. | English: to not consider sth | Example: The reasons for this characterization may seem irrefutable, but linking Unamuno with the Generation of '98 risks disregarding the subtleties in his style that do not neatly conform to the conventions of this literary movement."
+    ]
+  },
+  {
+    "name": "dissect",
+    "trans": [
+      "Day 10 | v. | English: to study sth closely and/or discuss it in great detail | Example: He might dissect, anatomize, and give names; but, not to speak of a final cause, causes in their secondary and tertiary grades were utterly unknown to him."
+    ]
+  },
+  {
+    "name": "disseminate",
+    "trans": [
+      "Day 10 | v. | English: to spread information, knowledge, etc. so that it reaches many people | Example: Their findings have been widely disseminated ."
+    ]
+  },
+  {
+    "name": "dissolution",
+    "trans": [
+      "Day 10 | n. | English: the process in which sth gradually disappears | Example: These animals are thought to be especially vulnerable to ocean acidification due to calcium carbonate's susceptibility to dissolution at lower pH values."
+    ]
+  },
+  {
+    "name": "dissolve",
+    "trans": [
+      "Day 10 | v. | English: to make a solid become part of a liquid | Example: In a 2012 study in the United States, Michael E. Berndt and Travis K. Bavin found a positive association between levels of dissolved organic carbon and mercury in bodies of fresh water."
+    ]
+  },
+  {
+    "name": "distinction",
+    "trans": [
+      "Day 10 | n. | English: the quality of being excellent or important | Example: He has the appearance of a distinguished figure, but it is uncertain whether he has accomplished anything to earn distinction."
+    ]
+  },
+  {
+    "name": "distinctive",
+    "trans": [
+      "Day 10 | adj. | English: having a quality or characteristic that makes sth different and easily noticed | Example: Although fewer companies trade their stocks on the Tehran Stock Exchange in Tehran, Iran, than on the stock exchanges in London, Mumbai, or Tokyo, the Tehran Stock Exchange has the advantage of focusing on local companies and thus reflecting economic circumstances that are distinctive to Iran."
+    ]
+  },
+  {
+    "name": "distinguished",
+    "trans": [
+      "Day 10 | adj. | English: having an appearance that makes sb look important or that makes people admire or respect them | Example: He has the appearance of a distinguished figure, but it is uncertain whether he has accomplished anything to earn distinction."
+    ]
+  },
+  {
+    "name": "distort",
+    "trans": [
+      "Day 10 | v. | English: to change the shape, appearance or sound of sth so that it is strange or not clear | Example: And even the hyperpop artists who don't rely on pitch-shifting, such as Shygirl, often distort their vocals using digital tools."
+    ]
+  },
+  {
+    "name": "distract",
+    "trans": [
+      "Day 10 | v. | English: to take sb's attention away from what they are trying to do | Example: Gold, conversely, could distract from the subtleties in a painted scene."
+    ]
+  },
+  {
+    "name": "distributary",
+    "trans": [
+      "Day 10 | n. | English: one of several outlet streams draining a river, esp on a delta The Chao Phraya River delta is a constantly changing landform made up of a network of distributaries, small channels that branch off from the main river."
+    ]
+  },
+  {
+    "name": "diverge",
+    "trans": [
+      "Day 10 | v. | English: to be different | Example: Her music diverges from the typical hyperpop sound but doesn't abandon it."
+    ]
+  },
+  {
+    "name": "divergence",
+    "trans": [
+      "Day 10 | n. | English: A divergence is a difference between two or more things, attitudes, or opinions. | Example: In harmonious periods and telling phrases the different shades of political opinion, the divergences and disagreements, are adjusted."
+    ]
+  },
+  {
+    "name": "diversity",
+    "trans": [
+      "Day 10 | n. | English: the quality or fact of including a range of many people or things | Example: They found that across the three microbial communities, peak diversity and richness was observed on pine and oak samples placed approximately 125 meters from the shipwrecks."
+    ]
+  },
+  {
+    "name": "divert",
+    "trans": [
+      "Day 10 | v. | English: to take sb's thoughts or attention away from sth | Example: Unfortunately, this flood of interesting writing can divert scholarly attention from the fascinating work of nineteenth-century figures like Guillermo Prieto."
+    ]
+  },
+  {
+    "name": "divest",
+    "trans": [
+      "Day 10 | v. | English: to take sth away from sb/sth | Example: The great men of culture are those who have had a passion for diffusing, for making prevail, for carrying from one end of society to the other, the best knowledge, the best ideas of their time; who have labored to divest knowledge of all that was harsh, uncouth, difficult, abstract, professional, exclusive; to humanise it, to make it efficient outside the clique of the cultivated and learned, yet still remaining the best knowledge and thought of the time, and a true source, therefore, of sweetness and light."
+    ]
+  },
+  {
+    "name": "dodge",
+    "trans": [
+      "Day 10 | v. | English: to move quickly and suddenly to one side in order to avoid sb/sth | Example: While the others are hopping about in the air, | can dodge under their feet and grab the ball."
+    ]
+  },
+  {
+    "name": "dogmatic",
+    "trans": [
+      "Day 11 | adj. | English: being certain that your beliefs are right and that others should accept them, without paying attention to evidence or other opinions | Example: Political scientists have found that although voters claim to prefer candidates who have nuanced perspectives on issues and who show a willingness to compromise, when asked to compare speeches expressing such views with speeches expressing dogmatic views, voters tend to regard the unyielding rhetoric of the latter more favorably."
+    ]
+  },
+  {
+    "name": "domain",
+    "trans": [
+      "Day 11 | n. | English: an area of knowledge or activity; especially one that sb is responsible for | Example: Some social scientists say that while a desire for cooperation rather than conflict is key to democracy, public understanding of economics is also central to public comprehension of state politics, and if a citizenry is to function, economic issues cannot remain the domain only of experts."
+    ]
+  },
+  {
+    "name": "domestic",
+    "trans": [
+      "Day 11 | adj. | English: of or inside a particular country; not foreign or international | Example: Karl Polanyi and other historians of capitalism rarely discuss domestic capitalism in Africa before the period of European colonization."
+    ]
+  },
+  {
+    "name": "domesticate",
+    "trans": [
+      "Day 11 | v. | English: to make a wild animal used to living with or working for humans | Example: Maize (corn), another crop domesticated by Indigenous Americans, shows so little resemblance to any wild plant that genetic research was necessary to confirm teosinte grass as its ancestor."
+    ]
+  },
+  {
+    "name": "dominant",
+    "trans": [
+      "Day 11 | adj. | English: more important, powerful or noticeable than other things | Example: The potential for knowledge spillovers, a dominant driver of collocation in this industry, was largely absent from the paint manufacturing industry."
+    ]
+  },
+  {
+    "name": "doom",
+    "trans": [
+      "Day 11 | v. | English: to make sb/sth certain to fail, suffer, die, etc | Example: The sun, already down, was manifest in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+    ]
+  },
+  {
+    "name": "downplay",
+    "trans": [
+      "Day 11 | v. | English: to make people think that sth is less important than it really is | Example: It downplays the significance of the size difference between the sei whale and the bowhead whale."
+    ]
+  },
+  {
+    "name": "doze",
+    "trans": [
+      "Day 11 | v. | English: to sleep lightly for a short time | dozed and floated on the clouds of Farsi that blew my way from the front seat of Dayi | Example: Uncle] lamsheed's SUV."
+    ]
+  },
+  {
+    "name": "drain",
+    "trans": [
+      "Day 11 | v. | English: to make liquid flow away from sth; to flow away The Nile River delta system is located in Northern Egypt, where the river drains into the Mediterranean Sea."
+    ]
+  },
+  {
+    "name": "drape",
+    "trans": [
+      "Day 11 | v. | English: to hang clothes, materials, etc. loosely on sb/sth | Example: At any rate, it was not without ample consideration that those thick, dark, costly carpets were put down; those embossed, but sombre [wallpapers] hung up; those heavy curtains draped so as to half exclude the light of the sun."
+    ]
+  },
+  {
+    "name": "draw",
+    "trans": [
+      "Day 11 | v. | English: to attract or interest sb | Example: lrest me deep within the wood, / Drawn by its silent call, / Far from the throbbing crowd of men, / On nature's breast | fall."
+    ]
+  },
+  {
+    "name": "draw on",
+    "trans": [
+      "Day 11 | English: If you draw on or draw upon something such as your skill or experience, you make use of it in order to do something. | Example: Ina variety of ways, Samuel Kamakau, Kristiana Kahakauwila, and other acclaimed writers have drawn on these stories to craft a rich portrait of the Hawaiian Islands and their people. drawing-room /F S23LFEMXL: A drawing room is a room, especially a large room in a large house, where people sit and relax, or entertain guests. By the laity of Milby and its neighbourhood [Mr. Ely] was regarded as a man of quite remarkable powers and learning, who must make a considerable sensation in London pulpits and drawing-rooms on his occasional visit to the metropolis."
+    ]
+  },
+  {
+    "name": "drawing-room",
+    "trans": [
+      "Day 11 | English: A drawing room is a room, especially a large room in a large house, where people sit and relax, or entertain guests. | Example: By the laity of Milby and its neighbourhood [Mr. Ely] was regarded as a man of quite remarkable powers and learning, who must make a considerable sensation in London pulpits and drawing-rooms on his occasional visit to the metropolis."
+    ]
+  },
+  {
+    "name": "dreadful",
+    "trans": [
+      "Day 11 | adj. | English: very bad or unpleasant | Example: The Mole saw the wood that had been so dreadful to him in quite a changed aspect."
+    ]
+  },
+  {
+    "name": "drill",
+    "trans": [
+      "Day 11 | v. | English: vto teach sb to do sth by making them repeat it a lot of times; v. to make a hole in sth, using a drill | Example: [1] He was daring, without being rash: prompt, but not thoughtless; firm, without being harsh. Kind and devoted to the company he drilled, he soon won the respect of his superior officers and the love of his comrades. 2] Companies involved in petroleum extraction include drilling equipment among their assets."
+    ]
+  },
+  {
+    "name": "driver",
+    "trans": [
+      "Day 11 | n. | English: one of the main things that influence sth or cause it to make progress | Example: The potential for knowledge spillovers, a dominant driver of collocation in this industry, was largely absent from the paint manufacturing industry."
+    ]
+  },
+  {
+    "name": "drudging",
+    "trans": [
+      "Day 11 | adj. | English: boring and hard, and taking a lot of time | Example: The motorman chafed in his box, thinking of the drudging lot of the laboring man. He registered discontent."
+    ]
+  },
+  {
+    "name": "dry",
+    "trans": [
+      "Day 11 | adj. | English: not interesting | Example: She was reading a book a day in alphabetical order and not skipping the dry ones."
+    ]
+  },
+  {
+    "name": "dull",
+    "trans": [
+      "Day 11 | adj. | English: adj. not bright, with a lot of clouds; v. to make a person slower or less lively | Example: [1] The tired cars go grumbling by, / The moaning, groaning cars, / And the old milk carts go rumbling by / Under the same dull stars. 2] The sun, beating down upon [the soldiers], dulled their minds and bodies and presently they were silent."
+    ]
+  },
+  {
+    "name": "duplicate",
+    "trans": [
+      "Day 11 | v. | English: to make an exact copy of sth | Example: His task will be to duplicate his success overseas here at home."
+    ]
+  },
+  {
+    "name": "dwindle",
+    "trans": [
+      "Day 11 | v. | English: to become gradually less or smaller | Example: Support for the party has dwindled away to nothing."
+    ]
+  },
+  {
+    "name": "dynamic",
+    "trans": [
+      "Day 11 | adj. | English: always changing and making progress | Example: As with other river deltas, the Krishna River delta is dynamic: it is a constantly evolving network of channels and strips of land that change in size and shape as the river deposits new sedimentary particles where the river meets the waters of the Bay of Bengal."
+    ]
+  },
+  {
+    "name": "ease",
+    "trans": [
+      "Day 11 | n. | English: n. lack of difficulty; v. to become or to make sth less unpleasant, painful, severe, etc. | Example: [1] Mr. French, the senior partner, who sat opposite Kirby, was an older man—a safe guess would have placed him somewhere in the debatable ground between forty and fifty; of a good height, as could be seen even from the seated figure, the upper part of which was held erect with the unconscious ease which one associates with military training. 2] Chekhov portrays Helena as trying to ease tensions between Vanya and the professor."
+    ]
+  },
+  {
+    "name": "eccentric",
+    "trans": [
+      "Day 11 | adj. | English: considered by other people to be strange or unusual Although the one exceptional moon orbits in the same direction as the planets spin, its orbit is highly eccentric compared to the rest, which may suggest that it has a different origin than the other 19 moons."
+    ]
+  },
+  {
+    "name": "eclipse",
+    "trans": [
+      "Day 11 | v. | English: to make sb/sth seem dull or unimportant by comparison | Example: A speaker at a recent children's book publishing conference noted that, while many illustrators do excellent work, in her mind, no one has ever eclipsed work as the illustrator of Under the Sunday Tree."
+    ]
+  },
+  {
+    "name": "efficacy",
+    "trans": [
+      "Day 11 | n. | English: the ability of sth, especially a drug or a medical treatment, to produce the results that are wanted | Example: The results of randomized clinical trials testing the efficacy of common medical interventions sometimes fail to corroborate conclusions that practitioners reach based on their real-world observations of patients."
+    ]
+  },
+  {
+    "name": "egocentric",
+    "trans": [
+      "Day 11 | adj. | English: thinking only about yourself and not about what other people need or want | Example: Previous research has found a tendency in many cultures to make temporal distinctions using spatial concepts and gestures, particularly along egocentric axes (i.e., relative to the orientation of the speaker)."
+    ]
+  },
+  {
+    "name": "eject",
+    "trans": [
+      "Day 11 | v. | English: to push sth out suddenly and with a lot of force | Example: And as Jane X. Luu et al. point out, the singular nature of impact ejection makes it untenable as an account of multiple loss episodes of similar duration over several years."
+    ]
+  },
+  {
+    "name": "elaborate",
+    "trans": [
+      "Day 11 | v. | English: to explain or describe sth in a more detailed way | Example: It elaborates on a potential consequence of Faleiro and colleagues’ reliance on a relatively small sample size."
+    ]
+  },
+  {
+    "name": "electrifying",
+    "trans": [
+      "Day 11 | adj. | English: very exciting | Example: Ina 2018 article celebrating films depicting the Black experience, critics for the New York Times commended William Greaves's 1968 film Symbiopsychotaxiplasm, Take One and Spike Lee's 1992 film Malcolm X, praising the former as \"a vital artifact of its time\" and the latter as \"electrifying.\""
+    ]
+  },
+  {
+    "name": "elevation",
+    "trans": [
+      "Day 11 | n. | English: the height of a place, especially its height above sea level | Example: To understand how temperature change affects microorganism-mediated cycling of soil nutrients in alpine ecosystems, Eva Kastovska et al, collected plant-soil cores in the Tatra Mountains at elevations around 2,100 meters and transplanted them to elevations of 1,700- 1,800 meters, where the mean air temperature was warmer by 2°C."
+    ]
+  },
+  {
+    "name": "elicit",
+    "trans": [
+      "Day 11 | v. | English: (formal) to get information or a reaction from sb, often with difficulty | Example: In their meta-analysis of research on advergames (video games developed to promote products or services), Zeph M.C. van Berlo et al. confirm that such games, though they can elicit player interest, may not facilitate subsequent recall of product and brand information."
+    ]
+  },
+  {
+    "name": "elusive",
+    "trans": [
+      "Day 11 | adj. | English: difficult to find, define, or achieve | Example: It was the kind of challenge that would set any art curator’s mind into motion: finding that elusive thread that could link artists as disparate as American abstract painter Anne Ryan, Romanian impressionist painter Micaela Eleutheriade, and Flemish mannerist painter Anthony van Dyck."
+    ]
+  },
+  {
+    "name": "emanate",
+    "trans": [
+      "Day 11 | v. | English: to come out from a source | Example: The declination, or celestial latitude, of the Aurigid meteor shower's radiant—the point in the sky from which, to a terrestrial observer, the shower's meteors appear to emanate—is 39 degrees, meaning that its radiant is located 39 degrees north of the celestial equator, in close proximity to the constellation Auriga."
+    ]
+  },
+  {
+    "name": "embed",
+    "trans": [
+      "Day 11 | v. | English: to fix sth firmly into a substance or solid object | Example: The limited capacity model of motivated mediated message processing developed by Lang provides a means of explaining the finding by van Berlo et al. that players may not readily recollect the brand and product information embedded in advergames."
+    ]
+  },
+  {
+    "name": "embossed",
+    "trans": [
+      "Day 11 | adj. | English: Ifa surface such as paper or wood is embossed with a design, the design stands up slightly from the surface. | Example: At any rate, it was not without ample consideration that those thick, dark, costly carpets were put down; those embossed, but sombre [wallpapers] hung up; those heavy curtains draped so as to half exclude the light of the sun."
+    ]
+  },
+  {
+    "name": "embrace",
+    "trans": [
+      "Day 11 | v. | English: to accept an idea, a proposal, a set of beliefs, etc., especially when it is done with enthusiasm | Example: Hunting Expedition is an important work of Nihonga, or classical Japanese painting. Unlike Wada Eisaku, who adopted traditional European methods such as painting with oil on canvas, Domoto Insh6 embraced traditional Japanese approaches."
+    ]
+  },
+  {
+    "name": "emergence",
+    "trans": [
+      "Day 11 | n. | English: when something begins to be known or noticed | Example: Documentation of the display in 285 species across 52 families suggests the behavior likely evolved independently multiple times, prompting the team to consider ecological and life- history characteristics with hypothesized associations to the behavior's emergence, including traits related to reproduction investment and future reproduction potential."
+    ]
+  },
+  {
+    "name": "eminence",
+    "trans": [
+      "Day 11 | n. | English: the quality of being famous and respected, especially in a profession | Example: Over time, the Aubrey/Maturin series has Jrcquired the same eminence among critics as orks like In Search of Lost Time that have similar structures."
+    ]
+  },
+  {
+    "name": "emit",
+    "trans": [
+      "Day 11 | English: to send out sth such as light, heat, sound, gas, etc. | Example: To combat predation by Arizona myotis and other insectivorous bats, many moth species, including Cycnia tenera, emit ultrasonic pulses that, in some cases, disrupt the echolocation bats rely on for foraging."
+    ]
+  },
+  {
+    "name": "empirical",
+    "trans": [
+      "Day 11 | adj. | English: based on experiments or experience rather than ideas or theories | Example: Text corpora such as the British National Corpus are enormous collections of electronically stored texts that can be used for empirical testing of hypotheses regarding how pervasive a word is in spoken and written English."
+    ]
+  },
+  {
+    "name": "emulate",
+    "trans": [
+      "Day 11 | v. | English: to try to do sth as well as sb else because you admire them | Example: She hopes to emulate her sister's sporting achievements."
+    ]
+  },
+  {
+    "name": "emulsion",
+    "trans": [
+      "Day 11 | n. | English: any mixture of liquids that do not normally mix together, such as oil and water; a type of paint used on walls and ceilings that dries without leaving a shiny surface | Example: An emulsifier is a type of compound that serves to stabilize an emulsion—a mixture of two or more liquids that otherwise would not easily blend together."
+    ]
+  },
+  {
+    "name": "enact",
+    "trans": [
+      "Day 11 | v. | English: to pass a law | Example: Karam Kang has demonstrated that lobbying does little to alter the probability that a particular energy policy under consideration by the United States Congress will be enacted."
+    ]
+  },
+  {
+    "name": "enchantment",
+    "trans": [
+      "Day 11 | n. | English: a feeling of great pleasure | Example: A thousand recollections of childhood came over me, awakened by these country odors, and | walked along, permeated with the fragrant, living enchantment, the emotional enchantment of the woods warmed by the sun of June."
+    ]
+  },
+  {
+    "name": "encompass",
+    "trans": [
+      "Day 11 | v. | English: to include a large number or range of things | Example: A region of the Soviet Union encompassing the present-day city of Sukhumi, Georgia, the Abkhazian-speaking Abkhaz Autonomous Soviet Socialist Republic was in fact only nominally autonomous."
+    ]
+  },
+  {
+    "name": "encyclopedia",
+    "trans": [
+      "Day 11 | n. | English: a book or set of books giving information about all areas of knowledge or about different areas of one particular subject, usually arranged in alphabetical order | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+    ]
+  },
+  {
+    "name": "end",
+    "trans": [
+      "Day 11 | n. | English: an aim or a purpose | Example: To that end, certain features such as the ability to respond to voice commands can help to buttress people's feelings of comfort."
+    ]
+  },
+  {
+    "name": "endeavor",
+    "trans": [
+      "Day 11 | n. | English: an attempt to do sth, especially sth new or difficult | Example: The little conductor stood on tiptoe in an effort to keep one hand on the signal rope, craning his neck in a vain and dissatisfied endeavor to pierce the miasma of the fog."
+    ]
+  },
+  {
+    "name": "endure",
+    "trans": [
+      "Day 11 | v. | English: to experience and deal with sth that is painful or unpleasant, especially without complaining | Example: Believe me, Anya, believe me! I'm not thirty yet, I'm young, I'm still a student, but | have endured a great deal!"
+    ]
+  },
+  {
+    "name": "enduring",
+    "trans": [
+      "Day 12 | adj. | English: lasting for a long time | Example: Inan analysis of economic data from 1976 to 1993, Ross Levine and Sara Zervos found that liberalization did not lead to enduring increases in investment in companies based in countries that liberalized."
+    ]
+  },
+  {
+    "name": "enfranchise",
+    "trans": [
+      "Day 12 | v. | English: to give sb the right to vote in an election | Example: When contrasting different forms of government, Aristotle holds that ‘oligarchies may last, not from any inherent stability in such forms of government, but because the rulers are on good terms both with the unenfranchised and with the governing classes.\" That is, oligarchic leaders who wish to hold on to power will introduce members of disenfranchised classes into government in a participatory role."
+    ]
+  },
+  {
+    "name": "engaging",
+    "trans": [
+      "Day 12 | adj. | English: interesting or pleasant in a way that attracts your attention | Example: Community science, which involves professional scientists collaborating with amateur science enthusiasts to study a topic, is often an effective and engaging way to conduct research."
+    ]
+  },
+  {
+    "name": "engender",
+    "trans": [
+      "Day 12 | v. | English: to make a feeling or situation exist | Example: In the 2010s, the price of vintage Teenage Mutant Ninja Turtles action figures rose dramatically, which had the counterintuitive effect of engendering demand."
+    ]
+  },
+  {
+    "name": "engraving",
+    "trans": [
+      "Day 12 | n. | English: a picture made by cutting a design on a piece of metal and then printing the design on paper | Example: They may have thought of the engravings as something akin to art in our modern sense, but it is entirely possible that they did not—we simply cannot say for certain."
+    ]
+  },
+  {
+    "name": "engulf",
+    "trans": [
+      "Day 12 | v. | English: to surround or to cover sb/sth completely | Example: She has a thick curtain of long, curly hair that practically engulfs her."
+    ]
+  },
+  {
+    "name": "enigma",
+    "trans": [
+      "Day 12 | n. | English: a person, thing or situation that is mysterious and difficult to understand | Example: His recently published memoirs possibly cast light on this enigma, but given that such details were not provided until after the thirty-page mark, they might as well have remained state secrets."
+    ]
+  },
+  {
+    "name": "enlist",
+    "trans": [
+      "Day 12 | v. | English: to persuade sb to help you or to join you in doing sth | Example: The institute enlisted botanist Janaki Ammal to breed a local variety of sugarcane."
+    ]
+  },
+  {
+    "name": "enliven",
+    "trans": [
+      "Day 12 | v. | English: to make sth more interesting or more fun | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+    ]
+  },
+  {
+    "name": "enormous",
+    "trans": [
+      "Day 12 | adj. | English: extremely large | Example: Text corpora such as the British National Corpus are enormous collections of electronically stored texts that can be used for empirical testing of hypotheses regarding the frequency of typical word usage."
+    ]
+  },
+  {
+    "name": "enroll",
+    "trans": [
+      "Day 12 | v. | English: to arrange for yourself or for sb else to officially join a course, school, etc. | Example: Pereira's team enrolled groups of Australian workers in two programs: one that gave employees exercise training (EET) and one that enrolled employees in health promotion seminars (EHP)."
+    ]
+  },
+  {
+    "name": "entail",
+    "trans": [
+      "Day 12 | n. | English: to involve sth that cannot be avoided | Example: The job entails a lot of hard work."
+    ]
+  },
+  {
+    "name": "entangle",
+    "trans": [
+      "Day 12 | v. | English: to involve sb in a difficult or complicated situation | Example: Each becomes entangled in a debate about art, and no one knows how to resolve the debate."
+    ]
+  },
+  {
+    "name": "entertaining",
+    "trans": [
+      "Day 12 | adj. | English: interesting and amusing | Example: Many readers find the Aubrey/Maturin novels to be remarkably entertaining despite flaws novels’ structures."
+    ]
+  },
+  {
+    "name": "entice",
+    "trans": [
+      "Day 12 | n. | English: to persuade sb/sth to go somewhere or to do sth | Example: External shopping cues are a type of marketing that uses obvious messaging—a display featuring a new product, for example, or a “buy one, get one free” offer—to entice consumers to make spontaneous purchases."
+    ]
+  },
+  {
+    "name": "entreat",
+    "trans": [
+      "Day 12 | v. | English: to ask sb to do sth in a serious and often emotional way | Example: Strepsiades encourages his son to learn to be a sophist, saying, “Go, | entreat you, dearest of men, go and be taught.”"
+    ]
+  },
+  {
+    "name": "entrepreneurship",
+    "trans": [
+      "Day 12 | n. | English: Entrepreneurship is the state of being an entrepreneur, or the activities associated with being an entrepreneur. | Example: The University of Illinois and the startup accelerator Y Combinator are two of the many institutions offering training programs in entrepreneurship."
+    ]
+  },
+  {
+    "name": "entry",
+    "trans": [
+      "Day 12 | n. | English: an item, for example a piece of information, that is written or printed in a dictionary, an account book, a diary, etc. | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+    ]
+  },
+  {
+    "name": "envision",
+    "trans": [
+      "Day 12 | v. | English: to imagine what a situation will be like in the future, especially a situation you intend to work towards | Example: Together, they envisioned a theater company that would nurture and showcase the work of Black theater professionals.]"
+    ]
+  },
+  {
+    "name": "ephemera",
+    "trans": [
+      "Day 12 | n. | English: things that are important or used for only a short period of time | Example: Studying wrappers from discontinued candies, menus from nineteenth-century restaurants, and flyers promoting long-forgotten sporting events may seem like a frivolous pursuit, but ephemeral objects like these are useful as markers of cultural change."
+    ]
+  },
+  {
+    "name": "ephemeral",
+    "trans": [
+      "Day 12 | adj. | English: lasting or used for only a short period of time | Example: Studying wrappers from discontinued candies, menus from nineteenth-century restaurants, and flyers promoting long-forgotten sporting events may seem like a frivolous pursuit, but ephemeral objects like these are useful as markers of cultural change."
+    ]
+  },
+  {
+    "name": "episode",
+    "trans": [
+      "Day 12 | n. | English: an event, a situation, or a period of time in sb's life, a novel, etc. that is important or interesting in some way | Example: Asteroid 6478 Gault has experienced intermittent mass loss since at least 2013, but in contrast to some other asteroids with repeated mass-loss episodes, 6478 Gault has not lost mass at its perihelion (the closest point of its orbit to the Sun), and thus the loss is not attributable to solar energy—driven ice vaporization."
+    ]
+  },
+  {
+    "name": "episodic",
+    "trans": [
+      "Day 12 | adj. | English: happening occasionally and not at regular intervals | Example: To characterize the nature of the depositional environment, Frances Rivera-Hernandez et al. analyzed the grain size of Murray Formation sediment, finding that although there are intervals of coarse grains, most of the sediment consists of fine grains that show signs of cracking due to episodic desiccation."
+    ]
+  },
+  {
+    "name": "epitomize",
+    "trans": [
+      "Day 12 | v. | English: to be a perfect example of sth | Example: As epitomized by the Aguilar House in Guadalajara, many of Barragan’s first projects integrated traditional Mexican building techniques into Mediterranean designs."
+    ]
+  },
+  {
+    "name": "epoch",
+    "trans": [
+      "Day 12 | n. | English: a period of time in history, especially one during which important events or changes happen | Example: The fossil remains of the individual known as KNM-KP 271, discovered in Kenya in 1965, can help paleoanthropologists not only identify steps in the evolution of hominids but also illuminate the Pliocene epoch generally, revealing important details about the time in which KNM-KP 271 lived."
+    ]
+  },
+  {
+    "name": "equalize",
+    "trans": [
+      "Day 12 | v. | English: to make things equal in size, quantity, value, etc. in the whole of a place or group | Example: Such measures are needed to equalize wage rates between countries."
+    ]
+  },
+  {
+    "name": "equitable",
+    "trans": [
+      "Day 12 | adj. | English: fair and reasonable; treating everyone in an equal way | Example: He has urged them to come to an equitable compromise that gives Hughes his proper due."
+    ]
+  },
+  {
+    "name": "equivalence",
+    "trans": [
+      "Day 12 | n. | English: If there is equivalence between two things, they have the same use, function, size, or value. | Example: Its metaphorical significance derives from the semantic equivalence of the two nouns constituting the difrasismo."
+    ]
+  },
+  {
+    "name": "equivalent",
+    "trans": [
+      "Day 12 | adj. | English: adj. equal in value, amount, meaning, importance, etc.; n. a thing, amount, word, etc. that is equivalent to sth else | Example: [1] Though not closely related, the hedgehog tenrecs of Madagascar share basic similarities with true hedgehogs, including protective spines, pointed snouts, and small body size—traits the two groups of mammals independently developed in response to equivalent roles in their respective habitats. 2] It doesn't have a clear equivalent in English."
+    ]
+  },
+  {
+    "name": "equivocal",
+    "trans": [
+      "Day 12 | adj. | English: not having one clear or definite meaning or intention; able to be understood in more than one way | Example: She gave an equivocal answer, typical of a politician."
+    ]
+  },
+  {
+    "name": "erect",
+    "trans": [
+      "Day 12 | adj. | English: ina vertical position; to build sth | Example: [1] Mr. French, the senior partner, who sat opposite Kirby, was an older man—a safe guess would have placed him somewhere in the debatable ground between forty and fifty; of a good height, as could be seen even from the seated figure, the upper part of which was held erect with the unconscious ease which one associates with military training. 2] At five-thirty the old Panhandle bridge, supported by massive sandstone pillars, stalwart, as when erected fifty years before to serve a generation now passed behind the portals of life, had become a spectral outline against the sky."
+    ]
+  },
+  {
+    "name": "erode",
+    "trans": [
+      "Day 12 | v. | English: to gradually destroy sth or make it weaker over a period of time | Example: President Richard Nixon is most famous for his participation in the 1970s Watergate political scandal, a convoluted tale of criminality and eroded ethics involving a constellation of associates such as security operative Jack Caulfield and Attorney General John Mitchell."
+    ]
+  },
+  {
+    "name": "erratic",
+    "trans": [
+      "Day 12 | adj. | English: not happening at regular times; not following any plan or regular pattern | Example: Entomologists Yash Sondhi and Samuel Fabian have tried to explain why moths fly erratically around light sources at night."
+    ]
+  },
+  {
+    "name": "erroneous",
+    "trans": [
+      "Day 12 | adj. | English: not correct; based on wrong information | Example: It could thus erroneously shift the focus of conservation efforts away from M. anniana itself."
+    ]
+  },
+  {
+    "name": "eruption",
+    "trans": [
+      "Day 12 | n. | English: an act or instance of erupting Opala in Russia is a caldera, a large cauldron-like hollow that forms shortly after the emptying of a magma chamber in a volcanic eruption."
+    ]
+  },
+  {
+    "name": "essential",
+    "trans": [
+      "Day 12 | adj. | English: completely necessary; extremely important in a particular situation or for a particular activity | Example: This difference is largely because the features that are essential for running on land restrict top speeds more than the features needed for flying through the air."
+    ]
+  },
+  {
+    "name": "established",
+    "trans": [
+      "Day 12 | adj. | English: respected or given official status because it has existed or been used for a long time | Example: While they might be eager to produce an established classic like Annie, for example, most would be hesitant to stage a work from a relatively unknown playwright."
+    ]
+  },
+  {
+    "name": "esteem",
+    "trans": [
+      "Day 12 | n. | English: great respect and admiration; a good opinion of sb | Example: This esteem surely helped him to convince France to assist the United States."
+    ]
+  },
+  {
+    "name": "esteemed",
+    "trans": [
+      "Day 12 | adj. | English: respected and admired | Example: These characteristic works include his esteemed portraits of poet Seamus Heaney and"
+    ]
+  },
+  {
+    "name": "eternity",
+    "trans": [
+      "Day 12 | n. | English: time without end, especially life continuing without end after death | Example: A book printed is a record, remaining in every man’s possession, always ready to renew its acquaintance with his memory, and always ready to be produced as an authority or voucher to any reports he makes out of it, and conveys its contents for ages to come, to the eternity of mortal time, when the author is forgotten in his grave."
+    ]
+  },
+  {
+    "name": "ethereal",
+    "trans": [
+      "Day 12 | adj. | English: extremely delicate and light; seeming to belong to another, more spiritual, world | Example: To conclude that this approach accounts for the ethereal qualities now synonymous with the Highwaymen aesthetic is tempting but inaccurate."
+    ]
+  },
+  {
+    "name": "eventful",
+    "trans": [
+      "Day 12 | adj. | English: full of things that happen, especially exciting, important or dangerous things | Example: Whether the reign of a French monarch such as Louis VII or Henry V was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy."
+    ]
+  },
+  {
+    "name": "evince",
+    "trans": [
+      "Day 12 | v. | English: to show clearly that you have a feeling or quality | Example: Although it seems ridiculous and useless to study old newspaper clippings and candy wrappers, these old newspapers, advertising leaflets, posters, and candy wrappers are actually able to evince the shifts in people’s behavior and values in the past and are therefore very valuable for this study."
+    ]
+  },
+  {
+    "name": "evocative",
+    "trans": [
+      "Day 12 | adj. | English: making you think of or remember a strong image or feeling, in a pleasant way Evocative of African sculpture and American and Scandinavian folk art, these portraits feature flat, deliberately oversimplified figures in a vibrant but limited color palette."
+    ]
+  },
+  {
+    "name": "evoke",
+    "trans": [
+      "Day 12 | v. | English: to bring a feeling, a memory or an image into your mind | Example: Utilizing vivid pastel colors, overexposed tones, and mirrorlike symmetry, Svarbova's photographs evoke a Socialist-era aesthetic that she describes as \"minimalistic but also futuristic.\""
+    ]
+  },
+  {
+    "name": "evolutionary",
+    "trans": [
+      "Day 12 | adj. | English: relating to or denoting the process by which different kinds of living organisms are believed to have developed from earlier forms | Example: Michael G. Campana and colleagues relied on historical DNA (hDNA)—genomic data incidentally preserved in specimens housed in natural history collections—to investigate the evolutionary origins of a fungal pathogen affecting bats."
+    ]
+  },
+  {
+    "name": "exacerbate",
+    "trans": [
+      "Day 12 | v. | English: to make sth worse, especially a disease or problem While some commentators lauded this development, asserting that such blogs had a welcome transparency missing from traditional news, less sanguine observers countered that such blogs tended to ideological extremes that exacerbated political polarization to problematic levels."
+    ]
+  },
+  {
+    "name": "exactitude",
+    "trans": [
+      "Day 12 | n. | English: the quality of being very accurate and exact | Example: Ecologist Exequiel Ezcurra and colleagues found that the inhabitants of the Mexica empire used natural landmarks to track time with a high degree of exactitude."
+    ]
+  },
+  {
+    "name": "exaggerate",
+    "trans": [
+      "Day 12 | v. | English: to make sth seem larger, better, worse or more important than it really is | Example: Clements and colleagues caution that relying on such a relatively small sample size can increase the potential for biased analysis. Such analysis, in turn, can contribute to reports of exaggerated effects."
+    ]
+  },
+  {
+    "name": "exalted",
+    "trans": [
+      "Day 12 | adj. | English: of high rank, position or great importance | Example: It should not be considered essential to the interest and value of biography, that its subject be of exalted rank, or illustrious name."
+    ]
+  },
+  {
+    "name": "excavate",
+    "trans": [
+      "Day 13 | v. | English: to dig in the ground to look for old buildings or objects that have been buried for a long time | Example: Archaeologist Christiana Kohler and her team excavated the Egyptian tomb of Queen Merneith, the wife of a First Dynasty pharaoh."
+    ]
+  },
+  {
+    "name": "exceptional",
+    "trans": [
+      "Day 13 | adj. | English: unusually good The National Heritage Fellowship was created to publicly recognize exceptional folk and traditional artists in the United States."
+    ]
+  },
+  {
+    "name": "excessive",
+    "trans": [
+      "Day 13 | adj. | English: greater than what seems reasonable or appropriate | Example: They complained about the excessive noise coming from the upstairs flat."
+    ]
+  },
+  {
+    "name": "exclude",
+    "trans": [
+      "Day 13 | v. | English: to deliberately not include sth in what you are doing or considering | Example: Fernandez and colleagues excluded all pathways other than the CMN by using barriers to keep the plants’ root systems separate while allowing mycorrhizal strands through—a crucial step Wahbi and colleagues' study did not take."
+    ]
+  },
+  {
+    "name": "exclusive",
+    "trans": [
+      "Day 13 | adj. | English: only to be used by one particular person or group; only given to one particular person or group | Example: But most minor planets are given only an identification number, both because there are over 500,000 such bodies known at present and because any name chosen needs to be exclusive to that body: no two minor planets are allowed to have the same name."
+    ]
+  },
+  {
+    "name": "exclusively",
+    "trans": [
+      "Day 13 | adv. | English: Exclusively is used to refer to situations or activities that involve only the thing or things mentioned, and nothing else. | Example: Today, the mobile application Instagram is thought of exclusively as a photo- and video- sharing program."
+    ]
+  },
+  {
+    "name": "exemplar",
+    "trans": [
+      "Day 13 | n. | English: a person or thing that is a good or typical example of sth | Example: They viewed their new building as an exemplar of taste."
+    ]
+  },
+  {
+    "name": "exemplify",
+    "trans": [
+      "Day 13 | v. | English: exemplify sth to be a typical example of sth; exemplify sth to give an example in order to make sth clearer | Example: Historians argue that Morris's repudiation of industrialization is manifest in the Kelmscott editions' use of handmade materials and intricate ornamentation reminiscent of medieval manuscripts: these meticulously handcrafted elements exemplify the artistry involved."
+    ]
+  },
+  {
+    "name": "exhaustion",
+    "trans": [
+      "Day 13 | n. | English: suffering from physical/mental/nervous exhaustion | Example: In her shopping-cart stroller she exercised to exhaustion, bouncing for hours to develop her leg muscles."
+    ]
+  },
+  {
+    "name": "exhaustive",
+    "trans": [
+      "Day 13 | adj. | English: including everything possible; very thorough or complete | Example: Barring major archaeological discoveries, we are unlikely to ever have an exhaustive account of ancient Egypt under the female pharaoh Hatshepsut, as much of the evidence of her reign was deliberately destroyed by her successors."
+    ]
+  },
+  {
+    "name": "exile",
+    "trans": [
+      "Day 13 | n. | English: the state of being sent to live in another country that is not your own, especially for political reasons or as a punishment | Example: When ye plead for the wrecked and fallen, / The exile from far-distant shores, / Remember that men are still wasting / Life's crimson around your own doors."
+    ]
+  },
+  {
+    "name": "exorbitant",
+    "trans": [
+      "Day 13 | adj. | English: much too high | Example: No amount of justification, however, is likely to persuade some drivers who believe the current toll is exorbitant."
+    ]
+  },
+  {
+    "name": "expectancy",
+    "trans": [
+      "Day 13 | n. | English: the state of expecting or hoping that sth, especially sth good or exciting, will happen | Example: They hypothesized that performance expectancy (how much the use of a service is perceived to benefit the consumer) would be positively correlated with users’ intentions to adopt premium versions."
+    ]
+  },
+  {
+    "name": "expedition",
+    "trans": [
+      "Day 13 | n. | English: an organized journey with a particular purpose, especially to find out about a place that is not well known | Example: Louise Arner Boyd, who led several scientific expeditions off the coast of Greenland in the 1930s, undoubtedly accomplished much, but to gain a lasting place in our historical memory, there is little that can prevail over being the first to do something."
+    ]
+  },
+  {
+    "name": "expenditure",
+    "trans": [
+      "Day 13 | n. | English: the act of spending or using money; an amount of money spent | Example: When constructing his argument regarding the characteristics of a well-functioning government, Aristotle asserts thar 'Transgression creeps in unperceived and at last ruins the state,’ illustrating this idea with a comparison to frequent small expenditures slowly and almost imperceptibly chipping away at a fortune until it is ultimately depleted."
+    ]
+  },
+  {
+    "name": "expense",
+    "trans": [
+      "Day 13 | n. | English: the money that you spend on sth | Example: This is a valuable service since the time and expense necessary to find individual investors might otherwise be prohibitive for these companies."
+    ]
+  },
+  {
+    "name": "expertise",
+    "trans": [
+      "Day 13 | n. | English: expert knowledge or skill in a particular subject, activity or job | Example: Despite the education specialist's hesitancy about her expertise on the subject in general, she found that she could speak authoritatively about the works of author Mildred Pitts Walter, particularly Justin and the Best Biscuits in the World, which she had used effectively in classroom instruction for many years."
+    ]
+  },
+  {
+    "name": "explicable",
+    "trans": [
+      "Day 13 | adj. | English: that can be explained or understood | Example: This discrepancy is explicable in terms of OFT: the monkeys’ greater reliance on vision means that higher lunar intensity benefits them more than it benefits the bats."
+    ]
+  },
+  {
+    "name": "exploit",
+    "trans": [
+      "Day 13 | v. | English: to use sth well in order to gain as much from it as possible | Example: It may seem that the optimal strategy for an animal pursuing prey or escaping predators is to move at maximal speed, but the energy expense of exploiting full speed capacity can disfavor such a strategy even in escape contexts."
+    ]
+  },
+  {
+    "name": "expound",
+    "trans": [
+      "Day 13 | v. | English: to explain sth by talking about it in detail | Example: It provides a general statement about the career of a particular architect, highlights a transition in that career, and then expounds on the ways that transition is evident in the architect's work."
+    ]
+  },
+  {
+    "name": "exquisite",
+    "trans": [
+      "Day 13 | adj. | English: delicate and sensitive | Example: Like this alabaster box whose art / Is frail as a cassia-flower, is my heart, / Carven with delicate dreams and wrought / With many a subtle and exquisite thought."
+    ]
+  },
+  {
+    "name": "extant",
+    "trans": [
+      "Day 13 | adj. | English: still in existence | Example: But Drelichman and Voth's unique contribution is their reconstruction of the earliest extant set of annual fiscal records for any sovereign state, which demonstrate that Philip's defaults were caused by short-term liquidity crises, not long-term unsustainable debts."
+    ]
+  },
+  {
+    "name": "extend",
+    "trans": [
+      "Day 13 | v. | English: to make sth longer or larger The fog extended its tentacles over city and river gradually obliterating traces of familiar landscapes."
+    ]
+  },
+  {
+    "name": "extended",
+    "trans": [
+      "Day 13 | adj. | English: long or longer than usual or expected | Example: It makes an extended comparison of nature to human emotions."
+    ]
+  },
+  {
+    "name": "extension",
+    "trans": [
+      "Day 13 | n. | English: the act of making sth longer or larger; the thing that is made longer and larger | Example: Postcranial skeletal pneumaticity (PSP) refers to the presence of extensions of an animal's lungs and air sacs inside its bones."
+    ]
+  },
+  {
+    "name": "extensive",
+    "trans": [
+      "Day 13 | adj. | English: great in amount | Example: In an extensive review of existing literature, Lena de Framond and team cataloged the prevalence of broken-wing display—a defensive behavior observed in Charadrius semipalmatus (semipalmated plover) and many other species—throughout the Aves class."
+    ]
+  },
+  {
+    "name": "extinguish",
+    "trans": [
+      "Day 13 | v. | English: to make a fire stop burning or a light stop shining | Example: The sun, already down, was manifest in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+    ]
+  },
+  {
+    "name": "extract",
+    "trans": [
+      "Day 13 | v. | English: to remove or obtain a substance from sth, for example by using an industrial or a chemical process | Example: And now, dear reader, a word with you. What is done cannot be undone. We cannot unravel this web of iniquity, and extract justice from this mass of cruel wrongs."
+    ]
+  },
+  {
+    "name": "extraneous",
+    "trans": [
+      "Day 13 | adj. | English: not directly connected with the particular situation you are in or the subject you are dealing with | Example: We do not want any extraneous information on the page."
+    ]
+  },
+  {
+    "name": "extraordinary",
+    "trans": [
+      "Day 13 | adj. | English: not normal or ordinary; greater or better than usual There is no doubt that Irving Langmuir must have proved himself to be extraordinarily adept at understanding some of the most advanced concepts in the field of chemistry"
+    ]
+  },
+  {
+    "name": "extrapolate",
+    "trans": [
+      "Day 13 | v. | English: to estimate sth or form an opinion about sth, using the facts that you have now and that are valid for one situation and supposing that they will be valid for the new one | Example: It is tempting to treat the clustering of information technology firms in Northern California as representative of industrial agglomeration generally, but Guilia Faggio et al. caution against extrapolating from this one example"
+    ]
+  },
+  {
+    "name": "extricate",
+    "trans": [
+      "Day 13 | v. | English: to escape or enable sb to escape from a difficult situation | Example: He had managed to extricate himself from most of his official duties."
+    ]
+  },
+  {
+    "name": "exuberant",
+    "trans": [
+      "Day 13 | adj. | English: full of energy, excitement and happiness | Example: In a 2018 article about films depicting the experiences of Black Americans, critics for the New York Times praise Madeline Anderson's 1970 film | Am Somebody as \"galvanizing\" and Reginald Hudlin's 1990 film House Party as \"exuberant.\""
+    ]
+  },
+  {
+    "name": "fabrication",
+    "trans": [
+      "Day 13 | n. | English: a product of fabrication; especcially LIE, FALSEHOOD | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+    ]
+  },
+  {
+    "name": "facade",
+    "trans": [
+      "Day 13 | n. | English: the front of a building | Example: The sloping tile roofs and picturesque facade of Mission San Luis Rey de Francia in Oceanside, California, exemplify the Spanish contribution to Californian architecture, an influence that is palpable throughout the state"
+    ]
+  },
+  {
+    "name": "facilitate",
+    "trans": [
+      "Day 13 | v. | English: to make an action or a process possible or easier | Example: In their meta-analysis of research on advergames (video games developed to promote products or services), Zeph M.C. van Berlo et al. confirm that such games, though they can elicit player interest, may not facilitate subsequent recall of product and brand information."
+    ]
+  },
+  {
+    "name": "facsimile",
+    "trans": [
+      "Day 13 | n. | English: an exact copy of sth | Example: One no longer widely read edition is the 1984 “critical and synoptic edition\" edited by Hans Walter Gabler, which followed French and German editorial theories rather than editorial traditions of the United States and United Kingdom and which was later found to have introduced errors due to Gabler's choice to consult facsimile manuscripts rather than using only originals."
+    ]
+  },
+  {
+    "name": "fade away",
+    "trans": [
+      "Day 13 | English: to disappear gradually | Example: [The] Mole stood still a moment, held in thought. As one wakened suddenly from a beautiful dream, who struggles to recall it, and can re-capture nothing but a dim sense of the beauty of it, the beauty! Till that, too, fades away in its turn."
+    ]
+  },
+  {
+    "name": "faint",
+    "trans": [
+      "Day 13 | adj. | English: that cannot be clearly seen, heard or smelt | Example: In 2016, Gabriela Gonzalez and team announced that a chirping sound captured by Laser Interferometer Gravitational-Wave Observatory antennas was direct evidence of gravitational waves, which skeptics had argued would be too faint for detection."
+    ]
+  },
+  {
+    "name": "fair",
+    "trans": [
+      "Day 13 | n. | English: a type of entertainment in a field or park at which farm animals and products are shown and take part in competitions Mrs. Tarpey, Bartley, and Mrs. Fallon have been buying and selling goods at the local fair."
+    ]
+  },
+  {
+    "name": "fame",
+    "trans": [
+      "Day 13 | n. | English: the state of being known and talked about by many people | Example: These masterpieces deserve as much fame as Joplin's biggest hits."
+    ]
+  },
+  {
+    "name": "fashion",
+    "trans": [
+      "Day 13 | v. | English: to make or shape sth, especially with your hands But culture indefatigably tries, not to make what each raw person may like, the rule by which he fashions himself."
+    ]
+  },
+  {
+    "name": "fate",
+    "trans": [
+      "Day 13 | n. | English: the power that is believed to control everything that happens and that cannot be stopped or change | Example: I'm as hungry as the winter, I'm ill, I'm shaken... and where haven't | been—fate has tossed me everywhere!"
+    ]
+  },
+  {
+    "name": "fauna",
+    "trans": [
+      "Day 13 | n. | English: all the animals living in an area or in a particular period of history | Example: Some researchers have characterized the flora and fauna of the South Pacific island of Grande Terre as members of clades that inhabited nearby islands before Grande Terre"
+    ]
+  },
+  {
+    "name": "feasible",
+    "trans": [
+      "Day 13 | adj. | English: that is possible and likely to be achieved | Example: Expanding the scope of such studies is unlikely to be feasible."
+    ]
+  },
+  {
+    "name": "feature",
+    "trans": [
+      "Day 13 | v. | English: to include a particular person or thing as a special feature | Example: Propped on the window ledge, it featured a portrait of Great-Great-Grandmother Rosita as a young woman."
+    ]
+  },
+  {
+    "name": "feline",
+    "trans": [
+      "Day 13 | n. | English: acat; an animal of the cat family | Example: Researchers hypothesize that this difference between the two feline species may be partly due to a U-shaped bone in their throats."
+    ]
+  },
+  {
+    "name": "fence",
+    "trans": [
+      "Day 13 | n. | English: a-structure made of wood or wire supported with posts that is put between two areas of land as a boundary , or around a garden yard, field, etc. to keep animals in, or to keep people and animals out | Example: He surveyed the fence, and all gladness left him and a deep melancholy settled down upon his spirit. Thirty yards of board fence nine feet high."
+    ]
+  },
+  {
+    "name": "fern",
+    "trans": [
+      "Day 13 | n. | English: a plant with large delicate leaves and no flowers that grows in wet areas or is grown in a pot. There are many types of fern. | Example: The little fern-leaf, bending / Upon the brink, its green reflection greets, / And kisses soft the shadow that it meets / With touch so fine, / The border line / The keenest vision can't define; / So perfect is the blending."
+    ]
+  },
+  {
+    "name": "fertile",
+    "trans": [
+      "Day 13 | adj. | English: that plants grow well in | Example: Natural humidity, which renders irrigation unnecessary or reduces its importance in the northern reaches of California, gradually decreases toward the sun-scorched but nonetheless fertile valleys of the southern part of the state."
+    ]
+  },
+  {
+    "name": "festoon",
+    "trans": [
+      "Day 14 | n. | English: achain of lights, coloured paper, flowers, etc., used to decorate sth | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+    ]
+  },
+  {
+    "name": "fictionalize",
+    "trans": [
+      "Day 14 | v. | English: to write a book or make a film/movie about a true story, but changing some of the details, characters, etc. | Example: Fitzgerald merely fictionalized true events."
+    ]
+  },
+  {
+    "name": "fictitious",
+    "trans": [
+      "Day 14 | adj. | English: invented by sb rather than true | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+    ]
+  },
+  {
+    "name": "fidelity",
+    "trans": [
+      "Day 14 | n. | English: the quality of being accurate | Example: Historians’ fidelity to the truth often results in work that is less engaging than it could be."
+    ]
+  },
+  {
+    "name": "figurative",
+    "trans": [
+      "Day 14 | adj. | English: used in a way that is different from the usual meaning, in order to create a particular mental picture | Example: They provide examples, one literal and one figurative, of a change that the speaker describes throughout the text."
+    ]
+  },
+  {
+    "name": "figure",
+    "trans": [
+      "Day 14 | n. | English: a person of the type mentioned | Example: It describes a writer's successful career, presents two literary figures who were supporters of that writer's career, and explains why the writer was able to achieve what he did."
+    ]
+  },
+  {
+    "name": "filter",
+    "trans": [
+      "Day 14 | v. | English: v. to pass liquid, light, etc. through a special device, especially to remove sth that is not wanted; n. a device containing paper, sand, chemicals, etc. that a liquid or gas is passed through in order to remove any materials that are not wanted | Example: [1] Like all species of baleen whales, the humpback whale feeds on tiny creatures known as krill by filtering water through bristlelike keratin structures called baleen plates. 2] In one study, Vivek Nityananda and his team fitted mantises' faces with two different color filters, one covering each eye, much like the filters in 3D glasses once worn at movies."
+    ]
+  },
+  {
+    "name": "finite",
+    "trans": [
+      "Day 14 | adj. | English: having a definite limit or fixed size | Example: This phenomenon can be explained by the finite nature of cognitive capacity as it is articulated in Annie Lang's limited capacity model of motivated mediated message processing."
+    ]
+  },
+  {
+    "name": "firm",
+    "trans": [
+      "Day 14 | adj. | English: adj. fairly hard; not easy to press into a different shape; adj. not likely to change | Example: He was daring, without being rash: prompt, but not thoughtless; firm, without being harsh."
+    ]
+  },
+  {
+    "name": "fiscal",
+    "trans": [
+      "Day 14 | adj. | English: connected with government or public money, especially taxes | Example: Although the government regularly defaulted on debt, it ran an even larger overall surplus than did the government of eighteenth-century Britain, which historians consider a model of fiscal virtue."
+    ]
+  },
+  {
+    "name": "fling",
+    "trans": [
+      "Day 14 | v. | English: to throw sb/sth somewhere with force | Example: One popular theory of the origin of the Moon, the \"big whack,\" posits that a protoplanet called Theia collided with Earth, flinging debris into orbit that eventually coalesced into the Moon."
+    ]
+  },
+  {
+    "name": "flora",
+    "trans": [
+      "Day 14 | n. | English: the plants of a particular area, type of environment or period of time | Example: Some researchers have characterized the flora and fauna of the South Pacific island of Grande Terre as members of clades that inhabited nearby islands before Grande Terre"
+    ]
+  },
+  {
+    "name": "flourish",
+    "trans": [
+      "Day 14 | v. | English: to develop quickly and be successful or common | Example: Some historians suggest that Maya mathematicians inherited it from the Olmec civilization, which flourished in the region 2,400-3,600 years ago."
+    ]
+  },
+  {
+    "name": "fluctuation",
+    "trans": [
+      "Day 14 | n. | English: the quality of being unsteady and subject to changes | Example: Having an ample reserve of stored energy can mitigate the effects of fluctuations in solar energy collection caused by unpredictable shifts in cloud cover and haze. flyer on. 1) CO) 8 S232: a small sheet of paper that advertises a product or an event and is given to a large number of people Studying wrappers from discontinued candies, menus from nineteenth-century restaurants, and flyers promoting long-forgotten sporting events may seem like a frivolous pursuit, but ephemeral objects like these are useful as markers of cultural change."
+    ]
+  },
+  {
+    "name": "flyer",
+    "trans": [
+      "Day 14 | n. | English: a small sheet of paper that advertises a product or an event and is given to a large number of people | Example: Studying wrappers from discontinued candies, menus from nineteenth-century restaurants, and flyers promoting long-forgotten sporting events may seem like a frivolous pursuit, but ephemeral objects like these are useful as markers of cultural change."
+    ]
+  },
+  {
+    "name": "folk",
+    "trans": [
+      "Day 14 | n. | English: people in general | Example: The National Heritage Fellowship was created to publicly recognize exceptional folk and"
+    ]
+  },
+  {
+    "name": "folklore",
+    "trans": [
+      "Day 14 | n. | English: the traditions and stories of a country or community | Example: This style has exerted a decisive influence on authors around the world, including Olga Tokarczuk, whose 1996 novel Primeval and Other Times resembles classic magical realist novels in its juxtaposition of literary realism with folklore—namely, that of Poland."
+    ]
+  },
+  {
+    "name": "forage",
+    "trans": [
+      "Day 14 | v. | English: to search for food | Example: The bird species Myiobius barbatus (the bearded flycatcher), which forages in relatively dense vegetation, and Platyrinchus saturatus (the cinnamon-crested spadebill), which forages in open areas or low-density vegetation, share territory in French Guiana with Thainnomanes caesius (the cinereous antshrike), which emits a loud alarm call when it detects predators."
+    ]
+  },
+  {
+    "name": "forecast",
+    "trans": [
+      "Day 14 | n. | English: n.a statement about what will happen in the future, based on information that is available now; v. to say what you think will happen in the future based on information that you have now | Example: [1] Researchers Youran Fu and Marshall Fisher have found that combining sellers' own data with information gathered from social media can dramatically improve the accuracy of such forecasts—by 24 to 57 percent in the cases they directly studied. 2] Businesses selling clothing and other fashion items face obstacles in trying to forecast how much product to order: tastes and styles change quickly, while manufacturing clothing takes a significant amount of time."
+    ]
+  },
+  {
+    "name": "foresight",
+    "trans": [
+      "Day 14 | n. | English: the ability to predict what is likely to happen and to use this to prepare for the future | Example: She had had the foresight to prepare herself financially in case of an accident."
+    ]
+  },
+  {
+    "name": "forestall",
+    "trans": [
+      "Day 14 | v. | English: to prevent sth from happening or sb from doing sth by doing sth first | Example: As having the effect of forestalling consideration of the full stylistic dimensions of poetry written in the period"
+    ]
+  },
+  {
+    "name": "forge",
+    "trans": [
+      "Day 14 | v. | English: to shape metal by heating it in a fire and hitting it with a hammer; to make an object in this way | Example: Poetry can forge connections between people from different cultures."
+    ]
+  },
+  {
+    "name": "fortification",
+    "trans": [
+      "Day 14 | n. | English: a tower, wall, gun position, etc. built to defend a place against attack | Example: | had gazed upon the fortifications and impediments that seemed to keep human beings from entering the citadel of nature, and rashly and ignorantly | had repined."
+    ]
+  },
+  {
+    "name": "fortune",
+    "trans": [
+      "Day 14 | n. | English: a large amount of money | Example: When constructing his argument regarding the characteristics of a well-functioning government, Aristotle asserts thar ‘Transgression creeps in unperceived and at last ruins the state,’ illustrating this idea with a comparison to frequent small expenditures slowly and almost imperceptibly chipping away at a fortune until it is ultimately depleted."
+    ]
+  },
+  {
+    "name": "foster",
+    "trans": [
+      "Day 14 | v. | English: to encourage sth to develop | Example: Ata conference for aspiring children's book authors, Candy Dawson Boyd, author of such lauded works as Circle of Gold, was the subject of a presentation that was intended specifically to foster insight into the techniques of successful authors so that attendees could use that understanding to improve their own work."
+    ]
+  },
+  {
+    "name": "fracture",
+    "trans": [
+      "Day 14 | v. | English: to break or crack; to make sth break or crack | Example: Researchers investigated the timing of the transition from a stagnant lid regime to a tectonic plate regime, in which the lithosphere is fractured into dynamic plates that in turn allow lithospheric and mantle material to mix. fracturing on. why 327%: If something such as a bone is fractured or fractures, it gets a crack or break in it. Many chondrites experience aqueous alteration as a result of exposure to fluids, as well as fracturing, veining, and localized melting due to collisions with other objects."
+    ]
+  },
+  {
+    "name": "fracturing",
+    "trans": [
+      "Day 14 | n. | English: If something such as a bone is fractured or fractures, it gets a crack or break in it. | Example: Many chondrites experience aqueous alteration as a result of exposure to fluids, as well as fracturing, veining, and localized melting due to collisions with other objects."
+    ]
+  },
+  {
+    "name": "fragile",
+    "trans": [
+      "Day 14 | adj. | English: easily broken or damaged | Example: A gleaming carpet was springing up everywhere, that looked too fragile to be trodden upon by rough feet."
+    ]
+  },
+  {
+    "name": "fragment",
+    "trans": [
+      "Day 14 | n. | English: a small part of sth that has broken off or comes from sth larger | Example: The team suggests that scientists have ignored the possibility that something other than a comet fragment could have made the crater."
+    ]
+  },
+  {
+    "name": "fragmentation",
+    "trans": [
+      "Day 14 | n. | English: the process or state of breaking or being broken into small or separate parts | Example: For too long, scholars have focused on narrative fragmentation versus coherence, inhibiting inquiry into other points of stylistic correspondence among works that would enrich our understanding of the modernist canon."
+    ]
+  },
+  {
+    "name": "fragrant",
+    "trans": [
+      "Day 14 | adj. | English: having a pleasant smell | walked slowly beneath the young leaves, drinking in the air, fragrant with the odor of young buds and sap."
+    ]
+  },
+  {
+    "name": "frail",
+    "trans": [
+      "Day 14 | adj. | English: weak; easily damaged or broken | Example: Like this alabaster box whose art / Is frail as a cassia-flower, is my heart, / Carven with delicate dreams and wrought / With many a subtle and exquisite thought."
+    ]
+  },
+  {
+    "name": "fraudulent",
+    "trans": [
+      "Day 14 | adj. | English: intended to cheat sb, usually in order to make money illegally | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few entries that knowledgeable readers should have realized were fraudulent, such as those for the town of Stone Ridge, Maryland, and the 18th-century forestry magnate Guillermo Garcia, persisted on the site for many years before they were finally recognized as falsehoods and deleted."
+    ]
+  },
+  {
+    "name": "frigate",
+    "trans": [
+      "Day 14 | n. | English: a small fast ship in the navy that travels with other ships in order to protect them | Example: There is no Frigate like a Book / To take us Lands away / Nor any Coursers like a Page / Of prancing Poetry— / This Traverse may the poorest take / Without oppress of Toll— / How frugal is the Chariot / That bears the Human soul."
+    ]
+  },
+  {
+    "name": "frivolous",
+    "trans": [
+      "Day 14 | adj. | English: silly or amusing, especially when such behaviour is not suitable | Example: Studying wrappers from discontinued candies, menus from nineteenth-century restaurants, and flyers promoting long-forgotten sporting events may seem like a frivolous pursuit, but ephemeral objects like these are useful as markers of cultural change."
+    ]
+  },
+  {
+    "name": "frugal",
+    "trans": [
+      "Day 14 | adj. | English: using only as much money or food as is necessary | Example: There is no Frigate like a Book / To take us Lands away / Nor any Coursers like a Page / Of prancing Poetry— / This Traverse may the poorest take / Without oppress of Toll— / How frugal is the Chariot / That bears the Human soul."
+    ]
+  },
+  {
+    "name": "fry",
+    "trans": [
+      "Day 14 | v. | English: to cook sth in hot fat or oil; to be cooked in hot fat or oil | Example: Many Indian snack foods, such as bhatoora and paneer pakora, acquire their flavor from being fried in oil."
+    ]
+  },
+  {
+    "name": "fully-fledged",
+    "trans": [
+      "Day 14 | adj. | English: Fully-fledged means complete or fully developed. | Example: Smith deploys this metaphor only once in his economic writings—to make a narrow point about the then-dominant economic theory of mercantilism—and it was largely ignored until some twentieth-century economists eager to secure an intellectual pedigree for their views elevated it to a fully-fledged paradigm."
+    ]
+  },
+  {
+    "name": "fume",
+    "trans": [
+      "Day 14 | n. | English: Fumes are the unpleasant and often unhealthy smoke and gases that are produced by fires or by things such as chemicals, fuel, or cooking. | Example: | think Québec City needs more streets like Rue du Petit-Champlain, not more streets full of loud cars spewing exhaust fumes into the air."
+    ]
+  },
+  {
+    "name": "funeral",
+    "trans": [
+      "Day 14 | n. | English: a ceremony, usually a religious one, for burying or cremating | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+    ]
+  },
+  {
+    "name": "fungal",
+    "trans": [
+      "Day 14 | adj. | English: of or caused by fungus | Example: Is there an available barrier material that can block roots and liquids while allowing fungal strands through?"
+    ]
+  },
+  {
+    "name": "fungi",
+    "trans": [
+      "Day 14 | n. | English: any plant without leaves, flowers or green colouring, usually growing on other plants or on decaying matter. Mushrooms and mildew are both fungi. | Example: The researchers studied two wooden shipwrecks in the Gulf of Mexico by placing pieces of pine and oak between zero and 200 meters away from each shipwreck to collect samples of three kinds of microbes: bacteria, archaea, and fungi."
+    ]
+  },
+  {
+    "name": "furrow",
+    "trans": [
+      "Day 14 | n. | English: a long narrow cut in the ground, especially one made by a plough for planting seeds in | Example: As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot."
+    ]
+  },
+  {
+    "name": "fuse",
+    "trans": [
+      "Day 14 | v. | English: when one thing fuses with another, or two things fuse or are fused , they are joined together to form a single thing Schiller thought works could be classified as either naive (seeking to describe reality) or sentimental (seeking to develop ideas), Little, Big fuses both modes of writing."
+    ]
+  },
+  {
+    "name": "fusion",
+    "trans": [
+      "Day 14 | n. | English: the process or result of joining two or more things together to form one | Example: Mosques often reflect multiple architectural styles, resulting in a unique fusion of those influences, as in the case of the Sheikh Zayed Mosque, which combines elements from the Persian, Mughal, and Moorish styles."
+    ]
+  },
+  {
+    "name": "futile",
+    "trans": [
+      "Day 14 | adj. | English: having no purpose because there is no chance of success | Example: Professor Serebrakoff says to Helena, “I am used to my library and the lecture hall and to the esteem and admiration of my colleagues. Now | suddenly find myself plunged into this wilderness (the cottage), condemned to see the same stupid people from morning till night and listen to their futile conversations.”"
+    ]
+  },
+  {
+    "name": "gadget",
+    "trans": [
+      "Day 14 | n. | English: a small tool or device that does sth useful | Example: Environmental policy researcher Jessika Richter warns that because new batteries can't be put in once the old ones no longer work, the gadgets stop functioning and are usually disposed of as trash."
+    ]
+  },
+  {
+    "name": "galactic",
+    "trans": [
+      "Day 14 | adj. | English: relating to a galaxy | Example: Using the Stratospheric Observatory for Infrared Astronomy (SOFIA), a team of astronomers mapped out the magnetic field of G47, one of the Milky Way's galactic bones (dense clouds of gas and dust that run through the middle of the arm of a spiral galaxy)."
+    ]
+  },
+  {
+    "name": "gallop",
+    "trans": [
+      "Day 14 | n. | English: the fastest speed at which a horse can run, with a stage in which all four feet are off the ground together | Example: They spurred their horses to a gallop as if in that mad race they laid claims of possession to the earth."
+    ]
+  },
+  {
+    "name": "galvanize",
+    "trans": [
+      "Day 14 | v. | English: to make sb take action by shocking them or by making them excited | Example: In a 2018 article about films depicting the experiences of Black Americans, critics for the New York Times praise Madeline Anderson's 1970 film | Am Somebody as \"galvanizing\" and Reginald Hudlin's 1990 film House Party as \"exuberant.\""
+    ]
+  },
+  {
+    "name": "gasp",
+    "trans": [
+      "Day 15 | n. | English: a quick deep breath, usually caused by a strong emotion | Example: The [train] engines of this valley have a whistle, the echoes of which sound like iterated gasps and sobs. | always think of them as crude music."
+    ]
+  },
+  {
+    "name": "gathering",
+    "trans": [
+      "Day 15 | adj. | English: adj. If there is gathering darkness, the light is gradually decreasing, usually because it is nearly night. n. a meeting of people for a particular purpose | Example: [1] Guiding himself by the sound, he made his way through the gathering darkness to the foot of an old beech tree. 2] The text makes which point about the people at the gathering?"
+    ]
+  },
+  {
+    "name": "gaudy",
+    "trans": [
+      "Day 15 | adj. | English: too brightly coloured in a way that lacks taste | Example: But there were vacant seats here and there, and into one of them she was ushered, between brilliantly dressed women who had gone there to kill time and eat candy and display their gaudy attire."
+    ]
+  },
+  {
+    "name": "gaze",
+    "trans": [
+      "Day 15 | v. | English: to look steadily at sb/sth for a long time, either because you are very interested or surprised, or because you are thinking of sth else | Example: | had gazed upon the fortifications and impediments that seemed to keep human beings from entering the citadel of nature, and rashly and ignorantly | had repined."
+    ]
+  },
+  {
+    "name": "gender",
+    "trans": [
+      "Day 15 | n. | English: the fact of being male or female | Example: In fact the work is a complex, dynamic meditation on gender and the legacy of colonialism that demands serious attention."
+    ]
+  },
+  {
+    "name": "generic",
+    "trans": [
+      "Day 15 | adj. | English: shared by, including or typical of a whole group of things; not specific | Example: If \"Kleenex\" were judged to have become a generic term, as \"cellophane\" was, other companies would be free to use it to promote similar products, making it harder for Kimberly- Clark to stand out from competitors."
+    ]
+  },
+  {
+    "name": "generous",
+    "trans": [
+      "Day 15 | adj. | English: giving or willing to give freely; given freely | Example: It was generous of him to offer to pay for us both."
+    ]
+  },
+  {
+    "name": "genome",
+    "trans": [
+      "Day 15 | n. | English: the complete set of genes in a cell or living thing | Example: Instead, success in fields like chemistry is usually achieved through direct cooperation with other experts, as was the case for Jennifer Doudna, who was among those awarded for “the development of a method for genome editing.”"
+    ]
+  },
+  {
+    "name": "gentility",
+    "trans": [
+      "Day 15 | n. | English: very good manners and behaviour; the fact of belonging to a high social class | Example: Newland Archer felt himself distinctly the superior of these chosen specimens of old New York gentility; he had probably read more, thought more, and even seen a good deal more of the world, than any other man of the number."
+    ]
+  },
+  {
+    "name": "genuine",
+    "trans": [
+      "Day 15 | adj. | English: sincere and honest; that can be trusted | Example: \"Reading [poetry], however, with a perfect contempt for it, one discovers that there is in / it after all, a place for the genuine.\""
+    ]
+  },
+  {
+    "name": "genus",
+    "trans": [
+      "Day 15 | n. | English: a group into which animals, plants, etc. that have similar characteristics are divided, smaller than a family and larger than a species | Example: The discoverers of the minor planet 1227 Geranium named it after the plant genus that includes cranesbills."
+    ]
+  },
+  {
+    "name": "geography",
+    "trans": [
+      "Day 15 | n. | English: the way in which the physical features of a place are arranged The Nile River delta system is located in Northern Egypt, where the river drains into the for example, the geography of the coastline influences sedimentary deposition, which over time alters coastal geography."
+    ]
+  },
+  {
+    "name": "geometric",
+    "trans": [
+      "Day 15 | adj. | English: of geometry ; of or like the lines, shapes, etc. used in geometry , especially because of having regular shapes or lines | Example: The project's unadorned geometric forms, typical of the modernist aesthetic, contrasted with the historically inspired architecture seen in his earlier projects in Guadalajara, such as the"
+    ]
+  },
+  {
+    "name": "germinate",
+    "trans": [
+      "Day 15 | v. | English: when the seed of a plant germinates or is germinated , it starts to grow | Example: Can field mustard plants grow on Mars? Can pea plants? You might think the answer to these questions is obviously no, but researchers in the Netherlands recently showed that the seeds of many common plant species can germinate in soil designed to simulate Martian conditions, as long as water is supplied."
+    ]
+  },
+  {
+    "name": "giggle",
+    "trans": [
+      "Day 15 | v. | English: to laugh in a silly way because you are amused, embarrassed or nervous | Example: They usually spent the entire day in the attic, playing dolls and giggling."
+    ]
+  },
+  {
+    "name": "gimmick",
+    "trans": [
+      "Day 15 | n. | English: an unusual trick or unnecessary device that is intended to attract attention or to persuade people to buy sth | Example: Today, the Michelin Guide is widely known as the arbiter of fine dining, but when it was created in 1900, it was little more than a marketing gimmick."
+    ]
+  },
+  {
+    "name": "give free rein to",
+    "trans": [
+      "Day 15 | English: to give sb complete freedom of action; to allow a feeling to be expressed freely | Example: Padre Florentino, who was an accomplished musician, was improvising, and, as he was alone, gave free rein to the sadness in his heart."
+    ]
+  },
+  {
+    "name": "gleaming",
+    "trans": [
+      "Day 15 | adj. | English: shining brightly | Example: A gleaming carpet was springing up everywhere."
+    ]
+  },
+  {
+    "name": "glide",
+    "trans": [
+      "Day 15 | v. | English: to move smoothly and quietly, especially as though it takes no effort | Example: Thy warm and land-locked waters swell with an easy motion, / And gently glides the light"
+    ]
+  },
+  {
+    "name": "grasp",
+    "trans": [
+      "Day 15 | v. | English: to understand sth completely | Example: One person after another rose, and, as with an ill-balanced axe, attempted to hew out his conception of art a little more clearly, and sat down with the feeling that, for some reason which he could not grasp, his strokes had gone awry."
+    ]
+  },
+  {
+    "name": "gratification",
+    "trans": [
+      "Day 15 | n. | English: the state of feeling pleasure when sth goes well for you or when your desires are satisfied; sth that gives you pleasure | Example: Cuttlefish appear to be surprisingly competent at exercising self-control: in a 2021 study conducted by behavioral ecologist Alexandra Schnell, these cephalopods routinely demonstrated restraint by delaying gratification, waiting for a favorite treat instead of instantly devouring a readily available meal."
+    ]
+  },
+  {
+    "name": "grave",
+    "trans": [
+      "Day 15 | v. | English: n.a place in the ground where a dead person is buried; adj. serious in manner, as if sth sad, important or worrying has just happened | Example: [1] A book printed is a record, remaining in every man’s possession, always ready to renew its acquaintance with his memory, and always ready to be produced as an authority or voucher to any reports he makes out of it, and conveys its contents for ages to come, to the eternity of mortal time, when the author is forgotten in his grave. 2] The sonorous, joyful bells rang again. From within the church, the honeyed voices of a female chorus rose melancholy and grave."
+    ]
+  },
+  {
+    "name": "gravely",
+    "trans": [
+      "Day 15 | adv. | English: toa degree that gives cause for alarm | Example: Before Juchipila was lost from sight, Valderrama got off his horse, bent down, kneeled, and gravely kissed the ground."
+    ]
+  },
+  {
+    "name": "gravitas",
+    "trans": [
+      "Day 15 | n. | English: the quality of being serious | Example: Finally, and adding much-needed gravitas, was Sir Winston Day, whose features seemed moulded to adorn a bust, or possibly a stamp, and whose forehead was so evidently bulging with grey matter that it would have been impertinent to inquire too closely into the actual achievements his half century of public service had produced."
+    ]
+  },
+  {
+    "name": "gravitational wave",
+    "trans": [
+      "Day 15 | n. | English: a wave propagated in a gravitational field, predicted to occur as a result of an accelerating mass | Example: In 2016, Gabriela Gonzalez and team announced that a chirping sound captured by Laser Interferometer Gravitational-Wave Observatory antennas was direct evidence of gravitational waves."
+    ]
+  },
+  {
+    "name": "grid",
+    "trans": [
+      "Day 15 | n. | English: a pattern of straight lines, usually crossing each other to form squares | Example: Hydrologist Yonghong Yi and her colleagues modeled seasonal changes in net CO2 in Alaska in a landscape grid of 1 square kilometer (km2) cells and again in a grid of 10 km2 cells, which are finer resolutions than most models of net CO2 have achieved."
+    ]
+  },
+  {
+    "name": "grief",
+    "trans": [
+      "Day 15 | n. | English: a feeling of great sadness, especially when sb dies | Example: Mercedes, being not quite seventeen, her grief at parting from Clarence was wild, vehement and all-absorbing."
+    ]
+  },
+  {
+    "name": "groan",
+    "trans": [
+      "Day 15 | v. | English: to make a long deep sound because you are annoyed, upset or in pain, or with pleasure | Example: [The wagon] bumps, and groans, and shakes as it crosses the railroad track."
+    ]
+  },
+  {
+    "name": "grooved",
+    "trans": [
+      "Day 15 | adj. | English: having a groove or several grooves | Example: Researchers have long hypothesized that woolly mammoths were hunted to extinction in North America by humans using spears with grooved tips known as Clovis points."
+    ]
+  },
+  {
+    "name": "grossly",
+    "trans": [
+      "Day 15 | adv. | English: extremely | Example: MOMA claims the video presentations are only for games that would be impractical to display in a playable form, but video games are an inherently interactive medium, a feature that is grossly absent in a video-only presentation."
+    ]
+  },
+  {
+    "name": "growl",
+    "trans": [
+      "Day 15 | v. | English: to say sth in a low angry voice | Example: Itis your duty to make peace [with Professor Serebrakoff], and not to growl at everything."
+    ]
+  },
+  {
+    "name": "grudging",
+    "trans": [
+      "Day 15 | adj. | English: given or done unwillingly | Example: He could not help feeling a grudging admiration for the old lady."
+    ]
+  },
+  {
+    "name": "hallmark",
+    "trans": [
+      "Day 15 | n. | English: a feature or quality that is typical of sb/sth | Example: Certain features are almost always included in the designs of mosques, like the minaret (or tower), which is considered to be a hallmark of mosques architecture."
+    ]
+  },
+  {
+    "name": "halt",
+    "trans": [
+      "Day 15 | v. | English: to stop; to make sb/sth stop | Example: Then, hurriedly, [the soldiers] took the Juchipila canyon northward, without halting to rest until nightfall."
+    ]
+  },
+  {
+    "name": "haphazard",
+    "trans": [
+      "Day 15 | adj. | English: not organized well | Example: Set in a world where science fiction tropes exist as everyday realities, Charles Yu’s 2010 novel How to Live Safely in a Science Fictional Universe traces a time traveler’s quest to find his father. Because the journey at the novel’s center is so haphazard, with the protagonist ricocheting chaotically across time, the reader often wonders whether the pair will ever be reunited."
+    ]
+  },
+  {
+    "name": "harbinger",
+    "trans": [
+      "Day 15 | n. | English: asign that shows that sth is going to happen soon, often sth bad | Example: The November air stung my cheeks, a harbinger of winter."
+    ]
+  },
+  {
+    "name": "harsh",
+    "trans": [
+      "Day 15 | adj. | English: cruel, severe and unkind | Example: He was daring, without being rash: prompt, but not thoughtless; firm, without being harsh."
+    ]
+  },
+  {
+    "name": "hasty",
+    "trans": [
+      "Day 15 | adj. | English: said, made or done very quickly, especially when this has bad results | Example: She did not wish to act hastily, to do anything she might afterward regret."
+    ]
+  },
+  {
+    "name": "hatchling",
+    "trans": [
+      "Day 15 | n. | English: a baby bird or animal which has just come out of its shell Based on observations made over three years, scientists concluded that temperatures at the site likely confer reproductive benefits and that the site is used exclusively for reproduction—6,000 M.robustus adults, hatchlings, and eggs were observed at the garden, but no juveniles were present."
+    ]
+  },
+  {
+    "name": "haunt",
+    "trans": [
+      "Day 15 | v. | English: to continue to cause problems for sb for a long time | Example: How [the sailor] haunted my dreams, | need scarcely tell you. On stormy nights, when the wind shook the four corners of the house and the surf roared along the cove and up the cliffs, | would see him in a thousand forms, and with a thousand diabolical expressions."
+    ]
+  },
+  {
+    "name": "haunted",
+    "trans": [
+      "Day 15 | adj. | English: believed to be visited by ghosts | Example: He'd be a hero among his friends if he was the first boy to cross the haunted gates!"
+    ]
+  },
+  {
+    "name": "havoc",
+    "trans": [
+      "Day 15 | n. | English: a situation in which there is a lot of damage, destruction or confusion | Example: On March 23, 2021, a gust of wind wreaked havoc on global trade."
+    ]
+  },
+  {
+    "name": "haze",
+    "trans": [
+      "Day 15 | n. | English: air that is difficult to see through because it contains very small drops of water, especially caused by hot weather | Example: Having an ample reserve of stored energy can mitigate the effects of fluctuations in solar energy collection caused by unpredictable shifts in cloud cover and haze."
+    ]
+  },
+  {
+    "name": "heritage",
+    "trans": [
+      "Day 15 | n. | English: the history, traditions and qualities that a country or society has had for many years and that are considered an important part of its character | Example: It summarizes the career of a particular architect, states how that architect's heritage influenced his career choice, and then emphasizes the impact of that architect's career."
+    ]
+  },
+  {
+    "name": "hesitancy",
+    "trans": [
+      "Day 15 | n. | English: the state or quality of being slow or uncertain in doing or saying sth Despite the education specialist's hesitancy about her expertise on the subject in general, she found that she could speak authoritatively about the works of author Mildred Pitts Walter, particularly Justin and the Best Biscuits in the World, which she had used effectively in classroom instruction for many years."
+    ]
+  },
+  {
+    "name": "hesitant",
+    "trans": [
+      "Day 15 | adj. | English: slow to speak or act because you feel uncertain, embarrassed or unwilling | Example: So while they might be eager to produce an established classic like Annie, for example, most would be hesitant to stage a work from a relatively unknown playwright."
+    ]
+  },
+  {
+    "name": "heterogeneous",
+    "trans": [
+      "Day 15 | adj. | English: consisting of many different kinds of people or things | Example: Although Hawaiian literature is highly heterogeneous in many ways, it is also characterized by considerable thematic continuity."
+    ]
+  },
+  {
+    "name": "hew",
+    "trans": [
+      "Day 15 | v. | English: to make or shape sth large by cutting One person after another rose, and, as with an ill-balanced axe, attempted to hew out his conception of art a little more clearly, and sat down with the feeling that, for some reason which he could not grasp, his strokes had gone awry."
+    ]
+  },
+  {
+    "name": "hideous",
+    "trans": [
+      "Day 15 | adj. | English: very ugly or unpleasant | Example: The whole experience had been like some hideous nightmare."
+    ]
+  },
+  {
+    "name": "hitherto",
+    "trans": [
+      "Day 15 | adv. | English: until now; until the particular time you are talking about | Example: The vast majority of invertebrate species found in a recent survey of the CCZ were hitherto unknown to scientists."
+    ]
+  },
+  {
+    "name": "hive",
+    "trans": [
+      "Day 16 | n. | English: a structure made for bees to live in | Example: Honeybee hives consist mainly of hexagonal (six-sided) units called cells, in which queens lay eggs."
+    ]
+  },
+  {
+    "name": "hoard",
+    "trans": [
+      "Day 16 | n. | English: acollection of money, food, valuable objects, etc., especially one that sb keeps in a secret place so that other people will not find or steal it | Example: And although the period is known as the Bronze Age, some hoards, like the Fittleworth hoard, contained decorative objects made of gold."
+    ]
+  },
+  {
+    "name": "hoax",
+    "trans": [
+      "Day 16 | n. | English: an act intended to make sb believe sth that is not true, especially sth unpleasant | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+    ]
+  },
+  {
+    "name": "hollow",
+    "trans": [
+      "Day 16 | adj. | English: having a hole or empty space inside | Example: Holes, hollows, pools, pitfalls, and other menaces to the wayfarer were vanishing fast."
+    ]
+  },
+  {
+    "name": "hominid",
+    "trans": [
+      "Day 16 | n. | English: a human, or a creature that lived in the past which humans developed from | Example: The fossil remains of the individual known as KNM-KP 271, discovered in Kenya in 1965, can help paleoanthropologists not only identify steps in the evolution of hominids but also illuminate the Pliocene epoch generally, revealing important details about the time in which KNM-KP 271 lived."
+    ]
+  },
+  {
+    "name": "homogeneity",
+    "trans": [
+      "Day 16 | n. | English: the quality of being homogeneous | Example: The results showed that the genetic homogeneity of M. anniana decreased over time."
+    ]
+  },
+  {
+    "name": "homogeneous",
+    "trans": [
+      "Day 16 | adj. | English: consisting of things or people that are all the same or all of the same type | Example: Previous research has shown that plant species with a narrow geographical range tend to be more genetically homogeneous than plant species with extensive ranges are."
+    ]
+  },
+  {
+    "name": "horizontal",
+    "trans": [
+      "Day 16 | adj. | English: Horizontal gene transfer involves the exchange of genetic material between organisms not in a parent-offspring relationship."
+    ]
+  },
+  {
+    "name": "horrid",
+    "trans": [
+      "Day 16 | adj. | English: very unpleasant or unkind | Example: I'm really getting quite fond of the big room, all but that horrid [wall] paper."
+    ]
+  },
+  {
+    "name": "hull",
+    "trans": [
+      "Day 16 | n. | English: the main, bottom part of a ship, that goes in the wate | Example: Marine archaeologists have found much of the wooden hull of a sixteenth-century ship in a flooded quarry in southeast England. humanoid on. (AHBA; BAR 3230: a machine or creature that looks and behaves like a human Some robots such as Salvius (developed in 2008) and REEM-C (developed in 2013) feature humanoid characteristics like bipedal locomotion so that people will find it easier to interact with them."
+    ]
+  },
+  {
+    "name": "humanoid",
+    "trans": [
+      "Day 16 | n. | English: a machine or creature that looks and behaves like a human | Example: Some robots such as Salvius (developed in 2008) and REEM-C (developed in 2013) feature humanoid characteristics like bipedal locomotion so that people will find it easier to interact with them."
+    ]
+  },
+  {
+    "name": "humid",
+    "trans": [
+      "Day 16 | adj. | English: warm and damp Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow's o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+    ]
+  },
+  {
+    "name": "hushed",
+    "trans": [
+      "Day 16 | adj. | English: quiet because nobody is talking; much quieter than usual | Example: Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow's o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+    ]
+  },
+  {
+    "name": "husk",
+    "trans": [
+      "Day 16 | n. | English: the dry outer covering of nuts, fruits and seeds, especially of grain | Example: All these things awoke in [Don Custodio] the farther he got from Europe, like the life-giving sap within the sown seed prevented from bursting out by the thick husk."
+    ]
+  },
+  {
+    "name": "hydraulic",
+    "trans": [
+      "Day 16 | adj. | English: connected with hydraulic systems | Example: The irrigation system developed by the Hohokam people in the 7th century CE in what is now known as central Arizona was simple but applied hydraulic engineering design features that are still used today."
+    ]
+  },
+  {
+    "name": "hyphae",
+    "trans": [
+      "Day 16 | n. | English: any of the filaments that constitute the body (mycelium) of a fungus | Example: Effects of this thermoregulation were not limited to the fungi's fruiting bodies and root-like hyphae: temperature reductions were observed in the air immediately surrounding the mushrooms."
+    ]
+  },
+  {
+    "name": "identical",
+    "trans": [
+      "Day 16 | adj. | English: similar in every detail | Example: The many editions of James Joyce's 1922 novel Ulysses are not textually identical, and scholars debate which versions reflect Joyce's authorial intent."
+    ]
+  },
+  {
+    "name": "identify",
+    "trans": [
+      "Day 16 | v. | English: to recognize sb/sth and be able to say who or what they are | Example: Since molecular analysis does not require distinguishing subtle physiological differences, it is more likely to properly distinguish between morphologically similar but distinct invertebrate species than is the method used to identify Prionospio branchilucida."
+    ]
+  },
+  {
+    "name": "ideological",
+    "trans": [
+      "Day 16 | adj. | English: Ideological means relating to principles or beliefs. | Example: Political blogs with conspicuous ideological alignments became an integral component of US media in the early 2000s."
+    ]
+  },
+  {
+    "name": "idiosyncratic",
+    "trans": [
+      "Day 16 | adj. | English: somewhat unusual. | Example: She still appeared to be an idiosyncratic figure."
+    ]
+  },
+  {
+    "name": "ignorantly",
+    "trans": [
+      "Day 16 | adj. | English: lacking knowledge or information about sth; not educated | Example: | had gazed upon the fortifications and impediments that seemed to keep human beings from entering the citadel of nature, and rashly and ignorantly | had repined."
+    ]
+  },
+  {
+    "name": "illusory",
+    "trans": [
+      "Day 16 | adj. | English: not real, although seeming to be | Example: First impressions can often prove illusory."
+    ]
+  },
+  {
+    "name": "illustration",
+    "trans": [
+      "Day 16 | n. | English: a drawing or picture in a book, magazine, etc. especially one that explains sth | Example: Whether Carmen Lomas Garza is creating small paintings and illustrations or large public artworks—such as Baile, a copper cutout of traditional Mexican dance in the San Francisco International Airport—she is inspired by direct experience, drawing from memories of her childhood in Texas or details of her current surroundings in California."
+    ]
+  },
+  {
+    "name": "imitator",
+    "trans": [
+      "Day 16 | n. | English: a person or thing that copies sb/sth else | Example: The band's success has inspired hundreds of would-be imitators."
+    ]
+  },
+  {
+    "name": "immense",
+    "trans": [
+      "Day 16 | adj. | English: extremely large or great | Example: Much like the continents themselves, the variety of native languages in the Americas is immense."
+    ]
+  },
+  {
+    "name": "immensity",
+    "trans": [
+      "Day 16 | n. | English: the large size of sth | Example: The men threw out their chests as if to breathe the widening horizon, the immensity of the sky, the blue from the mountains and the fresh air, redolent with the various odors of the sierra."
+    ]
+  },
+  {
+    "name": "immerse",
+    "trans": [
+      "Day 16 | v. | English: to become or make sb completely involved in sth | Example: After traveling to the United States and Europe in the early 1930s and immersing himself in a broader architectural discourse, Barragan shifted his style to incorporate principles of modernism, as seen in the Ortega House."
+    ]
+  },
+  {
+    "name": "immortal",
+    "trans": [
+      "Day 16 | adj. | English: that lives or lasts for ever | Example: The most learned philosopher knew little more. He had partially unveiled the face of Nature, but her immortal lineaments were still a wonder and a mystery."
+    ]
+  },
+  {
+    "name": "immutable",
+    "trans": [
+      "Day 16 | adj. | English: that cannot be changed; that will never change | Example: Willpower isn't some immutable trait we're either born with or not."
+    ]
+  },
+  {
+    "name": "impact",
+    "trans": [
+      "Day 16 | n. | English: the act of one object hitting another; the force with which this happens | Example: And as Jane X. Luu et al. point out, the singular nature of impact ejection makes it untenable as an account of multiple loss episodes of similar duration over several years."
+    ]
+  },
+  {
+    "name": "impart",
+    "trans": [
+      "Day 16 | v. | English: to give a particular quality to sth; | Example: To convey the speaker's longing for the ocean to impart a sense of inner tranquility"
+    ]
+  },
+  {
+    "name": "impartial",
+    "trans": [
+      "Day 16 | adj. | English: not supporting one person or group more than another | Example: Culture's duty is to impartially determine which ideas are most useful to a society."
+    ]
+  },
+  {
+    "name": "impede",
+    "trans": [
+      "Day 16 | v. | English: to delay or stop the progress of sth | Example: The morphological novelty of echinoderms marine—invertebrates with radial symmetry, usually starlike, around a central point—impedes comparisons with most other animals."
+    ]
+  },
+  {
+    "name": "impediment",
+    "trans": [
+      "Day 16 | n. | English: something that delays or stops the progress of sth | Example: I had gazed upon the fortifcations and impediments that seemed to keep human beings from entering the citadel of nature, and rashly and ignorantly | had repined."
+    ]
+  },
+  {
+    "name": "imperative",
+    "trans": [
+      "Day 16 | adj. | English: (formal) very important and needing immediate attention or action; | Example: Itis absolutely imperative that we finish by next week."
+    ]
+  },
+  {
+    "name": "imperceptible",
+    "trans": [
+      "Day 16 | adj. | English: very small and therefore unable to be seen | Example: When constructing his argument regarding the characteristics of a well-functioning government, Aristotle asserts thar 'Transgression creeps in unperceived and at last ruins the state,’ illustrating this idea with a comparison to frequent small expenditures slowly and almost imperceptibly chipping away at a fortune until it is ultimately depleted."
+    ]
+  },
+  {
+    "name": "impertinent",
+    "trans": [
+      "Day 16 | adj. | English: rude and not showing respect for sb who is older or more important | Example: Finally, and adding much-needed gravitas, was Sir Winston Day, whose features seemed moulded to adorn a bust, or possibly a stamp, and whose forehead was so evidently bulging with grey matter that it would have been impertinent to inquire too closely into the actual achievements his half century of public service had produced."
+    ]
+  },
+  {
+    "name": "impervious",
+    "trans": [
+      "Day 16 | adj. | English: not allowing a liquid or gas to pass through | Example: A barrier that is impervious to both roots and fungal strands is necessary to evaluate nutrient transfer via a CMN."
+    ]
+  },
+  {
+    "name": "implausible",
+    "trans": [
+      "Day 16 | adj. | English: not seeming reasonable or likely to be true | Example: These early quasars developed partly as a result of rare convergences of gases in space without the need for ultraviolet backgrounds or other extreme and implausible environmental conditions."
+    ]
+  },
+  {
+    "name": "implement",
+    "trans": [
+      "Day 16 | v. | English: to make sth that has been officially decided start to happen or be used | Example: Kwaxsistalla WathI'thla, a song keeper for the Kwakwaka'wakw people in Canada, collaborated with ethnobiologist Dana Lepofsky et al., sharing songs referencing terraced intertidal clam gardens the people implemented in the past to foster healthy development of a dietary staple."
+    ]
+  },
+  {
+    "name": "implication",
+    "trans": [
+      "Day 16 | n. | English: a possible effect or result of an action or a decision | Example: It likely has broad implications for other species of fish besides Sparus aurata."
+    ]
+  },
+  {
+    "name": "implicit",
+    "trans": [
+      "Day 16 | adj. | English: suggested without being directly expressed | Example: Fernand Braudel and other historians of capitalism rarely discuss domestic capitalism in Africa before the period of European colonization, implicitly presenting capitalism as external to and imposed on Africa."
+    ]
+  },
+  {
+    "name": "impose on",
+    "trans": [
+      "Day 16 | English: to force sb/sth to have to deal with sth that is difficult or unpleasant | Example: Fernand Braudel and other historians of capitalism rarely discuss domestic capitalism in Africa before the period of European colonization, implicitly presenting capitalism as external to and imposed on Africa."
+    ]
+  },
+  {
+    "name": "imposing",
+    "trans": [
+      "Day 16 | adj. | English: impressive to look at | Example: The Istiqlal Mosque in Jakarta, Indonesia, is a massive mosque that can accommodate approximately 200,000 people at once, making it an imposing sight to behold."
+    ]
+  },
+  {
+    "name": "impracticable",
+    "trans": [
+      "Day 16 | adj. | English: impossible or very difficult to do; not practical in a particular situation | Example: Socrates, a sophist, says to a new customer \"I have not seen any man so boorish, nor so impracticable, nor so stupid, nor so forgetful; who, while learning some little petty quibbles, forgets them before he has learned them.”"
+    ]
+  },
+  {
+    "name": "impractical",
+    "trans": [
+      "Day 16 | adj. | English: not sensible or realistic | Example: Because any name given to a minor planet needs to be unique to that body, naming each would be impractical."
+    ]
+  },
+  {
+    "name": "impress",
+    "trans": [
+      "Day 16 | v. | English: if a person or thing impresses you, you feel admiration for them or it | Example: Each is contemptuous of the other attendees but strives to impress them."
+    ]
+  },
+  {
+    "name": "impression",
+    "trans": [
+      "Day 16 | n. | English: an idea, a feeling or an opinion that you get about sb/sth, or that sb/sth gives you | Example: The speaker lists various impressions people might have of her and then explains why they don't matter to her."
+    ]
+  },
+  {
+    "name": "improvise",
+    "trans": [
+      "Day 16 | v. | English: to invent music, the words in a play, a statement, etc. while you are playing or speaking, instead of planning it in advance Padre Florentino, who was an accomplished musician, was improvising, and, as he was alone, gave free rein to the sadness in his heart."
+    ]
+  },
+  {
+    "name": "impurity",
+    "trans": [
+      "Day 16 | n. | English: a substance that is present in small amounts in another substance, making it dirty or of poor quality | Example: Every few days, Abuela Evila washed Elida's hair with lemon water because, according to her, lemon juice cleans the impurities of the hair and makes it shiny and healthy."
+    ]
+  },
+  {
+    "name": "inaccessible",
+    "trans": [
+      "Day 17 | adj. | English: difficult or impossible to reach or to get | Example: As discussed by scholar Anna Mladentseva, many artworks produced in the mid-1990s to the early 2000s exclusively for exhibition on the internet have become inaccessible because viewing them requires the use of defunct software."
+    ]
+  },
+  {
+    "name": "inadvertently",
+    "trans": [
+      "Day 17 | adv. | English: by accident; without intending to | Example: Those studying the works of Antonio Machado, for instance, may inadvertently overlook nuances in his work by focusing only on the most obvious ways in which his style"
+    ]
+  },
+  {
+    "name": "inarguable",
+    "trans": [
+      "Day 17 | adj. | English: that nobody can disagree with | Example: Although Polish folklore clearly informs the style and occasionally antirealistic plot of Primeval and Other Times, the novel also shows the inarguable influence of the magical realist tradition of Latin America."
+    ]
+  },
+  {
+    "name": "inattention",
+    "trans": [
+      "Day 17 | n. | English: lack of attention | Example: So as long as a listener's interpretation isn't willfully absurd or the result of inattention, it is difficult to justify the claim that the listener has misunderstood the piece."
+    ]
+  },
+  {
+    "name": "incentive",
+    "trans": [
+      "Day 17 | n. | English: something that encourages you to do sth | Example: Reducing this kind of subscriber turnover is especially challenging for subscription sellers: customers’ initial enthusiasm for a subscription is often quick to subside, and sellers must thus devise other incentives to bolster retention."
+    ]
+  },
+  {
+    "name": "incidence",
+    "trans": [
+      "Day 17 | n. | English: the extent to which sth happens or has an effect | Example: If one has a supposition that the word “own” has a high incidence in English, for example, an analysis of a corpus can support that hypothesis by showing that “own” is the eighth most commonly used adjective."
+    ]
+  },
+  {
+    "name": "incident",
+    "trans": [
+      "Day 17 | n. | English: something that happens, especially sth unusual or unpleasant After some trouble [Jim’s father] found the subject of the incident, the broken flower. Turning then, he saw the child lurking at the rear and scanning his countenance."
+    ]
+  },
+  {
+    "name": "inconclusive",
+    "trans": [
+      "Day 17 | adj. | English: not leading to a definite decision or result | Example: Research has so far proved inconclusive."
+    ]
+  },
+  {
+    "name": "incongruity",
+    "trans": [
+      "Day 17 | n. | English: The incongruity of something is its strangeness when considered together with other aspects of a situation. | Example: Mauricio Drelichman and Hans-Joachim Voth's analysis of the overall debt and revenue of the government of philip (who ruled an empire including Spain and Sicily from 1556 to 1598) found an intriguing incongruity."
+    ]
+  },
+  {
+    "name": "incongruous",
+    "trans": [
+      "Day 17 | adj. | English: strange, and not suitable in a particular situation | Example: Researchers Haley R. Dolton et al. found that its body temperature remains 1.0 to 1.5°C above ambient, which is incongruous with that classification."
+    ]
+  },
+  {
+    "name": "inconsequential",
+    "trans": [
+      "Day 17 | adj. | English: not important or worth considering | Example: While recent scholarship has undermined claims that the works of twelfth-century Islamic philosopher Ibn Rushd were inconsequential to other Muslim philosophers of his time, it is indisputable that his location in the Muslim-ruled area of what is now Spain meant that his works were primarily available thousands of miles west of the era’s center of Islamic thought."
+    ]
+  },
+  {
+    "name": "inconsistent",
+    "trans": [
+      "Day 17 | adj. | English: if two statements, etc. are inconsistent , or one is inconsistent with the other, they cannot both be true because they give the facts in a different way | Example: It describes a behavioral pattern displayed by Mohol bushbabies that is inconsistent with how they would be expected to respond to high lunar intensity based on benefits and costs."
+    ]
+  },
+  {
+    "name": "inconspicuous",
+    "trans": [
+      "Day 17 | adj. | English: not attracting attention; not easy to notice | Example: I'll try to be as inconspicuous as possible."
+    ]
+  },
+  {
+    "name": "incorporate",
+    "trans": [
+      "Day 17 | v. | English: to include sth so that it forms a part of sth | Example: For example, Inuit singer-songwriter Tanya Tagaq incorporated Inuit throat singing into electronic music on her album Tongues."
+    ]
+  },
+  {
+    "name": "incremental",
+    "trans": [
+      "Day 17 | adj. | English: Incremental is used to describe something that increases in value or worth, often by a regular amount. | Example: Because these effects are incremental and can generally be repaired (though at some cost), structures in southern and central Georgia are typically not built to resist them."
+    ]
+  },
+  {
+    "name": "incubation",
+    "trans": [
+      "Day 17 | n. | English: the hatching of eggs Based on their review of those traits, the team concluded that incubation duration and capacity for multiple broods are more strongly associated with the use of broken-wing display than the number of parental incubators is."
+    ]
+  },
+  {
+    "name": "incubator",
+    "trans": [
+      "Day 17 | n. | English: a machine like a box where eggs are kept warm until the young birds are born Based on their review of those traits, the team concluded that incubation duration and capacity for multiple broods are more strongly associated with the use of broken-wing display than the number of parental incubators is."
+    ]
+  },
+  {
+    "name": "indefatigable",
+    "trans": [
+      "Day 17 | adj. | English: never giving up or getting tired of doing sth | Example: But culture indefatigably tries, not to make what each raw person may like, the rule by which he fashions himself."
+    ]
+  },
+  {
+    "name": "indefatigably",
+    "trans": [
+      "Day 17 | adv. | English: determined and never giving up | Example: But culture indefatigably tries, not to make what each raw person may like the rule by which he fashions himself; but to draw ever nearer to a sense of what is indeed beautiful, graceful, and becoming, and to get the raw person to like that."
+    ]
+  },
+  {
+    "name": "index",
+    "trans": [
+      "Day 17 | n. | English: a system that shows the level of prices and wages, etc. so that they can be compared with those of a previous date | Example: Utilizing the Index of Waterbird Community Integrity (IWCl), on which a high score corresponds to high community integrity, the researchers found that bulkheads are more strongly negatively correlated with waterbird community integrity than is riprap."
+    ]
+  },
+  {
+    "name": "indication",
+    "trans": [
+      "Day 17 | n. | English: a remark or sign that shows that sth is happening or what sb is thinking or feeling | Example: Indications that the film is of high quality, such as an Oscar nomination, can dramatically boost public interest in the film and thus its overall earnings, even with a relatively modest opening weekend performance."
+    ]
+  },
+  {
+    "name": "indicative",
+    "trans": [
+      "Day 17 | adj. | English: (formal) showing or suggesting sth | Example: It would be a mistake to treat the relative inflation rates of Jamaica and Qatar as indicative of an inherent shortcoming in democratic institutions with regard to control over inflation."
+    ]
+  },
+  {
+    "name": "indices",
+    "trans": [
+      "Day 17 | n. | English: a sign or measure that sth else can be judged by | Example: Focusing on two characteristics that are positive indices of grammatical complexity, fusion (when new phonemes arise from the merger of previously distinct ones) and informativity (languages' capacity for meaningful variation), Olena Shcherbakova and colleagues conducted a quantitative analysis for more than 1,300 languages and claim the outcome is inconsistent with the LNH."
+    ]
+  },
+  {
+    "name": "indigenous",
+    "trans": [
+      "Day 17 | adj. | English: belonging to a particular place rather than coming to it from somewhere else | Example: Indigenous songs can be repositories of ecological information, from Yi songs about the natural environment to Tlingit songs about wildlife encounters."
+    ]
+  },
+  {
+    "name": "indisputable",
+    "trans": [
+      "Day 17 | adj. | English: that is true and cannot be disagreed with or denied | Example: The evidence that would indisputably prove that either Hamilton or Madison was the sole author of \"The Senate\" has been lost."
+    ]
+  },
+  {
+    "name": "indistinct",
+    "trans": [
+      "Day 17 | adj. | English: that cannot be seen, heard or remembered clearly | Example: Elizabeth Catlett's sculpture Recognition (1970) shows two African American figures with rounded, indistinct features."
+    ]
+  },
+  {
+    "name": "indoctrinate",
+    "trans": [
+      "Day 17 | v. | English: to force sb to accept a particular belief or set of beliefs and not allow them to consider any others | Example: They had been indoctrinated from an early age with their parents’ beliefs."
+    ]
+  },
+  {
+    "name": "induce",
+    "trans": [
+      "Day 17 | v. | English: to cause sth | Example: Some ethicists challenge the concept of personal character, claiming that if it were meaningful, situational factors could not, as they clearly can, induce behavior contrary to that character."
+    ]
+  },
+  {
+    "name": "indulgent",
+    "trans": [
+      "Day 17 | adj. | English: tending to allow sb to have or do whatever they want His indulgent mother was willing to let him do anything he wanted."
+    ]
+  },
+  {
+    "name": "ineffectual",
+    "trans": [
+      "Day 17 | adj. | English: If someone or something is ineffectual, they fail to do what they are expected to do or are trying to do. | Example: Karam Kang has demonstrated that lobbying does little to alter the probability that a particular energy policy under consideration by the United States Congress will be enacted, but lobbying is not as ineffectual as this finding seems to suggest."
+    ]
+  },
+  {
+    "name": "ineligible",
+    "trans": [
+      "Day 17 | adj. | English: not having the necessary qualifications to have or to do sth | Example: They were ineligible to remain in the U.S."
+    ]
+  },
+  {
+    "name": "ineluctable",
+    "trans": [
+      "Day 17 | adj. | English: that you cannot avoid | Example: Malthus's theories are about the ineluctable tendency of populations to exceed resources."
+    ]
+  },
+  {
+    "name": "inextricable",
+    "trans": [
+      "Day 17 | adj. | English: too closely linked to be separated | Example: Although the literary works of David Malo and Lee Cataluna have universal appeal, they are also inextricable from the Hawaiian literary tradition in which both authors work and that stretches back to the traditional stories of the Kanaka Maoli, the Native Hawaiian people."
+    ]
+  },
+  {
+    "name": "infamous",
+    "trans": [
+      "Day 17 | adj. | English: well known for being bad or evil | Example: Richard Nixon is commonly linked with an infamous historical event, but this overshadows some of his notable achievements."
+    ]
+  },
+  {
+    "name": "infant",
+    "trans": [
+      "Day 17 | n. | English: a baby or very young child | Example: Hypothesizing that lullabies, characterized by their slow tempos, are universally calming to infants, Constance M. Bainbridge and colleagues played a lullaby sung in the Scottish Gaelic language and a non-lullaby sung in the Seri language to a group of infants."
+    ]
+  },
+  {
+    "name": "infer",
+    "trans": [
+      "Day 17 | v. | English: to reach an opinion or decide that sth is true on the basis of information that is available | Example: To infer PSP from fossils, researchers look for indicators such as large foramina (holes in bones)."
+    ]
+  },
+  {
+    "name": "inferior",
+    "trans": [
+      "Day 17 | adj. | English: not good or not as good as sb/sth else | Example: It undermines the idea that a practical approach to understanding natural phenomena is inferior to a scientific approach."
+    ]
+  },
+  {
+    "name": "inferiority",
+    "trans": [
+      "Day 17 | n. | English: the state of not being as good as sb/sth else | Example: Singly [the men around Newland] betrayed their inferiority: but grouped together they represented ‘New York,’ and the habit of masculine solidarity made him accept their doctrine on all the issues called moral."
+    ]
+  },
+  {
+    "name": "infinite",
+    "trans": [
+      "Day 17 | adj. | English: without limits; without end The father reflected. After a time he said, ‘Jimmie, come here.’ With an infinite modesty of demeanor the child came forward."
+    ]
+  },
+  {
+    "name": "inflation",
+    "trans": [
+      "Day 17 | n. | English: a general rise in the prices of services and goods in a particular country, resulting in a fall in the value of money; the rate at which this happens | Example: The Netherlands, which, according to international indices, has relatively strong democratic institutions and low intranational income inequality, experienced an inflation rate of 2.63% in 2019."
+    ]
+  },
+  {
+    "name": "infraction",
+    "trans": [
+      "Day 17 | n. | English: an act of breaking a rule or law By suggesting that whatever infractions Luttrell might have committed are outweighed by the cultural value of the Luttrell Psalter"
+    ]
+  },
+  {
+    "name": "infrastructure",
+    "trans": [
+      "Day 17 | n. | English: the basic systems and services that are necessary for a country or an organization to run smoothly, for example buildings, transport and water and power supplies | Example: Vancouver, Canada, has installed engineered structures along 75% of its shoreline to protect infrastructure from storm surges and other hazards, a practice known as shoreline hardening."
+    ]
+  },
+  {
+    "name": "ingenious",
+    "trans": [
+      "Day 17 | adj. | English: having a lot of clever new ideas and good at inventing things | Example: She's very ingenious when it comes to finding excuses."
+    ]
+  },
+  {
+    "name": "ingest",
+    "trans": [
+      "Day 17 | v. | English: to take food, drugs, etc. into your body, usually by swallowing | Example: Mammoth tusks grew in sequential layers, incorporating ingested minerals and organics, and so each ivory stratum reflects the ratio of strontium isotopes (87Sr/86Sr) in the local environment."
+    ]
+  },
+  {
+    "name": "inherent",
+    "trans": [
+      "Day 17 | adj. | English: that is a basic or permanent part of sb/sth and that cannot be removed | Example: Zoo chimpanzees in Sweden and other mid-latitude countries tend to synthesize less vitamin D than they are inherently capable of synthesizing."
+    ]
+  },
+  {
+    "name": "inherit",
+    "trans": [
+      "Day 17 | v. | English: to receive money, property, etc. from sb when they die | Example: Perhaps it is a little depressing to inherit not lands but an example of intellectual virtue."
+    ]
+  },
+  {
+    "name": "inhibit",
+    "trans": [
+      "Day 17 | v. | English: to prevent sth from happening or make it happen more slowly or less frequently than normal | Example: For too long, scholars have focused on experimental versus conventional poetic forms, inhibiting inquiry into other points of stylistic correspondence among poems that would enrich our understanding of the modernist canon."
+    ]
+  },
+  {
+    "name": "iniquity",
+    "trans": [
+      "Day 17 | n. | English: the fact of being very unfair or wrong; sth that is very unfair or wrong | Example: And now, dear reader, a word with you. What is done cannot be undone. We cannot unravel this web of iniquity, and extract justice from this mass of cruel wrongs."
+    ]
+  },
+  {
+    "name": "initiative",
+    "trans": [
+      "Day 17 | n. | English: anew plan for dealing with a particular problem or for achieving a particular purpose | Example: Conservationists worldwide are working to protect ecosystems from habitat destruction and biodiversity loss, and in many cases, initiatives that rely on natural features or processes can help address such challenges."
+    ]
+  },
+  {
+    "name": "innate",
+    "trans": [
+      "Day 17 | adj. | English: a quality or a feeling that you have when you are born | Example: Modularity of mind is the notion that the mind is at least partly composed of innate neural structures (modules) that perform fast, necessary tasks."
+    ]
+  },
+  {
+    "name": "inquire",
+    "trans": [
+      "Day 18 | v. | English: ask for information from someone moulded to adorn a bust, or possibly a stamp, and whose forehead was so evidently bulging with grey matter that it would have been impertinent to inquire too closely into the actual achievements his half century of public service had produced."
+    ]
+  },
+  {
+    "name": "insert",
+    "trans": [
+      "Day 18 | v. | English: to put sth into sth else or between two things | Example: They would encourage engineers in southern and central Georgia to insert vapor barriers between new structures' foundations and the surrounding soil."
+    ]
+  },
+  {
+    "name": "insight",
+    "trans": [
+      "Day 18 | n. | English: the ability to see and understand the truth about people or situations | Example: At aconference for aspiring children's book authors, Candy Dawson Boyd, author of such lauded works as Circle of Gold, was the subject of a presentation that was intended specifically to foster insight into the techniques of successful authors so that attendees could use that understanding to improve their own work."
+    ]
+  },
+  {
+    "name": "instability",
+    "trans": [
+      "Day 18 | n. | English: the quality of a situation in which things are likely to change or fail suddenly | Example: Instead, Luu et al. are likely correct that 6478 Gault is shedding mass due to rotational instability."
+    ]
+  },
+  {
+    "name": "install",
+    "trans": [
+      "Day 18 | v. | English: to fix equipment or furniture into position so that it can be used | Example: Janet Echelman is a sculptor and fiber artist. She has installed giant sculptures all over the world."
+    ]
+  },
+  {
+    "name": "instantly",
+    "trans": [
+      "Day 18 | adj. | English: immediately | Example: Cuttlefish appear to be surprisingly competent at exercising self-control: in a 2021 study conducted by behavioral ecologist Alexandra Schnell, these cephalopods routinely demonstrated restraint by delaying gratification, waiting for a favorite treat instead of instantly devouring a readily available meal."
+    ]
+  },
+  {
+    "name": "insult",
+    "trans": [
+      "Day 18 | n. | English: a remark or an action that is said or done in order to offend sb | Example: There is no denying that, since he was rather brusque in his ways, he never spared the young authors who asked his advice and read him their productions, but criticized vigorously, even to the verge of insult."
+    ]
+  },
+  {
+    "name": "insuperable",
+    "trans": [
+      "Day 18 | adj. | English: that cannot be dealt with successfully | Example: Insuperable though it seemed to many mathematicians, the Marden tameness conjecture, posed in 1974, eventually yielded to the efforts of lan Agol, who presented a proof of it in 2004."
+    ]
+  },
+  {
+    "name": "insurmountable",
+    "trans": [
+      "Day 18 | adj. | English: that cannot be dealt with successfully | Example: Most of the recently discovered minor planets, however, are given only an identification number, largely due to there being over 500,000 such bodies known at present, which makes the already challenging task of finding a unique name for each nearly insurmountable."
+    ]
+  },
+  {
+    "name": "intact",
+    "trans": [
+      "Day 18 | adj. | English: complete and not damaged | Example: Victoria L. Peck and colleagues recently found that the periostracum (a protective coating on pteropods' outer shells) prevents this dissolution when intact."
+    ]
+  },
+  {
+    "name": "intangible",
+    "trans": [
+      "Day 18 | adj. | English: that exists but that is difficult to describe, understand or measure Stars form in cloudlike swirls of gas and dust that cannot be touched, but astrophysicist Nia she uses simulation data and sophisticated 3D printers to produce interactive models of these stellar nurseries."
+    ]
+  },
+  {
+    "name": "integral",
+    "trans": [
+      "Day 18 | adj. | English: being an essential part of sth | Example: Works from this period make up an outsized proportion of what is considered the canon of Mexican literature, but nineteenth-century writers like Justo Sierra O'Reilly should be considered just as integral to the Mexican literary canon."
+    ]
+  },
+  {
+    "name": "integrate",
+    "trans": [
+      "Day 18 | v. | English: to combine two or more things so that they work together; to combine with sth else in this way | Example: As epitomized by the Aguilar House in Guadalajara, many of Barragan's first projects integrated traditional Mexican building techniques into Mediterranean designs."
+    ]
+  },
+  {
+    "name": "integrated",
+    "trans": [
+      "Day 18 | adj. | English: in which many different parts are closely connected and work successfully together | Example: The invention in 1958 of the integrated circuit (or microchip) radically altered the semiconductor industry."
+    ]
+  },
+  {
+    "name": "intelligible",
+    "trans": [
+      "Day 18 | adj. | English: that can be easily understood | Example: Semantic relations among the two nouns and the concept they signify can be tenuous, as in the previous example, such that difrasismos are often only intelligible according to the conceptual associations observed in Aztec ceremonial culture."
+    ]
+  },
+  {
+    "name": "intense",
+    "trans": [
+      "Day 18 | adj. | English: very great; very strong | Example: Do | behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more intense seclusion; and connect / The landscape with the quiet of the sky."
+    ]
+  },
+  {
+    "name": "intent",
+    "trans": [
+      "Day 18 | n. | English: what you intend to do | Example: The many editions of James Joyce's 1922 novel Ulysses are not textually identical, and scholars debate which versions reflect Joyce's authorial intent."
+    ]
+  },
+  {
+    "name": "intentional",
+    "trans": [
+      "Day 18 | adj. | English: done deliberately | Example: Without an intentional effort to promote the city's food scene, many current and potential visitors to Buenaventura may not even be aware that it’s home to uniquely delicious food."
+    ]
+  },
+  {
+    "name": "interactive",
+    "trans": [
+      "Day 18 | adj. | English: that allows information to be passed continuously and in both directions between a computer and the person who uses it | Example: Stars form in cloudlike swirls of gas and dust that cannot be touched, but astrophysicist Nia Imara believes these formations need not remain completely intangible to researchers: she uses simulation data and sophisticated 3D printers to produce interactive models of these stellar nurseries."
+    ]
+  },
+  {
+    "name": "intercede",
+    "trans": [
+      "Day 18 | v. | English: to speak to sb in order to persuade them to show pity on sb else or to help settle an argument | Example: They interceded with the authorities on behalf of the detainees."
+    ]
+  },
+  {
+    "name": "interdependent",
+    "trans": [
+      "Day 18 | adj. | English: People or things that are interdependent all depend on each other. The Nile River delta system is located in Northern Egypt, where the river drains into the for example, the geography of the coastline influences sedimentary deposition, which over time alters coastal geography."
+    ]
+  },
+  {
+    "name": "interference",
+    "trans": [
+      "Day 18 | n. | English: the act of interfering | Example: Several advantages—the ability to react strongly with chip components, to avoid interference from other waves, and to be confined within tiny circuits—have positioned acoustic waves as a promising alternative to electrical waves for transmitting data on computer chips."
+    ]
+  },
+  {
+    "name": "intergeneric",
+    "trans": [
+      "Day 18 | adj. | English: involving more than one genus (= a group of plants or animals that are all related to each other) | Example: Writer Lydia Davis observed that while traditional literary forms, such as the novel, are recognizable as such even as they evolve, there are rarer “intergeneric” forms that might, for example, use elements of both fiction and essays to create something unclassifiable."
+    ]
+  },
+  {
+    "name": "intermediary",
+    "trans": [
+      "Day 18 | n. | English: a person or an organization that helps other people or organizations to make an agreement by being a means of communication between them M. robustus leave the Octopus Garden upon reaching an intermediary stage of development."
+    ]
+  },
+  {
+    "name": "intermittent",
+    "trans": [
+      "Day 18 | adj. | English: stopping and starting often over a period of time, but not regularly | Example: Asteroid 6478 Gault has experienced intermittent mass loss since at least 2013."
+    ]
+  },
+  {
+    "name": "interplay",
+    "trans": [
+      "Day 18 | v. | English: the way in which two or more things or people affect each other | Example: The Limén technique, developed by Mexican-born dancer and choreographer Jose Limon, is known for its emphasis on breath control and its interplay of weight and weightlessness."
+    ]
+  },
+  {
+    "name": "intervention",
+    "trans": [
+      "Day 18 | n. | English: the act of becoming involved in an argument, fight, or other difficult situation in order to change what happens | Example: The results of randomized clinical trials testing the efficacy of common medical interventions sometimes fail to corroborate conclusions that practitioners reach based on their real-world observations of patients."
+    ]
+  },
+  {
+    "name": "intricate",
+    "trans": [
+      "Day 18 | adj. | English: having a lot of different parts and small details that fit together The unusual structure that O'Brian uses for Master and Commander makes it one of his most intricate books."
+    ]
+  },
+  {
+    "name": "intriguing",
+    "trans": [
+      "Day 18 | adj. | English: very interesting because of being unusual or not having an obvious answer | Example: Mauricio Drelichman and Hans-Joachim Voth's analysis of the overall debt and revenue of the government of philip (who ruled an empire including Spain and Sicily from 1556 to 1598) found an intriguing incongruity."
+    ]
+  },
+  {
+    "name": "intrinsic",
+    "trans": [
+      "Day 18 | adj. | English: belonging to or part of the real nature of sth/sb | Example: There is often a kind of [deceptive] light, playing around such [famous] names, calculated to dazzle and mislead, by their false lustre, until the eye can no longer receive the pure light of Truth, or the mind appreciate real excellence, or intrinsic worth."
+    ]
+  },
+  {
+    "name": "intrusive",
+    "trans": [
+      "Day 18 | adj. | English: too noticeable, direct, etc. in a way that is disturbing or annoying While bioaccumulation of manufactured nanoparticles may be inherently worrisome, it has been hypothesized that CuO-NP bioaccumulation in invertebrates like L. stagnalis could serve a valuable proxy role, obviating the need for manufacturers to conduct costly and intrusive sampling of vertebrate species—such as African clawed frogs (Xenopus laevis), commonly used in regulatory compliance testing—for nanoparticle bioaccumulation, as environmental protection laws currently require."
+    ]
+  },
+  {
+    "name": "invalidate",
+    "trans": [
+      "Day 18 | v. | English: to prove that an idea, a story, an argument, etc. is wrong | Example: It has been largely invalidated by results obtained from similar studies."
+    ]
+  },
+  {
+    "name": "invariably",
+    "trans": [
+      "Day 18 | adv. | English: always | Example: As they sat down they turned almost invariably to the person sitting next them."
+    ]
+  },
+  {
+    "name": "inventive",
+    "trans": [
+      "Day 18 | adj. | English: having the ability to create or design new things or to think originally | Example: The early British postal system required the cost of mail delivery to be paid upon receipt, a system which encouraged inventive strategies by the intended recipient to avoid payment."
+    ]
+  },
+  {
+    "name": "inverse",
+    "trans": [
+      "Day 18 | adj. | English: opposite in amount or position to sth else | Example: Biologist Ari Martinez and colleagues, who studied the ecological community the species share, hypothesized that there is an inverse relationship between birds’ field of vision while foraging and their sensitivity to alarm calls from neighboring species."
+    ]
+  },
+  {
+    "name": "invertebrate",
+    "trans": [
+      "Day 18 | n. | English: any animal with no backbone , for example a worm | Example: The vast majority of invertebrate species found in a recent survey of the CCZ were hitherto unknown to scientists, and sampling for animal life has been highly concentrated in the eastern part of the zone."
+    ]
+  },
+  {
+    "name": "iridescent",
+    "trans": [
+      "Day 18 | adj. | English: showing many bright colours that seem to change in different lights | Example: Itis made of iridescent multicolored LED domes."
+    ]
+  },
+  {
+    "name": "irradiance",
+    "trans": [
+      "Day 18 | n. | English: a measurement of the amount of light that comes from sth | Example: Since UVB exposure enables vertebrates to synthesize vitamin D, this raises questions about how chimpanzees in mid-latitude zoos are affected by the lower and more variable UVB irradiance in those locations."
+    ]
+  },
+  {
+    "name": "irrefutable",
+    "trans": [
+      "Day 18 | adj. | English: that cannot be proved wrong and that must therefore be accepted | Example: The reasons for this characterization may seem irrefutable, but linking Unamuno with the Generation of '98 risks disregarding the subtleties in his style that do not neatly conform to the conventions of this literary movement."
+    ]
+  },
+  {
+    "name": "irrelevant",
+    "trans": [
+      "Day 18 | adj. | English: not important to or connected with a situation People sometimes dismiss a claim if it comes from a source they regard as self-interested, but from a strictly logical perspective, the source of a claim is irrelevant."
+    ]
+  },
+  {
+    "name": "irreproachable",
+    "trans": [
+      "Day 18 | adj. | English: free from fault and impossible to criticize She welcomed her unexpected visitor with irreproachable politeness."
+    ]
+  },
+  {
+    "name": "irresistible",
+    "trans": [
+      "Day 18 | adj. | English: s0 attractive that you feel you must have it | Example: Although Alfred E. Green's 1950 film The Jackie Robinson Story and Ossie Davis's 1970 film Cotton Comes to Harlem may have had some detractors at the time of their initial release, their place in critics' estimations is now more secure. In 2018, for example, critics for the New York Times described the former as \"irresistible\" and the latter as \"especially pointed.\""
+    ]
+  },
+  {
+    "name": "irresolvable",
+    "trans": [
+      "Day 18 | adj. | English: not able to be resolved into parts or elements | Example: The question of whether the people of the time understood the paintings as something akin to art in your modern sense or in some other way entirely is irresolvable: we will never be able to answer it."
+    ]
+  },
+  {
+    "name": "isolate",
+    "trans": [
+      "Day 18 | v. | English: to separate sb/sth physically or socially from other people or things | Example: They found that during harmless simulated attacks on isolated caterpillars, 33% of the tested species produced sound, which ranged from clicks in Actias luna to whistles in Phyllosphingia dissimilis."
+    ]
+  },
+  {
+    "name": "isolated",
+    "trans": [
+      "Day 18 | adj. | English: without much contact with other people or other countrie | Example: They found that during harmless simulated attacks on isolated caterpillars, 33% of the tested species produced sound, which ranged from clicks in Actias luna to chirps in Schausiella santarosensis."
+    ]
+  },
+  {
+    "name": "isotope",
+    "trans": [
+      "Day 18 | n. | English: one of two or more forms of a chemical element which have the same number of protons but a different number of neutrons in their atoms. They have different physical properties (= characteristics) but the same chemical ones | Example: Mammoth tusks grew in sequential layers, incorporating ingested minerals and organics, and so each ivory stratum reflects the ratio of strontium isotopes (87Sr/86Sr) in the local environment."
+    ]
+  },
+  {
+    "name": "iterate",
+    "trans": [
+      "Day 18 | v. | English: to say or do again; repeat | Example: The [train] engines of this valley have a whistle, the echoes of which sound like iterated gasps and sobs. | always think of them as crude music."
+    ]
+  },
+  {
+    "name": "jointly",
+    "trans": [
+      "Day 18 | adj. | English: involving two or more people together | Example: Often, the Nobel Prize in Chemistry is given to a single person, such as Frederick Sanger in 1958. But sometimes the Nobel Committee wants to reward work attributed to two or three individuals, in which case, the award is given jointly."
+    ]
+  },
+  {
+    "name": "judicial",
+    "trans": [
+      "Day 18 | adj. | English: connected with a court, a judge or legal judgement | Example: Jordan's constitution, enacted in 1952, contains just one of the six constitutional features that enhance judicial independence, as identified by legal scholars James Melton and Tom Ginsburg."
+    ]
+  },
+  {
+    "name": "juggler",
+    "trans": [
+      "Day 18 | n. | English: a person who juggles , especially an entertainer | Example: To illustrate Albert Einstein's special theory of relativity, picture two jugglers: one juggling on a steadily moving parade float, the other juggling while standing still on a sidewalk."
+    ]
+  },
+  {
+    "name": "justification",
+    "trans": [
+      "Day 19 | n. | English: a good reason why sth exists or is done | Example: No amount of justification, however, is likely to persuade some drivers who believe the current toll is exorbitant."
+    ]
+  },
+  {
+    "name": "juxtaposition",
+    "trans": [
+      "Day 19 | n. | English: The juxtaposition of two contrasting objects, images, or ideas is the fact that they are placed together or described together, so that the differences between them are emphasized. | Example: This style has exerted a decisive influence on authors around the world, including Olga Tokarczuk, whose 1996 novel Primeval and Other Times resembles classic magical realist novels in its juxtaposition of literary realism with folklore—namely, that of Poland."
+    ]
+  },
+  {
+    "name": "keen",
+    "trans": [
+      "Day 19 | n. | English: highly developed | Example: The little fern-leaf, bending / Upon the brink, its green reflection greets, / And kisses soft the shadow that it meets / With touch so fine, / The border line / The keenest vision can't define; / So perfect is the blending."
+    ]
+  },
+  {
+    "name": "laborious",
+    "trans": [
+      "Day 19 | adj. | English: taking a lot of time and effort | Example: She was not thinking at all. She seemed for the time to be taking a rest from that laborious and fatiguing function and to have abandoned herself to some mechanical impulse that directed her actions and freed her of responsibility."
+    ]
+  },
+  {
+    "name": "lagoon",
+    "trans": [
+      "Day 19 | n. | English: a lake of salt water that is separated from the sea by a reef or an area of rock or sand | Example: Among the wild rice in the still lagoon. / In monotone the lizard shrills his tune. / The wild goose, homing, seeks a sheltering, / Where rushes grow, and oozing lichens cling."
+    ]
+  },
+  {
+    "name": "landscape",
+    "trans": [
+      "Day 19 | n. | English: everything you can see when you look across a large area of land, especially in the country | Example: The fog extended its tentacles over city and river gradually obliterating traces of familiar landscapes."
+    ]
+  },
+  {
+    "name": "lane",
+    "trans": [
+      "Day 19 | n. | English: a narrow road in the country | Example: As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot."
+    ]
+  },
+  {
+    "name": "languid",
+    "trans": [
+      "Day 19 | adj. | English: moving slowly in an elegant manner, not needing energy or effort | Example: The sun, already down, was manifest in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+    ]
+  },
+  {
+    "name": "larynx",
+    "trans": [
+      "Day 19 | n. | English: the area at the top of the throat that contains the vocal cords | Example: Rusty-spotted cats, which are much smaller than jaguars, have a rigid hyoid that rumbles when the cat’s larynx vibrates, resulting in a purr."
+    ]
+  },
+  {
+    "name": "latitude",
+    "trans": [
+      "Day 19 | n. | English: the distance of a place north or south of the equator (= the line around the world dividing north and south) , measured in degrees | Example: Across the orders in the study, deceptive antipredator displays are observed in approximately 34% of species with brooding ranges of 0°-30° absolute latitude and approximately 60% of species with brooding ranges of 50°-80° absolute latitude."
+    ]
+  },
+  {
+    "name": "laud",
+    "trans": [
+      "Day 19 | v. | English: to praise sb/sth | Example: While some commentators lauded this development, asserting that such blogs had a welcome transparency missing from traditional news, less sanguine observers countered that such blogs tended to ideological extremes that exacerbated political polarization to problematic levels."
+    ]
+  },
+  {
+    "name": "launch",
+    "trans": [
+      "Day 19 | v. | English: v. to start an activity, especially an organized one v. to send sth such as a spacecraft , weapon, etc. into space, into the sky or through water | Example: [1] A group of 80 attackers launched an all-out assault just before dawn. 2] Since the Hubble Space Telescope was launched into space in 1990, astronauts have needed to complete regular missions to repair the telescope and keep it working smoothly."
+    ]
+  },
+  {
+    "name": "lay",
+    "trans": [
+      "Day 19 | adj. | English: not having expert knowledge or professional qualifications in a particular subject As Rachana Kamtekar observes, this argument is difficult to reconcile with our lay conception we expect a person of helpful character to be frequently helpful, not sporadically helpful."
+    ]
+  },
+  {
+    "name": "layout",
+    "trans": [
+      "Day 19 | n. | English: the way in which the parts of sth such as the page of a book, a garden or a building are arranged | Example: In a study, data scientist Sam K. Hui and colleagues found that this effect can also be achieved with a less obvious cue: rearranging a store’s layout."
+    ]
+  },
+  {
+    "name": "lean",
+    "trans": [
+      "Day 19 | adj. | English: adj. difficult and not producing much money, food, etc.; v. to bend or move from a vertical position | Example: [1] And when the wind is from the South, soil of my homeland falls like a fertile shower upon"
+    ]
+  },
+  {
+    "name": "ledge",
+    "trans": [
+      "Day 19 | n. | English: a narrow flat shelf fixed to a wall, especially one below a window Propped on the window ledge, it featured a portrait of Great-Great-Grandmother Rosita as a young woman."
+    ]
+  },
+  {
+    "name": "legacy",
+    "trans": [
+      "Day 19 | n. | English: money or property that is given to you by sb when they die | Example: In fact the work is a complex, dynamic meditation on gender and the legacy of colonialism that demands serious attention."
+    ]
+  },
+  {
+    "name": "legitimacy",
+    "trans": [
+      "Day 19 | n. | English: the quality or state of being legitimate | Example: Whether the reign of a French monarch such as Louis VII or Henry V was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy and therefore cannot be understood without a corollary understanding of the characteristics without which the monarch would have been forced to abandon the throne."
+    ]
+  },
+  {
+    "name": "legitimate",
+    "trans": [
+      "Day 19 | adj. | English: for which there is a fair and acceptable reason Duchamp's Fountain did just that, raising the question of whether displaying any object in an art gallery could be said to transform the object—even, as Duchamp's sculpture was, a urinal—into a legitimate work of art."
+    ]
+  },
+  {
+    "name": "liability",
+    "trans": [
+      "Day 19 | n. | English: the amount of money that a person or company owes | Example: But petroleum extraction is a very carbon-intensive industry, so as social attitudes increasingly favor using less carbon intensive sources of energy, demand for petroleum falls and the drilling equipment will eventually, or even suddenly, become a liability as reduced petroleum prices make it more difficult to recover the expense of maintaining such equipment."
+    ]
+  },
+  {
+    "name": "lichen",
+    "trans": [
+      "Day 19 | n. | English: avery small grey or yellow plant that spreads over the surface of rocks, walls and trees and does not have any flowers | Example: Among the wild rice in the still lagoon. / In monotone the lizard shrills his tune. / The wild goose, homing, seeks a sheltering, / Where rushes grow, and oozing lichens cling."
+    ]
+  },
+  {
+    "name": "liftoff",
+    "trans": [
+      "Day 19 | n. | English: a vertical takeoff by an aircraft or a rocket vehicle or missile | Example: The Apollo Moon landings (1969-1972) brought charged particle detectors and equipment too heavy for liftoff to the Moon and produced large amounts of data, much of which was stored on outdated technologies."
+    ]
+  },
+  {
+    "name": "ligament",
+    "trans": [
+      "Day 19 | n. | English: a strong band of tissue in the body that connects bones and supports organs and keeps them in position | Example: By contrast, jaguars have a somewhat flexible hyoid, and the bone is attached to the skull with a stretchy ligament that rusty-spotted cats lack."
+    ]
+  },
+  {
+    "name": "light",
+    "trans": [
+      "Day 19 | v. | English: to make sth start to burn | Example: The sun, already down, was manifest in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+    ]
+  },
+  {
+    "name": "lighthearted",
+    "trans": [
+      "Day 19 | adj. | English: free from care, anxiety, or seriousness | Example: | wanted to be brave, eager, confident, at ease, lighthearted."
+    ]
+  },
+  {
+    "name": "lineage",
+    "trans": [
+      "Day 19 | n. | English: the series of families that sb comes from originally | Example: Meredith E. Protas and colleagues have explored how convergent evolution—a phenomenon that occurs when the same trait evolves independently in two reproductively separate lineages—can result from a genetic mechanism shared by both lineages."
+    ]
+  },
+  {
+    "name": "lineament",
+    "trans": [
+      "Day 19 | n. | English: a feature of your face | Example: He had partially unveiled the face of Nature, but her immortal lineaments were still a wonder and a mystery."
+    ]
+  },
+  {
+    "name": "linger",
+    "trans": [
+      "Day 19 | v. | English: to stay somewhere for longer because you do not want to leave; to spend a long time doing sth | Example: As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot."
+    ]
+  },
+  {
+    "name": "liquidity",
+    "trans": [
+      "Day 19 | n. | English: the state of owning things of value that can easily be exchanged for cash | Example: But Drelichman and Voth's unique contribution is their reconstruction of the earliest extant set of annual fiscal records for any sovereign state, which demonstrate that Philip's defaults were caused by short-term liquidity crises, not long-term unsustainable debts."
+    ]
+  },
+  {
+    "name": "livestock",
+    "trans": [
+      "Day 19 | n. | English: the animals kept on a farm, for example cows or sheep | Example: The flavor of meat from livestock differs across species (from pig to chicken to cow), and is also influenced by farming conditions and the breeds and genders of animals."
+    ]
+  },
+  {
+    "name": "livid",
+    "trans": [
+      "Day 19 | adj. | English: extremely angry | Example: The sun, already down, was manifest in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+    ]
+  },
+  {
+    "name": "loan",
+    "trans": [
+      "Day 19 | n. | English: money that an organization such as a bank lends and sb borrows | Example: The bank went on to provide home loans and savings opportunities to thousands of Black families over the following decades."
+    ]
+  },
+  {
+    "name": "lobby",
+    "trans": [
+      "Day 19 | v. | English: to try to influence a politician or the government and, for example, persuade them to support or oppose a change in the law | Example: Karam Kang has demonstrated that lobbying does little to alter the probability that a particular energy policy under consideration by the United States Congress will be enacted."
+    ]
+  },
+  {
+    "name": "locomotion",
+    "trans": [
+      "Day 19 | n. | English: movement or the ability to move | Example: Some robots such as Salvius (developed in 2008) and REEM-C (developed in 2013) feature humanoid characteristics like bipedal locomotion so that people will find it easier to interact with them."
+    ]
+  },
+  {
+    "name": "lodge",
+    "trans": [
+      "Day 19 | v. | English: to become fixed or stuck somewhere | Example: On March 23, 2021, a gust of wind wreaked havoc on global trade. Ever Given, an international shipping container vessel, became lodged in Egypt's Suez Canal, a major"
+    ]
+  },
+  {
+    "name": "lofty",
+    "trans": [
+      "Day 19 | adj. | English: very high and impressive Do | behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more deep seclusion; and connect / The landscape with the quiet of the sky."
+    ]
+  },
+  {
+    "name": "long for",
+    "trans": [
+      "Day 19 | English: to want sth very much especially if it does not seem likely to happen soon | Example: Then we sit and sob, and long for the gas-lit streets, and the sound of human voices, and the answering throb of human life."
+    ]
+  },
+  {
+    "name": "longing",
+    "trans": [
+      "Day 19 | n. | English: a strong feeling of wanting sth/sb | Example: To convey the speaker's longing for the ocean to impart a sense of inner tranquility"
+    ]
+  },
+  {
+    "name": "longitudinal",
+    "trans": [
+      "Day 19 | adj. | English: going downwards rather than across | Example: One reason for this discrepancy is that historians of capitalism tend to focus on longitudinal economic data drawn from archival records, which do not exist for much of precolonial Africa."
+    ]
+  },
+  {
+    "name": "lot",
+    "trans": [
+      "Day 19 | n. | English: a person's luck or situation in life | Example: The motorman chafed in his box, thinking of the drudging lot of the laboring man. He registered discontent."
+    ]
+  },
+  {
+    "name": "lullaby",
+    "trans": [
+      "Day 19 | n. | English: a soft gentle song sung to make a child go to sleep | Example: Just let me drift far out from toil and care, / Where lapping of the waves shall be the sound, / Which mingled with the winds that gently bear / Me on between a peaceful sea and sky, /To make my soothing slumberous lullaby."
+    ]
+  },
+  {
+    "name": "luminous",
+    "trans": [
+      "Day 19 | adj. | English: shining in the dark; giving out light | Example: Quasars—such as APM 08279+5255, located in the Lynx constellation—are extremely luminous galactic nuclei powered by supermassive black holes."
+    ]
+  },
+  {
+    "name": "lunar",
+    "trans": [
+      "Day 19 | adj. | English: connected with the moon | Example: This discrepancy is explicable in terms of OFT: the monkeys’ greater reliance on vision means that higher lunar intensity benefits them more than it benefits the bats."
+    ]
+  },
+  {
+    "name": "lung",
+    "trans": [
+      "Day 19 | n. | English: either of the two organs in the chest that you use for breathing | Example: Postcranial skeletal pneumaticity (PSP) refers to the presence of extensions of an animal's lungs and air sacs inside its bones."
+    ]
+  },
+  {
+    "name": "lurk",
+    "trans": [
+      "Day 19 | v. | English: to wait somewhere secretly, especially because you are going to do sth bad or illegal | Example: After some trouble [Jim’s father] found the subject of the incident, the broken flower. Turning then, he saw the child lurking at the rear and scanning his countenance."
+    ]
+  },
+  {
+    "name": "magistrate",
+    "trans": [
+      "Day 19 | n. | English: an official who acts as a judge in the lowest courts of law | Example: Every state should be so administered and so regulated by law that its magistrates cannot possibly make money."
+    ]
+  },
+  {
+    "name": "magnetic field",
+    "trans": [
+      "Day 19 | English: an area around a magnet or magnetic object, where there is a force that will attract some metals towards it | Example: Whereas crayfish can detect fields emitted by household electronics, those are many times stronger than the fields created by water moving through Earth's magnetic field, which sharks are sensitive enough to detect."
+    ]
+  },
+  {
+    "name": "magnify",
+    "trans": [
+      "Day 19 | v. | English: to make sth look bigger than it really is, for example by using a lens or microscope | Example: The tendency to group authors together into distinct literary movements often encourages literary scholars to magnify subtleties in an author's style."
+    ]
+  },
+  {
+    "name": "magnitude",
+    "trans": [
+      "Day 19 | n. | English: the great size or importance of sth; the degree to which sth is large or important | Example: Both sharks and crayfish can detect electrical fields around them, but the magnitude of their sensitivities differs substantially."
+    ]
+  },
+  {
+    "name": "make off with",
+    "trans": [
+      "Day 19 | English: If you make off with something, you steal it and take it away with you. | Example: Most infamously, he participated in what was essentially a private war against Sempringham Priory, a monastery near his manor, even making off with 500 pounds' worth of monastery property during a raid."
+    ]
+  },
+  {
+    "name": "malice",
+    "trans": [
+      "Day 20 | n. | English: a feeling of hatred for sb that causes a desire to harm them | Example: You are cultured and intelligent, [Vanya], and you surely understand that the world is not destroyed by villains and conflagrations, but by hate and malice and all this spiteful tattling."
+    ]
+  },
+  {
+    "name": "mandatory",
+    "trans": [
+      "Day 20 | adj. | English: required by law | Example: But naming a minor planet is not mandatory; whether to assign it a name is entirely the choice of whoever discovers it."
+    ]
+  },
+  {
+    "name": "manifest",
+    "trans": [
+      "Day 20 | adj. | English: easy to see or understand | Example: [Katharine's] descent from [a celebrated poet] was no surprise to her, but matter for satisfaction, until, as the years wore on, certain drawbacks made themselves very manifest."
+    ]
+  },
+  {
+    "name": "manipulate",
+    "trans": [
+      "Day 20 | v. | English: to control or use sth in a skilful way | Example: A number of artists associated with hyperpop, a movement in electronic music that emerged in the 2010s, aggressively manipulate their recorded voice."
+    ]
+  },
+  {
+    "name": "manor",
+    "trans": [
+      "Day 20 | n. | English: a large country house surrounded by land that belongs to it | Example: Most infamously, he participated in what was essentially a private war against Sempringham Priory, a monastery near his manor, even making off with 500 pounds' worth of monastery property during a raid."
+    ]
+  },
+  {
+    "name": "mantle",
+    "trans": [
+      "Day 20 | n. | English: the part of the earth below the crust and surrounding the core | Example: Until recently, Theia was notional, but researcher Qian Yuan and colleagues now claim to have identified pieces of the protoplanet in the lowermost section of Earth's mantle."
+    ]
+  },
+  {
+    "name": "mar",
+    "trans": [
+      "Day 20 | v. | English: to damage or spoil sth good | Example: Colours might have been better chosen and lights more perfectly diffused; but perhaps in doing so the thorough clerical aspect of the whole might have been somewhat marred."
+    ]
+  },
+  {
+    "name": "margin",
+    "trans": [
+      "Day 20 | n. | English: the empty space at the side of a written or printed page | Example: Douglass observed that the concept of an \"interactive\" text is much older than technologists assume, extending back to the first time readers scratched notes into a text's margins."
+    ]
+  },
+  {
+    "name": "marginal",
+    "trans": [
+      "Day 20 | adj. | English: small and not important | Example: While they were used in a study that made an important scientific discovery, they are generally of marginal value as sources of genomic data. marvels on. AFAR: wea: AWE 322: wonderful results or things that have been achieved Hi) ‘a]: Her stockings and boots and well-fitting gloves had worked marvels in her bearing—had given her a feeling of assurance, a sense of belonging to the well-dressed multitude."
+    ]
+  },
+  {
+    "name": "marvels",
+    "trans": [
+      "Day 20 | n. | English: wonderful results or things that have been achieved Her stockings and boots and well-fitting gloves had worked marvels in her bearing—had given her a feeling of assurance, a sense of belonging to the well-dressed multitude."
+    ]
+  },
+  {
+    "name": "masculine",
+    "trans": [
+      "Day 20 | adj. | English: having the qualities or appearance considered to be typical of men; connected with or like men | Example: Singly [the men around Newland] betrayed their inferiority: but grouped together they represented ‘New York,’ and the habit of masculine solidarity made him accept their doctrine on all the issues called moral."
+    ]
+  },
+  {
+    "name": "mass loss",
+    "trans": [
+      "Day 20 | English: the loss of the quantity of material that sth contains | Example: Asteroid 6478 Gault has experienced intermittent mass loss since at least 2013, but in contrast to some other asteroids with repeated mass-loss episodes, 6478 Gault has not lost mass at its perihelion (the closest point of its orbit to the Sun), and thus the loss is not attributable to solar energy—driven ice vaporization."
+    ]
+  },
+  {
+    "name": "mass production",
+    "trans": [
+      "Day 20 | n. | English: Mass production is the production of something in large quantities, especially by machine. | Example: In fact, some historians argue that it fundamentally transformed the industry by enabling it to take advantage of mass production methods for the first time."
+    ]
+  },
+  {
+    "name": "massive",
+    "trans": [
+      "Day 20 | adj. | English: extremely large or serious | Example: The Al-Fattah Al-Aleem Mosque in the New Administrative Capital, Egypt, is a massive mosque that can accommodate approximately 17,000 people at once."
+    ]
+  },
+  {
+    "name": "meadow",
+    "trans": [
+      "Day 20 | n. | English: a field covered in grass, used especially for hay | Example: It was the end of Paris, the beginning of the country, and behind the double row of arches the Seine, suddenly spreading out as though it had regained space and liberty, became all at once the peaceful river which flows through the plains, alongside the wooded hills, amid the meadows, along the edge of the forests."
+    ]
+  },
+  {
+    "name": "meager",
+    "trans": [
+      "Day 20 | adj. | English: small in quantity and poor in quality | Example: She supplements her meagre income by cleaning at night."
+    ]
+  },
+  {
+    "name": "means",
+    "trans": [
+      "Day 20 | n. | English: n. the money that a person has; n. an action, an object or a system by which a result is achieved; a way of achieving or doing sth | Example: [1] Literature can metaphorically transport people to new places regardless of their means. 2] | aim to create a clear sense of the character and the world they inhabit. Sometimes this means adhering to the historical period's style, but frequently, as in stagings of A Midsummer Night's Dream, some flexibility is required to communicate an idea to the audience."
+    ]
+  },
+  {
+    "name": "mediate",
+    "trans": [
+      "Day 20 | v. | English: to influence sth and/or make it possible for it to happen | Example: Rather than being an arbitrary stylistic choice, hyperpop's persistent modification of the voice functions as a commentary on how digital technology mediates human experience today."
+    ]
+  },
+  {
+    "name": "mediocre",
+    "trans": [
+      "Day 20 | adj. | English: not very good; of only average standard | Example: Isaac Asimov, author of Nemesis and The Stars, Like Dust, is highly regarded despite his mediocre writing style."
+    ]
+  },
+  {
+    "name": "meditation",
+    "trans": [
+      "Day 20 | n. | English: the practice of thinking deeply in silence, especially for religious reasons or in order to make your mind calm | Example: In fact the work is a complex, dynamic meditation on gender and the legacy of colonialism that demands serious attention."
+    ]
+  },
+  {
+    "name": "mediterranean",
+    "trans": [
+      "Day 20 | adj. | English: connected with the Mediterranean Sea or the countries and regions that surround it; typical of this area | Example: It lends support to an argument about the Mediterranean design aesthetic that is made in the previous sentence."
+    ]
+  },
+  {
+    "name": "melancholy",
+    "trans": [
+      "Day 20 | n. | English: a deep feeling of sadness that lasts for a long time and often cannot be explained | Example: He surveyed the fence, and all gladness left him and a deep melancholy settled down upon his spirit."
+    ]
+  },
+  {
+    "name": "menace",
+    "trans": [
+      "Day 20 | n. | English: a person or thing that causes, or may cause, serious damage, harm or danger | Example: Holes, hollows, pools, pitfalls, and other menaces to the wayfarer were vanishing fast."
+    ]
+  },
+  {
+    "name": "mercantilism",
+    "trans": [
+      "Day 20 | n. | English: the economic theory that trade increases wealth | Example: Smith's metaphor of the invisible hand has been interpreted as a model of how individuals acting in their own interest produce aggregate benefits, but it was intended as a subtle critique of the economic theory of mercantilism."
+    ]
+  },
+  {
+    "name": "merger",
+    "trans": [
+      "Day 20 | n. | English: the act of joining two or more organizations or businesses into one | Example: Bursts caused by neutron mergers typically last fewer than 2 seconds."
+    ]
+  },
+  {
+    "name": "metabolic",
+    "trans": [
+      "Day 20 | adj. | English: relating to a person's or animal's metabolism | Example: Some scientists have hypothesized that this capability evolved because it imposes a lower metabolic cost than does the alternative mechanism of producing chemicals that render moths noxious to bats."
+    ]
+  },
+  {
+    "name": "metaphorical",
+    "trans": [
+      "Day 20 | adj. | English: connected with or containing metaphors | Example: Literature can metaphorically transport people to new places regardless of their means."
+    ]
+  },
+  {
+    "name": "methodology",
+    "trans": [
+      "Day 20 | n. | English: aset of methods and principles used to perform a particular activity | Example: It introduces a research team's study of urban neighborhoods, describes an aspect of the study's methodology, and suggests a potential application of the team's research."
+    ]
+  },
+  {
+    "name": "meticulous",
+    "trans": [
+      "Day 20 | adj. | English: paying careful attention to every detail Historians argue that Morris's repudiation of industrialization is manifest in the Kelmscott editions' use of handmade materials and intricate ornamentation reminiscent of medieval these meticulously handcrafted elements exemplify the artistry involved."
+    ]
+  },
+  {
+    "name": "metropolis",
+    "trans": [
+      "Day 20 | n. | English: a large important city (often the capital city of a country or region) | Example: By the laity of Milby and its neighbourhood [Mr. Ely] was regarded as a man of quite remarkable powers and learning, who must make a considerable sensation in London pulpits and drawing-rooms on his occasional visit to the metropolis."
+    ]
+  },
+  {
+    "name": "metropolitan",
+    "trans": [
+      "Day 20 | adj. | English: connected with a large or capital city | Example: Often, governments will report a value for the city proper (including only residents within the city limits) and another for the larger metropolitan area (including residents from nearby places beyond the city limits). miasma on. 5 SRMERIAVEE 3230: amass of air that is dirty and smells unpleasant The little conductor stood on tiptoe in an effort to keep one hand on the signal rope, craning his neck in a vain and dissatisfied endeavor to pierce the miasma of the fog."
+    ]
+  },
+  {
+    "name": "miasma",
+    "trans": [
+      "Day 20 | n. | English: amass of air that is dirty and smells unpleasant | Example: The little conductor stood on tiptoe in an effort to keep one hand on the signal rope, craning his neck in a vain and dissatisfied endeavor to pierce the miasma of the fog."
+    ]
+  },
+  {
+    "name": "microbe",
+    "trans": [
+      "Day 20 | n. | English: an extremely small living thing that you can only see under a microscope and that may cause disease The researchers studied two wooden shipwrecks in the Gulf of Mexico by placing pieces of pine and oak between zero and 200 meters away from each shipwreck to collect samples of bacteria, archaea, and fungi."
+    ]
+  },
+  {
+    "name": "microbial",
+    "trans": [
+      "Day 20 | adj. | English: Microbial means relating to or caused by microbes. | Example: Rachel Mugge and colleagues were particularly curious about the effects of wooden shipwrecks on seafloor microbial communities."
+    ]
+  },
+  {
+    "name": "microchip",
+    "trans": [
+      "Day 20 | n. | English: avery small piece of a material that is a semiconductor , used to carry a complicated electronic circuit | Example: The invention in 1958 of the integrated circuit (or microchip) radically altered the semiconductor industry."
+    ]
+  },
+  {
+    "name": "mimic",
+    "trans": [
+      "Day 20 | v. | English: to copy the way sb speaks, moves, behaves, etc., especially in order to make other people laugh | Example: Artificial leaves are a developing renewable energy technology that mimics the process of photosynthesis in plants."
+    ]
+  },
+  {
+    "name": "mingle",
+    "trans": [
+      "Day 20 | v. | English: to combine or make one thing combine with another | Example: Just let me drift far out from toil and care, / Where lapping of the waves shall be the sound, / Which mingled with the winds that gently bear / Me on between a peaceful sea and sky, /To make my soothing slumberous lullaby."
+    ]
+  },
+  {
+    "name": "minimalistic",
+    "trans": [
+      "Day 20 | adj. | English: using the using the smallest range of materials and colours possible, and only very simple shapes or forms | Example: Scholarship today overrepresents formal experimentation, such as William Carlos Williams's use of minimalistic, image-based structures, well beyond the degree to which it actually influenced US poetry during the modernist period (roughly 1900-1945)."
+    ]
+  },
+  {
+    "name": "mining",
+    "trans": [
+      "Day 20 | n. | English: the process of getting coal and other minerals from under the ground; the industry involved in this | Example: The Clarion-Clipperton Zone (CCZ) is an expanse of abyssal plain and seamounts (underwater mountains) between Hawai'i and Mexico in which mining is permitted. minor planet on. /)4{7# MEM: asteroid The discoverers of the minor planet 1227 Geranium named it after the plant genus that includes cranesbills."
+    ]
+  },
+  {
+    "name": "minor planet",
+    "trans": [
+      "Day 20 | n. | English: asteroid | Example: The discoverers of the minor planet 1227 Geranium named it after the plant genus that includes cranesbills."
+    ]
+  },
+  {
+    "name": "mint",
+    "trans": [
+      "Day 20 | v. | English: to make a coin from metal | Example: An analysis by Alain Elayi and colleagues of coins minted in Sidon in the fifth and fourth centuries BCE reveals a change in their composition over time."
+    ]
+  },
+  {
+    "name": "minute",
+    "trans": [
+      "Day 20 | adj. | English: very detailed, careful and thorough | Example: The knowledge, communicated by the historian and biographer, is analogous to that which we acquire of a country by the map, —minute, perhaps, and accurate, and available for all necessary purposes, but cold and naked, and wholly destitute of the mimic charm produced by landscape painting."
+    ]
+  },
+  {
+    "name": "minutiae",
+    "trans": [
+      "Day 20 | n. | English: very small details | Example: Knowing this can assuage potential investors' worries about bureaucratic minutiae and thereby allow them to instead focus on identifying sound business opportunities."
+    ]
+  },
+  {
+    "name": "miraculous",
+    "trans": [
+      "Day 20 | adj. | English: like a miracle ; completely unexpected and very lucky | Example: Behind the Lamassu, more columns sprouted from the ground like ancient trees in a petrified forest, forty feet tall, spindly but still miraculously upright."
+    ]
+  },
+  {
+    "name": "misanthropic",
+    "trans": [
+      "Day 20 | adj. | English: hating and avoiding other people | Example: He was paranoid, self-obsessed and misanthropic."
+    ]
+  },
+  {
+    "name": "mischievous",
+    "trans": [
+      "Day 20 | adj. | English: causing trouble, such as damaging sb's reputation | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+    ]
+  },
+  {
+    "name": "misconstrue",
+    "trans": [
+      "Day 20 | v. | English: to understand sb's words or actions wrongly | Example: She of course is complaining that her comments were sort of misconstrued."
+    ]
+  },
+  {
+    "name": "mitigate",
+    "trans": [
+      "Day 20 | v. | English: to make sth less harmful, serious, etc. | Example: Having an ample reserve of stored energy can mitigate the effects of fluctuations in solar energy collection caused by unpredictable shifts in cloud cover and haze."
+    ]
+  },
+  {
+    "name": "mock",
+    "trans": [
+      "Day 20 | v. | English: to laugh at sb/sth in an unkind way, especially by copying what they say or do | Example: He's always mocking my French accent."
+    ]
+  },
+  {
+    "name": "mollusk",
+    "trans": [
+      "Day 20 | n. | English: A mollusk is an animal such as a snail, clam, or octopus which has a soft body. Many types of mollusc have hard shells to protect them. | Example: With a shell that measured 1.7 meters, the extinct mollusk Parapuzosia seppenradensis is the largest ammonite in the fossil record."
+    ]
+  },
+  {
+    "name": "momentous",
+    "trans": [
+      "Day 21 | adj. | English: very important or serious, especially because there may be important results | Example: The prime minister called the eve of the Games “a truly momentous day for our country\"."
+    ]
+  },
+  {
+    "name": "monarch",
+    "trans": [
+      "Day 21 | n. | English: a person who rules a country, for example a king or a quee | Example: Whether the reign of a French monarch such as Louis VII or Henry V was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy and therefore cannot be understood without a corollary understanding of the characteristics without which the monarch would have been forced to abandon the throne."
+    ]
+  },
+  {
+    "name": "monastery",
+    "trans": [
+      "Day 21 | n. | English: A monastery is a building or collection of buildings in which monks live. | Example: Most infamously, he participated in what was essentially a private war against Sempringham Priory, a monastery near his manor, even making off with 500 pounds’ worth of monastery property during a raid."
+    ]
+  },
+  {
+    "name": "monetize",
+    "trans": [
+      "Day 21 | v. | English: to establish as the legal tender of a country Do you actually want to monetize your blog?"
+    ]
+  },
+  {
+    "name": "monotone",
+    "trans": [
+      "Day 21 | n. | English: a dull sound or way of speaking in which the tone and volume remain the same and therefore seem boring | Example: Among the wild rice in the still lagoon. / In monotone the lizard shrills his tune. / The wild goose, homing, seeks a sheltering, / Where rushes grow, and oozing lichens cling."
+    ]
+  },
+  {
+    "name": "monotonous",
+    "trans": [
+      "Day 21 | adj. | English: never changing and therefore boring | Example: They suggest Caravan's dismay about being trapped in a job that has become exceedingly monotonous."
+    ]
+  },
+  {
+    "name": "monotony",
+    "trans": [
+      "Day 21 | n. | English: boring lack of variety | Example: In his solitary retreat on the shore of the sea, whose mobile surface was visible through the open windows, extending outward until it mingled with the horizon, Padre Florentino was relieving the monotony by playing on his harmonium sad and melancholy tunes, to which the sonorous roar of the surf and the sighing of the treetops of the neighboring wood served as accompaniments."
+    ]
+  },
+  {
+    "name": "morphological",
+    "trans": [
+      "Day 21 | adj. | English: relating to the form or structure of things | Example: The morphological novelty of echinoderms marine—invertebrates with radial symmetry, usually starlike, around a central point—impedes comparisons with most other animals, in which bilateral symmetry on an anterior-posterior (head to tail) axis through a trunk is typical."
+    ]
+  },
+  {
+    "name": "mortal",
+    "trans": [
+      "Day 21 | n. | English: a human, especially an ordinary person with little power or influence | Example: Indeed, what mortal is there of us, who would find his satisfaction enhanced by an opportunity of comparing the picture he presents to himself of his own doings, with the picture they make on the mental retina of his neighbours?"
+    ]
+  },
+  {
+    "name": "mosque",
+    "trans": [
+      "Day 21 | n. | English: a building in which Muslims worship | Example: The Al-Fattah Al-Aleem Mosque in the New Administrative Capital, Egypt, is a massive mosque that can accommodate approximately 17,000 people at once."
+    ]
+  },
+  {
+    "name": "moss",
+    "trans": [
+      "Day 21 | n. | English: avery small green or yellow plant without flowers that spreads over damp surfaces, rocks, trees, etc. | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+    ]
+  },
+  {
+    "name": "motif",
+    "trans": [
+      "Day 21 | n. | English: a design or a pattern used as a decoration | Example: Linda Lomahaftewa often assembles compositions out of motifs common in the ceramics and other traditional arts of the Hopi Tribe."
+    ]
+  },
+  {
+    "name": "mound",
+    "trans": [
+      "Day 21 | n. | English: a large pile of earth or stones | Example: Using a mechanical spear-thrower, he launched spears with Clovis points into mounds of clay—substitutes for the animals’ large bodies."
+    ]
+  },
+  {
+    "name": "mourn",
+    "trans": [
+      "Day 21 | v. | English: to feel and show sadness because sb has died | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+    ]
+  },
+  {
+    "name": "mournful",
+    "trans": [
+      "Day 21 | adj. | English: very sad | Example: Notes long, full, mournful as a prayer, yet still vigorous, escaped from the old instrument."
+    ]
+  },
+  {
+    "name": "mule",
+    "trans": [
+      "Day 21 | n. | English: an animal that has a horse and a donkey as parents, used especially for carrying loads | Example: There are persons who go to the theater like the contestants in a mule-race: the last one in, wins, and we know very sensible men who would ascend the scaffold rather than enter a theater before the first act."
+    ]
+  },
+  {
+    "name": "multifaceted",
+    "trans": [
+      "Day 21 | adj. | English: having many different aspects to be considered | Example: In The Future of Nostalgia, Svetlana Boym offers readers a multifaceted exploration of the concept of nostalgia."
+    ]
+  },
+  {
+    "name": "multitude",
+    "trans": [
+      "Day 21 | n. | English: a large crowd of people | Example: Her stockings and boots and well-fitting gloves had worked marvels in her bearing—had given her a feeling of assurance, a sense of belonging to the well-dressed multitude."
+    ]
+  },
+  {
+    "name": "municipality",
+    "trans": [
+      "Day 21 | n. | English: a town, city or district with its own local government; the group of officials who govern it | Example: For example, the Puerto Rican municipality of Hatillo has also been called \"the Blue Coast of Puerto Rico,\" a nickname that alludes to what the area is well known for: the pristine blue ocean that surrounds it."
+    ]
+  },
+  {
+    "name": "musing",
+    "trans": [
+      "Day 21 | n. | English: a period of thinking carefully about sth or telling people your thoughts about it | Example: So shrewd an observer is Shnagon, a lady-in-waiting to Empress Teishi, that her book's musings on tenth-century Japanese courtly life fascinate readers a thousand years later."
+    ]
+  },
+  {
+    "name": "musty",
+    "trans": [
+      "Day 21 | adj. | English: smelling damp and unpleasant because of a lack of fresh air | Example: | sauntered along, forgetful of musty papers, of the offices, of my chief, my colleagues, my documents, and thinking of the good things that were sure to come to me, of all the veiled unknown contained in the future."
+    ]
+  },
+  {
+    "name": "mutable",
+    "trans": [
+      "Day 21 | adj. | English: that can change; likely to change | Example: The Fly River delta is a remarkably mutable landscape."
+    ]
+  },
+  {
+    "name": "mutation",
+    "trans": [
+      "Day 21 | n. | English: a process in which the genetic material of a person, a plant or an animal changes in structure when it is passed on to children, etc., causing different physical characteristics to develop; a change of this kind | Example: The genetic mutation exists in an ancestor of domestic dogs dating to 53,000 years ago."
+    ]
+  },
+  {
+    "name": "mute",
+    "trans": [
+      "Day 21 | v. | English: to make the sound of sth, especially a musical instrument, quieter or softer, sometimes using amute | Example: “The wooing kestrel.” | said, “mutes his mating-note / To please the harmony of this sweet silence.”"
+    ]
+  },
+  {
+    "name": "myopic",
+    "trans": [
+      "Day 21 | adj. | English: If you describe someone as myopic, you are critical of them because they seem unable to realize that their actions might have negative consequences. | Example: Despite stated claims of global relevance, much major research on income inequality performed in the 2010s suffered from a myopic focus on a few countries in North America and Western Europe, partly due to limited data availability."
+    ]
+  },
+  {
+    "name": "myth",
+    "trans": [
+      "Day 21 | n. | English: something that many people believe but that does not exist or is false | Example: Elephants and other animals, though, have busted the myth that tool use requires hands."
+    ]
+  },
+  {
+    "name": "naked",
+    "trans": [
+      "Day 21 | adj. | English: expressed strongly and not hidden | Example: The knowledge, communicated by the historian and biographer, is analogous to that which we acquire of a country by the map, —minute, perhaps, and accurate, and available for all necessary purposes, but cold and naked, and wholly destitute of the mimic charm produced by landscape painting."
+    ]
+  },
+  {
+    "name": "neatly",
+    "trans": [
+      "Day 21 | adv. | English: tidy and carefully arranged | Example: Difference in cell size results in a construction problem—it's hard to neatly connect sections of small cells to sections of large cells—that worsens as the difference increases."
+    ]
+  },
+  {
+    "name": "nebulous",
+    "trans": [
+      "Day 21 | adj. | English: not clear | Example: Our knowledge of the Pliocene epoch and the lives of the hominids during this time was once nebulous."
+    ]
+  },
+  {
+    "name": "nectar",
+    "trans": [
+      "Day 21 | n. | English: a sweet liquid that is produced by flowers and collected by bees for making honey | Example: In a 2021 paper, zoologist Guillaume Ghisbain notes that bumblebees are among the relatively few wild-bee genera that display social behaviors and dietary generalism (ability to obtain nectar and pollen from a diversity of plant species), two traits that are associated with increased resilience to some specific environmental changes."
+    ]
+  },
+  {
+    "name": "negligible",
+    "trans": [
+      "Day 21 | adj. | English: of very little importance or size and not worth considering | Example: Seira et al. asserted that such effects may nevertheless be worth pursuing, given the negligible cost of messaging."
+    ]
+  },
+  {
+    "name": "neutron star",
+    "trans": [
+      "Day 21 | n. | English: Aneutron star is a star that has collapsed under the weight of its own gravity. The recently observed gamma ray burst GRB 230307A lasted for 200 seconds, an oddity for a burst generated by the merger of neutron stars."
+    ]
+  },
+  {
+    "name": "nocturnal",
+    "trans": [
+      "Day 21 | adj. | English: active at night | Example: Though many other nocturnal mammals respond to lunar intensity variations similarly to greater short-nosed fruit bats, mongoose lemurs (Eulemur mongoz) display the opposite pattern, as their heavy reliance on visual foraging results in a different balance of reward and risk."
+    ]
+  },
+  {
+    "name": "nominally",
+    "trans": [
+      "Day 21 | adv. | English: in name only | Example: The present-day city of Yoshkar-Ola, Russia, was the capital of the Mari Autonomous Soviet Socialist Republic, one of many nominally autonomous republics within the Soviet Union."
+    ]
+  },
+  {
+    "name": "nomination",
+    "trans": [
+      "Day 21 | n. | English: the act of suggesting or choosing sb as a candidate in an election, or for a job or an award; the fact of being suggested for this | Example: A-student claims that opening weekend earnings can reliably predict whether a film will be nominated for an Oscar: films that draw large audiences at the beginning of their release are the most likely contenders to earn these coveted award nominations."
+    ]
+  },
+  {
+    "name": "nonetheless",
+    "trans": [
+      "Day 21 | adv. | English: despite this fact | Example: This approach has some limits—data from Places API tend to be restricted to places that are customer-facing—but the data set nonetheless provides an extremely reliable source to study colocation patterns of neighborhood amenities."
+    ]
+  },
+  {
+    "name": "norms",
+    "trans": [
+      "Day 21 | n. | English: standards of behaviour that are typical of or accepted within a particular group or society | Example: They can register shifts in norms, values, and concerns that traditional objects of historical inquiry may not."
+    ]
+  },
+  {
+    "name": "notable",
+    "trans": [
+      "Day 21 | adj. | English: deserving to be noticed or to receive attention; important | Example: British painter Peter Edwards has a reputation for painting portraits of notable figures from a variety of different fields."
+    ]
+  },
+  {
+    "name": "notional",
+    "trans": [
+      "Day 21 | adj. | English: based on a guess, estimate or theory; not existing in reality Until recently, Theia was notional, but researcher Qian Yuan and colleagues now claim to have identified pieces of the protoplanet in the lowermost section of Earth's mantle."
+    ]
+  },
+  {
+    "name": "notorious",
+    "trans": [
+      "Day 21 | adj. | English: well known for being bad | Example: The fact that this genus has not been observed in eastern and western Coahuila has been attributed to a lack of appropriate habitat, but much of the landscape in this area is notoriously inaccessible."
+    ]
+  },
+  {
+    "name": "noxious",
+    "trans": [
+      "Day 21 | adj. | English: poisonous or harmful Some scientists have hypothesized that this capability evolved because it imposes a lower metabolic cost than does the alternative mechanism of producing chemicals that render moths noxious to bats."
+    ]
+  },
+  {
+    "name": "nuance",
+    "trans": [
+      "Day 21 | n. | English: a very slight difference in meaning, sound, colour or sb's feelings that is not usually very obvious | Example: Those studying the works of Antonio Machado, for instance, may inadvertently overlook nuances in his work by focusing only on the most obvious ways in which his style"
+    ]
+  },
+  {
+    "name": "nuanced",
+    "trans": [
+      "Day 21 | adj. | English: characterized by subtle shades of meaning or expression | Example: Political scientists have found that although voters claim to prefer candidates who have nuanced perspectives on issues and who show a willingness to compromise, when asked to compare speeches expressing such views with speeches expressing dogmatic views, voters tend to regard the unyielding rhetoric of the latter more favorably."
+    ]
+  },
+  {
+    "name": "nuclei",
+    "trans": [
+      "Day 21 | n. | English: the central part of sth around which other parts are located or collected Quasars—such as APM 08279+5255, located in the Lynx constellation—are extremely luminous galactic nuclei powered by supermassive black holes."
+    ]
+  },
+  {
+    "name": "nullify",
+    "trans": [
+      "Day 21 | v. | English: to make sth lose its effect or power Economist Jingting Fan argues that the effects of international trade may display spatial variation at sub-national levels. For instance, imported goods may reduce expenses for a country's average consumer, but for consumers living far from ports, high intranational transport costs could nullify the price advantages associated with imports."
+    ]
+  },
+  {
+    "name": "nurture",
+    "trans": [
+      "Day 21 | v. | English: to help sb/sth to develop and be successful | Example: Although fewer companies trade their stocks on the Cambodia Securities Exchange in Phnom Penh, Cambodia, than on the stock exchanges in London, Mumbai, or Tokyo, the Cambodia Securities Exchange has the advantage of being able to nurture relatively small companies in Cambodia."
+    ]
+  },
+  {
+    "name": "oar",
+    "trans": [
+      "Day 21 | n. | English: along pole with a flat blade at one end that is used for rowing a boat | Example: Thy warm and land-locked waters swell with an easy motion, / And gently glides the light"
+    ]
+  },
+  {
+    "name": "obedience",
+    "trans": [
+      "Day 21 | n. | English: the fact that people or animals do what they are told to do | Example: But she had been trained to obedience, and her battles with the spirit always took place after she carefully locked her bedroom door."
+    ]
+  },
+  {
+    "name": "objective",
+    "trans": [
+      "Day 21 | n. | English: n. something that you are trying to achieve; adj. not influenced by personal feelings or opinions; considering only facts | Example: [1] The algorithm gave them an objective way to identify neighborhoods. 2] It illustrates the assertion that peace is a subjective state rather than an objective one."
+    ]
+  },
+  {
+    "name": "obligate",
+    "trans": [
+      "Day 21 | adj. | English: biologically essential for survival | Example: The migration's obligate nature is why diadromous fish can be demarcated from those that are merely euryhaline (able to tolerate high salinity)."
+    ]
+  },
+  {
+    "name": "obligated",
+    "trans": [
+      "Day 22 | adj. | English: having a moral or legal duty to do sth | Example: He felt obligated to help."
+    ]
+  },
+  {
+    "name": "obliterate",
+    "trans": [
+      "Day 22 | v. | English: to remove all signs of sth, either by destroying or covering it completely | Example: The fog extended its tentacles over city and river gradually obliterating traces of familiar landscapes."
+    ]
+  },
+  {
+    "name": "oblivious",
+    "trans": [
+      "Day 22 | adj. | English: not aware of sth | Example: He drove off, oblivious of the damage he had caused."
+    ]
+  },
+  {
+    "name": "obscure",
+    "trans": [
+      "Day 22 | v. | English: v. to make it difficult to see, hear or understand sth; adj. difficult to understand | Example: [1] Thus, in the case of Cannon's generation, the identification of an abstract painting as Indigenous art tends to obscure the Indigenous origins of certain motifs associated with Abstract Expressionism. 2] May herself could not understand [Newland's] obscure reluctance to fall in with so reasonable and pleasant a way of spending the summer."
+    ]
+  },
+  {
+    "name": "obscurity",
+    "trans": [
+      "Day 22 | n. | English: difficult to understand | Example: Its apparent obscurity can be resolved when considered in the proper cultural context."
+    ]
+  },
+  {
+    "name": "observatory",
+    "trans": [
+      "Day 22 | n. | English: a special building from which scientists watch the stars, the weather, etc | Example: In 2016, Gabriela Gonzalez and team announced that a chirping sound captured by Laser Interferometer Gravitational-Wave Observatory antennas was direct evidence of gravitational waves."
+    ]
+  },
+  {
+    "name": "obsolete",
+    "trans": [
+      "Day 22 | adj. | English: no longer used because sth new has been invented | Example: Its primary methods for analyzing fiction written in the period are growing obsolete as computer technology advances."
+    ]
+  },
+  {
+    "name": "obstacle",
+    "trans": [
+      "Day 22 | n. | English: a situation, an event, etc. that makes it difficult for you to do or achieve sth | Example: It seemed as if nature had determined to throw every conceivable obstacle in the way of those who should seek to join the two great oceans of the world."
+    ]
+  },
+  {
+    "name": "obstruct",
+    "trans": [
+      "Day 22 | v. | English: to prevent sb/sth from doing sth or making progress, especially when this is done deliberately | Example: They were charged with obstructing the police in the course of their duty."
+    ]
+  },
+  {
+    "name": "obviate",
+    "trans": [
+      "Day 22 | v. | English: to remove a problem or the need for sth | Example: While bioaccumulation of manufactured nanoparticles may be inherently worrisome, it has been hypothesized that CeO2-NP bioaccumulation in invertebrates like D. polymorpha could serve a valuable proxy role, obviating the need for manufacturers to conduct costly and intrusive sampling of vertebrate species—such as rainbow trout (Oncorhynchus mykiss), commonly used in regulatory compliance testing—for nanoparticle bioaccumulation, as environmental protection laws currently require."
+    ]
+  },
+  {
+    "name": "occasional",
+    "trans": [
+      "Day 22 | adj. | English: happening or done sometimes but not often | Example: By the laity of Milby and its neighbourhood [Mr. Ely] was regarded as a man of quite remarkable powers and learning, who must make a considerable sensation in London pulpits and drawing-rooms on his occasional visit to the metropolis."
+    ]
+  },
+  {
+    "name": "occurrence",
+    "trans": [
+      "Day 22 | n. | English: something that happens or exists | Example: To describe a regular occurrence from Grande's childhood"
+    ]
+  },
+  {
+    "name": "oddity",
+    "trans": [
+      "Day 22 | n. | English: a person or thing that is strange or unusual | Example: The recently observed gamma ray burst GRB 230307A lasted for 200 seconds, an oddity for a burst generated by the merger of neutron stars."
+    ]
+  },
+  {
+    "name": "odor",
+    "trans": [
+      "Day 22 | n. | English: asmell, especially one that is unpleasant | Example: | walked slowly beneath the young leaves, drinking in the air, fragrant with the odor of young buds and sap."
+    ]
+  },
+  {
+    "name": "offset",
+    "trans": [
+      "Day 22 | v. | English: to use one cost, payment or situation in order to cancel or reduce the effect of another | Example: Any advantages that the transmission strategy used by three-host CLPs may have conferred did not completely offset the negative effects of other temperature driven factors on CLP abundance."
+    ]
+  },
+  {
+    "name": "offspring",
+    "trans": [
+      "Day 22 | n. | English: a child of a particular person or couple | Example: Horizontal gene transfer involves the exchange of genetic material between organisms not in a parent-offspring relationship."
+    ]
+  },
+  {
+    "name": "oligarchy",
+    "trans": [
+      "Day 22 | n. | English: a form of government in which only a small group of people hold all the power | Example: Aristotle observes that different forms of government can fall in different ways—for example, oligarchies might grant power to military leaders during wartime who refuse to relinquish that power during peacetime—but some methods of preserving order apply across all forms of government. ontiptoe HF BER# 3232: standing or walking on the front part of your foot, with your heels off the ground, in order to make yourself taller or to move very quietly The little conductor stood on tiptoe in an efort to keep one hand on the signal rope, craning his neck in a vain and dissatisfed endeavor to pierce the miasma of the fog. on/to the verge of sth/of doing sth Big 327%: very near to the moment when sb does sth or sth happens There is no denying that, since he was rather brusque in his ways, he never spared the young authors who asked his advice and read him their productions, but criticized vigorously, even to the verge of insult."
+    ]
+  },
+  {
+    "name": "on tiptoe",
+    "trans": [
+      "Day 22 | English: standing or walking on the front part of your foot, with your heels off the ground, in order to make yourself taller or to move very quietly | Example: The little conductor stood on tiptoe in an efort to keep one hand on the signal rope, craning his neck in a vain and dissatisfed endeavor to pierce the miasma of the fog. on/to the verge of sth/of doing sth Big 327%: very near to the moment when sb does sth or sth happens"
+    ]
+  },
+  {
+    "name": "on/to the verge of sth/of doing sth",
+    "trans": [
+      "Day 22 | English: very near to the moment when sb does sth or sth happens | Example: There is no denying that, since he was rather brusque in his ways, he never spared the young authors who asked his advice and read him their productions, but criticized vigorously, even to the verge of insult."
+    ]
+  },
+  {
+    "name": "ongoing",
+    "trans": [
+      "Day 22 | adj. | English: continuing to exist or develop | Example: The student, however, claims that ultimately audiences of the time preferred resolution and closure over ongoing tension."
+    ]
+  },
+  {
+    "name": "ooze",
+    "trans": [
+      "Day 22 | v. | English: ifa thick liquid oozes from a place, or if sth oozes a thick liquid, the liquid flows from the place slowly Among the wild rice in the still lagoon. / In monotone the lizard shrills his tune. / The wild goose, homing, seeks a sheltering, / Where rushes grow, and oozing lichens cling."
+    ]
+  },
+  {
+    "name": "opalescent",
+    "trans": [
+      "Day 22 | adj. | English: changing colour like an opal The sierra is clad in gala colors. Over its inaccessible peaks the opalescent fog settles like a snowy veil on the forehead of a bride."
+    ]
+  },
+  {
+    "name": "opportune",
+    "trans": [
+      "Day 22 | n. | English: suitable for doing a particular thing, so that it is likely to be successfu | Example: The offer could not have come at a more opportune moment."
+    ]
+  },
+  {
+    "name": "oppressive",
+    "trans": [
+      "Day 22 | adj. | English: treating people in a cruel and unfair way and not giving them the same freedom, rights, etc. as other people | Example: Because coins with a silver content below 80% were widely considered unsuitable for trade, Elayi et al. speculate that a crisis in confidence in the currency occurred in Sidon around 367 BCE, which was likely relieved—despite Sidon's persistent oppressive financial obligations—as a result of Ba’al&illem II's successor Abd'aStart I's decision to keep the amount of silver in Sidonian coins consistent with that in coins minted in 367 BCE but decrease their weight."
+    ]
+  },
+  {
+    "name": "optimal",
+    "trans": [
+      "Day 22 | adj. | English: the best possible; producing the best possible results | Example: The predictive model, which incorporates this algorithm, is sure to be invaluable in determining the optimal mix of a city's amenities."
+    ]
+  },
+  {
+    "name": "orbit",
+    "trans": [
+      "Day 22 | n. | English: a curved path followed by a planet or an object as it moves around another planet, star, moon, etc. | Example: One popular theory of the origin of the Moon, the \"big whack,\" posits that a protoplanet called Theia collided with Earth, flinging debris into orbit that eventually coalesced into the Moon."
+    ]
+  },
+  {
+    "name": "ornamental",
+    "trans": [
+      "Day 22 | adj. | English: used as decoration rather than for a practical purpose | Example: Extensive travels abroad later sparked an engagement with modernist and functionalist aesthetics—styles whose emphasis on utility and whose repudiation of traditional architecture's more ornamental elements are readily apparent in Barragan's house in Calle Guadiana."
+    ]
+  },
+  {
+    "name": "ornamentation",
+    "trans": [
+      "Day 22 | n. | English: the use of objects, designs, etc. to decorate sth Historians argue that Morris's repudiation of industrialization is manifest in the Kelmscott editions' use of handmade materials and intricate ornamentation reminiscent of medieval these meticulously handcrafted elements exemplify the artistry involved."
+    ]
+  },
+  {
+    "name": "orthodox",
+    "trans": [
+      "Day 22 | adj. | English: following generally accepted beliefs | Example: Orthodox economists believe that a recession is now inevitable."
+    ]
+  },
+  {
+    "name": "outgrow",
+    "trans": [
+      "Day 22 | v. | English: to grow too big to be able to wear or fit into sth | Example: The young trees had not outgrown their [planter] boxes then. V Street [in Washington, DC] was lined with them."
+    ]
+  },
+  {
+    "name": "outlay",
+    "trans": [
+      "Day 22 | n. | English: the money that you have to spend in order to start a new project | Example: The success of the fitness study likely requires significantly less financial outlay than that needed for CLSA-ELCV."
+    ]
+  },
+  {
+    "name": "outnumber",
+    "trans": [
+      "Day 22 | v. | English: to be greater in number than sb/sth | Example: Night-blooming jessamine shrubs and other non-native forest plants only recently began to outnumber native forest plants in the wild."
+    ]
+  },
+  {
+    "name": "outpouring",
+    "trans": [
+      "Day 22 | n. | English: a large amount of sth produced in a short time | Example: Literary production in the period after the Mexican Revolution (which lasted from 1910-1920) was prolific, with writers like Octavio Paz contributing to the outpouring of poetry, fiction, essays, and more."
+    ]
+  },
+  {
+    "name": "outright",
+    "trans": [
+      "Day 22 | adv. | English: clearly and completely | Example: While some of her recordings conform to the model perfected by 100 gecs, others reject it outright."
+    ]
+  },
+  {
+    "name": "outsized",
+    "trans": [
+      "Day 22 | adj. | English: exceptionally large | Example: Works from this period make up an outsized proportion of what is considered the canon of Mexican literature, but nineteenth-century writers like Justo Sierra O'Reilly should be considered just as integral to the Mexican literary canon."
+    ]
+  },
+  {
+    "name": "outstrip",
+    "trans": [
+      "Day 22 | v. | English: to become larger, more important, etc. than sb/sth | Example: Consumers’ expectations for reduced delivery times may be outstripping what is viable for delivery companies to provide."
+    ]
+  },
+  {
+    "name": "outweigh",
+    "trans": [
+      "Day 22 | v. | English: to be greater or more important than sth | Example: By suggesting that whatever infractions Luttrell might have committed are outweighed by the"
+    ]
+  },
+  {
+    "name": "overdue",
+    "trans": [
+      "Day 22 | adj. | English: that should have happened or been done before now | Example: The naming of Buenaventura as a City Gastronomy was long overdue, given the city’s delicious food."
+    ]
+  },
+  {
+    "name": "overflow",
+    "trans": [
+      "Day 22 | v. | English: to be so full that the contents go over the sides | Example: | guess this means Pops is overflowing with riches because ever since | can remember | was never without a book within reach."
+    ]
+  },
+  {
+    "name": "overlook",
+    "trans": [
+      "Day 22 | v. | English: to fail to see or notice sth | Example: While there are several possible reasons for this, one is that practitioners may overlook confounding variables that account for the results they attribute to the interventions in question."
+    ]
+  },
+  {
+    "name": "overreach",
+    "trans": [
+      "Day 22 | v. | English: to fail by trying to achieve more than is possible | Example: In making these promises, the company had clearly overreached itself."
+    ]
+  },
+  {
+    "name": "oversee",
+    "trans": [
+      "Day 22 | v. | English: to watch sb/sth and make sure that a job or an activity is done correctly | Example: The text recounts Mukerjee's early training in the social scientific disciplines and then lists social policies whose implementation Mukerjee oversaw."
+    ]
+  },
+  {
+    "name": "overshadow",
+    "trans": [
+      "Day 22 | v. | English: to make sb/sth seem less important, or successful | Example: Richard Nixon is commonly linked with an infamous historical event, but this overshadows some of his notable achievements."
+    ]
+  },
+  {
+    "name": "overstate",
+    "trans": [
+      "Day 22 | v. | English: to say sth in a way that makes it seem more important than it really is | Example: It may overstate the effect of ocean acidification on the behavior of Sparus aurata."
+    ]
+  },
+  {
+    "name": "overstock",
+    "trans": [
+      "Day 22 | v. | English: to buy or make more of sth than you need or can sell | Example: Better predictions mean demand is easier to meet without retailers becoming overstocked."
+    ]
+  },
+  {
+    "name": "overturn",
+    "trans": [
+      "Day 22 | v. | English: to officially decide that a legal decision etc. is not correct, and to make it no longer valid | Example: It states a long-standing scientific assumption and then shows how recent research has overturned that assumption."
+    ]
+  },
+  {
+    "name": "overwhelmed",
+    "trans": [
+      "Day 22 | v. | English: to be so bad or so great that a person cannot deal with it; to give too much of a thing to a person | Example: We were overwhelmed by requests for information."
+    ]
+  },
+  {
+    "name": "painstaking",
+    "trans": [
+      "Day 22 | adj. | English: needing a lot of care, effort and attention to detail | Example: Over the course of three years, Reiniger and her collaborators painstakingly made more than 250,000 individual images of hand-cut paper silhouettes and repeatedly had to invent entirely new methods and tools to create the special effects Reiniger envisioned."
+    ]
+  },
+  {
+    "name": "palatable",
+    "trans": [
+      "Day 22 | adj. | English: having a pleasant or acceptable taste | Example: Nicholas T. Homziak et al. investigated the acoustic properties of moths' ultrasonic responses to audio of bat echolocation and then assessed the palatability of the ultrasound- producing moths."
+    ]
+  },
+  {
+    "name": "palatial",
+    "trans": [
+      "Day 22 | adj. | English: very large and impressive, like a palace | Example: The whole of Manhattan Island is turned into a city of skyscrapers, churches and palatial residences."
+    ]
+  },
+  {
+    "name": "pale",
+    "trans": [
+      "Day 23 | adj. | English: having skin that is almost white; having skin that is whiter than usual because of illness, a strong emotion, etc. | Example: Yes, the great cloud was ravelling, discovering here and there a pale and dying sky."
+    ]
+  },
+  {
+    "name": "palpable",
+    "trans": [
+      "Day 23 | adj. | English: that is easily noticed by the mind or the senses | Example: The sloping tile roofs and picturesque facade of Mission San Luis Rey de Francia in Oceanside, California, exemplify the Spanish contribution to Californian architecture, an influence that is palpable throughout the state"
+    ]
+  },
+  {
+    "name": "paradigm",
+    "trans": [
+      "Day 23 | n. | English: a typical example or pattern of sth | Example: Smith deploys this metaphor only once in his economic writings—to make a narrow point about the then-dominant economic theory of mercantilism—and it was largely ignored until some twentieth-century economists eager to secure an intellectual pedigree for their views elevated it to a fully-fledged paradigm."
+    ]
+  },
+  {
+    "name": "parallel",
+    "trans": [
+      "Day 23 | n. | English: similar features | Example: F. Scott Fitzgerald's 1920 novel This Side of Paradise contains elements drawn from Fitzgerald's own life—there are many parallels between the experiences of the novel's protagonist, Amory Blaine, and those of Fitzgerald."
+    ]
+  },
+  {
+    "name": "parcel",
+    "trans": [
+      "Day 23 | n. | English: something that is wrapped in paper or put into a thick envelope so that it can be sent by mail, carried easily, or given as a present | Example: She handed the girl a five-dollar bill and waited for her change and for her parcel. What a very small parcel it was!"
+    ]
+  },
+  {
+    "name": "parlor",
+    "trans": [
+      "Day 23 | n. | English: aroom ina private house for sitting in, entertaining visitors, etc. | Example: The front parlor had always been her special province, as she used it for her little school."
+    ]
+  },
+  {
+    "name": "partfrom",
+    "trans": [
+      "Day 23 | v. | English: if a person parts from another person, or two people part , they leave each other | Example: Mercedes, being not quite seventeen, her grief at parting from Clarence was wild, vehement and all-absorbing."
+    ]
+  },
+  {
+    "name": "partition",
+    "trans": [
+      "Day 23 | v. | English: to divide sth into parts The room is partitioned into three sections."
+    ]
+  },
+  {
+    "name": "pasture",
+    "trans": [
+      "Day 23 | n. | English: and covered with grass that is suitable for feeding animals on | Example: A dry ravine emerged under boughs / Into the pasture."
+    ]
+  },
+  {
+    "name": "pathogen",
+    "trans": [
+      "Day 23 | n. | English: a thing that causes disease | Example: An understanding of how to prevent horizontal gene transfer might result in the mitigation of dangerous pathogens (organisms that cause disease)."
+    ]
+  },
+  {
+    "name": "patron",
+    "trans": [
+      "Day 23 | n. | English: a person who uses a particular shop/store, restaurant, etc. | Example: It conveys the urgency some theater patrons feel to be the first ones to arrive at a performance."
+    ]
+  },
+  {
+    "name": "patronage",
+    "trans": [
+      "Day 23 | n. | English: the support, especially financial, that is given to a person or an organization by a patron | Example: As modern scholar Fabio Fernandes notes, however, these two traditions aren't as distinct as they seem, as both the emperor and the private library owners viewed their libraries as extensions of their personal patronage, just on vasty differing scales."
+    ]
+  },
+  {
+    "name": "pavement",
+    "trans": [
+      "Day 23 | n. | English: the surface of a road | Example: Civil engineer Jay X. Wang has noted that the effects of expansive soil appear slowly in the form of gradually growing cracks in foundations, walls, and pavements."
+    ]
+  },
+  {
+    "name": "peak",
+    "trans": [
+      "Day 23 | adj. | English: used to describe the highest level of sth, or a time when the greatest number of people are doing sth or using sth | Example: They found that across the three microbial communities, peak diversity and richness was observed on pine and oak samples placed approximately 125 meters from the shipwrecks."
+    ]
+  },
+  {
+    "name": "peasant",
+    "trans": [
+      "Day 23 | n. | English: (especially in the past, or in poorer countries) a farmer who owns or rents a small piece of land | Example: The emphasis on accurately representing the experiences of average working people that is characteristic of the realist style can be seen in The Gleaners, painted by Jean-Francois Millet, which depicts peasants picking stray wheat from a field after the harvest."
+    ]
+  },
+  {
+    "name": "peculiar",
+    "trans": [
+      "Day 23 | adj. | English: strange or unusual, especially in a way that is unpleasant or worrying | Example: [The soldiers] entered the streets of Juchipila as the church bells rang, loud and joyfully, with that peculiar tone that thrills every mountaineer."
+    ]
+  },
+  {
+    "name": "pedestrian",
+    "trans": [
+      "Day 23 | n. | English: a person walking in the street and not travelling in a vehicle | Example: Some cities track pedestrian activity to map their sidewalks."
+    ]
+  },
+  {
+    "name": "pedigree",
+    "trans": [
+      "Day 23 | n. | English: a person's family history or the background of sth, especially when this is impressive | Example: Smith deploys this metaphor only once in his economic writings—to make a narrow point about the then-dominant economic theory of mercantilism—and it was largely ignored until some twentieth-century economists eager to secure an intellectual pedigree for their views elevated it to a fully-fledged paradigm."
+    ]
+  },
+  {
+    "name": "peer review",
+    "trans": [
+      "Day 23 | English: the evaluation by fellow specialists of research that someone has done in order to assess its suitability for publication or further development | Example: For Carson's album, dubbed a “mixtap/e/ssay,” peer review involved both scholars and rap artists."
+    ]
+  },
+  {
+    "name": "penetrate",
+    "trans": [
+      "Day 23 | v. | English: to go into or through sth | Example: The projectiles generally penetrated only a few inches into the clay, an amount insufficient to have harmed most woolly mammoths."
+    ]
+  },
+  {
+    "name": "perceptible",
+    "trans": [
+      "Day 23 | adj. | English: great enough for you to notice it | Example: The sun, already down, was perceptible in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+    ]
+  },
+  {
+    "name": "perceptive",
+    "trans": [
+      "Day 23 | adj. | English: having or showing the ability to see or understand things quickly, especially things that are not obvious | Example: It helps explain why some people are especially perceptive of the social dynamics at theaters."
+    ]
+  },
+  {
+    "name": "peripheral",
+    "trans": [
+      "Day 23 | adj. | English: adj. in the outer area of something, or relating to this area; adj. not as important as the main aim, part, etc. of sth | Example: [1] Because Xoconochco’s location within the empire was so peripheral, cacao and other trade goods produced there could reach the capital only after a long overland journey. 2] It establishes a contrast between the aesthetic qualities of works by artists who were central to a movement introduced earlier in the text and those of an artist who was more peripheral to that movement."
+    ]
+  },
+  {
+    "name": "periphery",
+    "trans": [
+      "Day 23 | n. | English: If something is on the periphery of an area, place, or thing, it is on the edge of it _ The way in which individual elements are balanced within a photographic image tends to symmetry tends to give the elements equal importance, asymmetry emphasizes differences, and radial balance (organizing the elements around a central point) emphasizes the center over the periphery."
+    ]
+  },
+  {
+    "name": "permanent",
+    "trans": [
+      "Day 23 | adj. | English: lasting for a long time or for all time in the future; existing all the time | Example: Since its founding, it has acquired more than 4,800 objects for its permanent collection."
+    ]
+  },
+  {
+    "name": "permeability",
+    "trans": [
+      "Day 23 | n. | English: the state or quality of being permeable | Example: However, any barrier used must allow the thread-like hyphae of a CMN to pass through, and this permeability would also allow liquids through."
+    ]
+  },
+  {
+    "name": "permeable",
+    "trans": [
+      "Day 23 | adj. | English: allowing a liquid or gas to pass through | Example: As the process continues, water from the food's center moves to the crust as long as the crust remains permeable."
+    ]
+  },
+  {
+    "name": "permeate",
+    "trans": [
+      "Day 23 | v. | English: to spread to every part of an object or a place | Example: A thousand recollections of childhood came over me, awakened by these country odors, and | walked along, permeated with the fragrant, living enchantment, the emotional enchantment of the woods warmed by the sun of June."
+    ]
+  },
+  {
+    "name": "permissible",
+    "trans": [
+      "Day 23 | adj. | English: acceptable according to the law or a particular set of rules | Example: Under current astronomical conventions, it is permissible for the discoverers to name their discoveries, but they are not required to do so; whether to assign a minor planet a name is entirely the choice of whoever discovers it."
+    ]
+  },
+  {
+    "name": "perpetrate",
+    "trans": [
+      "Day 23 | v. | English: to commit a crime or do sth wrong or evil | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+    ]
+  },
+  {
+    "name": "perpetual",
+    "trans": [
+      "Day 23 | adj. | English: never ending or changing | Example: Remarkable for anticipating and amplifying cultural perceptions of Florida that became pervasive in the public consciousness, paintings by the Highwaymen are readily identifiable by the natural iconography—placid inland rivers, windswept palm trees—that McLendon and colleagues perpetually revisited."
+    ]
+  },
+  {
+    "name": "perplexed",
+    "trans": [
+      "Day 23 | adj. | English: If you are perplexed, you feel confused and slightly worried by something because you do not understand it. | Example: Ever since fossilized remains of this species were discovered in 1895, scientists have been perplexed by its size."
+    ]
+  },
+  {
+    "name": "persist",
+    "trans": [
+      "Day 23 | v. | English: to continue to exist | Example: For centuries, people in Ireland and Northern Ireland have been finding deposits of valuable objects, called hoards, that earlier people buried. These discoveries have persisted into the 2000s."
+    ]
+  },
+  {
+    "name": "persistent",
+    "trans": [
+      "Day 23 | adj. | English: adj. determined to do sth despite difficulties, especially when other people are against you and think that you are being annoying or unreasonable; adj. continuing for a long period of time without interruption, or repeated frequently, especially in a way that is annoying and cannot be stopped | Example: [1] Rather than being an arbitrary stylistic choice, hyperpop's persistent modification of the voice functions as a commentary on how digital technology mediates human experience today. 2] a crisis in confidence in the currency occurred in Sidon around 367 BCE, which was likely relieved—despite Sidon's persistent oppressive financial obligations—as a result of Ba‘alsillem II's successor Abd'a&tart I's decision to keep the amount of silver in Sidonian coins consistent with that in coins minted in 367 BCE but decrease their weight."
+    ]
+  },
+  {
+    "name": "personage",
+    "trans": [
+      "Day 23 | n. | English: an important or famous person | Example: Few of the personages of past times (except such as have gained renown in fireside legends as well as in written history) are anything but mere names to their successors."
+    ]
+  },
+  {
+    "name": "perspective",
+    "trans": [
+      "Day 23 | n. | English: a particular attitude towards sth; a way of thinking about sth | Example: People sometimes dismiss a claim if it comes from a source they regard as self-interested, but from a strictly logical perspective, the source of a claim is irrelevant."
+    ]
+  },
+  {
+    "name": "persuasive",
+    "trans": [
+      "Day 23 | adj. | English: able to persuade sb to do or believe sth | Example: In the play, Aristophanes satirizes sophists as teaching students how to be persuasive without regard for what is morally good."
+    ]
+  },
+  {
+    "name": "pervasive",
+    "trans": [
+      "Day 23 | adj. | English: existing in all parts of a place or thing | Example: Text corpora such as the British National Corpus are enormous collections of electronically stored texts that can be used for empirical testing of hypotheses regarding how pervasive a"
+    ]
+  },
+  {
+    "name": "petition",
+    "trans": [
+      "Day 23 | v. | English: v. to make a formal request to sb in authority, especially by sending them a petition; n. a written document signed by a large number of people that asks sb in a position of authority to do or change sth | Example: [1] Local residents have successfully petitioned against the siting of a prison in their area. 2] Louis Pipestone is collecting signatures for a petition from fellow members of the Turtle Mountain Band of Chippewa on the tribe's reservation in North Dakota."
+    ]
+  },
+  {
+    "name": "petrified",
+    "trans": [
+      "Day 23 | adj. | English: petrified trees, insects, etc. have died and been changed into stone over a very long period of time | Example: Behind the Lamassu, more columns sprouted from the ground like ancient trees in a petrified forest, forty feet tall, spindly but still miraculously upright."
+    ]
+  },
+  {
+    "name": "petroleum",
+    "trans": [
+      "Day 23 | n. | English: mineral oil that is found under the ground or the sea and is used to produce petrol/gas, paraffin , diesel oil, etc. | Example: Companies involved in petroleum extraction include drilling equipment among their assets."
+    ]
+  },
+  {
+    "name": "pharaoh",
+    "trans": [
+      "Day 23 | n. | English: a ruler of ancient Egypt | Example: Archaeologist Christiana Kohler and her team excavated the Egyptian tomb of Queen Merneith, the wife of a First Dynasty pharaoh."
+    ]
+  },
+  {
+    "name": "pierce",
+    "trans": [
+      "Day 23 | v. | English: to force a way through a barrier The little conductor stood on tiptoe in an effort to keep one hand on the signal rope, craning his neck in a vain and dissatisfied endeavor to pierce the miasma of the fog."
+    ]
+  },
+  {
+    "name": "pigment",
+    "trans": [
+      "Day 23 | n. | English: a substance that exists naturally in people, animals and plants and gives their skin, leaves, etc. a particular colour | Example: For instance, Démoto produced Hunting Expedition by applying color pigments to a silk screen."
+    ]
+  },
+  {
+    "name": "pile",
+    "trans": [
+      "Day 23 | v. | English: to put sth on/into sth; to load sth with sth | Example: \"I'm going to have one of these gorgeous oranges,\" said Mrs. Wilkins, staying where she was and reaching across to a black bowl piled with them."
+    ]
+  },
+  {
+    "name": "pillar",
+    "trans": [
+      "Day 23 | n. | English: alarge round stone, metal or wooden post that is used to support a bridge, the roof of a building, etc., especially when it is also decorative | Example: At five-thirty the old Panhandle bridge, supported by massive sandstone pillars, stalwart, as when erected fifty years before to serve a generation now passed behind the portals of life, had become a spectral outline against the sky."
+    ]
+  },
+  {
+    "name": "pique",
+    "trans": [
+      "Day 23 | v. | English: to make sb annoyed or upset | Example: As time went on, [Avey's] indifference to things began to pique me; | was ambitious. | left [our small hometown] earlier than she did."
+    ]
+  },
+  {
+    "name": "pitch",
+    "trans": [
+      "Day 23 | n. | English: how high or low a sound is, especially a musical note | Example: Her combination of dense synthesizer arrangements and metallic percussion with vocals electronically shifted in pitch above her natural range exemplifies the hyperpop sound."
+    ]
+  },
+  {
+    "name": "pitfall",
+    "trans": [
+      "Day 23 | n. | English: a danger or difficulty, especially one that is hidden or not obvious at first | Example: Holes, hollows, pools, pitfalls, and other menaces to the wayfarer were vanishing fast."
+    ]
+  },
+  {
+    "name": "placate",
+    "trans": [
+      "Day 23 | v. | English: to make sb feel less angry about sth The concessions did little to placate the students."
+    ]
+  },
+  {
+    "name": "placid",
+    "trans": [
+      "Day 24 | adj. | English: calm and peaceful, with very little movemen | Example: Remarkable for anticipating and amplifying cultural perceptions of Florida that became pervasive in the public consciousness, paintings by the Highwaymen are readily identifiable by the natural iconography—placid inland rivers, windswept palm trees—that McLendon and colleagues perpetually revisited."
+    ]
+  },
+  {
+    "name": "plague",
+    "trans": [
+      "Day 24 | v. | English: to cause pain or trouble to sb/sth over a period of time | Example: These studies are plagued by insufficient sample sizes, a lack of control groups, and failures to establish pretraining baselines for the measured attributes of participants."
+    ]
+  },
+  {
+    "name": "plateau",
+    "trans": [
+      "Day 24 | v. | English: to stay at a steady level after a period of growth or progress | Example: In a study of zoo chimpanzees in Swenden and other mid-latitude countries, Sophie Moittié and colleagues found not only that chimpanzees' vitamin D levels correlate with UVB irradiance but also that vitamin D levels show no evidence of plateauing as UVB irradiance reaches its highest local levels."
+    ]
+  },
+  {
+    "name": "plausible",
+    "trans": [
+      "Day 24 | adj. | English: reasonable and likely to be true | Example: It introduces a natural phenomenon, refutes two potential explanations for that phenomenon, and then presents a third explanation for that phenomenon that the author regards as plausible."
+    ]
+  },
+  {
+    "name": "playwright",
+    "trans": [
+      "Day 24 | n. | English: a person who writes plays for the theatre, television or radio | Example: While they might be eager to produce an established classic like Annie, for example, most would be hesitant to stage a work from a relatively unknown playwright."
+    ]
+  },
+  {
+    "name": "plod",
+    "trans": [
+      "Day 24 | v. | English: to walk slowly with heavy steps, especially because you are tired | Example: | remember [the sailor] as if it were yesterday, as he came plodding to the inn door, his sea- chest following behind him in a hand-barrow."
+    ]
+  },
+  {
+    "name": "plot",
+    "trans": [
+      "Day 24 | n. | English: a small piece of land that is used or intended for a special purpose | Example: As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot."
+    ]
+  },
+  {
+    "name": "plough",
+    "trans": [
+      "Day 24 | v. | English: to dig and turn over a field or other area of land with a plough | Example: As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot."
+    ]
+  },
+  {
+    "name": "plunge",
+    "trans": [
+      "Day 24 | v. | English: the act of becoming involved in a situation or activity | Example: Now | suddenly find myself plunged into this wilderness [the estate], condemned to see the same stupid people from morning till night and listen to their futile conversations."
+    ]
+  },
+  {
+    "name": "poetry",
+    "trans": [
+      "Day 24 | n. | English: acollection of poems; poems in general | Example: The late-period pieces of James Tate arguably fit this description, since they straddle the line between prose and poetry."
+    ]
+  },
+  {
+    "name": "polarize",
+    "trans": [
+      "Day 24 | v. | English: to separate or make people separate into two groups with completely opposite opinions While some commentators lauded this development, asserting that such blogs had a welcome transparency missing from traditional news, less sanguine observers countered that such blogs tended to ideological extremes that exacerbated political polarization to problematic levels."
+    ]
+  },
+  {
+    "name": "pollen",
+    "trans": [
+      "Day 24 | n. | English: fine powder, usually yellow, that is formed in flowers and carried to other flowers of the same kind by the wind or by insects, to make those flowers produce seeds | Example: In a 2021 paper, zoologist Guillaume Ghisbain notes that bumblebees are among the relatively few wild-bee genera that display social behaviors and dietary generalism (ability to obtain nectar and pollen from a diversity of plant species), two traits that are associated with increased resilience to some specific environmental changes."
+    ]
+  },
+  {
+    "name": "pollinate",
+    "trans": [
+      "Day 24 | v. | English: to put pollen into a flower or plant so that it produces seeds | Example: The first phase of their study involved shielding some cucumber plants to prevent insects from pollinating them, resulting in those plants having 40 to 90 percent lower crop production than plants that were pollinated normally."
+    ]
+  },
+  {
+    "name": "polling",
+    "trans": [
+      "Day 24 | n. | English: the act of asking questions as part of an opinion poll | Example: There are many famous examples of election pollsters making inaccurate predictions in presidential elections. But neuroscientist and election pollster Sam Wang has said that these prediction failures should not lead campaigns to neglect election polling entirely."
+    ]
+  },
+  {
+    "name": "pollster",
+    "trans": [
+      "Day 24 | n. | English: a person who makes or asks the questions in an opinion poll | Example: There are many famous examples of election pollsters making inaccurate predictions in presidential elections."
+    ]
+  },
+  {
+    "name": "polymer",
+    "trans": [
+      "Day 24 | n. | English: a natural or artificial substance consisting of large molecules (= groups of atoms) that are made from combinations of small simple molecules | Example: Chemists Mare A. Meyers and Andrew Grazela studied the mass and heat transfer processes that occur when foods are fried in batters containing hydrocolloids, polymers that become viscous or gel-like in water."
+    ]
+  },
+  {
+    "name": "populous",
+    "trans": [
+      "Day 24 | adj. | English: where a large number of people live | Example: While other even-toed ungulate species, such as the water buffalo (Bubalus bubalis), are among the most populous animal species on earth, the Przewalski's gazelle (Procapra przewalskii) has a total population between 700 and 800 individuals."
+    ]
+  },
+  {
+    "name": "port",
+    "trans": [
+      "Day 24 | n. | English: aplace where ships load and unload goods or shelter from storms | Example: For instance, imported goods may reduce expenses for a country's average consumer, but for consumers living far from ports, high intranational transport costs could nullify the price advantages associated with imports."
+    ]
+  },
+  {
+    "name": "portal",
+    "trans": [
+      "Day 24 | n. | English: a large, impressive gate or entrance to a building | Example: At five-thirty the old Panhandle bridge, supported by massive sandstone pillars, stalwart, as when erected fifty years before to serve a generation now passed behind the portals of life, had become a spectral outline against the sky."
+    ]
+  },
+  {
+    "name": "posit",
+    "trans": [
+      "Day 24 | v. | English: to suggest or accept that sth is true so that it can be used as the basis for an argument or discussion | Example: One popular theory of the origin of the Moon, the \"big whack,\" posits that a protoplanet called Theia collided with Earth, flinging debris into orbit that eventually coalesced into the Moon."
+    ]
+  },
+  {
+    "name": "possess",
+    "trans": [
+      "Day 24 | v. | English: to have or own sth | Example: Possessing an outstanding collection of public art, Chicago has everything from monumental sculptures like Anish Kapoor's Cloud Gate at sites like Millennium Park to innovative street art like Amuse 126's mural High Tide located on South State Street."
+    ]
+  },
+  {
+    "name": "possession",
+    "trans": [
+      "Day 24 | n. | English: something that you own or have with you at a particular time | Example: A book printed is a record, remaining in every man’s possession, always ready to renew its acquaintance with his memory."
+    ]
+  },
+  {
+    "name": "postulate",
+    "trans": [
+      "Day 24 | v. | English: to suggest or accept that sth is true so that it can be used as the basis for a theory, etc. | Example: They postulated a 500-year lifespan for a plastic container."
+    ]
+  },
+  {
+    "name": "practicality",
+    "trans": [
+      "Day 24 | n. | English: the quality of being suitable, or likely to be successfu | Example: Ihave doubts about the practicality of their proposal."
+    ]
+  },
+  {
+    "name": "practically",
+    "trans": [
+      "Day 24 | adv. | English: almost; very nearly | Example: She has a thick curtain of long, curly hair that practically engulfs her."
+    ]
+  },
+  {
+    "name": "practitioner",
+    "trans": [
+      "Day 24 | n. | English: Doctors are sometimes referred to as practitioners or medical practitioners. | Example: The results of randomized clinical trials testing the efficacy of common medical interventions sometimes fail to corroborate conclusions that practitioners reach based on their real-world observations of patients."
+    ]
+  },
+  {
+    "name": "prance",
+    "trans": [
+      "Day 24 | v. | English: to move with high steps | Example: There is no Frigate like a Book / To take us Lands away / Nor any Coursers like a Page / Of prancing Poetry— / This Traverse may the poorest take / Without oppress of Toll— / How frugal is the Chariot / That bears the Human soul."
+    ]
+  },
+  {
+    "name": "prayer",
+    "trans": [
+      "Day 24 | n. | English: a fixed form of words that you can say when you speak to God | Example: Notes long, full, mournful as a prayer, yet still vigorous, escaped from the old instrument."
+    ]
+  },
+  {
+    "name": "precariousness",
+    "trans": [
+      "Day 24 | n. | English: being unsettled or in doubt or dependent on chance | Example: Yet the conclave is likely to do little to change perceptions about the precariousness of world oil markets."
+    ]
+  },
+  {
+    "name": "precaution",
+    "trans": [
+      "Day 24 | n. | English: something that is done in advance in order to prevent problems or to avoid danger | Example: Fernandez and colleagues took the necessary precaution of separating the plants’ root systems (thereby excluding root-to-root transmission)."
+    ]
+  },
+  {
+    "name": "precede",
+    "trans": [
+      "Day 24 | v. | English: to happen before sth or come before sth/sb in order | Example: His resignation was preceded by weeks of speculation."
+    ]
+  },
+  {
+    "name": "precedent",
+    "trans": [
+      "Day 24 | n. | English: a similar action or event that happened earlier | Example: There is no precedent for a disaster of this scale."
+    ]
+  },
+  {
+    "name": "precipitate",
+    "trans": [
+      "Day 24 | v. | English: If something precipitates an event or situation, usually a bad one, it causes it to happen suddenly or sooner than normal. | Example: In the 2010s, the price of vintage My Little Pony figures rose dramatically, which had the counterintuitive effect of precipitating demand."
+    ]
+  },
+  {
+    "name": "precipitation",
+    "trans": [
+      "Day 24 | n. | English: rain, snow, etc. that falls; the amount of this that falls | Example: Persad and her colleagues concluded that concentration of precipitation into fewer events would result in a higher number of dry days, triggering more irrigation."
+    ]
+  },
+  {
+    "name": "preclude",
+    "trans": [
+      "Day 24 | v. | English: (formal) to prevent sth from happening or sb from doing sth | Example: Based on the texts, the author of Text 2 would most likely want to know if Friedrich and colleagues took steps to preclude which potential objection to the finding described in Text 1?"
+    ]
+  },
+  {
+    "name": "precursor",
+    "trans": [
+      "Day 24 | n. | English: (formal) a person or thing that comes before sb/sth similar and that leads to or influences its development | Example: But Nixon’s legacy is complex: he has been praised for his role in affirming the sovereignty of tribal nations, and he once made an attempt at reforming United States health care policy that is arguably a precursor to the Affordable Care Act, which became law during the Barack Obama administration."
+    ]
+  },
+  {
+    "name": "predate",
+    "trans": [
+      "Day 24 | v. | English: exist or occur at a date earlier than | Example: John lliffe and other Africanist scholars have shown, however, that in parts of Africa, institutionally protected private land ownership, the existence of salaried labor, and other features of capitalism predated colonization."
+    ]
+  },
+  {
+    "name": "predominantly",
+    "trans": [
+      "Day 24 | adv. | English: mostly; mainly | Example: During Rome's republican period, which ended in the first century BCE., libraries were predominantly owned by wealthy individuals who tightly controlled access to their book collections."
+    ]
+  },
+  {
+    "name": "preeminent",
+    "trans": [
+      "Day 24 | adj. | English: more important, powerful, or capable than other people or things in the group | Example: Long attributed to Jacques-Louis David, the preeminent Neoclassical painter of his day, the 1801 painting Marie Josephine Charlotte du Val d'Ognes gained fresh attention in the 1990s."
+    ]
+  },
+  {
+    "name": "preliminary",
+    "trans": [
+      "Day 24 | adj. | English: happening before a more important action or event | Example: It provided preliminary evidence that microorganism mediated nutrient cycling was accelerated in the transplanted cores."
+    ]
+  },
+  {
+    "name": "premiere",
+    "trans": [
+      "Day 24 | v. | English: to perform a play or piece of music or show a film/movie to an audience for the first time; to be performed or shown to an audience for the first time | Example: A revised version of the musical premiered on Broadway in 2019, in a larger production."
+    ]
+  },
+  {
+    "name": "premium",
+    "trans": [
+      "Day 24 | adj. | English: of high quality | Example: They hypothesized that performance expectancy (how much the use of a service is perceived to benefit the consumer) would be positively correlated with users' intentions to adopt premium versions."
+    ]
+  },
+  {
+    "name": "preoccupation",
+    "trans": [
+      "Day 24 | n. | English: a state of thinking about sth continuously; sth that you think about frequently or for a long time | Example: Becoming overstocked is the main preoccupation of sellers trying to forecast demand for fashion items."
+    ]
+  },
+  {
+    "name": "prerogative",
+    "trans": [
+      "Day 24 | n. | English: a right or advantage belonging to a particular person or group because of their importance or social positio | Example: By giving these restive republics the right to assert their prerogatives, President Mikhail Gorbachev likely hastened the Soviet Union's breakup."
+    ]
+  },
+  {
+    "name": "presage",
+    "trans": [
+      "Day 24 | v. | English: to be a warning or sign that sth will happen, usually sth unpleasant | Example: The dawn's loud chorus seemed to presage a bright hot summer's day."
+    ]
+  },
+  {
+    "name": "preserve",
+    "trans": [
+      "Day 24 | v. | English: to keep a particular quality, feature, etc.; to make sure that sth is kept | Example: This material breaks down, becoming canopy soil. Canopy soil helps preserve healthy nutrient cycling (how nutrients move through the environment) in rainforests."
+    ]
+  },
+  {
+    "name": "prestige",
+    "trans": [
+      "Day 24 | n. | English: the respect and admiration that sb/sth has because of their social position, or what they have done | Example: Widespread admiration of these works has helped Edwards gain substantial prestige as an artist."
+    ]
+  },
+  {
+    "name": "presumptuous",
+    "trans": [
+      "Day 24 | adj. | English: too confident, in a way that shows a lack of respect for other people | Example: It would be presumptuous to judge what the outcome will be."
+    ]
+  },
+  {
+    "name": "presuppose",
+    "trans": [
+      "Day 24 | v. | English: to accept sth as true or existing and act on that basis, before it has been proved to be true | Example: By broadly agreeing with the claim but objecting that the timelines it presupposes conflicts with the findings of the genetic analysis conducted by Storey's team"
+    ]
+  },
+  {
+    "name": "pretend",
+    "trans": [
+      "Day 24 | v. | English: to behave in a particular way, in order to make other people believe sth that is not true | Example: She pretended to be examining their texture, which the clerk assured her was excellent."
+    ]
+  },
+  {
+    "name": "pretentious",
+    "trans": [
+      "Day 25 | adj. | English: trying to appear important, intelligent, etc. in order to impress other people | Example: They are decorated in a style that the narrator considers pretentious."
+    ]
+  },
+  {
+    "name": "prevail over",
+    "trans": [
+      "Day 25 | English: to be accepted, especially after a struggle or an argument | Example: Louise Arner Boyd, who led several scientific expeditions off the coast of Greenland in the 1930s, undoubtedly accomplished much, but to gain a lasting place in our historical memory, there is little that can prevail over being the first to do something."
+    ]
+  },
+  {
+    "name": "prevalence",
+    "trans": [
+      "Day 25 | n. | English: the fact or condition of being prevalent; commonness | Example: Meanwhile, Cynthia C. Steiner and colleagues have investigated how convergence occurs through different genetic mechanisms, but the relative prevalence of convergence through shared and different genetic processes is still poorly understood."
+    ]
+  },
+  {
+    "name": "prevalent",
+    "trans": [
+      "Day 25 | adj. | English: that exists or is very common at a particular time or in a particular place | Example: These are currently used throughout the United States and are especially prevalent in California."
+    ]
+  },
+  {
+    "name": "prey",
+    "trans": [
+      "Day 25 | v. | English: to hunt and kill another animal for food | Example: Andrew S. Gale, and colleagues concluded that P.seppenradensis may have evolved from P.leptophylla and gradually increased in size as larger ammonites were better able to escape being preyed on by mosasaurs."
+    ]
+  },
+  {
+    "name": "priest",
+    "trans": [
+      "Day 25 | n. | English: a person who is qualified to perform religious duties and ceremonies in the Roman Catholic, Anglican and Orthodox Churches | Example: [Jim's father] was shaving this lawn as if it were a priest's chin."
+    ]
+  },
+  {
+    "name": "primate",
+    "trans": [
+      "Day 25 | n. | English: any animal that belongs to the group of mammals that includes humans, apes and monkeys | Example: Fora long time, people thought tool use was unique to primates."
+    ]
+  },
+  {
+    "name": "principal",
+    "trans": [
+      "Day 25 | adj. | English: most important; main | Example: This led the anthropologist to conclude that hunters using spears with Clovis points likely weren't the principal drivers of the extinction."
+    ]
+  },
+  {
+    "name": "prioritize",
+    "trans": [
+      "Day 25 | v. | English: to put tasks, problems, etc. in order of importance, so that you can deal with the most important first | Example: Parents of small children likely prioritize other factors over a product's environmental sustainability when making purchasing decisions."
+    ]
+  },
+  {
+    "name": "pristine",
+    "trans": [
+      "Day 25 | adj. | English: not developed or changed in any way; left in its original condition For example, the Puerto Rican municipality of Hatillo has also been called \"the Blue Coast of the pristine blue ocean that surrounds it."
+    ]
+  },
+  {
+    "name": "proceed",
+    "trans": [
+      "Day 25 | v. | English: to move or travel in a particular direction | Example: At busy intersections, this often causes a backup of vehicles waiting to turn left or being prevented from proceeding by left-turning vehicles in front of them."
+    ]
+  },
+  {
+    "name": "proclaim",
+    "trans": [
+      "Day 25 | v. | English: to publicly and officially tell people about sth important | Example: Ba’al8illem II's successor Abd'a8tart | decided to proclaim that the percentage of silver in coins suitable for trade would be raised to a threshold higher than 80%."
+    ]
+  },
+  {
+    "name": "prodigious",
+    "trans": [
+      "Day 25 | adj. | English: very large or powerful and causing surprise or admiration | Example: That his work is enjoyable despite this is a testament to his prodigious imagination—even if people read his books only for the ideas, they will have plenty to consider."
+    ]
+  },
+  {
+    "name": "profound",
+    "trans": [
+      "Day 25 | adj. | English: very great | Example: But historical fiction can be used to explore profound themes and complex characters—in fact, many writers find that writing about the past gives them a creative freedom they'd lack if they wrote about the present."
+    ]
+  },
+  {
+    "name": "prohibitive",
+    "trans": [
+      "Day 25 | adj. | English: so high that it prevents people from buying sth or doing sth | Example: This is a valuable service since the time and expense necessary to find individual investors might otherwise be prohibitive for these companies."
+    ]
+  },
+  {
+    "name": "projectile",
+    "trans": [
+      "Day 25 | n. | English: any object that is thrown as a weapon | Example: The projectiles generally penetrated only a few inches into the clay, an amount insufficient to have harmed most woolly mammoths."
+    ]
+  },
+  {
+    "name": "proliferation",
+    "trans": [
+      "Day 25 | n. | English: the sudden increase in the number or amount of sth; a large number of a particular thing | Example: Blatt concluded that in Hemingway's oeuvre, there is a negative correlation between -ly adverb proliferation and perceived literary merit."
+    ]
+  },
+  {
+    "name": "prolific",
+    "trans": [
+      "Day 25 | adj. | English: producing many works | Example: Literary production in the period after the Mexican Revolution (which lasted from 1910-1920) was prolific, with writers like Octavio Paz contributing to the outpouring of poetry, fiction, essays, and more."
+    ]
+  },
+  {
+    "name": "prolong",
+    "trans": [
+      "Day 25 | n. | English: to make sth last longer | Example: These scientists therefore imply that prolonged deep sleep is likely advantageous in ways that have yet to be discovered."
+    ]
+  },
+  {
+    "name": "prolonged",
+    "trans": [
+      "Day 25 | adj. | English: continuing for a long time | Example: A lake existed at the Murray Formation for a prolonged period, though the lake occasionally experienced drying and there were periods in which one or more streams were present."
+    ]
+  },
+  {
+    "name": "prominence",
+    "trans": [
+      "Day 25 | n. | English: the state of being important, well known or noticeable | Example: Originating in the traditional stories of the Kanaka Maoli, the Native Hawaiian people, the literature of Hawaii has a rich history that was later brought to international prominence by"
+    ]
+  },
+  {
+    "name": "prominent",
+    "trans": [
+      "Day 25 | adj. | English: important or well known | Example: In contrast, the prominent Indigenous practitioners of abstract painting during the mid- twentieth century, such as the Kiowa artist T.C. Cannon, typically aligned their compositional strategies with Abstract Expressionism—a school of painting dominated by European American artists—instead of with traditionally nonrepresentational forms of Indigenous art."
+    ]
+  },
+  {
+    "name": "promote",
+    "trans": [
+      "Day 25 | v. | English: to help sell a product, service, etc. or make it more popular by advertising it or offering it at a special price | Example: As amember of Indigenous Photograph, artist Tshepiso Mabula ka Ndogngeni (Xhosa) can promote her work more broadly than she could without the organization's reach."
+    ]
+  },
+  {
+    "name": "prompt",
+    "trans": [
+      "Day 25 | v. | English: v. to make sb decide to do sth; to cause sth to happen adj. acting without delay | Example: [1] While the potential for knowledge spillovers can prompt agglomeration, collocation among tube manufacturers occurs for different reasons. prompt, but not thoughtless; firm, without being harsh."
+    ]
+  },
+  {
+    "name": "pronounced",
+    "trans": [
+      "Day 25 | adj. | English: very noticeable, obvious or strongly expressed | Example: This was the case for both separation problems and dog rivalry but was especially pronounced for attachment and attention-seeking, which can be seen when a dog solicits affection or attention."
+    ]
+  },
+  {
+    "name": "prop",
+    "trans": [
+      "Day 25 | v. | English: to support an object by leaning it against sth, or putting sth under it etc.; to support a person in the same way | Example: Propped on the window ledge, it featured a portrait of Great-Great-Grandmother Rosita as a young woman."
+    ]
+  },
+  {
+    "name": "propel",
+    "trans": [
+      "Day 25 | v. | English: to move, drive or push sth forward or in a particular direction | Example: Occurring in the constellation Virgo, 60 million light-years from Earth, the transient yet powerful blast propelled particles and debris into space at extremely high speeds."
+    ]
+  },
+  {
+    "name": "property",
+    "trans": [
+      "Day 25 | n. | English: n.a quality or characteristic that sth has; n. a thing or things that are owned by sb; a possession or possessions | Example: [1] To assist with the development of new water-repellant materials for aviation and other applications, a team including both engineers and entomologists conducted a study of the water-repellant properties of cicada wings. 2] Most infamously, he participated in what was essentially a private war against Sempringham Priory, a monastery near his manor, even making off with 500 pounds’ worth of monastery property during a raid."
+    ]
+  },
+  {
+    "name": "proposal",
+    "trans": [
+      "Day 25 | n. | English: a formal suggestion or plan; the act of making a suggestion | Example: As Kang herself notes, lobbying can shape which policy proposals members of Congress bring forward for consideration in the first place."
+    ]
+  },
+  {
+    "name": "propriety",
+    "trans": [
+      "Day 25 | n. | English: moral and social behaviour that is considered to be correct and acceptable | Example: There was an air of heaviness about the rooms which might have been avoided without any sacrifice of propriety."
+    ]
+  },
+  {
+    "name": "prose",
+    "trans": [
+      "Day 25 | n. | English: writing that is not poetry | Example: The late-period pieces of James Tate arguably fit this description, since they straddle the line between prose and poetry."
+    ]
+  },
+  {
+    "name": "protagonist",
+    "trans": [
+      "Day 25 | n. | English: the main character in a play, film/movie or book | Example: F. Scott Fitzgerald's 1920 novel This Side of Paradise contains elements drawn from Fitzgerald's own life—there are many parallels between the experiences of the novel's protagonist, Amory Blaine, and those of Fitzgerald."
+    ]
+  },
+  {
+    "name": "proton",
+    "trans": [
+      "Day 25 | n. | English: a substance with a positive electric charge that forms part of the nucleus | Example: In the periodic table, an element's atomic number indicates the number of protons in an atom of that element."
+    ]
+  },
+  {
+    "name": "protoplanet",
+    "trans": [
+      "Day 25 | n. | English: a planet in its early stages of evolution by the process of accretion | Example: One popular theory of the origin of the Moon, the \"big whack,\" posits that a protoplanet called Theia collided with Earth, flinging debris into orbit that eventually coalesced into the Moon."
+    ]
+  },
+  {
+    "name": "prototype",
+    "trans": [
+      "Day 25 | n. | English: the first design of sth from which other forms are copied or developed Though slight, the reductions inspired an air-cooling device; using approximately 400 grams of mushrooms, the team's prototype lowered the air temperature in a controlled environment by 10°C in forty minutes."
+    ]
+  },
+  {
+    "name": "provincial",
+    "trans": [
+      "Day 25 | n. | English: a person who lives in or comes from a part of the country that is not near the capital city | Example: She had the air of a queen and gazed disdainfully at the whole house, as if to say, \"I've come later than all of you, you crowd of upstarts and provincials, I've come later than you!\""
+    ]
+  },
+  {
+    "name": "provocative",
+    "trans": [
+      "Day 25 | adj. | English: intended to make people angry or upset; intended to make people argue about sth | Example: He doesn't really mean that—he's just being deliberately provocative."
+    ]
+  },
+  {
+    "name": "provoke",
+    "trans": [
+      "Day 25 | v. | English: to cause a particular reaction or have a particular effect | Example: Physical aspects of musicians’ brains may suppress the hedonic response to music at volumes that provoke the hedonic response in nonmusicians."
+    ]
+  },
+  {
+    "name": "proximity",
+    "trans": [
+      "Day 25 | n. | English: the state of being near sb/sth in distance or time | Example: It is caused by something other than the parks’ proximity to residents."
+    ]
+  },
+  {
+    "name": "proxy",
+    "trans": [
+      "Day 25 | n. | English: a person who has been given the authority to represent sb else While bioaccumulation of manufactured nanoparticles may be inherently worrisome, it has been hypothesized that CeO2-NP bioaccumulation in invertebrates like D. polymorpha could serve a valuable proxy role."
+    ]
+  },
+  {
+    "name": "prudence",
+    "trans": [
+      "Day 25 | n. | English: Prudence is care and good sense that someone shows when making a decision or taking action. | Example: Western businessmen are showing remarkable prudence in investing in the region."
+    ]
+  },
+  {
+    "name": "pseudonymous",
+    "trans": [
+      "Day 25 | adj. | English: having or using a false or assumed name | Example: The Federalist Papers are a collection of 85 essays written by Alexander Hamilton, john jay, and James Madison. They were published pseudonymously in the New York Packet and other New York newspapers in 1787-88 and argue that New Yorkers should vote to ratify the proposed United States Constitution."
+    ]
+  },
+  {
+    "name": "publicity",
+    "trans": [
+      "Day 25 | n. | English: the attention that is given to sb/sth by newspapers, television, etc. | Example: Though it does not guarantee a book's commercial success, publicity can play a big role in that success"
+    ]
+  },
+  {
+    "name": "pulpit",
+    "trans": [
+      "Day 25 | n. | English: a small platform in a church that is like a box and is high above the ground, where a priest, etc. stands to speak to the people | Example: By the laity of Milby and its neighbourhood [Mr. Ely] was regarded as a man of quite remarkable powers and learning, who must make a considerable sensation in London pulpits and drawing-rooms on his occasional visit to the metropolis."
+    ]
+  },
+  {
+    "name": "pupil",
+    "trans": [
+      "Day 25 | n. | English: the small round black area at the centre of the eye | Example: Bainbridge and colleagues also measured pupil size, as pupils typically become larger when a stimulus captures a person's attention."
+    ]
+  },
+  {
+    "name": "putative",
+    "trans": [
+      "Day 25 | adj. | English: believed to be the person or thing mentioned | Example: Eighteenth-century economist Adam Smith is famed for his metaphor of the invisible hand, which he putatively used to illustrate a robust model of how individuals produce aggregate benefits by pursuing their own economic interests."
+    ]
+  },
+  {
+    "name": "puzzle",
+    "trans": [
+      "Day 25 | v. | English: to make sb feel confused because they do not understand sth | Example: May is puzzled by Newland's lack of enthusiasm for Newport"
+    ]
+  },
+  {
+    "name": "qualify",
+    "trans": [
+      "Day 25 | v. | English: v. to add sth to a previous statement to make the meaning less strong or less general; v. to have the right qualities to be described as a particular thing | Example: [1] It qualifies an earlier description of Mr. Verloc. 2] Each qualifying party is awarded a number of seats proportional to the number of votes it received."
+    ]
+  },
+  {
+    "name": "qualm",
+    "trans": [
+      "Day 25 | n. | English: a feeling of doubt or worry about whether what you are doing is righ | Example: To justify the speaker's qualms about being transported by the ocean to a quiet destination"
+    ]
+  },
+  {
+    "name": "quantity",
+    "trans": [
+      "Day 25 | n. | English: an amount or a number of sth | Example: It draws a distinction between the overall size of the sei whale and the relatively small quantity of krill it can consume per day."
+    ]
+  },
+  {
+    "name": "quarry",
+    "trans": [
+      "Day 26 | n. | English: a place where large amounts of stone, etc. are dug out of the ground | Example: Marine archaeologists have found much of the wooden hull of a sixteenth-century ship in a flooded quarry in southeast England."
+    ]
+  },
+  {
+    "name": "quibble",
+    "trans": [
+      "Day 26 | n. | English: asmall complaint or criticism, especially one that is not important | Example: Socrates, a sophist, says to a new customer \"I have not seen any man so boorish, nor so impracticable, nor so stupid, nor so forgetful; who, while learning some little petty quibbles, forgets them before he has learned them.\""
+    ]
+  },
+  {
+    "name": "quintessential",
+    "trans": [
+      "Day 26 | adj. | English: representing a perfect or typical example of something. | Example: Google's introduction of the Chrome web browser in 2008 is a quintessential instance of brand extension—the company leveraged its brand recognition as an internet search provider to enter a product category where it had not previously competed."
+    ]
+  },
+  {
+    "name": "quiver",
+    "trans": [
+      "Day 26 | n. | English: a-slight movement in part of your body | Example: | sang, with a strange quiver in my voice, a promise-song."
+    ]
+  },
+  {
+    "name": "radically",
+    "trans": [
+      "Day 26 | adv. | English: ina radical or extreme mamner | Example: The invention in 1958 of the integrated circuit (or microchip) radically altered the semiconductor industry."
+    ]
+  },
+  {
+    "name": "raid",
+    "trans": [
+      "Day 26 | n. | English: n. an attack on a building, etc. in order to commit a crime; v. to enter a place, usually using force, and steal from it | Example: [1] Most infamously, he participated in what was essentially a private war against Sempringham Priory, a monastery near his manor, even making off with 500 pounds’ worth of monastery property during a raid. 2] By agreeing that though the law might have permitted Luttrell to do so, Luttrell was wrong to have raided Sempringham Priory"
+    ]
+  },
+  {
+    "name": "rampart",
+    "trans": [
+      "Day 26 | n. | English: a high wide wall of stone or earth with a path on top, built around a castle, town, etc. to defend it In the text, Molloy has arrived at the town ramparts, an elevated walkway atop the city walls."
+    ]
+  },
+  {
+    "name": "rash",
+    "trans": [
+      "Day 26 | adj. | English: doing sth that may not be sensible without first thinking about the possible results | Example: | had gazed upon the fortifications and impediments that seemed to keep human beings from entering the citadel of nature, and rashly and ignorantly | had repined."
+    ]
+  },
+  {
+    "name": "ratify",
+    "trans": [
+      "Day 26 | v. | English: to make an agreement officially valid by voting for or signing it | Example: The Federalist Papers are a collection of 85 essays written by Alexander Hamilton, john jay, and James Madison. They were published pseudonymously in the New York Packet and other New York newspapers in 1787-88 and argue that New Yorkers should vote to ratify the proposed United States Constitution."
+    ]
+  },
+  {
+    "name": "rationalize",
+    "trans": [
+      "Day 26 | v. | English: to find or try to find a logical reason to explain sth | Example: He further rationalized his activity by convincing himself that he was actually promoting peace."
+    ]
+  },
+  {
+    "name": "rave",
+    "trans": [
+      "Day 26 | v. | English: to shout in a loud and emotional way at sb because you are angry with them | Example: And while outside the tempest is raving o'er the ocean, / And the ship is madly driving on some lone and desert shore."
+    ]
+  },
+  {
+    "name": "ravelling",
+    "trans": [
+      "Day 26 | v. | English: to separate or undo the texture of | Example: Yes, the great cloud was ravelling, discovering here and there a pale and dying sky."
+    ]
+  },
+  {
+    "name": "ravine",
+    "trans": [
+      "Day 26 | n. | English: a deep and narrow valley with steep sides | Example: A dry ravine emerged under boughs / Into the pasture."
+    ]
+  },
+  {
+    "name": "readily",
+    "trans": [
+      "Day 26 | adv. | English: quickly and without difficulty | Example: Cuttlefish appear to be surprisingly competent at exercising self-control: in a 2021 study conducted by behavioral ecologist Alexandra Schnell, these cephalopods routinely demonstrated restraint by delaying gratification, waiting for a favorite treat instead of instantly devouring a readily available meal."
+    ]
+  },
+  {
+    "name": "rear",
+    "trans": [
+      "Day 26 | n. | English: the back part of sth | Example: After some trouble [Jim’s father] found the subject of the incident, the broken flower. Turning then, he saw the child lurking at the rear and scanning his countenance."
+    ]
+  },
+  {
+    "name": "rebuke",
+    "trans": [
+      "Day 26 | n. | English: an expression of strong disapproval | Example: He were expecting a rebuke for some neglect of duty of which he might have been guilty."
+    ]
+  },
+  {
+    "name": "rebut",
+    "trans": [
+      "Day 26 | v. | English: to say or prove that a statement or criticism is false | Example: It considers and rebuts an interpretation of the effect of a painting technique mentioned earlier in the text on the perception of work by a group of artists."
+    ]
+  },
+  {
+    "name": "recalcitrant",
+    "trans": [
+      "Day 26 | adj. | English: unwilling to obey rules or follow instructions; difficult to control | Example: The danger is that recalcitrant local authorities will reject their responsibilities."
+    ]
+  },
+  {
+    "name": "reception",
+    "trans": [
+      "Day 26 | n. | English: the type of welcome that is given to sb/sth | Example: The reception of Keshni Kashyap's book Tina's Mouth has been very positive."
+    ]
+  },
+  {
+    "name": "reciprocate",
+    "trans": [
+      "Day 26 | v. | English: to behave or feel towards sb in the same way as they behave or feel towards you | Example: In habitats with limited nutrients, certain fungus species grow on the roots of trees, engaging in mutually beneficial relationships known as ectomycorrhizae: in this symbiotic exchange, the tree provides the fungus with carbon, a nutrient necessary for both species, and the fungus reciprocate by enhancing the tree’s ability to absorb nitrogen, another key nutrient, from the soil."
+    ]
+  },
+  {
+    "name": "recite",
+    "trans": [
+      "Day 26 | v. | English: to say a poem, piece of literature, etc. that you have learned, especially to an audience | Example: It's hard to describe Farsi chanting: the way Mom drew her voice out like the notes of a cello as she recited poems by Rumi or Hafez."
+    ]
+  },
+  {
+    "name": "reckon with",
+    "trans": [
+      "Day 26 | English: to consider or treat sb/sth as a serious opponent, problem , etc. | Example: Any assessment of the state of contemporary poetry must reckon with the professionalization of the field."
+    ]
+  },
+  {
+    "name": "reckoning",
+    "trans": [
+      "Day 26 | n. | English: the act of calculating sth, especially in a way that is not very exact | Example: The banker, spoilt and frivolous, with millions beyond his reckoning, was delighted at the bet."
+    ]
+  },
+  {
+    "name": "recommend",
+    "trans": [
+      "Day 26 | v. | English: to tell sb that sth is good or useful, or that sb would be suitable for a particular job, etc. | Example: The reception of Hena Khan's book Amina's Song has been very good. Many reviewers, booksellers, and librarians have recommended the book, and it won the Asian/Pacific American Award for Literature."
+    ]
+  },
+  {
+    "name": "reconcile",
+    "trans": [
+      "Day 26 | v. | English: to find an acceptable way of dealing with two or more ideas, needs, etc. that seem to be opposed to each other | Example: As Rachana Kamtekar observes, this argument is difficult to reconcile with our lay conception of character: we expect a person of helpful character to be frequently helpful, not sporadically helpful."
+    ]
+  },
+  {
+    "name": "reconstitute",
+    "trans": [
+      "Day 26 | v. | English: to form an organization or a group again in a different wa | Example: The group reconstituted itself as a political party."
+    ]
+  },
+  {
+    "name": "recount",
+    "trans": [
+      "Day 26 | v. | English: (formal) to tell sb about sth, especially sth that you have experienced | Example: The speaker presents herself as fiercely independent and then recounts scenarios that demonstrate that independence."
+    ]
+  },
+  {
+    "name": "recreational",
+    "trans": [
+      "Day 26 | adj. | English: connected with activities that people do for enjoyment when they are not working | Example: As urbanist Mariela Alfonzo argues, our understanding of individuals’ decision-making about whether to walk is insufficiently robust: some studies emphasize the role of climate conditions, others the role of recreational amenities, and so on, but walking decisions are made in complex contexts in which multiple conditions and needs inform individuals’ choices."
+    ]
+  },
+  {
+    "name": "rectify",
+    "trans": [
+      "Day 26 | v. | English: to put right sth that is wrong | Example: As they sat down they turned almost invariably to the person sitting next them, and rectified and continued what they had just said in public."
+    ]
+  },
+  {
+    "name": "recurrent",
+    "trans": [
+      "Day 26 | adj. | English: that happens again and again | Example: Poverty is a recurrent theme in her novels."
+    ]
+  },
+  {
+    "name": "reduplication",
+    "trans": [
+      "Day 26 | n. | English: the process or an instance of redoubling | Example: This phenomenon, in which an element of a root word is repeated, sometimes with modification, within another word that is related to the root word, is called reduplication."
+    ]
+  },
+  {
+    "name": "reference",
+    "trans": [
+      "Day 26 | v. | English: to refer to sth; to provide a book, etc. with references | Example: For example, a count of other scholars’ citations shows that Boston University economist Marianne Baxter, who studies international finance, is referenced frequently, indicating that her work has been significant in the field."
+    ]
+  },
+  {
+    "name": "reflective",
+    "trans": [
+      "Day 26 | adj. | English: typical of a particular situation or thing; showing the state or nature of sth | Example: It may lead to conclusions that are not reflective of all the amenities in a given neighborhood"
+    ]
+  },
+  {
+    "name": "refute",
+    "trans": [
+      "Day 26 | v. | English: to prove that sth is wrong | Example: It introduces a natural phenomenon, refutes two potential explanations for that phenomenon, and then presents a third explanation for that phenomenon that the author regards as plausible."
+    ]
+  },
+  {
+    "name": "regard",
+    "trans": [
+      "Day 26 | n. | English: respect or admiration for sb | Example: It conveys how Mr. Ely initially established a positive reputation among his colleagues and then recounts the events that led them to alter their regard."
+    ]
+  },
+  {
+    "name": "register",
+    "trans": [
+      "Day 26 | v. | English: to show or express a feeling | Example: The motorman chafed in his box, thinking of the drudging lot of the laboring man. He registered discontent."
+    ]
+  },
+  {
+    "name": "regulate",
+    "trans": [
+      "Day 26 | v. | English: to control the speed, pressure, temperature, etc. in a machine or system | Example: The researchers determined that among dogs as a whole, there are many different variations of the gene that regulates the production of IGF-1 (insulin growth factor 1), a hormone that promotes growth."
+    ]
+  },
+  {
+    "name": "rehabilitate",
+    "trans": [
+      "Day 26 | v. | English: to begin to consider that sb is good or acceptable after a long period during which they were considered bad or unacceptable | Example: Instead of engaging in unproductive debates, it should work to rehabilitate the reputations of neglected modernist works."
+    ]
+  },
+  {
+    "name": "rehearse",
+    "trans": [
+      "Day 26 | v. | English: to prepare in your mind or practise privately what you are going to do or say to sb | Example: | made a mental map and located myself upon it. At night in bed | rehearsed the small world’s scheme and set challenges: Find the store using backyards only. Imagine a route from the school to my friend’s house."
+    ]
+  },
+  {
+    "name": "reign",
+    "trans": [
+      "Day 26 | n. | English: the period during which a king, queen, emperor , etc. rules | Example: Barring major archaeological discoveries, we are unlikely to ever have an exhaustive account of ancient Egypt under the female pharaoh Hatshepsut, as much of the evidence of her reign was deliberately destroyed by her successors."
+    ]
+  },
+  {
+    "name": "rejuvenate",
+    "trans": [
+      "Day 26 | v. | English: to make something work much better or become much better again | Example: Although inhabiting a home surrounded by fanciful features such as those designed by Gins and Arakawa can be rejuvenating, it is unsustainable."
+    ]
+  },
+  {
+    "name": "relief",
+    "trans": [
+      "Day 26 | n. | English: a way of decorating wood, stone, etc. by cutting designs into the surface of it so that some parts stick out more than others; a design that is made in this way | Example: The Roc-aux-Sorciers frieze—a group of relief carvings of animals found in what is now France and dating from around 14,000 years ago—is sometimes said to be emotionally powerful despite its age."
+    ]
+  },
+  {
+    "name": "relieve",
+    "trans": [
+      "Day 26 | v. | English: to make a problem less serious | Example: Not only does additional road capacity often fail to relieve congestion, but it can also make traffic worse by encouraging more people to drive."
+    ]
+  },
+  {
+    "name": "relinquish",
+    "trans": [
+      "Day 26 | v. | English: to stop having sth, especially when this happens unwillingly | Example: Oligarchies might grant power to military leaders during wartime who refuse to relinquish that power during peacetime."
+    ]
+  },
+  {
+    "name": "reluctant",
+    "trans": [
+      "Day 26 | adj. | English: hesitating before doing sth because you do not want to do it or because you are not sure that it is the right thing to do | Example: Miranda's doubts about the accuracy of one recollection of a place other than the island are clouding her judgment and seem to be making her reluctant to explore her recollection of traveling to the island."
+    ]
+  },
+  {
+    "name": "remarkable",
+    "trans": [
+      "Day 26 | adj. | English: unusual or surprising in a way that causes people to take notice | Example: By the laity of Milby and its neighbourhood [Mr. Ely] was regarded as a man of quite remarkable powers and learning, who must make a considerable sensation in London pulpits and drawing-rooms on his occasional visit to the metropolis."
+    ]
+  },
+  {
+    "name": "reminiscence",
+    "trans": [
+      "Day 26 | n. | English: the act of remembering things that happened in the pas | Example: Miranda's reminiscences about her early childhood have a melancholy quality that betrays her discontented view of her current circumstances."
+    ]
+  },
+  {
+    "name": "reminiscent of",
+    "trans": [
+      "Day 26 | English: reminding you of sb/sth | Example: Historians argue that Morris's repudiation of industrialization is manifest in the Kelmscott editions' use of handmade materials and intricate ornamentation reminiscent of medieval manuscripts: these meticulously handcrafted elements exemplify the artistry involved."
+    ]
+  },
+  {
+    "name": "render",
+    "trans": [
+      "Day 26 | v. | English: to cause sb/sth to be in a particular state or condition | Example: Some scientists have hypothesized that this capability evolved because it imposes a lower metabolic cost than does the alternative mechanism of producing chemicals that render moths noxious to bats."
+    ]
+  },
+  {
+    "name": "renounce",
+    "trans": [
+      "Day 26 | n. | English: to state officially that you are no longer going to keep a title, position, etc. | Example: Vanya says to Professor Serebrakoff, \"This place [the country estate] could never have been bought had | not renounced my inheritance in favor of my sister [the professor's late wife], whom | deeply loved—and what is more, | worked for ten years like an ox, and paid off the debt.\""
+    ]
+  },
+  {
+    "name": "renown",
+    "trans": [
+      "Day 27 | n. | English: fame and respect because of sth you have done that people admire | Example: Few of the personages of past times (except such as have gained renown in fireside legends as well as in written history) are anything but mere names to their successors."
+    ]
+  },
+  {
+    "name": "repellant",
+    "trans": [
+      "Day 27 | adj. | English: adj. not letting a particular substance, especially water, pass through it; adj. very unpleasant; causing strong dislike | Example: [1] To assist with the development of new water-repellant materials for aviation and other applications, a team including both engineers and entomologists conducted a study of the water-repellant properties of cicada wings. 2] “The color is repellant, almost revolting; a smouldering unclean yellow, strangely faded by the slow-turning sunlight.”"
+    ]
+  },
+  {
+    "name": "repine",
+    "trans": [
+      "Day 27 | v. | English: to feel sad or complain about something, especially a bad situation | Example: | had gazed upon the fortifcations and impediments that seemed to keep human beings from entering the citadel of nature, and rashly and ignorantly | had repined."
+    ]
+  },
+  {
+    "name": "replica",
+    "trans": [
+      "Day 27 | n. | English: copy that is not the original | Example: Built at a scale of 1:110, the Eiffel Tower in Baku, Azerbaijan, is one of many replicas of the famous Eiffel Tower in Paris, France."
+    ]
+  },
+  {
+    "name": "replicate",
+    "trans": [
+      "Day 27 | v. | English: to copy sth exactly | Example: Correlations in a country between languages and regions where they are spoken can replicate themselves in a new country to which the original country's citizens emigrate."
+    ]
+  },
+  {
+    "name": "repository",
+    "trans": [
+      "Day 27 | n. | English: a place where sth is stored in large quantities | Example: Indigenous songs can be repositories of ecological information, from Yi songs about the natural environment to Tlingit songs about wildlife encounters."
+    ]
+  },
+  {
+    "name": "representative",
+    "trans": [
+      "Day 27 | adj. | English: typical of a particular group of people | Example: It is tempting to treat the clustering of information technology firms in Northern California as representative of industrial agglomeration generally."
+    ]
+  },
+  {
+    "name": "repress",
+    "trans": [
+      "Day 27 | v. | English: to try not to have or show an emotion, a feeling, etc. In a discussion of the study, a student hypothesizes that small breeds of dogs (for example, Havaneses) must share a version that represses IGF-1 production that would otherwise confer larger body size."
+    ]
+  },
+  {
+    "name": "reprieve",
+    "trans": [
+      "Day 27 | v. | English: adelay before sth bad happens | Example: Campaigners have won a reprieve for the hospital threatened with closure."
+    ]
+  },
+  {
+    "name": "repudiate",
+    "trans": [
+      "Day 27 | v. | English: to refuse to accept sth | Example: Seminole/Muscogee director Sterlin Harjo repudiates television’s tendency to situate Native characters in the distant past."
+    ]
+  },
+  {
+    "name": "repudiation",
+    "trans": [
+      "Day 27 | n. | English: the act of repudiating the state of being repudiated; especially the refusal of public authorities or acknowledge or pay a debt Historians argue that Morris's repudiation of industrialization is manifest in the Kelmscott editions' use of handmade materials and intricate ornamentation reminiscent of medieval these meticulously handcrafted elements exemplify the artistry involved."
+    ]
+  },
+  {
+    "name": "reputation",
+    "trans": [
+      "Day 27 | n. | English: the opinion that people have about what sb/sth is like, based on what has happened in the past | Example: British painter Peter Edwards has a reputation for painting portraits of notable figures from a variety of different fields."
+    ]
+  },
+  {
+    "name": "requisite",
+    "trans": [
+      "Day 27 | adj. | English: necessary for a particular purpose | Example: As a result, this lovely region is atrociously poor and its few scattered farms provide just the requisite number of red roofs to set off the velvety green of the woods."
+    ]
+  },
+  {
+    "name": "resemblance",
+    "trans": [
+      "Day 27 | English: the fact of being or looking similar to sb/sth | Example: Maize (corn), another crop domesticated by Indigenous Americans, shows so little resemblance to any wild plant that genetic research was necessary to confirm teosinte grass as its ancestor."
+    ]
+  },
+  {
+    "name": "resemble",
+    "trans": [
+      "Day 27 | v. | English: to look like or be similar to another person or thing | Example: Summer squash, another domesticated crop from the Americas, doesn’t closely resemble any wild plant"
+    ]
+  },
+  {
+    "name": "reservation",
+    "trans": [
+      "Day 27 | n. | English: an area of land in the US that is kept separate for Native Americans to live in | Example: Louis Pipestone is collecting signatures for a petition from fellow members of the Turtle Mountain Band of Chippewa on the tribe's reservation in North Dakota."
+    ]
+  },
+  {
+    "name": "reserve",
+    "trans": [
+      "Day 27 | n. | English: n.a supply of sth that is available to be used in the future or when it is needed v. to keep sth for sb/sth, so that it cannot be used by any other person or for any other reason | Example: [1] Having an ample reserve of stored energy can mitigate the effects of fluctuations in solar energy collection caused by unpredictable shifts in cloud cover and haze. 2] These seats are reserved for special guests."
+    ]
+  },
+  {
+    "name": "resilience",
+    "trans": [
+      "Day 27 | n. | English: the ability of people or things to feel better quickly after sth unpleasant, such as shock, injury, etc. In a 2021 paper, zoologist Guillaume Ghisbain notes that bumblebees are among the relatively few wild-bee genera that display social behaviors and dietary generalism (ability to obtain nectar and pollen from a diversity of plant species), two traits that are associated with increased resilience to some specific environmental changes."
+    ]
+  },
+  {
+    "name": "resolve",
+    "trans": [
+      "Day 27 | v. | English: to find an acceptable solution to a problem or difficulty | Example: Each becomes entangled in a debate about art, and no one knows how to resolve the debate."
+    ]
+  },
+  {
+    "name": "resonance",
+    "trans": [
+      "Day 27 | n. | English: the power to bring images, feelings, etc. into the mind of the person reading or listening; the images, etc. produced in this way | Example: Itis the link of shared humanity with the artist across so many centuries that gives the Roc- aux-Sorciers frieze such resonance."
+    ]
+  },
+  {
+    "name": "respective",
+    "trans": [
+      "Day 27 | adj. | English: belonging or relating separately to each of the people or things already mentioned | Example: Though not closely related, the hedgehog tenrecs of Madagascar share basic similarities with true hedgehogs, including protective spines, pointed snouts, and small body size—traits the two groups of mammals independently developed in response to equivalent roles in their respective habitats."
+    ]
+  },
+  {
+    "name": "resplendent",
+    "trans": [
+      "Day 27 | adj. | English: brightly coloured in an impressive way | Example: The pine green is resplendent."
+    ]
+  },
+  {
+    "name": "restraint",
+    "trans": [
+      "Day 27 | n. | English: the quality of behaving calmly and with control | Example: Cuttlefish appear to be surprisingly competent at exercising self-control: in a 2021 study conducted by behavioral ecologist Alexandra Schnell, these cephalopods routinely demonstrated restraint by delaying gratification, waiting for a favorite treat instead of instantly devouring a readily available meal."
+    ]
+  },
+  {
+    "name": "retain",
+    "trans": [
+      "Day 27 | v. | English: to continue to have sth | Example: \"Coyote\" changed in meaning significantly when English borrowed the word from Spanish, whereas \"iguana\" retained its original meaning."
+    ]
+  },
+  {
+    "name": "retention",
+    "trans": [
+      "Day 27 | n. | English: the action of keeping sth rather than losing it or stopping it | Example: Reducing this kind of subscriber turnover is especially challenging for subscription sellers: customers’ initial enthusiasm for a subscription is often quick to subside, and sellers must thus devise other incentives to bolster retention."
+    ]
+  },
+  {
+    "name": "retentive",
+    "trans": [
+      "Day 27 | adj. | English: able to store facts and remember things easily | Example: She had a good sense of logic, a strong power of concentration, and a remarkably retentive and visualizing memory."
+    ]
+  },
+  {
+    "name": "retina",
+    "trans": [
+      "Day 27 | n. | English: a layer of tissue at the back of the eye that is sensitive to light and sends signals to the brain about what is seen | Example: Indeed, what mortal is there of us, who would find his satisfaction enhanced by an opportunity of comparing the picture he presents to himself of his own doings, with the picture they make on the mental retina of his neighbours?"
+    ]
+  },
+  {
+    "name": "retiree",
+    "trans": [
+      "Day 27 | n. | English: a person who has stopped working because of their age | Example: Proposals to raise the age at which retirees begin receiving government transfers of funds are generally discussed in terms of the effects on transfer recipients."
+    ]
+  },
+  {
+    "name": "retreat",
+    "trans": [
+      "Day 27 | n. | English: a movement away from a place or an enemy because of danger or defeat | Example: If instead the giant short-faced bear died out before humans could have altered its habitat, that suggests that its extinction was the result of some other factor, such as change in sea levels as a result of glaciers retreating."
+    ]
+  },
+  {
+    "name": "retrieve",
+    "trans": [
+      "Day 27 | v. | English: to bring or get sth back, especially from a place where it should not be | Example: The cognitive abilities of monkeys given problems requiring little dexterity, such as sliding a panel to retrieve food, were judged by the same criteria as were those of monkeys given physically demanding problems, such as unscrewing a bottle and inserting a straw."
+    ]
+  },
+  {
+    "name": "retroactive",
+    "trans": [
+      "Day 27 | adj. | English: Ifa decision or action is retroactive, it is intended to take effect from a date in the past. Itisn't yet clear whether the new law can actually be applied retroactively."
+    ]
+  },
+  {
+    "name": "revelation",
+    "trans": [
+      "Day 27 | n. | English: a fact that people are made aware of, especially one that has been secret and is surprising While hDNA has yielded many revelations about evolutionary history, it is relatively underused due to a shortage of specimens from the appropriate time periods."
+    ]
+  },
+  {
+    "name": "reverence",
+    "trans": [
+      "Day 27 | n. | English: (formal) a feeling of great respect or admiration for sb/sth | Example: In the United States, historians of the American Revolution once had a tendency to approach their subject with reverence."
+    ]
+  },
+  {
+    "name": "reverential",
+    "trans": [
+      "Day 27 | adj. | English: full of respect or admiration | Example: His name was always mentioned in almost reverential tones."
+    ]
+  },
+  {
+    "name": "revise",
+    "trans": [
+      "Day 27 | v. | English: to change your opinions or plans, for example because of sth you have learned | Example: However, new evidence that the change in conditions occurred well before those species went extinct is forcing paleontologists to revise that hypothesis."
+    ]
+  },
+  {
+    "name": "revolt",
+    "trans": [
+      "Day 27 | v. | English: to take violent action against the people in power | Example: The peasants threatened to revolt."
+    ]
+  },
+  {
+    "name": "revolting",
+    "trans": [
+      "Day 27 | adj. | English: extremely unpleasant | Example: “I'm really getting quite fond of the big room, all but that horrid [wall] paper.”"
+    ]
+  },
+  {
+    "name": "rhetoric",
+    "trans": [
+      "Day 27 | n. | English: the skill of using language in speech or writing in a special way that influences or entertains people | Example: Political scientists have found that although voters claim to prefer candidates who have nuanced perspectives on issues and who show a willingness to compromise, when asked to compare speeches expressing such views with speeches expressing dogmatic views, voters tend to regard the unyielding rhetoric of the latter more favorably."
+    ]
+  },
+  {
+    "name": "ribbon",
+    "trans": [
+      "Day 27 | n. | English: anarrow strip of material, used to tie things or for decoration | Example: During many historic New York City parades, including the 1924 ticker-tape parade for US Olympic champions, the ribbonlike swirls descending on the scene were paper spools from \"tickers,\" telegraph machines that were used to transmit stock prices."
+    ]
+  },
+  {
+    "name": "rift",
+    "trans": [
+      "Day 27 | n. | English: a large crack or opening in the ground, rocks or clouds | Example: Green meadows make rifts in [the woods] here and there, so do little patches of cultivation."
+    ]
+  },
+  {
+    "name": "rigid",
+    "trans": [
+      "Day 27 | adj. | English: stiff and difficult to move or bend | Example: Both ocelots and jaguars have U-shaped hyoid bones, but ocelots' hyoids are rigid whereas aguars’ hyoids are flexible."
+    ]
+  },
+  {
+    "name": "ripple",
+    "trans": [
+      "Day 27 | v. | English: to move or to make sth move in very small waves He watches his father raise a kite within minutes into the wind, so high that Gogol must tip his head back in order to see, a rippling speck against the sky."
+    ]
+  },
+  {
+    "name": "rival",
+    "trans": [
+      "Day 27 | n. | English: n.a person, group, or organization that you compete with in sport, business, a fight etc; v. to be as good, impressive, etc. as sb/sth else | Example: [1] One such theory points to various primary sources that indicate an escalation in infighting among rival factions in the society that coincided with increasing droughts. 2] It was a city of only 250,000 or 300,000 inhabitants; now it is a metropolis rivaling London in population, wealth and commerce."
+    ]
+  },
+  {
+    "name": "rivalry",
+    "trans": [
+      "Day 27 | n. | English: a state in which two people, companies, etc. are competing for the same thing | Example: This was the case for both separation problems and dog rivalry but was especially pronounced for attachment and attention-seeking, which can be seen when a dog solicits affection or attention."
+    ]
+  },
+  {
+    "name": "roar",
+    "trans": [
+      "Day 27 | n. | English: aloud deep sound made by an animal, especially a lion , or by sb's voice | Example: In his solitary retreat on the shore of the sea, whose mobile surface was visible through the open windows, extending outward until it mingled with the horizon, Padre Florentino was relieving the monotony by playing on his harmonium sad and melancholy tunes, to which the sonorous roar of the surf and the sighing of the treetops of the neighboring wood served as accompaniments."
+    ]
+  },
+  {
+    "name": "robust",
+    "trans": [
+      "Day 27 | adj. | English: strong and not likely to fail or become weak | Example: Although Smith is famed for his metaphor of the invisible hand, the metaphor was largely ignored until economists in the twentieth century came to realize that the metaphor was a robust model that anticipated their own views."
+    ]
+  },
+  {
+    "name": "rotation",
+    "trans": [
+      "Day 27 | n. | English: the action of an object moving in a circle around a central fixed point Instead, Luu et al. are likely correct that 6478 Gault is shedding mass due to rotational instability."
+    ]
+  },
+  {
+    "name": "rough",
+    "trans": [
+      "Day 27 | adj. | English: not gentle or careful; violent | Example: [1] A gleaming carpet was springing up everywhere, that looked too delicate to be trodden upon by rough feet. 2] Ocean currents can be powerful and rough, making it difficult for animals to find safe places to hide from predators. The underwater forests slow down the currents."
+    ]
+  },
+  {
+    "name": "route",
+    "trans": [
+      "Day 27 | n. | English: away that you follow to get from one place to another | Example: Haworth and Schramm asked adult bike riders questions about their level of experience, reasons for riding a bike, and route preferences."
+    ]
+  },
+  {
+    "name": "rudimentary",
+    "trans": [
+      "Day 27 | adj. | English: dealing with only the most basic matters or ideas | Example: The method used in 1920 by the US Geological Survey to calculate the geographic center of Louisiana, involving a cardboard cutout of the state and a piece of string, seems rudimentary today."
+    ]
+  },
+  {
+    "name": "rumble",
+    "trans": [
+      "Day 28 | v. | English: to make a long deep sound or series of sounds | Example: Iberian lynxes, which are much smaller than lions, have a rigid hyoid that rumbles when the cat's larynx vibrates."
+    ]
+  },
+  {
+    "name": "rural",
+    "trans": [
+      "Day 28 | adj. | English: connected with or like the countryside | Example: The Last Report on the Miracles at Little No Horse is a 2001 novel by Ojibwe writer Louise Erdrich. It explores how historical events affect families on a reservation in rural North Dakota."
+    ]
+  },
+  {
+    "name": "sac",
+    "trans": [
+      "Day 28 | n. | English: a part inside the body of a person, an animal or a plant, that is shaped like a bag, has thin skin around it, and contains liquid or air | Example: Postcranial skeletal pneumaticity (PSP) refers to the presence of extensions of an animal's lungs and air sacs inside its bones."
+    ]
+  },
+  {
+    "name": "sacred",
+    "trans": [
+      "Day 28 | adj. | English: connected with God or a god; considered to be holy | Example: Home is home, to the lowly as well as the great: and no rank, or color, destroys its sacred character, its power over the mind, and the affections."
+    ]
+  },
+  {
+    "name": "salient",
+    "trans": [
+      "Day 28 | adj. | English: most important or noticeable | Example: In this case, players’ cognitive resources are directed foremost toward the advergame's mechanics, leaving little or no capacity for encoding and storing the information the advertiser intends to be salient."
+    ]
+  },
+  {
+    "name": "saline",
+    "trans": [
+      "Day 28 | adj. | English: containing salt | Example: The migration's obligate nature is why diadromous fish can be demarcated from those that are merely euryhaline (able to tolerate high salinity)."
+    ]
+  },
+  {
+    "name": "sanction",
+    "trans": [
+      "Day 28 | n. | English: official permission or approval for an action or a change | Example: These changes will require the sanction of the court."
+    ]
+  },
+  {
+    "name": "sanguine",
+    "trans": [
+      "Day 28 | adj. | English: cheerful and confident about the future | Example: While some commentators lauded this development, asserting that such blogs had a welcome transparency missing from traditional news, less sanguine observers countered that such blogs tended to ideological extremes that exacerbated political polarization to problematic levels."
+    ]
+  },
+  {
+    "name": "sap",
+    "trans": [
+      "Day 28 | n. | English: the liquid in a plant or tree that carries food to all its parts | Example: | walked slowly beneath the young leaves, drinking in the air, fragrant with the odor of young buds and sap."
+    ]
+  },
+  {
+    "name": "satiate",
+    "trans": [
+      "Day 28 | v. | English: to give sb so much of sth that they do not feel they want any more | Example: From sculptures like Mird's Chicago by Joan Miré, found at Brunswick Plaza, to street art like Justus Roe's mural South Shore on South Exchange Avenue, Chicago offers an array of works to satiate the tastes of art lovers."
+    ]
+  },
+  {
+    "name": "satirize",
+    "trans": [
+      "Day 28 | v. | English: to use satire to show the faults in a person, an organization, a system, etc. | Example: In the play, Aristophanes satirizes sophists as teaching students how to be persuasive without regard for what is morally good."
+    ]
+  },
+  {
+    "name": "saturation",
+    "trans": [
+      "Day 28 | n. | English: the degree to which something has been mixed into something else | Example: Contrasting a high saturation color palette against dark paper and stoneware, Atlanta-based artist Jina Moon creates fused pieces, wherein Korean folk art, Western contemporary art, and global popular culture mix."
+    ]
+  },
+  {
+    "name": "saunter",
+    "trans": [
+      "Day 28 | v. | English: to walk in a slow relaxed way | Example: | sauntered along, forgetful of musty papers, of the offices, of my chief, my colleagues, my documents, and thinking of the good things that were sure to come to me, of all the veiled unknown contained in the future."
+    ]
+  },
+  {
+    "name": "scandal",
+    "trans": [
+      "Day 28 | n. | English: behaviour or an event that people think is morally or legally wrong and causes public feelings of shock or anger | Example: President Richard Nixon is most famous for his participation in the 1970s Watergate political scandal, a convoluted tale of criminality and eroded ethics involving a constellation of associates such as security operative Jack Caulfield and Attorney General John Mitchell."
+    ]
+  },
+  {
+    "name": "scarcely",
+    "trans": [
+      "Day 28 | adv. | English: only just; almost not | Example: How [the sailor] haunted my dreams, | need scarcely tell you. On stormy nights, when the wind shook the four corners of the house and the surf roared along the cove and up the cliffs, | would see him in a thousand forms, and with a thousand diabolical expressions."
+    ]
+  },
+  {
+    "name": "scatter",
+    "trans": [
+      "Day 28 | v. | English: to move or to make people or animals move very quickly in different directions | Example: Other bird species than M. barbatus also showed a tendency to freeze in place or scatter into vegetation when Martinez and colleagues played T. caesius alarm calls."
+    ]
+  },
+  {
+    "name": "scattered",
+    "trans": [
+      "Day 28 | adj. | English: spread far apart over a wide area or over a long period of time | Example: It was a scattered sort of a fair. If we didn't expect more, we got less."
+    ]
+  },
+  {
+    "name": "scenario",
+    "trans": [
+      "Day 28 | n. | English: a description of how things might happen in the future | Example: The speaker presents herself as fiercely independent and then recounts scenarios that demonstrate that independence."
+    ]
+  },
+  {
+    "name": "scene",
+    "trans": [
+      "Day 28 | n. | English: a view that you see | Example: Do | behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more deep seclusion; and connect / The landscape with the quiet of the sky."
+    ]
+  },
+  {
+    "name": "scope",
+    "trans": [
+      "Day 28 | n. | English: the range of things that a subject, an organization, an activity, etc. deals with | Example: Given how little consensus there is among scientists regarding the scope of these categories, this discrepancy shouldn't be surprising: forest researchers regularly dispute one another's classifications."
+    ]
+  },
+  {
+    "name": "scrupulous",
+    "trans": [
+      "Day 28 | adj. | English: careful about paying attention to every detail | Example: The grey Prince Albert was scrupulously buttoned about his form, and a shiny top hat replaced the felt of the afternoon."
+    ]
+  },
+  {
+    "name": "scrutinize",
+    "trans": [
+      "Day 28 | v. | English: to look at or examine sb/sth carefully The statement was carefully scrutinized before publication."
+    ]
+  },
+  {
+    "name": "seam",
+    "trans": [
+      "Day 28 | n. | English: a line along which two edges of cloth, etc. are joined or sewn together | Example: _Babou hummed to himself as he smoothed out my shoulder seams and rested his hands on them."
+    ]
+  },
+  {
+    "name": "secluded",
+    "trans": [
+      "Day 28 | adj. | English: quiet and private; not used or disturbed by other people | Example: Do | behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more deep seclusion; and connect / The landscape with the quiet of the sky."
+    ]
+  },
+  {
+    "name": "seclusion",
+    "trans": [
+      "Day 28 | n. | English: the state of being private or of having little contact with other people | Example: Do | behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more deep seclusion; and connect / The landscape with the quiet of the sky."
+    ]
+  },
+  {
+    "name": "secretive",
+    "trans": [
+      "Day 28 | adj. | English: tending or liking to hide your thoughts, feelings, ideas, etc. from other people | Example: Maya civilization was highly secretive about its intellectual achievements."
+    ]
+  },
+  {
+    "name": "sediment",
+    "trans": [
+      "Day 28 | n. | English: the solid material that settles at the bottom of a liquid | Example: When it is exposed to air and water, wood rots quickly unless it is protected by sediment that shields it from oxygen."
+    ]
+  },
+  {
+    "name": "sedimentary",
+    "trans": [
+      "Day 28 | adj. | English: connected with or formed from the sand, stones, mud, etc. that settle at the bottom of lakes, etc. | Example: The Nile River delta system is located in Northern Egypt, where the river drains into the Mediterranean Sea, and is shaped by interdependent factors: for example, the geography of the coastline influences sedimentary deposition, which over time alters coastal geography."
+    ]
+  },
+  {
+    "name": "seismic",
+    "trans": [
+      "Day 28 | adj. | English: connected with or caused by earthquakes | Example: The equipment from the Apollo Moon landings (1969-1972), such as solar wind sensors and seismic sensors, remains there to this day, but the data from these missions were mostly inaccessible until a recent data-transfer project made them available."
+    ]
+  },
+  {
+    "name": "semantic",
+    "trans": [
+      "Day 28 | adj. | English: connected with the meaning of words and sentences | Example: Semantic relations among the two nouns and the concept they signify can be tenuous."
+    ]
+  },
+  {
+    "name": "semblance",
+    "trans": [
+      "Day 28 | n. | English: a situation in which sth seems to exist although this may not, in fact, be the case Some robots such as Surena (developed in 2008) and COMAN (developed in 2012) are designed to resemble humans so that people will find it easier to interact with them. To this end, certain features such as the ability to respond to voice commands can help to create the comforting semblance of humanity."
+    ]
+  },
+  {
+    "name": "semiconductor",
+    "trans": [
+      "Day 28 | n. | English: asolid substance that conducts electricity in particular conditions, better than insulators but not as well as conductors | Example: The invention in 1958 of the integrated circuit (or microchip) radically altered the semiconductor industry."
+    ]
+  },
+  {
+    "name": "sensation",
+    "trans": [
+      "Day 28 | n. | English: very great surprise, excitement, or interest among a lot of people; the person or the thing that causes this surprise | Example: By the laity of Milby and its neighbourhood [Mr. Ely] was regarded as a man of quite remarkable powers and learning, who must make a considerable sensation in London pulpits and drawing-rooms on his occasional visit to the metropolis."
+    ]
+  },
+  {
+    "name": "sentimental",
+    "trans": [
+      "Day 28 | adj. | English: producing emotions such as pity, romantic love or sadness, which may be too strong or not appropriate; feeling these emotions too much | Example: In his afterword to Crowley's book Little, Big, Bloom argues that the novel adroitly blends what playwright Friedrich Schiller termed the naive and sentimental modes."
+    ]
+  },
+  {
+    "name": "serenity",
+    "trans": [
+      "Day 28 | n. | English: peacefulness and calmness | Example: To contrast the demands of the speaker's everyday life with the serenity of being rocked to sleep by the ocean"
+    ]
+  },
+  {
+    "name": "sermon",
+    "trans": [
+      "Day 28 | n. | English: moral advice that a person tries to give you in a long talk | Example: The sermon is a sound of words spoken to the ear, and prepared only for present meditation and extends no farther than the strength of memory can convey it."
+    ]
+  },
+  {
+    "name": "setting",
+    "trans": [
+      "Day 28 | n. | English: a set of surroundings; the place at which sth happens | Example: It sketches a setting by presenting a series of images of nature."
+    ]
+  },
+  {
+    "name": "settlement",
+    "trans": [
+      "Day 28 | n. | English: a place where people have come to live and make their homes, especially where few or no people lived before | Example: One challenge faced by researchers studying global urbanization is that countries may define urban settlements differently."
+    ]
+  },
+  {
+    "name": "severity",
+    "trans": [
+      "Day 28 | n. | English: seriousness | Example: It emphasizes the severity of a storm that is expected to arrive soon in Puerto Cabello."
+    ]
+  },
+  {
+    "name": "sharpen",
+    "trans": [
+      "Day 28 | v. | English: to become or make sth better, more skilful, more effective, etc. than before | Example: Recent analyses of fossils like that of the individual known as KNM-KP 271, discovered in Kenya in 1963, have sharpened our picture of what a day in the life of KNM-KP 271 may have looked like."
+    ]
+  },
+  {
+    "name": "shed",
+    "trans": [
+      "Day 28 | v. | English: to get rid of sth that is no longer wanted | Example: Instead, Luu et al. are likely correct that 6478 Gault is shedding mass due to rotational instability."
+    ]
+  },
+  {
+    "name": "sheen",
+    "trans": [
+      "Day 28 | n. | English: a soft smooth shiny quality | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+    ]
+  },
+  {
+    "name": "sheer",
+    "trans": [
+      "Day 28 | v. | English: v. to change direction suddenly, especially in order to avoid hitting sth; adj. (used to emphasize the size, degree or amount of sth) | Example: [1] And the shaggy Nannie goat is calling, calling, calling / From her little trampled corner of the long wide lea / That stretches to the waters of the hill-stream falling / Sheer upon the flat rocks joyously. 2] The minor planet 1095 Tulipa was named after the plant genus that includes tulips, but given the sheer number of minor planets that have been discovered (more than 500,000 so far), most are given only an identification number."
+    ]
+  },
+  {
+    "name": "shell",
+    "trans": [
+      "Day 28 | n. | English: the hard outer part of eggs, nuts, some seeds and some animals | Example: With a shell that measured 1.7 meters, the extinct mollusk Parapuzosia seppenradensis is the largest ammonite in the fossil record."
+    ]
+  },
+  {
+    "name": "shipwreck",
+    "trans": [
+      "Day 28 | n. | English: a ship that has been lost or destroyed at sea | Example: Rachel Mugge and colleagues were particularly curious about the effects of wooden shipwrecks on seafloor microbial communities."
+    ]
+  },
+  {
+    "name": "shrewd",
+    "trans": [
+      "Day 28 | adj. | English: clever at understanding and making judgements about a situation | Example: She is a shrewd judge of character."
+    ]
+  },
+  {
+    "name": "shriek",
+    "trans": [
+      "Day 28 | n. | English: a loud high shout, for example one that you make when you are excited, frightened or in pain | Example: Two shrieks pierced the air simultaneously, as the two trains passed each other."
+    ]
+  },
+  {
+    "name": "shrill",
+    "trans": [
+      "Day 28 | v. | English: to make an unpleasant high loud sound | Example: Among the wild rice in the still lagoon. / In monotone the lizard shrills his tune. / The wild goose, homing, seeks a sheltering, / Where rushes grow, and oozing lichens cling."
+    ]
+  },
+  {
+    "name": "shrink",
+    "trans": [
+      "Day 28 | v. | English: to become or to make sth smaller in size or amount | Example: In southern and central Georgia, many buildings and other structures rest on soil that is expansive, meaning that it swells or shrinks as its moisture level changes."
+    ]
+  },
+  {
+    "name": "shroud",
+    "trans": [
+      "Day 28 | n. | English: a thing that covers, surrounds or hides sth | Example: And having cleared the ramparts | had to confess the sky was clearing, prior to its winding in the other shroud, night."
+    ]
+  },
+  {
+    "name": "shuffle",
+    "trans": [
+      "Day 29 | v. | English: to move paper or things into different positions or a different order | Example: When exposed to low levels of light, the plant's chloroplasts— the cellular organs that generate energy from light—reshuffled to form a tightly packed, glass-like surface ideal for collecting more light."
+    ]
+  },
+  {
+    "name": "sidewalk",
+    "trans": [
+      "Day 29 | n. | English: A sidewalk is a path with a hard surface by the side of a road. | Example: Some cities track pedestrian activity to map their sidewalks, but this method often neglects sidewalks few pedestrians use, resulting in incomplete maps."
+    ]
+  },
+  {
+    "name": "sierra",
+    "trans": [
+      "Day 29 | n. | English: a long range of steep mountains with sharp points, especially in Spain and America | Example: The sierra is clad in gala colors. Over its inaccessible peaks the opalescent fog settles like a snowy veil on the forehead of a bride."
+    ]
+  },
+  {
+    "name": "sigh",
+    "trans": [
+      "Day 29 | v. | English: to take and then let out a long deep breath that can be heard, to show that you are disappointed, sad, tired, etc. | Example: In his solitary retreat on the shore of the sea, whose mobile surface was visible through the open windows, extending outward until it mingled with the horizon, Padre Florentino was relieving the monotony by playing on his harmonium sad and melancholy tunes, to which the sonorous roar of the surf and the sighing of the treetops of the neighboring wood served as accompaniments."
+    ]
+  },
+  {
+    "name": "signature",
+    "trans": [
+      "Day 29 | n. | English: a particular quality that makes sth different from other similar things and makes it easy to recognize | Example: In addition, while wild foxes have a diet entirely made of meat, isotopic signatures of the skeleton's teeth indicated that the fox's diet, like that of the humans, was partly composed of plant material."
+    ]
+  },
+  {
+    "name": "silhouette",
+    "trans": [
+      "Day 29 | n. | English: a picture that shows sb/sth as a black shape against a light background, especially one that shows the side view of a person's fac | Example: Over the course of three years, Reiniger and her collaborators painstakingly made more than 250,000 individual images of hand-cut paper silhouettes and repeatedly had to invent entirely new methods and tools to create the special effects Reiniger envisioned."
+    ]
+  },
+  {
+    "name": "simulate",
+    "trans": [
+      "Day 29 | v. | English: to create particular conditions that exist in real life using computers, models, etc., usually for study or training purposes | Example: They found that during harmless simulated attacks on isolated caterpillars, 33% of the tested species produced sound, which ranged from clicks in Actias luna to chirps in Schausiella santarosensis."
+    ]
+  },
+  {
+    "name": "simulation",
+    "trans": [
+      "Day 29 | n. | English: a situation in which a particular set of conditions is created artificially in order to study or experience sth that could exist in reality | Example: Stars form in cloudlike swirls of gas and dust that cannot be touched, but astrophysicist Nia Imara believes these formations need not remain completely intangible to researchers: she uses simulation data and sophisticated 3D printers to produce interactive models of these stellar nurseries."
+    ]
+  },
+  {
+    "name": "simultaneous",
+    "trans": [
+      "Day 29 | adj. | English: happening or done at the same time as sth else | Example: Two shrieks pierced the air simultaneously, as the two trains passed each other."
+    ]
+  },
+  {
+    "name": "skeptical",
+    "trans": [
+      "Day 29 | adj. | English: having doubts that a claim or statement is true or that sth will happen | Example: Participants regarded the experiences of both the doctors and former trial volunteers as relevant to the subject of clinical trials but were skeptical of the doctors' status as credentialed experts."
+    ]
+  },
+  {
+    "name": "sketch",
+    "trans": [
+      "Day 29 | v. | English: to give a general description of sth, giving only the basic facts | Example: It sketches a setting by presenting a series of images of nature."
+    ]
+  },
+  {
+    "name": "slumber",
+    "trans": [
+      "Day 29 | v. | English: v. to sleep; n. sleep | Example: [1] You have not known what you are, you have slumber'd upon yourself / all your life, / Your eyelids have been the same as closed most of the time. 2] Blessed are the slumbers of the innocent! They are kindlier than balm, and they refresh and gladden the spirit of childhood, like ministerings from a better world."
+    ]
+  },
+  {
+    "name": "slumberous",
+    "trans": [
+      "Day 29 | adj. | English: sleepy; drowsy | Example: Just let me drift far out from toil and care, / Where lapping of the waves shall be the sound, / Which mingled with the winds that gently bear / Me on between a peaceful sea and sky, /To make my soothing slumberous lullaby."
+    ]
+  },
+  {
+    "name": "smoulder",
+    "trans": [
+      "Day 29 | v. | English: Ifa feeling such as anger or hatred smoulders inside you, you continue to feel it but do not show it. | Example: “The color is repellant, almost revolting; a smouldering unclean yellow, strangely faded by the slow-turning sunlight.”"
+    ]
+  },
+  {
+    "name": "sob",
+    "trans": [
+      "Day 29 | n. | English: n. an act or the sound of sobbing; v. to cry noisily, taking sudden, sharp breaths | Example: [1] “The [train] engines of this valley have a whistle, the echoes of which sound like iterated gasps and sobs. | always think of them as crude music.” 2] Then we sit and sob, and long for the gas-lit streets, and the sound of human voices, and the answering throb of human life."
+    ]
+  },
+  {
+    "name": "solicit",
+    "trans": [
+      "Day 29 | v. | English: to ask sb for sth, such as support, money, or information; to try to get sth or persuade sb to do sth | Example: This was the case for both separation problems and dog rivalry but was especially pronounced for attachment and attention-seeking, which can be seen when a dog solicits affection or attention."
+    ]
+  },
+  {
+    "name": "solidify",
+    "trans": [
+      "Day 29 | v. | English: to become or to make sth become more definite and less likely to change | Example: Now, by producing acclaimed works, Gary Pak has solidified his place in that literary tradition."
+    ]
+  },
+  {
+    "name": "solitary",
+    "trans": [
+      "Day 29 | adj. | English: done alone; without other people | Example: Caterpillars that were found to produce sounds in response to simulated attacks are typically solitary and were tested in isolation."
+    ]
+  },
+  {
+    "name": "solitude",
+    "trans": [
+      "Day 29 | n. | English: the state of being alone, especially when you find this pleasant | Example: The following text is from Sara Teasdale’s 1922 poem “Two Songs for Solitude.”"
+    ]
+  },
+  {
+    "name": "solstice",
+    "trans": [
+      "Day 29 | n. | English: either of the two times of the year at which the sun reaches its highest or lowest point in the sky at midday, marked by the longest and shortest days | Example: By observing the sun's position in relation to various points on the mountains surrounding the Basin of Mexico, the Mexica were able to precisely identify the dates when significant events such as solstices occurred."
+    ]
+  },
+  {
+    "name": "sonorous",
+    "trans": [
+      "Day 29 | adj. | English: having a pleasant full deep sound The sonorous, joyful bells rang again. From within the church, the honeyed voices of a female chorus rose melancholy and grave."
+    ]
+  },
+  {
+    "name": "soothe",
+    "trans": [
+      "Day 29 | v. | English: to make sb who is anxious, upset, etc. feel calmer | Example: Some robots such as Surena (developed in 2008) and COMAN (developed in 2012) are designed to resemble humans so that people will find it easier to interact with them. To this end, certain features such as the ability to respond to voice commands can help to create the comforting semblance of humanity, but a robot that appears too similar to humans can make people feel more unsettled than soothed."
+    ]
+  },
+  {
+    "name": "sophist",
+    "trans": [
+      "Day 29 | n. | English: a teacher of philosophy in ancient Greece, especially one with an attitude of doubting that statements are true | Example: Socrates, a sophist, explains why he studies astronomy while sitting in a basket hanging a few feet off the ground, saying, \"| should not have rightly discovered things celestial if | had not suspended the intellect, and mixed the thought in a subtle form with its kindred air.\""
+    ]
+  },
+  {
+    "name": "sophisticated",
+    "trans": [
+      "Day 29 | adj. | English: clever and complicated in the way that it works or is presented | Example: By conceding that the genre of historical fiction contains many works that are less sophisticated than Sula is"
+    ]
+  },
+  {
+    "name": "sophistication",
+    "trans": [
+      "Day 29 | n. | English: the quality of being sophisticated | Example: It would take many decades to build up the level of education and sophistication required."
+    ]
+  },
+  {
+    "name": "sovereignty",
+    "trans": [
+      "Day 29 | n. | English: the state of being a country with freedom to govern itself | Example: He has been praised for his role in affirming the sovereignty of tribal nations, and he once made an attempt at reforming United States health care policy that is arguably a precursor to the Affordable Care Act, which became law during the Barack Obama administration."
+    ]
+  },
+  {
+    "name": "spark",
+    "trans": [
+      "Day 29 | v. | English: to cause sth to start or develop, especially suddenly | Example: Extensive travels abroad later sparked an engagement with modernist and functionalist aesthetics."
+    ]
+  },
+  {
+    "name": "spatial",
+    "trans": [
+      "Day 29 | adj. | English: relating to space and the position, size, shape, etc. of things in it | Example: Economist Jingting Fan argues that the effects of international trade may display spatial variation at sub-national levels."
+    ]
+  },
+  {
+    "name": "spawn",
+    "trans": [
+      "Day 29 | n. | English: to lay eggs | Example: The logjams create shady pools where the blueback salmon can rest and spawn, thus promoting blueback population recovery."
+    ]
+  },
+  {
+    "name": "spear",
+    "trans": [
+      "Day 29 | n. | English: a weapon with a long wooden handle and a sharp metal point used for fighting, hunting and fishing in the past | Example: Researchers have long hypothesized that woolly mammoths were hunted to extinction in North America by humans using spears with grooved tips known as Clovis points."
+    ]
+  },
+  {
+    "name": "spearhead",
+    "trans": [
+      "Day 29 | v. | English: to begin an activity or lead an attack against sb/sth | Example: Led by experienced organizers such as Dorothy Cotton and Septima Clark, CEP attendees—more than 7,000 in all—participated in workshops on topics ranging from public speaking to legal doctrine before returning home and using their newly acquired knowledge to spearhead local civil rights initiatives."
+    ]
+  },
+  {
+    "name": "specimen",
+    "trans": [
+      "Day 29 | n. | English: a small amount of sth that shows what the rest of it is like | Example: Excavating a pterosaur fossil is a difficult process, since it can take weeks or even months of hard, physically tiring work to clear away the dirt and rock covering the specimen."
+    ]
+  },
+  {
+    "name": "speck",
+    "trans": [
+      "Day 29 | n. | English: avery small spot; a small piece of dirt, etc | Example: He watches his father raise a kite within minutes into the wind, so high that Gogol must tip his head back in order to see, a rippling speck against the sky."
+    ]
+  },
+  {
+    "name": "spectacle",
+    "trans": [
+      "Day 29 | n. | English: a performance or an event that is very impressive and exciting to look at | Example: The bald cypresses spread themselves along the water courses while the willows wept as they always did. Mr. Bradford was conscious of this gorgeous spectacle of nature."
+    ]
+  },
+  {
+    "name": "spectral",
+    "trans": [
+      "Day 29 | adj. | English: like a ghost ; connected with a ghost | Example: At five-thirty the old Panhandle bridge, supported by massive sandstone pillars, stalwart, as when erected fifty years before to serve a generation now passed behind the portals of life, had become a spectral outline against the sky."
+    ]
+  },
+  {
+    "name": "speculate",
+    "trans": [
+      "Day 29 | v. | English: to form an opinion about sth without knowing all the details or facts | Example: It examines how tribal citizens responded to exhibits at tribal cultural centers, then speculates how non-Indigenous audiences would respond to the same exhibits."
+    ]
+  },
+  {
+    "name": "spew",
+    "trans": [
+      "Day 29 | v. | English: to flow out quickly, or to make sth flow out quickly, in large amounts | Example: | think Québec City needs more streets like Rue du Petit-Champlain, not more streets full of loud cars spewing exhaust fumes into the air."
+    ]
+  },
+  {
+    "name": "spillover",
+    "trans": [
+      "Day 29 | n. | English: the results or the effects of sth that have spread to other situations or places | Example: The potential for knowledge spillovers, a dominant driver of collocation in this industry, was largely absent from the paint manufacturing industry."
+    ]
+  },
+  {
+    "name": "spiteful",
+    "trans": [
+      "Day 29 | adj. | English: behaving in an unkind way in order to hurt or upset sb | Example: You are cultured and intelligent, [Vanya], and you surely understand that the world is not destroyed by villains and conflagrations, but by hate and malice and all this spiteful tattling."
+    ]
+  },
+  {
+    "name": "splash",
+    "trans": [
+      "Day 29 | v. | English: to make sb/sth wet by making water, mud, etc. fall on them/it | Example: People splash and spray each other for fun at the festival's community-wide water fights."
+    ]
+  },
+  {
+    "name": "spoilt",
+    "trans": [
+      "Day 29 | adj. | English: rude and badly behaved because they are given everything they ask for and not enough discipline | Example: The banker, spoilt and frivolous, with millions beyond his reckoning, was delighted at the bet."
+    ]
+  },
+  {
+    "name": "spontaneously",
+    "trans": [
+      "Day 29 | n. | English: happen naturally without being made to happen | Example: When classical pianist Martha Argerich performs, it appears as if the music is coming to her spontaneously."
+    ]
+  },
+  {
+    "name": "sporadic",
+    "trans": [
+      "Day 29 | adj. | English: happening only occasionally or at intervals that are not regular | Example: As Rachana Kamtekar observes, this argument is difficult to reconcile with our lay conception of character: we expect a person of helpful character to be frequently helpful, not sporadically helpful."
+    ]
+  },
+  {
+    "name": "spray",
+    "trans": [
+      "Day 29 | v. | English: to cover sb/sth with very small drops of a liquid that are forced out of a container or sent through the air | Example: Sprinkler irrigation systems are a contemporary way of irrigating that requires machinery to spray water in all directions. springup Bi, iW 32 3CF% SL: If something springs up, it suddenly appears or begins to exist. A gleaming carpet was springing up everywhere."
+    ]
+  },
+  {
+    "name": "spring up",
+    "trans": [
+      "Day 29 | English: If something springs up, it suddenly appears or begins to exist. | Example: A gleaming carpet was springing up everywhere."
+    ]
+  },
+  {
+    "name": "sprout",
+    "trans": [
+      "Day 29 | v. | English: (of plants or seeds) to produce new leaves or buds | Example: In fact, some species actually did better in Martian soil than in Earth soil: 30 percent of field mustard seeds sprouted when planted in simulated Martian soil, compared with 4 percent that did when planted in soil from their home planet."
+    ]
+  },
+  {
+    "name": "spur",
+    "trans": [
+      "Day 29 | v. | English: to encourage a horse to go faster, especially by pushing the spurs on your boots into its side | Example: They spurred their horses to a gallop as if in that mad race they laid claims of possession to the earth."
+    ]
+  },
+  {
+    "name": "spurious",
+    "trans": [
+      "Day 29 | adj. | English: false, although seeming to be genuine | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few entries that knowledgeable readers should have realized were spurious, such as those for the American new wave band Transforatix and the 19th-century German poet Emilia Dering, persisted on the site for many years before they were finally recognized as falsehoods and deleted."
+    ]
+  },
+  {
+    "name": "stage",
+    "trans": [
+      "Day 29 | v. | English: to organize and present a play or an event for people to see | Example: While they might be eager to produce an established classic like Annie, for example, most would be hesitant to stage a work from a relatively unknown playwright."
+    ]
+  },
+  {
+    "name": "staging",
+    "trans": [
+      "Day 29 | n. | English: the way in which a play is produced and presented on stage | Example: | aim to create a clear sense of the character and the world they inhabit. Sometimes this means adhering to the historical period's style, but frequently, as in stagings of A Midsummer Night's Dream, some flexibility is required to communicate an idea to the audience."
+    ]
+  },
+  {
+    "name": "stagnant",
+    "trans": [
+      "Day 30 | adj. | English: not developing, growing or changing | Example: Early Earth is thought to have been characterized by a stagnant lid tectonic regime."
+    ]
+  },
+  {
+    "name": "stalwart",
+    "trans": [
+      "Day 30 | adj. | English: loyal and able to be relied on, even in a difficult situation | Example: At five-thirty the old Panhandle bridge, supported by massive sandstone pillars, stalwart, as when erected fifty years before to serve a generation now passed behind the portals of life, had become a spectral outline against the sky."
+    ]
+  },
+  {
+    "name": "stance",
+    "trans": [
+      "Day 30 | n. | English: the opinions that sb has about sth and expresses publicly | Example: Thus, Enke et al. suggest that although the behavior of high-income earners who advocate for higher taxes may seem counterintuitive, such people likely do so because they feel enabled by their economic security to take a stance they think is morally correct."
+    ]
+  },
+  {
+    "name": "staple",
+    "trans": [
+      "Day 30 | English: a basic type of food that is used a lot | Example: Kwaxsistalla WathI'thla, a song keeper for the Kwakwaka'wakw people in Canada, collaborated with ethnobiologist Dana Lepofsky et al., sharing songs referencing terraced intertidal clam gardens the people implemented in the past to foster healthy development of a dietary staple."
+    ]
+  },
+  {
+    "name": "startle",
+    "trans": [
+      "Day 30 | v. | English: to surprise sb suddenly in a way that slightly shocks or frightens them | Example: I didn't mean to startle you."
+    ]
+  },
+  {
+    "name": "statue",
+    "trans": [
+      "Day 30 | n. | English: a figure of a person or an animal in stone, metal, etc., usually the same size as in real life or larger We simply do not know enough about the people of the time to say with certainty what the statue meant to them."
+    ]
+  },
+  {
+    "name": "steady",
+    "trans": [
+      "Day 30 | adj. | English: not changing and not interrupted | Example: Many believe that lullabies, characterized by their less steady beat, contain some acoustic features that are universally calming to infants."
+    ]
+  },
+  {
+    "name": "steep",
+    "trans": [
+      "Day 30 | adj. | English: rising or falling quickly, not gradually | Example: Do | behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more deep seclusion; and connect / The landscape with the quiet of the sky."
+    ]
+  },
+  {
+    "name": "steer",
+    "trans": [
+      "Day 30 | v. | English: if you steer someone in a particular direction, you guide them there | Example: [The Rat] had patiently hunted through the wood for an hour or more, when at last to his joy he heard a little answering cry. Steering himself by the sound, he made his way through the gathering darkness to the foot of an old beech tree."
+    ]
+  },
+  {
+    "name": "stellar",
+    "trans": [
+      "Day 30 | adj. | English: connected with the stars | Example: Stars form in cloudlike swirls of gas and dust that cannot be touched, but astrophysicist Nia Imara believes these formations need not remain completely intangible to researchers: she uses simulation data and sophisticated 3D printers to produce interactive models of these stellar nurseries."
+    ]
+  },
+  {
+    "name": "still",
+    "trans": [
+      "Day 30 | adj. | English: not moving; calm and quiet | Example: [The] Mole stood still a moment, held in thought."
+    ]
+  },
+  {
+    "name": "stimulus",
+    "trans": [
+      "Day 30 | n. | English: something that helps sb/sth to develop better or more quickly | Example: Bainbridge and colleagues also measured pupil size, as pupils typically become larger when a stimulus captures a person's attention."
+    ]
+  },
+  {
+    "name": "stirring",
+    "trans": [
+      "Day 30 | adj. | English: causing strong feelings; exciting | Example: Those who have had the rare privilege of reading her stirring biography, will, | am sure, bear me out in this statement."
+    ]
+  },
+  {
+    "name": "straddle",
+    "trans": [
+      "Day 30 | v. | English: to sit or stand with one of your legs on either side of sb/sth | Example: The late-period pieces of James Tate arguably fit this description, since they straddle the line between prose and poetry."
+    ]
+  },
+  {
+    "name": "straighten",
+    "trans": [
+      "Day 30 | v. | English: to make your body straight and vertical | Example: He stood up and straightened his shoulders."
+    ]
+  },
+  {
+    "name": "strand",
+    "trans": [
+      "Day 30 | n. | English: a single thin piece of thread, wire, hair, etc. | Example: Is there an available barrier material that can block roots and liquids while allowing fungal strands through?"
+    ]
+  },
+  {
+    "name": "strata",
+    "trans": [
+      "Day 30 | n. | English: a layer or set of layers of rock, earth, etc. | Example: The sequence of strata shows where the animal roamed during life."
+    ]
+  },
+  {
+    "name": "stratum",
+    "trans": [
+      "Day 30 | n. | English: a layer or set of layers of rock, earth, etc. | Example: Mammoth tusks grew in sequential layers, incorporating ingested minerals and organics, and so each ivory stratum reflects the ratio of strontium isotopes (87Sr/86Sr) in the local environment."
+    ]
+  },
+  {
+    "name": "strenuous",
+    "trans": [
+      "Day 30 | adj. | English: needing great effort and energy; showing great energy and determination | Example: In the novel, a group of soldiers travel through a canyon, where their collective mood becomes strongly affected by the strenuous conditions of their journey."
+    ]
+  },
+  {
+    "name": "stretch",
+    "trans": [
+      "Day 30 | v. | English: v. to put out an arm ora leg in order to reach sth; v. to continue over a period of time [1] \"I'm going to have one of these gorgeous oranges,\" said Mrs. Wilkins, staying where she was and stretching toward a black bowl piled with them. | Example: 2] Although the literary works of David Malo and Lee Cataluna have universal appeal, they are also inextricable from the Hawaiian literary tradition in which both authors work and that stretches back to the traditional stories of the Kanaka Maoli, the Native Hawaiian people."
+    ]
+  },
+  {
+    "name": "strictly",
+    "trans": [
+      "Day 30 | adv. | English: with a lot of control and rules that must be obeyed | Example: People sometimes dismiss a claim if it comes from a source they regard as self-interested, but from a strictly logical perspective, the source of a claim is irrelevant."
+    ]
+  },
+  {
+    "name": "stricture",
+    "trans": [
+      "Day 30 | n. | English: a severe criticism, especially of sb's behaviou | Example: The Times [a British newspaper], replying to some foreign strictures on the dress, looks, and behavior of the English abroad, urges that the English ideal is that everyone should be free to do and to look just as he likes."
+    ]
+  },
+  {
+    "name": "strife",
+    "trans": [
+      "Day 30 | n. | English: angry or violent disagreement between two people or groups of people | Example: He told me how calm his soul was laid / By the lack of anvil and strife."
+    ]
+  },
+  {
+    "name": "striking",
+    "trans": [
+      "Day 30 | adj. | English: interesting and unusual enough to attract attention | Example: Cuttlefish changed their striking position to match the 3D images, suggesting that their vision is more like that of sheep and falcons than that of octopuses or squid."
+    ]
+  },
+  {
+    "name": "strip",
+    "trans": [
+      "Day 30 | n. | English: along narrow area of land, sea, etc | Example: As with other river deltas, the Krishna River delta is dynamic: it is a constantly evolving network of channels and strips of land that change in size and shape as the river deposits new sedimentary particles where the river meets the waters of the Bay of Bengal."
+    ]
+  },
+  {
+    "name": "strive",
+    "trans": [
+      "Day 30 | v. | English: to try very hard to achieve sth | Example: Each is contemptuous of the other attendees but strives to impress them."
+    ]
+  },
+  {
+    "name": "stroke",
+    "trans": [
+      "Day 30 | n. | English: a single movement of the arm when hitting sb/sth One person after another rose, and, as with an ill-balanced axe, attempted to hew out his conception of art a little more clearly, and sat down with the feeling that, for some reason which he could not grasp, his strokes had gone awry."
+    ]
+  },
+  {
+    "name": "sturdy",
+    "trans": [
+      "Day 30 | adj. | English: physically strong and healthy | Example: It compares the sturdiness of two types of boats."
+    ]
+  },
+  {
+    "name": "stymie",
+    "trans": [
+      "Day 30 | v. | English: to prevent sb from doing sth that they have planned or want to do; to prevent sth from happening | Example: Proposals to raise the age at which retirees begin receiving government transfers of funds are generally discussed in terms of the effects on transfer recipients, but Andria Smythe has argued that delaying such transfers could stymie wealth creation among working adults by lengthening the period in which they are providing financial support to their nonworking parents."
+    ]
+  },
+  {
+    "name": "subdued",
+    "trans": [
+      "Day 30 | adj. | English: not very bright | Example: Although oil shocks—such as the 16% rise in oil prices from April to September of 1973—can strongly affect individual consumers, Gbadebo Oladosu and colleagues have shown that at the level of national economies, their effects are often quite subdued."
+    ]
+  },
+  {
+    "name": "subordinate",
+    "trans": [
+      "Day 30 | adj. | English: less important than sth else | Example: Today, the mobile application Instagram is thought of exclusively as a photo- and video- sharing program, but image sharing was originally subordinate to the app's main purpose, which was to allow users to indicate their locations to other users in real time."
+    ]
+  },
+  {
+    "name": "subscribe",
+    "trans": [
+      "Day 30 | v. | English: to pay an amount of money regularly in order to receive or use sth | Example: A survey found that in April 2022, 7.6 percent of subscribers to fashion and apparel services canceled their subscriptions."
+    ]
+  },
+  {
+    "name": "subsequent",
+    "trans": [
+      "Day 30 | adj. | English: happening or coming after sth else | Example: It recounts a moment in Johnson's personal life that enabled the success of his subsequent career, which is summarized in the following sentence."
+    ]
+  },
+  {
+    "name": "subside",
+    "trans": [
+      "Day 30 | v. | English: to become calmer or quieter | Example: Reducing this kind of subscriber turnover is especially challenging for subscription sellers: customers’ initial enthusiasm for a subscription is often quick to subside, and sellers must thus devise other incentives to bolster retention."
+    ]
+  },
+  {
+    "name": "substantial",
+    "trans": [
+      "Day 30 | adj. | English: of considerable importance, size, or worth | Example: By suggesting that future research may provide substantial advancements in the field of automated genre classification"
+    ]
+  },
+  {
+    "name": "substitute",
+    "trans": [
+      "Day 30 | v. | English: v. to take the place of sb/sth else; to use sb/sth instead of sb/sth els; n. a person or thing that you use or have instead of the one you normally use or have | Example: [1] Rai's approach substitutes a natural plant-based substance for the hazardous Chemicals that manufacturers have traditionally used. 2] Using a mechanical spear-thrower, he launched spears with Clovis points into mounds of clay—substitutes for the animals’ large bodies."
+    ]
+  },
+  {
+    "name": "subtlety",
+    "trans": [
+      "Day 30 | n. | English: the small but important details or aspects of sth | Example: The tendency to group authors together into distinct literary movements often encourages literary scholars to discount subtleties in an author's style."
+    ]
+  },
+  {
+    "name": "subvert",
+    "trans": [
+      "Day 30 | v. | English: to try to destroy the authority of a political, religious, etc. system by attacking it secretly or indirectly | Example: In general terms, the young tend to subvert traditions."
+    ]
+  },
+  {
+    "name": "succession",
+    "trans": [
+      "Day 30 | n. | English: the regular pattern of one thing following another thing All day long [the soldiers] rode through the canyon, up and down the steep, round hills, dirty and bald as a man’s head, hill after hill in endless succession."
+    ]
+  },
+  {
+    "name": "successor",
+    "trans": [
+      "Day 30 | n. | English: a person or thing that comes after sb/sth else and takes their/its place | Example: Barring major archaeological discoveries, we are unlikely to ever have an exhaustive account of ancient Egypt under the female pharaoh Hatshepsut, as much of the evidence of her reign was deliberately destroyed by her successors."
+    ]
+  },
+  {
+    "name": "summation",
+    "trans": [
+      "Day 30 | n. | English: a summary of what has been done or said | Example: What he said was a fair summation of the discussion."
+    ]
+  },
+  {
+    "name": "summit",
+    "trans": [
+      "Day 30 | n. | English: the highest point of sth, especially the top of a mountai | Example: When he reached the summit, he glanced down to see the sun steeping the valley in a lake of gold."
+    ]
+  },
+  {
+    "name": "summon",
+    "trans": [
+      "Day 30 | v. | English: to make a feeling, an idea, a memory, etc. come into your mind | Example: Miranda's ability to summon details of an experience she had before arriving on the island suggests that she may also be able to summon details of her arrival on the island."
+    ]
+  },
+  {
+    "name": "superfluous",
+    "trans": [
+      "Day 30 | adj. | English: Something that is superfluous is unnecessary or is no longer needed. | Example: In short, knowledge of economics is not superfluous and must not be left to economists alone."
+    ]
+  },
+  {
+    "name": "superior",
+    "trans": [
+      "Day 30 | adj. | English: better in quality than sb/sth else; greater than sb/sth else | Example: The program's performance was superior to that of the road-map method: it more accurately identified sidewalks, and it even distinguished between concrete and brick."
+    ]
+  },
+  {
+    "name": "supersede",
+    "trans": [
+      "Day 30 | v. | English: to take the place of sth/sb that is considered to be old-fashioned or no longer the best available | Example: The theory has been superseded by more recent research."
+    ]
+  },
+  {
+    "name": "supplant",
+    "trans": [
+      "Day 30 | v. | English: to take the place of sb/sth | Example: Douglass believes that rather than supplanting books, technology is simply making new forms of expression possible."
+    ]
+  },
+  {
+    "name": "supplement",
+    "trans": [
+      "Day 30 | v. | English: to add sth to sth in order to improve it or make it more complete | Example: There are many art exhibitions in the Art Institute of Chicago, but browsing some other art works in the street can supplement the visitor’s experience."
+    ]
+  },
+  {
+    "name": "supplemental",
+    "trans": [
+      "Day 30 | adj. | English: provided in addition to sth else in order to improve or complete it | Example: Providing supplemental vitamin D to chimpanzees in zoos in Sweden and other mid-latitude countries would likely not be beneficial."
+    ]
+  },
+  {
+    "name": "supposition",
+    "trans": [
+      "Day 30 | n. | English: an idea that you think is true although you may not be able to prove it | Example: Ifone has a supposition that the word “own” has a high incidence in English, for example, an analysis of a corpus can support that hypothesis by showing that “own” is the eighth most commonly used adjective."
+    ]
+  },
+  {
+    "name": "suppress",
+    "trans": [
+      "Day 31 | v. | English: vv. to prevent sth from being published or made known; v. to prevent yourself from having or expressing a feeling or an emotion | Example: [1] Although the government of the Soviet Union attempted to suppress Georgi Viadimov's novel Faithful Ruslan, copies of the book circulated in secret among readers in several parts of the country. 2] Demetrio suppressed a sigh. Memories crowded and buzzed through his brain like bees about a hive."
+    ]
+  },
+  {
+    "name": "surf",
+    "trans": [
+      "Day 31 | n. | English: large waves in the sea or ocean, and the white foam that they produce as they fall on the beach, on rocks, etc. | Example: In his solitary retreat on the shore of the sea, whose mobile surface was visible through the open windows, extending outward until it mingled with the horizon, Padre Florentino was relieving the monotony by playing on his harmonium sad and melancholy tunes, to which the sonorous roar of the surf and the sighing of the treetops of the neighboring wood served as accompaniments."
+    ]
+  },
+  {
+    "name": "surpass",
+    "trans": [
+      "Day 31 | v. | English: to do or be better than sb/sth | Example: But El Paso surpassed all other cities in the state."
+    ]
+  },
+  {
+    "name": "surplus",
+    "trans": [
+      "Day 31 | n. | English: the amount by which the amount of money received is greater than the amount of money spent | Example: Although the government regularly defaulted on debt, it ran an even larger overall surplus than did the government of eighteenth-century Britain, which historians consider a model of fiscal virtue."
+    ]
+  },
+  {
+    "name": "surrender",
+    "trans": [
+      "Day 31 | v. | English: to admit that you have been defeated and want to stop fighting; to allow yourself to be caught, taken prisoner, etc. | Example: The hijackers eventually surrendered themselves to the police."
+    ]
+  },
+  {
+    "name": "survey",
+    "trans": [
+      "Day 31 | v. | English: to look carefully at the whole of sth, especially in order to get a general impression of it | Example: He surveyed the fence, and all gladness left him and a deep melancholy settled down upon his spirit."
+    ]
+  },
+  {
+    "name": "susceptibility",
+    "trans": [
+      "Day 31 | n. | English: the state of being very likely to be influenced, harmed or affected by sth | Example: These animals are thought to be especially vulnerable to ocean acidification due to calcium carbonate's susceptibility to dissolution at lower pH values."
+    ]
+  },
+  {
+    "name": "susceptible",
+    "trans": [
+      "Day 31 | adj. | English: very likely to be influenced, harmed or affected by sb/sth | Example: The Kaua''amakihi is an example of a species unique to the Hawaiian archipelago that is highly specialized and therefore particularly susceptible to habitat disturbances."
+    ]
+  },
+  {
+    "name": "suspect",
+    "trans": [
+      "Day 31 | v. | English: to be suspicious about sth | Example: Although historians strongly suspect that a particular sculpture is Desiderio's portrait bust of Strozzi, they do not currently have a method for conclusively verifying the artist or subject."
+    ]
+  },
+  {
+    "name": "sustain",
+    "trans": [
+      "Day 31 | v. | English: to provide enough of what sb/sth needs in order to live or exist | Example: Matthew S. Savoca and colleagues resolve this apparent discrepancy by pointing out that baleen whales cycle iron in the ocean, helping support phytoplankton populations, which, in turn, sustain krill populations."
+    ]
+  },
+  {
+    "name": "swale",
+    "trans": [
+      "Day 31 | n. | English: a moist depression in a tract of land, usually with rank vegetation | Example: Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow's o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+    ]
+  },
+  {
+    "name": "swap",
+    "trans": [
+      "Day 31 | v. | English: to replace one person or thing with another | Example: Wireless headphones and other small electronic devices sometimes use batteries that can't be taken out and swapped for new ones."
+    ]
+  },
+  {
+    "name": "swathe",
+    "trans": [
+      "Day 31 | v. | English: to wrap or cover sb/sth in sth | Example: Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow’s o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+    ]
+  },
+  {
+    "name": "sweep",
+    "trans": [
+      "Day 31 | n. | English: the range of an idea, a piece of writing, etc. that considers many different things | Example: Asimov wanted to convey the vast sweep of human history over centuries, and one of his points is that at such a timescale, individuals don't matter."
+    ]
+  },
+  {
+    "name": "swell",
+    "trans": [
+      "Day 31 | v. | English: to increase or make sth increase in number or size | Example: Thy warm and land-locked waters swell with an easy motion, / And gently glides the light"
+    ]
+  },
+  {
+    "name": "sweltering",
+    "trans": [
+      "Day 31 | adj. | English: If you describe the weather as sweltering, you mean that it is extremely hot and makes you feel uncomfortable | Example: Summer is typically thought of as a sweltering season."
+    ]
+  },
+  {
+    "name": "swoon",
+    "trans": [
+      "Day 31 | v. | English: If you swoon, you are strongly affected by your feelings for someone you love or admire very much. | Example: My spirit swoons, and all my senses cry / For Ocean's breast and covering of the sky."
+    ]
+  },
+  {
+    "name": "symbolize",
+    "trans": [
+      "Day 31 | v. | English: to be a symbol of sth | Example: The figures reach out to each other in a pose that symbolizes a close, supportive relationship."
+    ]
+  },
+  {
+    "name": "symmetry",
+    "trans": [
+      "Day 31 | n. | English: the exact match in size and shape between two halves, parts or sides of sth | Example: The way in which individual elements are balanced within a photographic image tends to affect how viewers perceive it: symmetry tends to give the elements equal importance, asymmetry emphasizes differences, and radial balance (organizing the elements around a central point) emphasizes the center over the periphery."
+    ]
+  },
+  {
+    "name": "synonymous",
+    "trans": [
+      "Day 31 | adj. | English: so closely connected with sth that the two things appear to be the same To conclude that this approach accounts for the ethereal qualities now synonymous with the Highwaymen aesthetic is tempting but inaccurate."
+    ]
+  },
+  {
+    "name": "synopsis",
+    "trans": [
+      "Day 31 | n. | English: asummary of a piece of writing, a play, etc. | Example: It provides a synopsis of an interaction in an Austen novel that illustrates a literary concept discussed in the following sentence."
+    ]
+  },
+  {
+    "name": "tablet",
+    "trans": [
+      "Day 31 | n. | English: a flat piece of stone that has words written on it, especially one that has been fixed to a wall in memory of an important person or event | Example: The team found a tablet in Merneith's tomb with writing suggesting that she was in charge of the country's treasury and other central offices."
+    ]
+  },
+  {
+    "name": "tactile",
+    "trans": [
+      "Day 31 | adj. | English: connected with the sense of touch; using your sense of touch | Example: Woven from recycled yarn and hand tufted using a carpet weaving technique passed down by the artist's Turkish grandmother, the topological tapestries of Argentine textile artist Alexandra Kehayoglou are so lush and tactilely inviting that you are tempted to reach out and touch them."
+    ]
+  },
+  {
+    "name": "tally",
+    "trans": [
+      "Day 31 | v. | English: to calculate the total number, cost, etc. of sth | Example: One way to evaluate the importance of a scholar's research is to tally other scholars’ references to that research."
+    ]
+  },
+  {
+    "name": "tattle",
+    "trans": [
+      "Day 31 | v. | English: to tell sb, especially sb in authority, about sth bad that sb else has done | Example: You are cultured and intelligent, [Vanya], and you surely understand that the world is not destroyed by villains and conflagrations, but by hate and malice and all this spiteful tattling."
+    ]
+  },
+  {
+    "name": "tectonic plate",
+    "trans": [
+      "Day 31 | English: one of the parts of the earth's surface that move in relation to each other | Example: This project has allowed researcher Renee Weber to make use of the information in investigating tectonic activity on the Moon."
+    ]
+  },
+  {
+    "name": "telling",
+    "trans": [
+      "Day 31 | adj. | English: showing effectively what sb/sth is really like, but often without intending to | Example: In harmonious periods and telling phrases the different shades of political opinion, the divergences and disagreements, are adjusted."
+    ]
+  },
+  {
+    "name": "telltale",
+    "trans": [
+      "Day 31 | adj. | English: showing that sth exists or has happened | Example: This structure, which the team named Nadir, exhibits all the telltale signs of a high-velocity impact crater."
+    ]
+  },
+  {
+    "name": "temperate",
+    "trans": [
+      "Day 31 | adj. | English: having a mild temperature without extremes of heat or cold | Example: Much of the research ornithologists have carried out has been near universities in the temperate northern hemisphere, where female birdsong is less common than it is in the tropics."
+    ]
+  },
+  {
+    "name": "tempest",
+    "trans": [
+      "Day 31 | n. | English: a violent storm | Example: And while outside the tempest is raving o’er the ocean, / And the ship is madly driving on some lone and desert shore."
+    ]
+  },
+  {
+    "name": "temporal",
+    "trans": [
+      "Day 31 | adj. | English: connected with or limited by time | Example: Rafael Nufiez and colleagues recorded Yupno speakers explaining several of these temporal-related words and phrases and coded each speaker's manual gestures."
+    ]
+  },
+  {
+    "name": "temporary",
+    "trans": [
+      "Day 31 | adj. | English: lasting or intended to last or be used only for a short time; not permanen | Example: In the story, Mrs. Sommers attends a play, which she experiences as a temporary escape from the circumstances of her daily life."
+    ]
+  },
+  {
+    "name": "tempting",
+    "trans": [
+      "Day 31 | adj. | English: something that is tempting is attractive, and makes people want to have it, do it, etc. | Example: It is tempting to treat the clustering of information technology firms in Northern California as representative of industrial agglomeration generally."
+    ]
+  },
+  {
+    "name": "tend",
+    "trans": [
+      "Day 31 | v. | English: to care for sb/sth | Example: Louis Pipestone tended the petition like a garden."
+    ]
+  },
+  {
+    "name": "tender",
+    "trans": [
+      "Day 31 | adj. | English: kind, gentle and loving | Example: Trade and science and craft and art, / Have opened their doors to the call of woman; / And greater she grows in her greater part, / More tenderly wise, and more sweetly human."
+    ]
+  },
+  {
+    "name": "tentacle",
+    "trans": [
+      "Day 31 | n. | English: along thin part of the body of some creatures, such as an octopus , used for feeling or holding things, for moving or for getting food | Example: The fog extended its tentacles over city and river gradually obliterating traces of familiar landscapes."
+    ]
+  },
+  {
+    "name": "tenuous",
+    "trans": [
+      "Day 31 | adj. | English: so weak or uncertain that it hardly exists | Example: Semantic relations among the two nouns and the concept they signify can be tenuous."
+    ]
+  },
+  {
+    "name": "tenure",
+    "trans": [
+      "Day 31 | n. | English: the period of time when sb holds an important job, especially a political one; the act of holding an important job | Example: Legal scholars James Melton and Tom Ginsburg's analysis of de jure judicial independence and its growth over decades identifies six constitutional features that enhance such independence, including judicial tenure and selection procedure. Romania's constitution contains one of these features."
+    ]
+  },
+  {
+    "name": "term",
+    "trans": [
+      "Day 31 | v. | English: to use a particular name or word to describe sb/sth | Example: In his afterword to Crowley's book Little, Big, Bloom argues that the novel adroitly blends what playwright Friedrich Schiller termed the naive and sentimental modes."
+    ]
+  },
+  {
+    "name": "terrain",
+    "trans": [
+      "Day 31 | n. | English: used to refer to an area of land when you are mentioning its natural features, for example, if it is rough, flat, etc. | Example: Conservationists have argued that an ecosystem-based approach that incorporates the many interactions between the climate, terrain, and various species of a given geographical area may lead to better outcomes for all the species in a given location."
+    ]
+  },
+  {
+    "name": "terrestrial",
+    "trans": [
+      "Day 31 | adj. | English: operating on earth rather than from a satellit | Example: The declination, or celestial latitude, of the Aurigid meteor shower's radiant—the point in the sky from which, to a terrestrial observer, the shower's meteors appear to emanate—is 39 degrees, meaning that its radiant is located 39 degrees north of the celestial equator, in close"
+    ]
+  },
+  {
+    "name": "tertiary",
+    "trans": [
+      "Day 31 | adj. | English: third in order, rank or importance | Example: He might dissect, anatomize, and give names; but, not to speak of a final cause, causes in their secondary and tertiary grades were utterly unknown to him."
+    ]
+  },
+  {
+    "name": "testament",
+    "trans": [
+      "Day 31 | n. | English: a thing that shows that sth else exists or is true | Example: That his work is enjoyable despite this is a testament to his prodigious imagination—even if people read his books only for the ideas, they will have plenty to consider."
+    ]
+  },
+  {
+    "name": "thematic",
+    "trans": [
+      "Day 31 | adj. | English: connected with the theme or themes of sth | Example: Although Hawaiian literature is highly heterogeneous in many ways, it is also characterized by considerable thematic continuity."
+    ]
+  },
+  {
+    "name": "thereby",
+    "trans": [
+      "Day 31 | adv. | English: used to introduce the result of the action or situation mentioned | Example: Knowing this can assuage potential investors' worries about bureaucratic minutiae and thereby allow them to instead focus on identifying sound business opportunities."
+    ]
+  },
+  {
+    "name": "thermal",
+    "trans": [
+      "Day 31 | adj. | English: connected with heat | Example: Shedding light on the thermal biology of fungi, research by Radamés Cordero et al. indicates that certain mushrooms (including Marasmius capillaris and species from the genus Russula) can achieve a hypothermic state through evaporative cooling."
+    ]
+  },
+  {
+    "name": "thick",
+    "trans": [
+      "Day 31 | adj. | English: having a larger distance between opposite sides or surfaces than other similar objects or than normal | Example: She has a thick curtain of long, curly hair that practically engulfs her."
+    ]
+  },
+  {
+    "name": "thorough",
+    "trans": [
+      "Day 31 | adj. | English: done completely; with great attention to detail | Example: Colours might have been better chosen and lights more perfectly diffused; but perhaps in doing so the thorough clerical aspect of the whole might have been somewhat marred."
+    ]
+  },
+  {
+    "name": "thoughtful",
+    "trans": [
+      "Day 31 | adj. | English: showing that you think about and care for other people | Example: It was very thoughtful of you to send the flowers."
+    ]
+  },
+  {
+    "name": "thrill",
+    "trans": [
+      "Day 31 | v. | English: to excite or please sb very much | Example: For example, her 1991 novel The Crown of Columbus is essentially adventure fiction, and the thrilling events in its plot are set largely on a Caribbean island."
+    ]
+  },
+  {
+    "name": "thrive",
+    "trans": [
+      "Day 32 | v. | English: to become, and continue to be, successful, strong, healthy, etc. | Example: Elderberry bushes grow best when planted in shaded areas, while chia flowers do not require shade to thrive."
+    ]
+  },
+  {
+    "name": "throb",
+    "trans": [
+      "Day 32 | v. | English: v. to beat or sound with a strong, regular rhythm; n. a strong regular beat | Example: | rest me deep within the wood, / Drawn by its silent call, / Far from the throbbing crowd of men, / On nature's breast | fall."
+    ]
+  },
+  {
+    "name": "throne",
+    "trans": [
+      "Day 32 | n. | English: the position of being a king or queen | Example: Whether the reign of a French monarch such as Louis VII or Henry V was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy and therefore cannot be understood without a corollary understanding of the characteristics without which the monarch would have been forced to abandon the throne."
+    ]
+  },
+  {
+    "name": "throng",
+    "trans": [
+      "Day 32 | n. | English: to go somewhere or be present somewhere in large numbers | Example: Buyers who hadn't previously wanted to purchase old action figures thronged the market, believing prices would continue to rise and the toys could be resold later at a profit."
+    ]
+  },
+  {
+    "name": "thundering",
+    "trans": [
+      "Day 32 | adj. | English: very great or excessive | Example: [Mercedes] was still very pale, and her hands yet trembled, when the thundering of the east- bound train was heard in the distance."
+    ]
+  },
+  {
+    "name": "till",
+    "trans": [
+      "Day 32 | v. | English: to prepare and use land for growing crops | Example: As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot."
+    ]
+  },
+  {
+    "name": "timeworn",
+    "trans": [
+      "Day 32 | adj. | English: Something that is timeworn is old or has been used a lot over a long period of time. Even in the dim light the equipment looked old and timeworn."
+    ]
+  },
+  {
+    "name": "tip",
+    "trans": [
+      "Day 32 | v. | English: to move so that one end or side is higher than the other; to move sth into this position | Example: He watches his father raise a kite within minutes into the wind, so high that Gogol must tip his head back in order to see, a rippling speck against the sky."
+    ]
+  },
+  {
+    "name": "toil",
+    "trans": [
+      "Day 32 | n. | English: hard unpleasant work that makes you very tired | Example: Just let me drift far out from toil and care, / Where lapping of the waves shall be the sound."
+    ]
+  },
+  {
+    "name": "toll",
+    "trans": [
+      "Day 32 | n. | English: 1. money that you pay to use a particular road or bridge adj. happening now; of the present time | Example: Any effort to raise the toll that drivers must pay to use the Ogdensburg-Prescott Bridge, which spans the Saint Lawrence River to connect New York State and Ontario, Canada, should explain why a higher toll is necessary."
+    ]
+  },
+  {
+    "name": "tomb",
+    "trans": [
+      "Day 32 | n. | English: a large grave, especially one built of stone above or below the ground | Example: The team found a tablet in Merneith's tomb with writing suggesting that she was in charge of the country's treasury and other central offices."
+    ]
+  },
+  {
+    "name": "torrent",
+    "trans": [
+      "Day 32 | n. | English: a large amount of water moving very quickly | Example: Then Clarence was wildly apostrophized, and a torrent of tears relieved the overcharged, aching heart."
+    ]
+  },
+  {
+    "name": "toss",
+    "trans": [
+      "Day 32 | v. | English: to throw sth lightly or carelessly | Example: I'm as hungry as the winter, I'm ill, I'm shaken... and where haven't | been—fate has tossed me everywhere!"
+    ]
+  },
+  {
+    "name": "tough",
+    "trans": [
+      "Day 32 | adj. | English: strong enough to deal successfully with difficult conditions or situations | Example: I'm little of course, but terribly quick and wiry and tough."
+    ]
+  },
+  {
+    "name": "towering",
+    "trans": [
+      "Day 32 | adj. | English: extremely tall or high and therefore impressive | Example: [1] The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead. 2] Pops’s pride and joy is his wall of towering bookshelves."
+    ]
+  },
+  {
+    "name": "track",
+    "trans": [
+      "Day 32 | v. | English: to follow the movements of sb/sth, especially by using special electronic equipment | Example: The work of Tobias Gerstenberg et al. on tracking eye movements supports a theory that people engage in counterfactual thinking when making causal judgments."
+    ]
+  },
+  {
+    "name": "trade-off",
+    "trans": [
+      "Day 32 | n. | English: the act of balancing two things that you need or want but which are opposed to each other | Example: Optimal foraging theory (OFT) holds that animals foraging behaviors reflect cost-benefit trade-offs that vary by species and width dynamic ecological circumstances."
+    ]
+  },
+  {
+    "name": "trait",
+    "trans": [
+      "Day 32 | n. | English: a particular quality in your personality | Example: That's because birdsong has long been considered a male trait; researchers have argued that singing enables males to attract mates and claim territory."
+    ]
+  },
+  {
+    "name": "trajectory",
+    "trans": [
+      "Day 32 | n. | English: the curved path of sth that has been fired, hit or thrown into the air | Example: J. Mason Heberling and David J. Burke relied on historical DNA (nDNA)—genomic data incidentally preserved in specimens housed in natural history collections—to investigate the evolutionary trajectory of arbuscular mycorrhizal fungi."
+    ]
+  },
+  {
+    "name": "tranquil",
+    "trans": [
+      "Day 32 | adj. | English: quiet and peaceful | Example: This creates a more tranquil environment with calmer waters where animals can take shelter."
+    ]
+  },
+  {
+    "name": "tranquility",
+    "trans": [
+      "Day 32 | n. | English: a peaceful, calm state, without noise, violence, worry, etc. | Example: It contrasts the tranquility of the waters near Puerto Cabello with the roughness of waters elsewhere."
+    ]
+  },
+  {
+    "name": "transform",
+    "trans": [
+      "Day 32 | v. | English: to change the form of sth | Example: In fact, some historians argue that it fundamentally transformed the industry by enabling it to take advantage of mass production methods for the first time."
+    ]
+  },
+  {
+    "name": "transient",
+    "trans": [
+      "Day 32 | adj. | English: Transient is used to describe a situation that lasts only a short time or is constantly changing | Example: Occurring in the constellation Virgo, 60 million light-years from Earth, the transient yet powerful blast propelled particles and debris into space at extremely high speeds."
+    ]
+  },
+  {
+    "name": "translucent",
+    "trans": [
+      "Day 32 | adj. | English: allowing light to pass through but not transparent Allowing only some light to pass through, hauyne is instead classified as translucent."
+    ]
+  },
+  {
+    "name": "transparency",
+    "trans": [
+      "Day 32 | n. | English: the quality of sth, such as glass, that allows you to see through it | Example: While some commentators lauded this development, asserting that such blogs had a welcome transparency missing from traditional news, less sanguine observers countered that such blogs tended to ideological extremes that exacerbated political polarization to problematic levels."
+    ]
+  },
+  {
+    "name": "transpose",
+    "trans": [
+      "Day 32 | v. | English: to move or change sth to a different place or environment or into a different form | Example: The director transposes Shakespeare's play from 16th century Venice to present-day England."
+    ]
+  },
+  {
+    "name": "traverse",
+    "trans": [
+      "Day 32 | v. | English: an act of moving sideways or walking across a steep slope, not climbing up or down it; a place where this is possible or necessary | Example: There is no Frigate like a Book / To take us Lands away / Nor any Coursers like a Page / Of prancing Poetry— / This Traverse may the poorest take / Without oppress of Toll— / How frugal is the Chariot / That bears the Human soul."
+    ]
+  },
+  {
+    "name": "tread",
+    "trans": [
+      "Day 32 | v. | English: to put your foot down while you are stepping or walking | Example: A gleaming carpet was springing up everywhere, that looked too delicate to be trodden upon by rough feet."
+    ]
+  },
+  {
+    "name": "treasury",
+    "trans": [
+      "Day 32 | n. | English: aplace ina castle, etc. where valuable things are stored | Example: The team found a tablet in Merneith's tomb with writing suggesting that she was in charge of the country's treasury and other central offices."
+    ]
+  },
+  {
+    "name": "treat",
+    "trans": [
+      "Day 32 | n. | English: something very pleasant and enjoyable, especially sth that you give sb or do for them | Example: Cuttlefish appear to be surprisingly competent at exercising self-control: in a 2021 study conducted by behavioral ecologist Alexandra Schnell, these cephalopods routinely demonstrated restraint by delaying gratification, waiting for a favorite treat instead of instantly devouring a readily available meal."
+    ]
+  },
+  {
+    "name": "trek",
+    "trans": [
+      "Day 32 | v. | English: to make a long or difficult journey, especially on foot | Example: We trekked into a far country, / My friend and |."
+    ]
+  },
+  {
+    "name": "tremble",
+    "trans": [
+      "Day 32 | v. | English: to shake in a way that you cannot control, especially because you are very nervous, excited, frightened, etc. | Example: [Mercedes] was still very pale, and her hands yet trembled, when the thundering of the east- bound train was heard in the distance."
+    ]
+  },
+  {
+    "name": "trial",
+    "trans": [
+      "Day 32 | n. | English: an experience or a person that causes difficulties for sb | Example: She went through the crucible of unprecedented adversities and trials of life and came out one of the rare shining lights that beautify the New England sky."
+    ]
+  },
+  {
+    "name": "tribe",
+    "trans": [
+      "Day 32 | n. | English: (in developing countries) a group of people of the same race, and with the same customs, language, religion, etc., living in a particular area and often led by a chief | Example: In what is now Washington state, the Tulalip Tribes operate the Hibulb Cultural Center. Relying on traditional knowledge to guide the design of exhibits, this institution presents Tulalip history and culture to the tribes’ citizens."
+    ]
+  },
+  {
+    "name": "tribute",
+    "trans": [
+      "Day 32 | n. | English: an act, a statement or a gift that is intended to show your respect or admiration, especially for a dead person | Example: Novelist Leon Forrest admired William Faulkner's writing style. Forrest's novel Divine Days contains a long passage in tribute to Faulkner that is a perfect imitation of Faulkner's style: anyone familiar with Faulkner's writing would see the resemblance."
+    ]
+  },
+  {
+    "name": "trifling",
+    "trans": [
+      "Day 32 | adj. | English: small and not important | Example: How careful ought we to be to speak nothing but the truth, even in regard to the most trifling circumstances; and not only so, but to be well assured that what we suppose to be true, is truth, before we receive it as such."
+    ]
+  },
+  {
+    "name": "trigger",
+    "trans": [
+      "Day 32 | v. | English: to make sth happen suddenly | Example: The arrival of humans to the Americas is thought to have triggered a sudden decrease in biodiversity throughout the continents."
+    ]
+  },
+  {
+    "name": "trivial",
+    "trans": [
+      "Day 32 | adj. | English: not important or serious; not worth considering | Example: | know it sounds trivial , but I'm worried about it."
+    ]
+  },
+  {
+    "name": "trunk",
+    "trans": [
+      "Day 32 | n. | English: the main part of the human body apart from the head, arms and legs | Example: The morphological novelty of echinoderms marine—invertebrates with radial symmetry, usually starlike, around a central point—impedes comparisons with most other animals, in which bilateral symmetry on an anterior-posterior (head to tail) axis through a trunk is typical."
+    ]
+  },
+  {
+    "name": "tune",
+    "trans": [
+      "Day 32 | n. | English: a series of musical notes that are sung or played in a particular order to form a piece of music Among the wild rice in the still lagoon. / In monotone the lizard shrills his tune. / The wild goose, homing, seeks a sheltering, / Where rushes grow, and oozing lichens cling."
+    ]
+  },
+  {
+    "name": "turbulence",
+    "trans": [
+      "Day 32 | n. | English: a series of sudden and violent changes in the direction that air or water is moving in | Example: For large vortices, fish with intermediate heads would be better able than narrow-headed fish to distinguish between vortices and general turbulence in the water."
+    ]
+  },
+  {
+    "name": "turf",
+    "trans": [
+      "Day 32 | n. | English: short grass and the surface layer of soil that is held together by its roots; a piece of this that has been cut from the ground and is used especially for making lawns (= the area of grass in a garden/yard) | Example: [Jim] went on to the lawn, very slowly, and kicking wretchedly at the turf."
+    ]
+  },
+  {
+    "name": "turnover",
+    "trans": [
+      "Day 32 | n. | English: the rate at which goods are sold in a shop/store and replaced by others Reducing this kind of subscriber turnover is especially challenging for subscription sellers: customers’ initial enthusiasm for a subscription is often quick to subside, and sellers must thus devise other incentives to bolster retention. tusk on. (RARER oA) KF either of the long curved teeth that stick out of the mouth of elephants and some other animals | Example: Narwhals are shy whales that live in the remote Arctic Ocean. Some of them have a long tusk, like a unicorn horn, with sensitive nerves."
+    ]
+  },
+  {
+    "name": "tusk",
+    "trans": [
+      "Day 32 | n. | English: either of the long curved teeth that stick out of the mouth of elephants and some other animals | Example: Narwhals are shy whales that live in the remote Arctic Ocean. Some of them have a long tusk, like a unicorn horn, with sensitive nerves."
+    ]
+  },
+  {
+    "name": "twilight",
+    "trans": [
+      "Day 32 | n. | English: the faint light or the period of time at the end of the day after the sun has gone down | Example: Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow's o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+    ]
+  },
+  {
+    "name": "ubiquitous",
+    "trans": [
+      "Day 32 | adj. | English: seeming to be everywhere or in several places at the same time; very common | Example: However, Nufiez and colleagues claim that this tendency is not in fact ubiquitous."
+    ]
+  },
+  {
+    "name": "ultrasonic",
+    "trans": [
+      "Day 32 | adj. | English: higher than humans can hear | Example: The jade hawkmoth, a large-bodied moth, defends itself against the eastern red bat and other insect-eating bats, which use echolocation to hunt, by emitting ultrasonic clicks that can, for instance, disrupt the bats' echolocation signals."
+    ]
+  },
+  {
+    "name": "ultrasound",
+    "trans": [
+      "Day 32 | n. | English: sound that is higher than humans can hear | Example: To investigate moths' defensive ultrasound—which researchers had thought was exclusive to tiger moths, hawkmoths, and one species of geometer moths—Akito Y, Kawahara et al."
+    ]
+  },
+  {
+    "name": "unadorned",
+    "trans": [
+      "Day 32 | adj. | English: without any decoration | Example: The project's unadorned geometric forms, typical of the modernist aesthetic, contrasted with the historically inspired architecture seen in his earlier projects in Guadalajara, such as the house for Emiliano Robles Leon."
+    ]
+  },
+  {
+    "name": "unaffiliated",
+    "trans": [
+      "Day 32 | adj. | English: not belonging to or connected with a political party or a large organization | Example: Scholar's who reviewed the 1984 edition were unaffiliated with its production and were mostly either Joyce specialists who were largely unfamiliar with editorial theories and practices or specialists in such theories and practices who were insufficiently familiar with Joyce."
+    ]
+  },
+  {
+    "name": "unanimous",
+    "trans": [
+      "Day 33 | adj. | English: if.a decision or an opinion is unanimous , it is agreed or shared by everyone in a group | Example: The text summarizes an argument made in a collection of essays and then suggests that the essays’ authors didn't unanimously agree with the argument."
+    ]
+  },
+  {
+    "name": "unassuming",
+    "trans": [
+      "Day 33 | adj. | English: not wanting to draw attention to yourself or to your abilities or status | Example: A casual description of Scherezade Garcia's 2019 mural Blame It on the Bean: The Power of Coffee can make the work seem unassuming."
+    ]
+  },
+  {
+    "name": "unattainable",
+    "trans": [
+      "Day 33 | adj. | English: impossible to achieve or reach | Example: It presents evidence in support of the hypothesis that seed germination in lunar habitats is an unattainable goal."
+    ]
+  },
+  {
+    "name": "unblemished",
+    "trans": [
+      "Day 33 | adj. | English: not spoiled, damaged or marked in any wa | Example: This style largely rejected the conventions of the romantic style evident in many paintings by Thomas Couture, which instead accentuated their subjects’ positive traits by, for example, placing them in staged settings with expensive looking decorations and presenting them with smooth, unblemished skin."
+    ]
+  },
+  {
+    "name": "uncanny",
+    "trans": [
+      "Day 33 | adj. | English: strange and difficult to explain | Example: While these features can help to engender feelings of comfort in people, a robot that looks too like human can fall into the “uncanny valley,” meaning that its appearance unintentionally unsettles those who encounter it."
+    ]
+  },
+  {
+    "name": "unclassifiable",
+    "trans": [
+      "Day 33 | adj. | English: impossible to classify (= say which group or type something or someone belongs to) Writer Lydia Davis observed that while traditional literary forms, such as the novel, are recognizable as such even as they evolve, there are rarer “intergeneric” forms that might, for example, use elements of both fiction and essays to create something unclassifiable."
+    ]
+  },
+  {
+    "name": "uncouth",
+    "trans": [
+      "Day 33 | adj. | English: rude or socially unacceptable | Example: The great men of culture are those who have had a passion for diffusing, for making prevail, for carrying from one end of society to the other, the best knowledge, the best ideas of their time; who have labored to divest knowledge of all that was harsh, uncouth, difficult, abstract, professional, exclusive; to humanise it, to make it efficient outside the clique of the cultivated and learned, yet still remaining the best knowledge and thought of the time, and a true source, therefore, of sweetness and light."
+    ]
+  },
+  {
+    "name": "underestimate",
+    "trans": [
+      "Day 33 | v. | English: to think or guess that the amount, cost or size of sth is smaller than it really is | Example: By claiming that the author of Text 1 has underestimated the richness and complexity of Sula"
+    ]
+  },
+  {
+    "name": "undergo",
+    "trans": [
+      "Day 33 | v. | English: to experience sth, especially a change or sth unpleasant | Example: Believe me, Anya, believe me! I'm not thirty yet, I'm young, I'm still a student, but | have undergone a great deal!"
+    ]
+  },
+  {
+    "name": "undermine",
+    "trans": [
+      "Day 33 | v. | English: to make sth, especially sb's confidence or authority, gradually weaker or less effective | Example: It undermines an assertion made later in the text."
+    ]
+  },
+  {
+    "name": "underpin",
+    "trans": [
+      "Day 33 | v. | English: to support or form the basis of an argument, a claim, etc. | Example: The French bulldog and the cairn terrier differ with respect to the genetic underpinnings for attachment and attention-seeking."
+    ]
+  },
+  {
+    "name": "underscore",
+    "trans": [
+      "Day 33 | v. | English: underline | Example: The fact that publications by University of Minnesota economist Ellen R. McGrattan, who studies financial policy, are so frequently cited in other scholars' work underscores the usefulness of her research for her peers—other economists clearly find her studies valuable for their own scholarship."
+    ]
+  },
+  {
+    "name": "unearth",
+    "trans": [
+      "Day 33 | v. | English: to find sth in the ground by digging | Example: _Hoards found before the 1960s, however, such as the discovery of the Auchnacree hoard around 1921 were not aided by such technologies and thus were much more likely to result from artifacts being unearthed accidentally."
+    ]
+  },
+  {
+    "name": "unequivocal",
+    "trans": [
+      "Day 33 | adj. | English: expressing your opinion or intention very clearly and firmly | Example: Unequivocal though it seemed to many mathematicians, Nagata’s conjecture, posed in 1972, eventually yielded to the combined efforts of Ualbai U. Umirbaev and Ivan P. Shestakov, who presented a proof of it in 2004."
+    ]
+  },
+  {
+    "name": "uneventful",
+    "trans": [
+      "Day 33 | adj. | English: in which nothing interesting, unusual or exciting happens | Example: Whether the reign of a French monarch such as Louis VII or Henry V was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy and therefore cannot be understood without a corollary understanding of the characteristics without which the monarch would have been forced to abandon the throne."
+    ]
+  },
+  {
+    "name": "unfailing",
+    "trans": [
+      "Day 33 | adj. | English: that you can rely on to always be there and always be the same | Example: She fought the disease with unfailing good humour ."
+    ]
+  },
+  {
+    "name": "unflattering",
+    "trans": [
+      "Day 33 | adj. | English: making sb/sth seem worse or less attractive than they really are | Example: Ancient Greek and Roman sculpture is sometimes characterized as idealizing human subjects, but in fact there are many Greco-Roman sculptures that depict people in decidedly unflattering ways."
+    ]
+  },
+  {
+    "name": "unfold",
+    "trans": [
+      "Day 33 | v. | English: to spread open or flat sth that has previously been folded; to become open and flat To describe how each step of the peer review process unfolds."
+    ]
+  },
+  {
+    "name": "unintended",
+    "trans": [
+      "Day 33 | adj. | English: an unintended effect, result or meaning is one that you did not plan or intend to happen | Example: About half of all pregnancies globally are unintended"
+    ]
+  },
+  {
+    "name": "unprecedented",
+    "trans": [
+      "Day 33 | adj. | English: that has never happened, been done or been known before | Example: She went through the crucible of unprecedented adversities and trials of life and came out one of the rare shining lights that beautify the New England sky."
+    ]
+  },
+  {
+    "name": "unravel",
+    "trans": [
+      "Day 33 | v. | English: if you unravel threads that are twisted, woven or knitted, or if they unravel , they become separated | Example: and leave thou (inexpressibly to unravel) / thou life, with its immensity and fear, / so that, now bounded, now immeasurable, / it is alternately stone in thy and star."
+    ]
+  },
+  {
+    "name": "unrivaled",
+    "trans": [
+      "Day 33 | adj. | English: having no rival | Example: The views afforded here are unrivaled."
+    ]
+  },
+  {
+    "name": "unsettle",
+    "trans": [
+      "Day 33 | v. | English: to make sb feel upset or worried, especially because a situation has changed | Example: While these features can help to engender feelings of comfort in people, a robot that looks too like human can fall into the “uncanny valley,” meaning that its appearance unintentionally unsettles those who encounter it."
+    ]
+  },
+  {
+    "name": "unsettled",
+    "trans": [
+      "Day 33 | adj. | English: not calm or relaxed | Example: To this end, certain features such as the ability to respond to voice commands can help to create the comforting semblance of humanity, but a robot that appears too similar to humans can make people feel more unsettled than soothed."
+    ]
+  },
+  {
+    "name": "unsympathetic",
+    "trans": [
+      "Day 33 | adj. | English: not in agreement with sth; not supporting an idea, aim, etc. | Example: Drivers who strongly believe that the toll they must pay to use the San Luis Pass-Vacek Toll Bridge, which spans the San Luis Pass in Texas, is currently too high are likely to be unsympathetic to arguments for increasing the toll."
+    ]
+  },
+  {
+    "name": "untaught",
+    "trans": [
+      "Day 33 | adj. | English: without training or education | Example: The untaught peasant beheld the elements around him and was acquainted with their practical uses."
+    ]
+  },
+  {
+    "name": "untenable",
+    "trans": [
+      "Day 33 | adj. | English: that cannot be defended against attack or criticism | Example: And as Jane X. Luu et al. point out, the singular nature of impact ejection makes it untenable as an account of multiple loss episodes of similar duration over several years."
+    ]
+  },
+  {
+    "name": "unveil",
+    "trans": [
+      "Day 33 | v. | English: to show or introduce a new plan, product, etc. to the public for the first time | Example: The most learned philosopher knew little more. He had partially unveiled the face of Nature, but her immortal lineaments were still a wonder and a mystery."
+    ]
+  },
+  {
+    "name": "unwarranted",
+    "trans": [
+      "Day 33 | adj. | English: not reasonable or necessary; not appropriate | Example: To present findings that suggest that a concern about the effects of ocean acidification on pteropod shells may be unwarranted."
+    ]
+  },
+  {
+    "name": "unwavering",
+    "trans": [
+      "Day 33 | adj. | English: not changing or becoming weaker in any way They reveal that Caravan is unwaveringly precise in his daily routine because of the unreasonable expectations of his employers."
+    ]
+  },
+  {
+    "name": "unyielding",
+    "trans": [
+      "Day 33 | adj. | English: ifa person is unyielding , they are not easily influenced and they are unlikely to change their mind | Example: Political scientists have found that although voters claim to prefer candidates who have nuanced perspectives on issues and who show a willingness to compromise, when asked to compare speeches expressing such views with speeches expressing dogmatic views, voters tend to regard the unyielding rhetoric of the latter more favorably."
+    ]
+  },
+  {
+    "name": "upstart",
+    "trans": [
+      "Day 33 | n. | English: a person who has just started in a new position or job but who behaves as if they are more important than other people, in a way that is annoying | Example: She had the air of a queen and gazed disdainfully at the whole house, as if to say, \"I've come later than all of you, you crowd of upstarts and provincials, I've come later than you!\""
+    ]
+  },
+  {
+    "name": "uptake",
+    "trans": [
+      "Day 33 | n. | English: the process by which sth is taken into a body or system | Example: Among nautilids, there is no effect of sex on the uptake of oxygen-18 from water or its deposition in septa."
+    ]
+  },
+  {
+    "name": "urbanization",
+    "trans": [
+      "Day 33 | n. | English: Urbanization is the process of creating cities or towns in country areas. | Example: This new measure establishes global criteria used to define three types of settlements (cities, towns, and rural areas) and allows researchers to better understand global urbanization rates."
+    ]
+  },
+  {
+    "name": "urge",
+    "trans": [
+      "Day 33 | v. | English: to advise or try hard to persuade sb to do sth | Example: The Times [a British newspaper], replying to some foreign strictures on the dress, looks, and behavior of the English abroad, urges that the English ideal is that everyone should be free to do and to look just as he likes."
+    ]
+  },
+  {
+    "name": "usher",
+    "trans": [
+      "Day 33 | v. | English: to take or show sb where they should go | Example: But there were vacant seats here and there, and into one of them she was ushered, between brilliantly dressed women who had gone there to kill time and eat candy and display their gaudy attire."
+    ]
+  },
+  {
+    "name": "utensil",
+    "trans": [
+      "Day 33 | n. | English: a tool that is used in the house | Example: Guojun He and colleagues studied a food-delivery phone app that is popular in China. The researchers found that having \"no cutlery\" automatically selected influences whether customers request disposable plastic utensils with their food orders."
+    ]
+  },
+  {
+    "name": "utterly",
+    "trans": [
+      "Day 33 | adj. | English: You use utterly to emphasize that something is very great in extent, degree, or amount. | Example: He might dissect, anatomise, and give names; but, not to speak of a final cause, causes in their secondary and tertiary grades were utterly unknown to him."
+    ]
+  },
+  {
+    "name": "vacant",
+    "trans": [
+      "Day 33 | adj. | English: empty; not being used | Example: A lady accompanied by her husband entered at that moment and took her place in one of the two vacant boxes."
+    ]
+  },
+  {
+    "name": "vacate",
+    "trans": [
+      "Day 33 | v. | English: to leave a building, seat, etc., especially so that sb else can use it Guests are requested to vacate their rooms by noon on the day of departure."
+    ]
+  },
+  {
+    "name": "vacillating",
+    "trans": [
+      "Day 33 | adj. | English: inclined to waver; indecisive | Example: Vacillating people seldom succeed."
+    ]
+  },
+  {
+    "name": "vague",
+    "trans": [
+      "Day 33 | adj. | English: not having or giving enough information or details about sth | Example: Miranda's impression of a scene is vague because she is remembering a scenario she had daydreamed about as a child rather than a scenario that had occurred in reality."
+    ]
+  },
+  {
+    "name": "vain",
+    "trans": [
+      "Day 33 | adj. | English: that does not produce the result you want; too proud of your own appearance, abilities or achievements | Example: The little conductor stood on tiptoe in an effort to keep one hand on the signal rope, craning his neck in a vain and dissatisfied endeavor to pierce the miasma of the fog."
+    ]
+  },
+  {
+    "name": "validate",
+    "trans": [
+      "Day 33 | v. | English: to prove that sth is true | Example: For example, a linguist who assumes that the word “own” appears quite often in written English could validate that assumption with data from a corpus: “own” is the eighth most commonly used adjective."
+    ]
+  },
+  {
+    "name": "vanish",
+    "trans": [
+      "Day 33 | v. | English: to stop existing | Example: Holes, hollows, pools, pitfalls, and other menaces to the wayfarer were vanishing fast."
+    ]
+  },
+  {
+    "name": "vaporize",
+    "trans": [
+      "Day 33 | v. | English: to turn into gas; to make sth turn into gas | Example: Asteroid 6478 Gault has experienced intermittent mass loss since at least 2013, but in contrast to some other asteroids with repeated mass-loss episodes, 6478 Gault has not lost mass at its perihelion (the closest point of its orbit to the Sun), and thus the loss is not attributable to solar energy—driven ice vaporization."
+    ]
+  },
+  {
+    "name": "vapour",
+    "trans": [
+      "Day 33 | n. | English: amass of very small drops of liquid in the air, for example steam | Example: Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow's o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+    ]
+  },
+  {
+    "name": "variable",
+    "trans": [
+      "Day 33 | n. | English: n.a situation, number or quantity that can vary or be varied; adj. often changing; likely to change | Example: [1] While there are several possible reasons for this, one is that practitioners may overlook confounding variables that account for the results they attribute to the interventions in question. what drives firms in certain industries to cluster may not be especially relevant among other industries."
+    ]
+  },
+  {
+    "name": "vehement",
+    "trans": [
+      "Day 33 | vi. | English: showing very strong feelings, especially anger | Example: Mercedes, being not quite seventeen, her grief at parting from Clarence was wild, vehement and all-absorbing."
+    ]
+  },
+  {
+    "name": "veil",
+    "trans": [
+      "Day 33 | n. | English: a covering of very thin transparent material worn, especially by women | Example: Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow's o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+    ]
+  },
+  {
+    "name": "veiled",
+    "trans": [
+      "Day 34 | adj. | English: not expressed directly or clearly because you do not want your meaning to be obvious | Example: | sauntered along, forgetful of musty papers, of the offices, of my chief, my colleagues, my documents, and thinking of the good things that were sure to come to me, of all the veiled unknown contained in the future."
+    ]
+  },
+  {
+    "name": "venerate",
+    "trans": [
+      "Day 34 | v. | English: (formal) to have and show a lot of respect for sb/sth, especially sb/sth that is considered to be holy or very important | Example: These children are venerated as holy beings."
+    ]
+  },
+  {
+    "name": "verdant",
+    "trans": [
+      "Day 34 | adj. | English: fresh and green | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+    ]
+  },
+  {
+    "name": "veritable",
+    "trans": [
+      "Day 34 | adj. | English: aword used to emphasize that sb/sth can be compared to sb/sth else that is more exciting, more impressive, etc. | Example: The meal that followed was a veritable banquet."
+    ]
+  },
+  {
+    "name": "verse",
+    "trans": [
+      "Day 34 | n. | English: writing that is arranged in lines, often with a regular rhythm or pattern of rhyme, | Example: Its unintelligibility may cause its formal function within a line of verse to go unnoticed by present-day readers."
+    ]
+  },
+  {
+    "name": "vertical",
+    "trans": [
+      "Day 34 | adj. | English: going straight up or down from a level surface or from top to bottom in a picture, etc. | Example: Vertical gene transfer involves the transmission of genetic material from a parent to offspring: horizontal gene transfer, on the other hand, involves the exchange of genetic material between organisms not in a parent-offspring relationship."
+    ]
+  },
+  {
+    "name": "viable",
+    "trans": [
+      "Day 34 | adj. | English: that can be done | Example: While hDNA has potential for enhancing scientists’ understanding of the evolutionary past, the difficulty of deriving viable data from it at present has limited its use."
+    ]
+  },
+  {
+    "name": "viaduct",
+    "trans": [
+      "Day 34 | n. | English: along high bridge, usually with arches , that carries a road or railway/railroad across a river or valley | Example: And suddenly | perceived the great viaduct of Point du Jour which blocked the river."
+    ]
+  },
+  {
+    "name": "vibrant",
+    "trans": [
+      "Day 34 | adj. | English: full of life and energy | Example: Evocative of African sculpture and American and Scandinavian folk art, these portraits feature flat, deliberately oversimplified figures in a vibrant but limited color palette."
+    ]
+  },
+  {
+    "name": "vibrate",
+    "trans": [
+      "Day 34 | v. | English: to move or make sth move from side to side very quickly and with small movements Rusty-spotted cats, which are much smaller than jaguars, have a rigid hyoid that rumbles when the cat's larynx vibrates, resulting in a purr."
+    ]
+  },
+  {
+    "name": "vie",
+    "trans": [
+      "Day 34 | v. | English: to compete strongly with sb in order to obtain or achieve sth | Example: These lions weren't just there to be admired by visitors, though. Rather, they lived free lives, prowling the game reserve in coalitions (bands of male lions) and vying for territory."
+    ]
+  },
+  {
+    "name": "vigilance",
+    "trans": [
+      "Day 34 | n. | English: very careful to notice any signs of danger or trouble | Example: Constant vigilance is necessary in order to avoid accidents."
+    ]
+  },
+  {
+    "name": "vigorous",
+    "trans": [
+      "Day 34 | adj. | English: very active, determined or full of energy | Example: Notes long, full, mournful as a prayer, yet still vigorous, escaped from the old instrument."
+    ]
+  },
+  {
+    "name": "villain",
+    "trans": [
+      "Day 34 | n. | English: a person who is morally bad or responsible for causing trouble or harm | Example: You are cultured and intelligent, [Vanya], and you surely understand that the world is not destroyed by villains and conflagrations, but by hate and malice and all this spiteful tattling."
+    ]
+  },
+  {
+    "name": "vindicate",
+    "trans": [
+      "Day 34 | v. | English: to prove that sth is true or that you were right to do sth, especially when other people had a different opinion I have every confidence that this decision will be fully vindicated."
+    ]
+  },
+  {
+    "name": "virtually",
+    "trans": [
+      "Day 34 | adv. | English: almost or very nearly, so that any slight difference is not important | Example: Superlubricity, the state of virtually no friction between materials, has desirable applications in many industries."
+    ]
+  },
+  {
+    "name": "virtue",
+    "trans": [
+      "Day 34 | n. | English: an attractive or useful quality | Example: Perhaps it is a little depressing to inherit not lands but an example of intellectual virtue."
+    ]
+  },
+  {
+    "name": "virtuosity",
+    "trans": [
+      "Day 34 | n. | English: a very high degree of skill in performing or playing | Example: Despite Argerich's experience and virtuosity, she never takes for granted that she knows a piece of music."
+    ]
+  },
+  {
+    "name": "virtuous",
+    "trans": [
+      "Day 34 | adj. | English: behaving in a very good and moral way | Example: Although people seek to be viewed as virtuous, the most insignificant setbacks will often inhibit them from being so."
+    ]
+  },
+  {
+    "name": "viscous",
+    "trans": [
+      "Day 34 | adj. | English: thick and sticky; not flowing freely | Example: Chemists Mare A. Meyers and Andrew Grazela studied the mass and heat transfer processes that occur when foods are fried in batters containing hydrocolloids, polymers that become viscous or gel-like in water."
+    ]
+  },
+  {
+    "name": "vision",
+    "trans": [
+      "Day 34 | n. | English: an idea or a picture in your imagination | Example: Each fails at presenting a wholly coherent vision of art but does not understand why."
+    ]
+  },
+  {
+    "name": "visualize",
+    "trans": [
+      "Day 34 | v. | English: to form a picture of sb/sth in your mind | Example: I can't visualize what this room looked like before it was decorated."
+    ]
+  },
+  {
+    "name": "vital",
+    "trans": [
+      "Day 34 | adj. | English: necessary or essential in order for sth to succeed or exist | Example: Ina 2018 article celebrating films depicting the Black experience, critics for the New York Times commended William Greaves's 1968 film Symbiopsychotaxiplasm, Take One and Spike Lee's 1992 film Malcolm X, praising the former as \"a vital artifact of its time\" and the latter as \"electrifying.\""
+    ]
+  },
+  {
+    "name": "voucher",
+    "trans": [
+      "Day 34 | n. | English: one that gurantees | Example: A book printed is a record, remaining in every man’s possession, always ready to renew its acquaintance with his memory, and always ready to be produced as an authority or voucher to any reports he makes out of it, and conveys its contents for ages to come, to the eternity- of mortal time, when the author is forgotten in his grave."
+    ]
+  },
+  {
+    "name": "vowel",
+    "trans": [
+      "Day 34 | n. | English: a speech sound in which the mouth is open and the tongue is not touching the top of the , e, O:/ | Example: For example, the way certain vowel sounds are pronounced in it can be traced to how they"
+    ]
+  },
+  {
+    "name": "wander",
+    "trans": [
+      "Day 34 | v. | English: to walk slowly around or to a place, often without any particular sense of purpose or direction Night, guardian of dreams, / Now wanders through the land; / The moon, a lily white, / Blossoms within her hand."
+    ]
+  },
+  {
+    "name": "warranted",
+    "trans": [
+      "Day 34 | adj. | English: justified or well-founded | Example: There is thus no cause for uncertainty here, and no warranted basis for any speculation."
+    ]
+  },
+  {
+    "name": "wayfarer",
+    "trans": [
+      "Day 34 | n. | English: a person who travels from one place to another, usually on foot | Example: Holes, hollows, pools, pitfalls, and other menaces to the wayfarer were vanishing fast."
+    ]
+  },
+  {
+    "name": "wear on",
+    "trans": [
+      "Day 34 | English: pass slowly (of time) | Example: [Katharine's] descent from [a celebrated poet] was no surprise to her, but matter for satisfaction, until, as the years wore on, certain drawbacks made themselves very manifest."
+    ]
+  },
+  {
+    "name": "weary",
+    "trans": [
+      "Day 34 | adj. | English: very tired, especially after you have been working hard or doing sth for a long time | Example: Our world, so worn and weary, / Needs music, pure and strong. /To hush the jangle and discords / Of sorrow, pain, and wrong."
+    ]
+  },
+  {
+    "name": "weave",
+    "trans": [
+      "Day 34 | v. | English: to make cloth, a carpet, a basket , etc. by crossing threads or strips across, over and under each other by hand or on a machine | Example: Mexican textile artist Victoria Villasana weaves stories of triumph, using her unique method of applying colorful yarn to photographs of people."
+    ]
+  },
+  {
+    "name": "weep",
+    "trans": [
+      "Day 34 | v. | English: to cry, usually because you are sad | Example: The bald cypresses spread themselves along the water courses while the willows wept as they always did."
+    ]
+  },
+  {
+    "name": "weld",
+    "trans": [
+      "Day 34 | v. | English: to join pieces of metal together by heating their edges and pressing them together | Example: Cut, bent, and welded from discarded metal materials, the sculptures of London-based Nigerian artist Sokari Douglas Camp are meant to challenge viewers to consider their own relationships to material wastes."
+    ]
+  },
+  {
+    "name": "whip",
+    "trans": [
+      "Day 34 | v. | English: to move, or make sth move, quickly and suddenly or violently in a particular direction | Example: The wind whips around their ears, turning their faces cold."
+    ]
+  },
+  {
+    "name": "willful",
+    "trans": [
+      "Day 34 | adj. | English: determined to do what you want; not caring about what other people want | Example: So as long as a listener's interpretation isn't willfully absurd or the result of inattention, it is difficult to justify the claim that the listener has misunderstood the piece."
+    ]
+  },
+  {
+    "name": "wind",
+    "trans": [
+      "Day 34 | v. | English: to wrap or twist sth around itself or sth else | Example: And having cleared the ramparts | had to confess the sky was clearing, prior to its winding in the other shroud, night."
+    ]
+  },
+  {
+    "name": "wiry",
+    "trans": [
+      "Day 34 | adj. | English: thin but strong | Example: I'm little of course, but terribly quick and wiry and tough."
+    ]
+  },
+  {
+    "name": "withdrawal",
+    "trans": [
+      "Day 34 | n. | English: the act of moving or taking sth away or back Roughly 70% of the world's water withdrawals, from sources such as rivers, lakes, and aquifers, is for irrigation water used to meet various agricultural demands."
+    ]
+  },
+  {
+    "name": "withstand",
+    "trans": [
+      "Day 34 | v. | English: to be strong enough not to be hurt or damaged by extreme conditions, the use of force, etc. | Example: By contrast, the black bear (makwa in Ojibwe) should be able to withstand the highest predicted warming without much harm and so likely won't require the conservation efforts that the northern wild rice will."
+    ]
+  },
+  {
+    "name": "woeful",
+    "trans": [
+      "Day 34 | adj. | English: very bad or serious; that you disapprove of | Example: Meanwhile, the work of Countee Cullen, who relied on conventional poetic forms associated with previous literary periods, attracts woefully little attention from scholars of modernism."
+    ]
+  },
+  {
+    "name": "woods",
+    "trans": [
+      "Day 34 | n. | English: A wood or woods is a fairly large area of trees growing near each other. | Example: The following text is from Kenneth Grahame’s 1908 novel The Wind in the Willows. The Rat is looking for the Mole, his friend, in the woods."
+    ]
+  },
+  {
+    "name": "woolly",
+    "trans": [
+      "Day 34 | adj. | English: covered with wool or with hair like wool | Example: Researchers have long hypothesized that woolly mammoths were hunted to extinction in North America by humans using spears with grooved tips known as Clovis points."
+    ]
+  },
+  {
+    "name": "workmanlike",
+    "trans": [
+      "Day 34 | adj. | English: done, made, etc. in a skilful and thorough way but not usually very original or exciting | Example: His prose is workmanlike: his characters are flat and discuss ideas rather than emotions."
+    ]
+  },
+  {
+    "name": "worrisome",
+    "trans": [
+      "Day 34 | adj. | English: that makes you worry | Example: While bioaccumulation of manufactured nanoparticles may be inherently worrisome, it has been hypothesized that CuO-NP bioaccumulation in invertebrates like L. stagnalis could serve a valuable proxy role, obviating the need for manufacturers to conduct costly and intrusive sampling of vertebrate species—such as African clawed frogs (Xenopus laevis), commonly used in regulatory compliance testing—for nanoparticle bioaccumulation, as environmental protection laws currently require."
+    ]
+  },
+  {
+    "name": "wrapper",
+    "trans": [
+      "Day 34 | n. | English: a piece of paper, plastic, etc. that is wrapped around sth, especially food, when you buy it in order to protect it and keep it clean | Example: Studying wrappers from discontinued candies, menus from nineteenth-century restaurants, and flyers promoting long-forgotten sporting events may seem like a frivolous pursuit, but ephemeral objects like these are useful as markers of cultural change."
+    ]
+  },
+  {
+    "name": "wreak",
+    "trans": [
+      "Day 34 | v. | English: to do great damage or harm to sb/sth | Example: On March 23, 2021, a gust of wind wreaked havoc on global trade."
+    ]
+  },
+  {
+    "name": "wretched",
+    "trans": [
+      "Day 34 | adj. | English: making you feel sympathy or pity | Example: “[Jim] went on to the lawn, very slowly, and kicking wretchedly at the turf. Presently his father came along with the whirring machine, while the sweet, new grass blades spun from the knives.”"
+    ]
+  },
+  {
+    "name": "wrought",
+    "trans": [
+      "Day 34 | v. | English: caused sth to happen, especially a change | Example: Though few critics consider Vasily Grossman's novel Stalingrad—which focuses on the experience of the Soviet Union in the early years of World War —to be as well written as his later book Everything Flows, some compliment it despite the damage wrought by Soviet censors."
+    ]
+  },
+  {
+    "name": "yield",
+    "trans": [
+      "Day 34 | v. | English: to produce or provide sth, for example a profit, result or crop | Example: The compositions of Delia Derbyshire can yield as many different interpretations as there are people to listen to them."
+    ]
+  },
+  {
+    "name": "zenith",
+    "trans": [
+      "Day 34 | n. | English: the highest point that the sun or moon reaches in the sky, directly above you; | Example: The sun, already down, was manifest in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+    ]
+  }
+]

--- a/public/dicts/SAT_1700_2025_Day_Grouped.json
+++ b/public/dicts/SAT_1700_2025_Day_Grouped.json
@@ -2,10201 +2,10201 @@
   {
     "name": "abrupt",
     "trans": [
-      "Day 1 | adj. | English: speaking or acting in a way that seems unfriendly and rude | Example: On painter William H. Johnson's return to the United States in 1938 after a decade in Europe, his style underwent an abrupt transformation."
+      "[a'brapt] adj. （行为）粗鲁的"
     ]
   },
   {
     "name": "absurd",
     "trans": [
-      "Day 1 | adj. | English: completely ridiculous | Example: So as long as a listener's interpretation isn't willfully absurd or the result of inattention, it is difficult to justify the claim that the listener has misunderstood the piece."
+      "[36'83:d] adj. 荒谬的"
     ]
   },
   {
     "name": "abyssal",
     "trans": [
-      "Day 1 | adj. | English: relating to the bottom of the ocean, especially to depths of between 3 000 and 6 000 metres | Example: The Clarion-Clipperton Zone (CCZ) is an expanse of abyssal plain and seamounts (underwater mountains) between Hawai'i and Mexico in which mining is permitted."
+      "[3'bIsI] adj. 深海的,深渊的"
     ]
   },
   {
     "name": "accentuate",
     "trans": [
-      "Day 1 | v. | English: to emphasize sth or make it more noticeable | Example: The realists’ emphasis on accurately portraying the experiences of average working people was largely a rejection of the romantic style evident in many paintings by Jérome-Martin Langlois, which instead accentuate their subjects’ beauty or heroism while hiding all imperfection."
+      "[ak'sentjuert] v. 使突出"
     ]
   },
   {
     "name": "accessible",
     "trans": [
-      "Day 1 | adj. | English: that can be reached, entered, used, seen, etc. | Example: It identifies a writer whose work is regarded as difficult to read, brings up two admirers of that writer's work, and gives information that may make the writer's work more accessible to new readers."
+      "[ak'scsabl] adj. 可到达的"
     ]
   },
   {
     "name": "accessory",
     "trans": [
-      "Day 1 | adj. | English: adj. not the most important when compared to others; n. an extra piece of equipment that is useful but not essential or that can be added to sth else as a decoration | Example: [1] Within baleen species, some individuals developed accessory spleen. 2] | tend to pay careful attention to a character's accessories like gloves, hats, and jackets. These elements help communicate information about how this person would have fit into society at the time."
+      "[ak'sesari] adj.；adj.；n. 辅助的"
     ]
   },
   {
     "name": "acclaim",
     "trans": [
-      "Day 1 | v. | English: v. to praise or welcome sb/sth publicly n. praise and approval for sb/sth, especially an artistic achievement | Example: [1] In a variety of ways, Samuel Kamakau, Kristiana Kahakauwila, and other acclaimed writers have drawn on these stories to craft a rich portrait of the Hawaiian Islands and their people. 2] These works are widely praised, meaning that Edwards receives substantial acclaim as an artist."
+      "[3'kleIm] v.；v.；n. 赞扬"
     ]
   },
   {
     "name": "acclaimed",
     "trans": [
-      "Day 1 | adj. | English: attracting public approval and praise | Example: Her acclaimed 2019 novel Empire of Wild is set in a Métis community in southern Canada."
+      "[3'klermd] adj. 受到赞扬的"
     ]
   },
   {
     "name": "accommodate",
     "trans": [
-      "Day 1 | v. | English: to provide enough space for sb/sth | Example: The Al-Fattah Al-Aleem Mosque in the New Administrative Capital, Egypt, is a massive mosque that can accommodate approximately 17,000 people at once."
+      "[3'ka:madert] v. 容纳"
     ]
   },
   {
     "name": "accompaniment",
     "trans": [
-      "Day 1 | n. | English: something that happens at the same time as another thing In his solitary retreat on the shore of the sea, whose mobile surface was visible through the open windows, extending outward until it mingled with the horizon, Padre Florentino was relieving the monotony by playing on his harmonium sad and melancholy tunes, to which the sonorous roar of the surf and the sighing of the treetops of the neighboring wood served as accompaniments."
+      "[3kmpanimant] n. 伴随发生的事情"
     ]
   },
   {
     "name": "account",
     "trans": [
-      "Day 1 | n. | English: n. an explanation or a description of an idea, a theory or a process; n. a written or spoken description of sth that has happened | Example: [1] And as Jane X. Luu et al. point out, the singular nature of impact ejection makes it untenable as an account of multiple loss episodes of similar duration over several years. 2] It discusses a physical process, evaluates possible causes of that process, and then states that a persuasive account of the process has yet to be put forward."
+      "[3'kaont] n.；n.；n. 解释"
     ]
   },
   {
     "name": "account for",
     "trans": [
-      "Day 1 | v. | English: If you can account for something, you can explain it or give the necessary information about it. | Example: It accounts for a writer's lack of popular appeal, cites a literary figure who appreciates that writer, and summarizes the qualities that make the writer's work unique."
+      "v. 解释"
     ]
   },
   {
     "name": "accrue",
     "trans": [
-      "Day 1 | v. | English: to increase over a period of time | Example: It is a remarkable story that happened to an unremarkable person, though one could plausibly argue that because the story is valuable, some of its value accrues to the person at its center. accustomed to ta 322 FX: familiar with sth and accepting it as normal or usual The pattern of brain activity that long-headed dogs showed when hearing the scrambled recording was different from the pattern of brain activity that short headed dogs showed when hearing the language they were accustomed to."
+      "[a'kru:] v. （逐渐）增长"
     ]
   },
   {
     "name": "accustomed to",
     "trans": [
-      "Day 1 | English: familiar with sth and accepting it as normal or usual | Example: The pattern of brain activity that long-headed dogs showed when hearing the scrambled recording was different from the pattern of brain activity that short headed dogs showed when hearing the language they were accustomed to."
+      "习惯于"
     ]
   },
   {
     "name": "acidify",
     "trans": [
-      "Day 1 | v. | English: to become or make sth become an acid | Example: In 2015 Filipa Faleiro and colleagues published a study concluding that ocean acidification has a strong effect on the behavior of Hippocampus guttulatus, a species of fish."
+      "v. 娈成酸"
     ]
   },
   {
     "name": "acoustic",
     "trans": [
-      "Day 1 | adj. | English: related to sound or to the sense of hearing | Example: Nicholas T. Homziak et al. investigated the acoustic properties of moths’ ultrasonic responses to audio of bat echolocation and then assessed the palatability of the ultrasound- producing moths."
+      "[3'ku:stk] adj. 声音的"
     ]
   },
   {
     "name": "acquaintance",
     "trans": [
-      "Day 1 | n. | English: n.a person that you know but who is not a close friend; n. knowledge of sth | Example: [1] People tend to fixate more often than they should on whether their acquaintances think highly of them. 2] a book printed is a record, remaining in every man’s possession, always ready to renew its acquaintance with his memory"
+      "[3'kwcmtans] n.；n.；n. （对某事物的"
     ]
   },
   {
     "name": "acquainted",
     "trans": [
-      "Day 1 | adj. | English: familiar with sth, having read, seen or experienced it | Example: The untaught peasant beheld the elements around him and was acquainted with their practical uses."
+      "[3'kwemntd] adj. 熟悉的"
     ]
   },
   {
     "name": "act",
     "trans": [
-      "Day 1 | n. | English: one of the main divisions of a play, an opera , etc. | Example: There are persons who go to the theater like the contestants in a mule-race: the last one in, wins, and we know very sensible men who would ascend the scaffold rather than enter a theater before the first act."
+      "[ekt] n. （歌剧等的）"
     ]
   },
   {
     "name": "adapt",
     "trans": [
-      "Day 1 | v. | English: to change a book or play so that it can be made into a play, film/movie, television programme, etc. | Example: It offers information about how Yamauchi adapted her short story into a play."
+      "[3'dapt] v. 改编"
     ]
   },
   {
     "name": "adept",
     "trans": [
-      "Day 1 | adj. | English: good at doing sth that is quite difficult | Example: There is no doubt that Irving Langmuir must have proved himself to be extraordinarily adept at understanding some of the most advanced concepts in the field of chemistry"
+      "[3'dept] adj. 熟练的"
     ]
   },
   {
     "name": "adhere",
     "trans": [
-      "Day 1 | v. | English: to behave according to a particular law, rule, set of instructions, etc; to follow a particular set of beliefs or a fixed way of doing sth | Example: | aim to create a clear sense of the character and the world they inhabit. Sometimes this means adhering to the historical period's style, but frequently, as in stagings of A Midsummer Night's Dream, some flexibility is required to communicate an idea to the audience."
+      "[ad'W] v. 遵守"
     ]
   },
   {
     "name": "adjective",
     "trans": [
-      "Day 1 | n. | English: a word that describes a person or thing | Example: If one has a supposition that the word “own” has a high incidence in English, for example, an analysis of a corpus can support that hypothesis by showing that “own” is the eighth most commonly used adjective."
+      "['ed3iktwv] n. 形容词"
     ]
   },
   {
     "name": "adore",
     "trans": [
-      "Day 1 | v. | English: to love sb very much | Example: It's obvious that she adores him."
+      "[3'do:r] v. 爱慕"
     ]
   },
   {
     "name": "adroit",
     "trans": [
-      "Day 1 | adj. | English: skilful and clever, especially in dealing with people | Example: In his afterword to Crowley's book Little, Big, Bloom argues that the novel adroitly blends what playwright Friedrich Schiller termed the naive and sentimental modes."
+      "[3'drort] adj. 机敏的"
     ]
   },
   {
     "name": "advance",
     "trans": [
-      "Day 1 | v. | English: v. to help sth to succeed; v. to suggest an idea, a theory, or a plan for other people to discuss | Example: [1] Studying for new qualifications is one way of advancing your career. 2] It introduces a trait shared by certain animals in order to contextualize a hypothesis about the origin of that trait that is advanced later in the text."
+      "[ad'vans] v.；v.；v. 推动,促进"
     ]
   },
   {
     "name": "adventure",
     "trans": [
-      "Day 1 | n. | English: an unusual, exciting or dangerous experience, journey or series of events | Example: Audiences of the time considered Clancy of the Mounted to belong to a genre other than the northern adventure genre."
+      "[ad'ventfar] n. 冒险"
     ]
   },
   {
     "name": "adverse",
     "trans": [
-      "Day 1 | adj. | English: negative and unpleasant; not likely to produce a good result | Example: CLPs primarily transmitted by ingestion were less dependent on host species adversely affected by warming temperatures than were CLPs that use other transmission strategies."
+      "[ad'v3:rSs,'8dv3:rs] adj. 不利的"
     ]
   },
   {
     "name": "adversity",
     "trans": [
-      "Day 1 | n. | English: a difficult or unpleasant situation | Example: She went through the crucible of unprecedented adversities and trials of life and came out one of the rare shining lights that beautify the New England sky."
+      "[ad'v3:rsati] n. 困境,逆境"
     ]
   },
   {
     "name": "advocate",
     "trans": [
-      "Day 1 | v. | English: to support sth publicly | Example: Thus, Enke et al. suggest that although the behavior of high-income earners who advocate for higher taxes may seem counterintuitive, such people likely do so because they feel enabled by their economic security to take a stance they think is morally correct."
+      "['edvakert;'edvakat] v. 拥护"
     ]
   },
   {
     "name": "aerial",
     "trans": [
-      "Day 1 | adj. | English: You talk about aerial attacks and aerial photographs to indicate that people or things on the ground are attacked or photographed by people in aeroplanes. | Example: Maryam Hosseini and her team found that a computer program trained to identify sidewalks in aerial images of Boston could also accurately identify sidewalks in aerial images of Chicago and even distinguished between brick and asphalt."
+      "['erial] adj. 从空中的"
     ]
   },
   {
     "name": "affecting",
     "trans": [
-      "Day 1 | adj. | English: producing strong feelings of sadness and sympathy | Example: The Roc-aux-Sorciers frieze—a group of relief carvings of animals found in what is now France and dating from around 14,000 years ago—is sometimes said to be emotionally powerful despite its age, but in fact the frieze is affecting precisely because of its age."
+      "[3'fckt] adj. 深深打动人的"
     ]
   },
   {
     "name": "affection",
     "trans": [
-      "Day 1 | n. | English: the feeling of liking or loving sb/sth very much and caring about them | Example: This was the case for both separation problems and dog rivalry but was especially pronounced for attachment and attention-seeking, which can be seen when a dog solicits affection or attention."
+      "[3'feka] n. 喜爱"
     ]
   },
   {
     "name": "affiliate",
     "trans": [
-      "Day 1 | n. | English: acompany, an organization, etc. that is connected with or controlled by another larger one | Example: To conclude that this approach accounts for the ethereal qualities now synonymous with the Highwaymen aesthetic is tempting but inaccurate, as Hair's methods weren't universally practiced by his affiliates: Roy McLendon, for example, painted with greater deliberateness but achieved the same effects."
+      "[3'filiert] n. 附属者"
     ]
   },
   {
     "name": "affinity",
     "trans": [
-      "Day 1 | n. | English: a strong feeling that you understand sb/sth and like them or it | Example: Sam was born in the country and had a deep affinity with nature."
+      "[3'finati] n. 喜好,喜爱"
     ]
   },
   {
     "name": "agglomeration",
     "trans": [
-      "Day 1 | n. | English: a group of things put together in no particular order or arrangement | Example: It is tempting to treat the clustering of information technology firms in Northern California as representative of industrial agglomeration generally."
+      "n. 聚集"
     ]
   },
   {
     "name": "aggregate",
     "trans": [
-      "Day 1 | adj. | English: made up of several amounts that are added together to form a total number | Example: ighteenth-century economist Adam Smith is famed for his metaphor of the invisible hand, which he putatively used to illustrate a robust model of how individuals produce aggregate benefits by pursuing their own economic interests."
+      "['agrigat] adj. 总计的"
     ]
   },
   {
     "name": "agreeable",
     "trans": [
-      "Day 1 | adj. | English: pleasant and easy to like | Example: And by his brother clergy he was regarded as a discreet and agreeable fellow."
+      "[3'gri:abl] adj. 讨人喜欢的"
     ]
   },
   {
     "name": "air",
     "trans": [
-      "Day 1 | n. | English: the particular feeling or impression that is given by sb/sth; the way sb does sth | Example: She had the air of a queen and gazed disdainfully at the whole house."
+      "[er] n. 神态,感觉"
     ]
   },
   {
     "name": "akin",
     "trans": [
-      "Day 1 | adj. | English: similar to | Example: The question of whether the people of the time understood the paintings as something akin to art in your modern sense or in some other way entirely is irresolvable: we will never be able to answer it."
+      "[3'knn] adj. 相似的"
     ]
   },
   {
     "name": "algorithm",
     "trans": [
-      "Day 1 | n. | English: a set of rules that must be followed when solving a particular problem | Example: How we define a neighborhood and its boundaries is subjective, so the team used a clustering algorithm to locate dense groupings of amenities that represent human-identified neighborhoods like Boston's Central Square."
+      "['algordom] n. 计算程序"
     ]
   },
   {
     "name": "align with",
     "trans": [
-      "Day 1 | English: to change sth slightly so that it is in the correct relationship to sth else | Example: It presents the natural world as aligning with the experience of the speaker and her friend."
+      "使一致"
     ]
   },
   {
     "name": "alignment",
     "trans": [
-      "Day 1 | n. | English: arrangement in a straight line | Example: Political blogs with conspicuous ideological alignments became an integral component of US media in the early 2000s."
+      "[3'lanmant] n. 排成直线"
     ]
   },
   {
     "name": "allegedly",
     "trans": [
-      "Day 1 | adv. | English: used when reporting something that people say is true, although it has not been proved | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+      "[3'ledidli] adv. 据说"
     ]
   },
   {
     "name": "allegory",
     "trans": [
-      "Day 1 | n. | English: astory, play, picture, etc. in which each character or event is a symbol representing an idea or a quality, such as truth, evil, death, etc The Great Wave off Kanagawa employs visual allegory to convey its deeper thematic meaning to viewers."
+      "['8lag3:ri] n. 寓言"
     ]
   },
   {
     "name": "alleviate",
     "trans": [
-      "Day 1 | v. | English: to make sth less severe | Example: Many experts, like lawyer and cycling advocate Ernesto Hernandez-Lopez, have proposed bike travel as one possible way to alleviate congestion on the busy roadways of Los Angeles County, California."
+      "[3'li:vicrt] v. 减轻"
     ]
   },
   {
     "name": "alliance",
     "trans": [
-      "Day 1 | n. | English: a group of people, political parties, etc. who work together in order to achieve sth that they all want | Example: Argyroxiphium sandwicense is a species in a family of plants known collectively as the silversword alliance, all of which grow only on the Hawaiian Islands. Members of this alliance exhibit an extraordinary range of phenotypes, with some species maturing into vines and others into shrubs and trees."
+      "[3'larans] n. 联盟"
     ]
   },
   {
     "name": "allocate",
     "trans": [
-      "Day 1 | v. | English: to give sth officially to sb/sth for a particular purpose | Example: In the 1960s, Greece, Malta, and dozens of other countries were allocated unique country dialing codes to route international calls."
+      "['elakert] v. 分配"
     ]
   },
   {
     "name": "allude",
     "trans": [
-      "Day 1 | v. | English: to mention sth in an indirect way | Example: It stresses the discrepancy between Mr. Ely's public and private conduct and then alludes to his motivation for hiding his true personality."
+      "[3'lu:d] v. 暗指"
     ]
   },
   {
     "name": "alphabetical",
     "trans": [
-      "Day 1 | adj. | English: according to the correct order of the letters of the alphabet | Example: She was reading a book a day in alphabetical order and not skipping the dry ones."
+      "[.alfa'betikl] adj. 按字母"
     ]
   },
   {
     "name": "alteration",
     "trans": [
-      "Day 2 | n. | English: an alteration is a change in or to something | Example: To evaluate the responses of local waterbird species, including the osprey, to landscape alterations, the researchers utilized the Index of Waterbird Community Integrity (IWCl), on which a low score Acorresponds to low community integrity."
+      "[.3:lta'rerln] n. 改动"
     ]
   },
   {
     "name": "amass",
     "trans": [
-      "Day 2 | v. | English: to collect sth, especially in large quantities | Example: Agglomeration economies arise when multiple firms in related industries amass in an area, as with leather production firms and footwear manufacturers in Glasgow, UK."
+      "[3'm85] v. （尤指大量）"
     ]
   },
   {
     "name": "amateur",
     "trans": [
-      "Day 2 | n. | English: a person who takes part in a sport or other activity for enjoyment, not as a job | Example: Community science, which involves professional scientists collaborating with amateur science enthusiasts to study a topic, is often an effective and engaging way to conduct research."
+      "['amatar;'ematjar] n. 业余爱好者"
     ]
   },
   {
     "name": "ambient",
     "trans": [
-      "Day 2 | adj. | English: relating to the surrounding area; on all sides | Example: Water temperatures at this site—named the Octopus Garden—climb as high as 11°C, much warmer than the ambient 1.6°C typical at this depth."
+      "['embiant] adj. 周围环境的"
     ]
   },
   {
     "name": "ambiguity",
     "trans": [
-      "Day 2 | n. | English: the state of being difficult to understand or explain because of involving many different aspects Detailed statistical analysis helped preclude claims of the event's ambiguity, confirming the signal at a confidence level of over 99%."
+      "[.embr'gju:ati] n. 不确定"
     ]
   },
   {
     "name": "ambiguous",
     "trans": [
-      "Day 2 | adj. | English: having different meanings | Example: It is also unclear whether categorizing music by genre is useful, since genre categories are ambiguous, subjective, and simplistic."
+      "[am'brgjuas] adj. 模棱两可的"
     ]
   },
   {
     "name": "ambivalence",
     "trans": [
-      "Day 2 | n. | English: the simultaneous existence of two opposed and conflicting attitudes, emotions, etc | Example: \"Poetry\" is a 1919 poem by Marianne Moore. The poem highlights an ambivalence toward poetry as the speaker acknowledges its merits while also expressing a sense of displeasure."
+      "[em'bIvalans] n. 矛盾情绪"
     ]
   },
   {
     "name": "ambivalent",
     "trans": [
-      "Day 2 | adj. | English: having or showing both good and bad feelings about sb/sth | Example: ‘She seems to feel ambivalent about her new job."
+      "[am'brvalant] adj. （好坏参半等）矛盾情绪的"
     ]
   },
   {
     "name": "ameliorate",
     "trans": [
-      "Day 2 | v. | English: to make sth better | Example: Researchers would later ameliorate this shortcoming after gaining new access to administrative records located in nations in Africa, such as Ivory Coast, and Eastern Europe,"
+      "[3'mi:liarert] v. 改善"
     ]
   },
   {
     "name": "amenity",
     "trans": [
-      "Day 2 | n. | English: a feature that makes a place pleasant, comfortable or easy to live in | Example: As urbanist Mariela Alfonzo argues, our understanding of individuals’ decision-making about whether to walk is insufficiently robust: some studies emphasize the role of climate conditions, others the role of recreational amenities, and so on, but walking decisions are made in complex contexts in which multiple conditions and needs inform individuals’ choices."
+      "[3'mcnati,a'mi:nati] n. 便利设施"
     ]
   },
   {
     "name": "amorphous",
     "trans": [
-      "Day 2 | adj. | English: having no definite shape, form or structure | Example: Writer Lydia Davis observed that while traditional literary forms, such as the novel, are recognizable as such even as they evolve, there are more amorphous forms that might, for example, borrow elements from both fables and realist narratives to make something unconventional."
+      "[3'm3:rfas] adj. 无定形的"
     ]
   },
   {
     "name": "ample",
     "trans": [
-      "Day 2 | adj. | English: enough or more than enough | Example: Having an ample reserve of stored energy can mitigate the effects of fluctuations in solar energy collection caused by unpredictable shifts in cloud cover and haze."
+      "['ampl] adj. 丰富的"
     ]
   },
   {
     "name": "amplify",
     "trans": [
-      "Day 2 | v. | English: to increase sth in strength, especially sound | Example: Remarkable for anticipating and amplifying cultural perceptions of Florida that became pervasive in the public consciousness, paintings by the Highwaymen are readily identifiable by the natural iconography—placid inland rivers, windswept palm trees—that McLendon and colleagues perpetually revisited."
+      "['amplifar] v. 放大"
     ]
   },
   {
     "name": "amusing",
     "trans": [
-      "Day 2 | adj. | English: funny and enjoyable | Example: If newcomers to the little provincial city of S. complained that life there was monotonous and dull, its inhabitants would answer that, on the contrary, S. was a very amusing place."
+      "[a'mju:zI] adj. 有趣的"
     ]
   },
   {
     "name": "analogical",
     "trans": [
-      "Day 2 | adj. | English: of, relating to, or based on analogy | Example: Analogical method was applied for the evaluation."
+      "adj. 类似的"
     ]
   },
   {
     "name": "analogous",
     "trans": [
-      "Day 2 | adj. | English: similar in some way to another thing or situation and therefore able to be compared with it | Example: The knowledge, communicated by the historian and biographer, is analogous to that which we acquire of a country by the map, —minute, perhaps, and accurate, and available for all necessary purposes, but cold and naked, and wholly destitute of the mimic charm produced by landscape painting."
+      "[3'181393s] adj. 相似的,类似的俄"
     ]
   },
   {
     "name": "analogue",
     "trans": [
-      "Day 2 | n. | English: a thing that is similar to another thing | Example: The novel is largely pure invention, and readers who neglect this fact and instead try to identify more and more real-life analogues thus risk positing unsupportable connections between Heartburn and Ephron's life."
+      "n. 相似物,类似事情"
     ]
   },
   {
     "name": "anatomical",
     "trans": [
-      "Day 2 | adj. | English: relating to the structure of the bodies of people and animals The team concluded that differences in dogs' anatomical features may affect their ability to distinguish speech from nonspeech."
+      "[.&na'ta:mikl] adj. 身体结构的"
     ]
   },
   {
     "name": "anatomize",
     "trans": [
-      "Day 2 | vt. | English: If you anatomise a subject or an issue, you examine it in great detail. | Example: _He might dissect, anatomize, and give names; but, not to speak of a final cause, causes in their secondary and tertiary grades were utterly unknown to him."
+      "[3'nata.marz] vt. 仔细分析"
     ]
   },
   {
     "name": "annotate",
     "trans": [
-      "Day 2 | v. | English: to add notes to a book or text, giving explanations or comments | Example: Historians annotate, check and interpret the diary selections."
+      "['anatert] v. 作注解"
     ]
   },
   {
     "name": "antagonistic",
     "trans": [
-      "Day 2 | adj. | English: showing or feeling opposition | Example: It can also be antagonistic, such as when a political candidate turns toward their competitor during a debate and makes eye contact that signals hostility."
+      "[entga'nstk] adj. 敌对的"
     ]
   },
   {
     "name": "antennae",
     "trans": [
-      "Day 2 | n. | English: The antennae of something such as an insect or crustacean are the two long, thin parts attached to its head that it uses to feel things with | Example: At the TIGER-Unwin observatory site in New Zealand, radars point their antennae to the sky to track geomagnetic storms and other geospace phenomena."
+      "[an'teni:] n. 天线"
     ]
   },
   {
     "name": "antibiotic",
     "trans": [
-      "Day 2 | n. | English: a substance, for example penicillin , that can destroy or prevent the growth of bacteria and cure infections | Example: The process can have the effect of increasing bacterial resistance to antibiotics."
+      "[antibar'a:t] n. 抗生素"
     ]
   },
   {
     "name": "anticipate",
     "trans": [
-      "Day 2 | v. | English: to expect sth | Example: As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot."
+      "[en'tsIpert] v. 期待"
     ]
   },
   {
     "name": "anvil",
     "trans": [
-      "Day 2 | n. | English: an iron block on which a blacksmith puts hot pieces of metal before shaping them with a hammer | Example: He told me how calm his soul was laid / By the lack of anvil and strife."
+      "n. 铁砧"
     ]
   },
   {
     "name": "apathy",
     "trans": [
-      "Day 2 | n. | English: the feeling of not being interested in or enthusiastic about anything | Example: There is widespread apathy among the electorate."
+      "['apadi] n. 冷漠"
     ]
   },
   {
     "name": "aperture",
     "trans": [
-      "Day 2 | n. | English: an opening that allows light to reach a lens , especially in cameras | Example: A telescope allows us to see very faint objects mostly due to the large size of the opening that light passes through, known as the aperture."
+      "['apartfor] n. （尤指摄影机等的光圈）"
     ]
   },
   {
     "name": "apostle",
     "trans": [
-      "Day 2 | n. | English: a person who strongly believes in a policy or an idea and tries to make other people believe in it | Example: The men of culture are the true apostles of equality."
+      "[3'pa:sl] n. 倡导者,鼓吹者"
     ]
   },
   {
     "name": "apostrophize",
     "trans": [
-      "Day 2 | v. | English: to address what you are saying, or a poem, a speech in a play, etc. to a particular person | Example: Then Clarence was wildly apostrophized, and a torrent of tears relieved the overcharged, aching heart."
+      "v. 述说"
     ]
   },
   {
     "name": "apparel",
     "trans": [
-      "Day 2 | n. | English: clothing, when it is being sold in shops/stores | Example: A survey found that in April 2022, 7.6 percent of subscribers to fashion and apparel services canceled their subscriptions."
+      "[3'peral] n. 衣服,服装"
     ]
   },
   {
     "name": "appeal",
     "trans": [
-      "Day 2 | v. | English: v. to attract or interest sb; n. a quality that makes sb/sth attractive or interesting | Example: [1] The Aztecs would have disputed the idea that the morality of an individual's actions can be assessed by appealing to standards of behavior that are independent of the individual's social circumstances. 2] Although the literary works of David Malo and Lee Cataluna have universal appeal, they are also inextricable from the Hawaiian literary tradition in which both authors work and that stretches back to the traditional stories of the Kanaka Maoli, the Native Hawaiian people."
+      "[a'pi:l] v.；v.；n. 吸引"
     ]
   },
   {
     "name": "appealing",
     "trans": [
-      "Day 2 | adj. | English: attractive or interesting | Example: The new skin-care product is less appealing to college students than other similar products on the market are."
+      "[3'pi:I] adj. 有吸引力的"
     ]
   },
   {
     "name": "appease",
     "trans": [
-      "Day 2 | v. | English: to make sb calmer or less angry by giving them what they want | Example: The move was widely seen as an attempt to appease critics of the regime."
+      "[3'pi:z] v. 安抚,抚慰"
     ]
   },
   {
     "name": "applaud",
     "trans": [
-      "Day 2 | v. | English: to express praise for sb/sth because you approve of them or it | Example: The reception of Ji-li Jiang's book Red Kite, Blue Kite has been very good. Many reviewers have applauded the book, and it won the Asian/Pacific American Award for Literature."
+      "[3plo:d] v. 赞赏"
     ]
   },
   {
     "name": "applicable",
     "trans": [
-      "Day 2 | adj. | English: that can be said to be true in the case of sb/sth | Example: It has some evidential support, but it should not be regarded as universally applicable."
+      "['eplkobl,o'plikabl] adj. 适用的"
     ]
   },
   {
     "name": "appraise",
     "trans": [
-      "Day 2 | v. | English: If you appraise something or someone, you consider them carefully and form an opinion about them. | Example: This prompted many employers to appraise their selection and recruitment policies."
+      "[3'prerz] v. 评价"
     ]
   },
   {
     "name": "apprehension",
     "trans": [
-      "Day 2 | n. | English: worry or fear that sth unpleasant may happen | Example: The narrator contrasts his feelings of apprehension with the apparent tranquility of the river as the boat enters the countryside."
+      "[.RpII'henjn] n. 忧虑"
     ]
   },
   {
     "name": "apprehensive",
     "trans": [
-      "Day 2 | adj. | English: worried or frightened that sth unpleasant may happen | Example: They convey Caravan's growing apprehensiveness about having failed to complete an important work task for the first time in his long career."
+      "[.eprr'hensrv] adj. 担忧的,焦虑的"
     ]
   },
   {
     "name": "apprise",
     "trans": [
-      "Day 2 | v. | English: to tell or inform sb of sth | Example: We must apprise them of the dangers that may be involved."
+      "[3'prarz] v. 通知"
     ]
   },
   {
     "name": "approach",
     "trans": [
-      "Day 2 | v. | English: to start dealing with a problem, task, etc. in a particular way | Example: In the United States, historians of the American Revolution once had a tendency to approach their subject with reverence."
+      "[3'prootl] v. 着手处理"
     ]
   },
   {
     "name": "appropriate",
     "trans": [
-      "Day 2 | adj. | English: suitable, acceptable or correct for the particular circumstances | Example: They have been furnished with the intention of maintaining a sense of appropriateness."
+      "[3'proUpriat] adj. 合适的"
     ]
   },
   {
     "name": "arbiter",
     "trans": [
-      "Day 2 | n. | English: a person with the power or influence to make judgements and decide what will be done or accepted | Example: Today, the Michelin Guide is widely known as the arbiter of fine dining, with its coveted 3-star rating being awarded to top restaurants like Xin Rong Ji in Beijing."
+      "['a:rbrtar] n. 裁决人,决定者"
     ]
   },
   {
     "name": "arbitrary",
     "trans": [
-      "Day 2 | adj. | English: not seeming to be based on a reason, system or plan and sometimes seeming unfair Rather than being an arbitrary stylistic choice, hyperpop's persistent modification of the voice functions as a commentary on how digital technology mediates human experience today."
+      "['a:rbItreri] adj. 任意的"
     ]
   },
   {
     "name": "arcane",
     "trans": [
-      "Day 2 | adj. | English: secret and mysterious and therefore difficult to understand | Example: Until a few months ago few people outside the arcane world of contemporary music had heard of Gorecki."
+      "[a:r'kem] adj. 晦涩难懂的"
     ]
   },
   {
     "name": "archaea",
     "trans": [
-      "Day 2 | n. | English: micro-organisms which are similar to bacteria in size and simplicity of structure but radically different in molecular organization. They are now believed to constitute an ancient group which is intermediate between the bacteria and eukaryotes. | Example: The researchers studied two wooden shipwrecks in the Gulf of Mexico by placing pieces of pine and oak between zero and 200 meters away from each shipwreck to collect samples of three kinds of microbes: bacteria, archaea, and fungi."
+      "n. 原始细菌"
     ]
   },
   {
     "name": "archival",
     "trans": [
-      "Day 2 | adj. | English: Archival means belonging or relating to archives. | Example: One reason for this discrepancy is that historians of capitalism tend to focus on longitudinal economic data drawn from archival records, which do not exist for much of precolonial Africa."
+      "adj. 档案的"
     ]
   },
   {
     "name": "arduous",
     "trans": [
-      "Day 2 | adj. | English: involving a lot of effort and energy, especially over a period of time | Example: The creation of Lotte Reiniger's 1926 animated film The Adventures of Prince Achmed was an arduous process."
+      "['a:rdzuas] adj. 艰难的"
     ]
   },
   {
     "name": "arguably",
     "trans": [
-      "Day 2 | adv. | English: used, often before a comparative or superlative adjective, when you are stating an opinion which you believe you could give reasons to support But Nixon’s legacy is complex: he has been praised for his role in affirming the sovereignty of tribal nations, and he once made an attempt at reforming United States health care policy that is arguably a precursor to the Affordable Care Act, which became law during the Barack Obama administration."
+      "['a:rgjuabli] adv. （常用于形容词比较级或最高级前）"
     ]
   },
   {
     "name": "arid",
     "trans": [
-      "Day 2 | adj. | English: having little or no rain; very dry | Example: Some paleontologists thought that a sudden shift toward an arid climate on the Australian continent may have brought about the rapid extinction of several species of large kangaroos around 200,000 years ago."
+      "['erd] adj. 干旱的"
     ]
   },
   {
     "name": "articulate",
     "trans": [
-      "Day 2 | v. | English: to express or explain your thoughts or feelings clearly in word | Example: To emphasize the extent of individuals’ struggles to articulate thoughts on art"
+      "[a:r'tikjulert] v. 明确表达"
     ]
   },
   {
     "name": "artificial",
     "trans": [
-      "Day 3 | adj. | English: created by people | Example: Artificial leaves are a developing renewable energy technology that mimics the process of photosynthesis in plants."
+      "[a:rtr't] adj. 人为的"
     ]
   },
   {
     "name": "ascertain",
     "trans": [
-      "Day 3 | v. | English: to find out the true or correct information about sth | Example: Geochemists analyzing a given rock formation can ascertain that an igneous intrusion that bisects a layer of 393.3-million-year-old Eifelian rock but not the 254.1-million-year-old Changhsingian rock above it is younger than the former but older than the latter."
+      "[,asar'tem] v. 查明"
     ]
   },
   {
     "name": "asphalt",
     "trans": [
-      "Day 3 | n. | English: a thick black sticky substance used especially for making the surface of roads | Example: Maryam Hosseini and her team found that a computer program trained to identify sidewalks in aerial images of Boston could also accurately identify sidewalks in aerial images of Chicago and even distinguished between brick and asphalt."
+      "n. 沥青"
     ]
   },
   {
     "name": "assemble",
     "trans": [
-      "Day 3 | v. | English: to come together as a group; to bring people or things together as a group | Example: Linda Lomahaftewa often assembles compositions out of motifs common in the ceramics and other traditional arts of the Hopi Tribe."
+      "[3'sembl] v. 聚集"
     ]
   },
   {
     "name": "assent",
     "trans": [
-      "Day 3 | v. | English: to agree to a request, an idea or a suggestion | Example: Nobody would assent to the terms they proposed."
+      "[3'sent] v. 赞同"
     ]
   },
   {
     "name": "assert",
     "trans": [
-      "Day 3 | v. | English: to make other people recognize your right or authority to do sth, by behaving firmly and confidently | Example: Whether the reign of a French monarch such as Louis XII or Louis IV was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy and therefore cannot be understood without a corollary understanding of the factors that allowed the monarch to assert his right to hold the throne successfully."
+      "[3'83:t] v. 维护自己的权利"
     ]
   },
   {
     "name": "assertive",
     "trans": [
-      "Day 3 | adj. | English: expressing opinions or desires strongly and with confidence, so that people take notice | Example: You should try and be more assertive."
+      "[3'83:rtV] adj. 坚定自信的"
     ]
   },
   {
     "name": "assess",
     "trans": [
-      "Day 3 | v. | English: to make a judgement about the nature or quality of sb/sth | Example: One way to assess the importance of a scholar's research is to track how often other scholars refer to that research."
+      "[3'ses] v. 评估"
     ]
   },
   {
     "name": "asset",
     "trans": [
-      "Day 3 | n. | English: a thing of value, especially property, that a person or company owns, which can be used or sold to pay debts | Example: Companies involved in petroleum extraction include drilling equipment among their assets."
+      "['eset] n. 资产"
     ]
   },
   {
     "name": "assign",
     "trans": [
-      "Day 3 | v. | English: to say that sth has a particular value or function, or happens at a particular time or place | Example: Based on the text, which choice best explains why it is challenging to confidently assign authorship of the essay \"The Senate\"?"
+      "[3'sam] v. （价值"
     ]
   },
   {
     "name": "associative",
     "trans": [
-      "Day 3 | adj. | English: Associative thoughts are things that you think of because you see, hear, or think of something that reminds you of those things or which you associate with those things. | Example: The associative guilt was ingrained in his soul."
+      "adj. 联想的"
     ]
   },
   {
     "name": "assuage",
     "trans": [
-      "Day 3 | v. | English: to make an unpleasant feeling less severe | Example: Knowing this can assuage potential investors' worries about bureaucratic minutiae and thereby allow them to instead focus on identifying sound business opportunities."
+      "[3'SweId3] v. （不快）"
     ]
   },
   {
     "name": "asteroid",
     "trans": [
-      "Day 3 | n. | English: any one of the many small planets which go around the sun | Example: Asteroid 6478 Gault has experienced intermittent mass loss since at least 2013, but in contrast to some other asteroids with repeated mass-loss episodes, 6478 Gault has not lost mass at its perihelion (the closest point of its orbit to the Sun), and thus the loss is not attributable to solar energy—driven ice vaporization."
+      "['RstaroId] n. 小行星"
     ]
   },
   {
     "name": "astronomical",
     "trans": [
-      "Day 3 | adj. | English: connected with astronomy | Example: It describes an astronomical finding, discusses competing theories about that finding that the author regards as flawed, and then describes new evidence that supports an alternative theory."
+      "[Rstra'na:ni] adj. 天文的"
     ]
   },
   {
     "name": "asymmetrical",
     "trans": [
-      "Day 3 | adj. | English: Something that is asymmetrical has two sides or halves that are different in shape, size, or style. | Example: Many plants have leaves that are larger on one side of their long central axis than the other, a phenomenon known as asymmetrical orientation."
+      "[,esr'mtrkl] adj. 不对称的"
     ]
   },
   {
     "name": "asymmetry",
     "trans": [
-      "Day 3 | n. | English: lack of symmetry | Example: The way in which individual elements are balanced within a photographic image tends to affect how viewers perceive it: symmetry tends to give the elements equal importance, asymmetry emphasizes differences, and radial balance (organizing the elements around a central point) emphasizes the center over the periphery."
+      "n. 不对称"
     ]
   },
   {
     "name": "atrocious",
     "trans": [
-      "Day 3 | adj. | English: very bad or unpleasant | Example: Asa result, this lovely region is atrociously poor and its few scattered farms provide just the requisite number of red roofs to set off the velvety green of the woods."
+      "[3'troUjas] adj. 糟透的"
     ]
   },
   {
     "name": "attachment",
     "trans": [
-      "Day 3 | n. | English: strong feeling of affection for sb/sth | Example: She presents herself as having a strong emotional attachment to the surrounding forests."
+      "[3'tetfmant] n. 依恋"
     ]
   },
   {
     "name": "attendee",
     "trans": [
-      "Day 3 | n. | English: a person who attends a meeting, etc Each is contemptuous of the other attendees but strives to impress them."
+      "n. 出席者,在场者"
     ]
   },
   {
     "name": "attic",
     "trans": [
-      "Day 3 | n. | English: a room or space just below the roof of a house, often used for storing things | Example: They usually spent the entire day in the attic, playing dolls and giggling."
+      "['atk] n. 阁楼"
     ]
   },
   {
     "name": "attire",
     "trans": [
-      "Day 3 | n. | English: clothes But there were vacant seats here and there, and into one of them she was ushered, between brilliantly dressed women who had gone there to kill time and eat candy and display their gaudy attire."
+      "[3'taIar] n. 服装"
     ]
   },
   {
     "name": "attributable",
     "trans": [
-      "Day 3 | adj. | English: probably caused by the thing mentioned | Example: Asteroid 6478 Gault has experienced intermittent mass loss since at least 2013, but in contrast to some other asteroids with repeated mass-loss episodes, 6478 Gault has not lost mass at its perihelion (the closest point of its orbit to the Sun), and thus the loss is not attributable to solar energy—driven ice vaporization."
+      "[Rstra'na:ni] adj. 天文的"
     ]
   },
   {
     "name": "attribute to",
     "trans": [
-      "Day 3 | English: to say or believe that sth is the result of a particular thing | Example: While there are several possible reasons for this, one is that practitioners may overlook confounding variables that account for the results they attribute to the interventions in question."
+      "归因于"
     ]
   },
   {
     "name": "atypical",
     "trans": [
-      "Day 3 | adj. | English: not typical or usual | Example: Contrary to the belief that they evolved from early ancestors with the bilateral form typical of many other animals, sea stars instead originated with an atypical body layout that was neither bilaterally nor radially symmetrical."
+      "[.eI'tplk(a)l] adj. 反常的"
     ]
   },
   {
     "name": "augment",
     "trans": [
-      "Day 3 | v. | English: to increase the amount, value, size, etc. of sth | Example: While searching for a way to augment the family income, she began making dolls."
+      "[D:9'ment] v. 增加,提高,扩大"
     ]
   },
   {
     "name": "authentic",
     "trans": [
-      "Day 3 | adj. | English: known to be real and genuine and not a copy | Example: Siemowit appears in the Gesta principum Polonorum, an authentic chronicle of medieval Polish history written in the 12th century."
+      "[3:'Oenfik] adj. 真正的"
     ]
   },
   {
     "name": "authenticate",
     "trans": [
-      "Day 3 | v. | English: to prove that sth is genuine, real or true | Example: Multiple sculptures dating to the period have been alleged to be the reported bust, but none have been authenticated as Desiderio's depiction of Strozzi."
+      "[3:Oentikert] v. 证实"
     ]
   },
   {
     "name": "authenticity",
     "trans": [
-      "Day 3 | n. | English: the quality of being authentic | Example: Nicholas Galanin is known for using video and photography to explore questions of authenticity in the identification and presentation of Native art."
+      "[.3:Qen'tsoti] n. 真实性"
     ]
   },
   {
     "name": "authoritative",
     "trans": [
-      "Day 3 | adj. | English: showing that you expect people to obey and respect you | Example: Despite the education specialist's hesitancy about her expertise on the subject in general, she found that she could speak authoritatively about the works of author Mildred Pitts Walter, particularly Justin and the Best Biscuits in the World, which she had used effectively in classroom instruction for many years."
+      "[3'O3:ratcrtw] adj. 权威式的"
     ]
   },
   {
     "name": "automate",
     "trans": [
-      "Day 3 | v. | English: to use machines and computers instead of people to do a job or task | Example: Attempts to automate classification of music into genres have not been very successful, and we may be at the limit of what is technologically possible."
+      "['3:tamert] v. 使自动化"
     ]
   },
   {
     "name": "automatic",
     "trans": [
-      "Day 3 | adj. | English: having controls that work without needing a person to operate them | Example: The author of Text 1 states that the benefits are automatic, while the author of Text 2 states that effort is required to fully achieve the benefits."
+      "[.3:ta'matk] adj. 自动的"
     ]
   },
   {
     "name": "aviation",
     "trans": [
-      "Day 3 | n. | English: the designing, building and flying of aircraft | Example: To assist with the development of new water-repellant materials for aviation and other applications, a team including both engineers and entomologists conducted a study of the water-repellant properties of cicada wings."
+      "[.ervi'erln] n. 航空"
     ]
   },
   {
     "name": "awry",
     "trans": [
-      "Day 3 | adj. | English: if sth goes awry , it does not happen in the way that was planned One person after another rose, and, as with an ill-balanced axe, attempted to hew out his conception of art a little more clearly, and sat down with the feeling that, for some reason which he could not grasp, his strokes had gone awry."
+      "[3'rar] adj. 出错,出岔子"
     ]
   },
   {
     "name": "axe",
     "trans": [
-      "Day 3 | n. | English: a tool with a wooden handle and a heavy metal blade, used for chopping wood, cutting down trees, etc. | Example: One person after another rose, and, as with an ill-balanced axe, attempted to hew out his conception of art a little more clearly, and sat down with the feeling that, for some reason which he could not grasp, his strokes had gone awry."
+      "[eks] n. 斧头"
     ]
   },
   {
     "name": "bald",
     "trans": [
-      "Day 3 | adj. | English: having little or no hair on the head | Example: All day long [the soldiers] rode through the canyon, up and down the steep, round hills, dirty and bald as a man’s head, hill after hill in endless succession."
+      "[b3:1d] adj. 秃头的"
     ]
   },
   {
     "name": "banal",
     "trans": [
-      "Day 3 | adj. | English: very ordinary and containing nothing that is interesting or important | Example: The lyrics of the song are embarrassingly banal."
+      "[b3'na:1,'bernl] adj. 平淡乏味的"
     ]
   },
   {
     "name": "barring",
     "trans": [
-      "Day 3 | prep. | English: except for; unless there is/are | Example: Barring major archaeological discoveries, we are unlikely to ever have an exhaustive account of ancient Egypt under the female pharaoh Hatshepsut, as much of the evidence of her reign was deliberately destroyed by her successors."
+      "['ba:n] prep. 除了,除非"
     ]
   },
   {
     "name": "base",
     "trans": [
-      "Day 3 | adj. | English: not having moral principles or rules | Example: Vanya says to himself, \"| was proud of [Professor Serebrakoff] and of his learning; | received all his words and writings as inspired and now? Now he has retired, and what is the total of his life? A blank! He is absolutely unknown, and his fame has burst like a soap-bubble. | have been deceived; | see that now, basely deceived.\""
+      "[beIs] adj. 卑鄙的,不道德的"
     ]
   },
   {
     "name": "be descended from",
     "trans": [
-      "Day 3 | English: to be related to sb who lived a long time ago Domesticated thousands of years ago by Indigenous people in South America, the tomatillo deviates structurally from the wild plant it is descended from."
+      "是某人的后裔"
     ]
   },
   {
     "name": "bear out",
     "trans": [
-      "Day 3 | English: If someone or something bears a person out or bears out what that person is saying, they support what that person is saying. | Example: Those who have had the rare privilege of reading her stirring biography, will, | am sure, bear me out in this statement."
+      "支持"
     ]
   },
   {
     "name": "bearing",
     "trans": [
-      "Day 3 | n. | English: n. the way in which sth is related to sth or influences it; n. the way in which you stand, walk or behave | Example: [1] It has no direct bearing on whether the claim is true. 2]Her stockings and boots and well-fitting gloves had worked marvels in her bearing—had given her a feeling of assurance, a sense of belonging to the well-dressed multitude."
+      "['bern] n.；n.；n. 关系"
     ]
   },
   {
     "name": "becoming",
     "trans": [
-      "Day 3 | adj. | English: suitable or appropriate for sb or their situation | Example: But culture indefatigably tries, not to make what each raw person may like, the rule by which he fashions himself; but to draw ever nearer to a sense of what is indeed beautiful, graceful, and becoming, and to get the raw person to like that."
+      "[br'kmn] adj. 合适的,恰当的"
     ]
   },
   {
     "name": "behold",
     "trans": [
-      "Day 3 | v. | English: to look at or see sb/sth | Example: [1] Do | behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more deep seclusion; and connect / The landscape with the quiet of the sky. 2] The Istiqlal Mosque in Jakarta, Indonesia, is a massive mosque that can accommodate approximately 200,000 people at once, making it an imposing sight to behold."
+      "[br'hoold] v. 看"
     ]
   },
   {
     "name": "belie",
     "trans": [
-      "Day 3 | v. | English: to give a false impression of sb/sth | Example: Her energy and youthful good looks belie her 65 years."
+      "[br'1aI] v. 掩饰,遮掩,使"
     ]
   },
   {
     "name": "bemoan",
     "trans": [
-      "Day 3 | v. | English: to complain or say that you are not happy about sth | Example: In “Things That Have Lost Their Power,” which appears in her tenth-century account or Japanese courtly life, Pillow Book, she bemoans boats run aground, toppled trees, and defeated wrestlers."
+      "[br'moun] v. 哀怨"
     ]
   },
   {
     "name": "bend",
     "trans": [
-      "Day 3 | v. | English: if you bend your arm, leg, etc. or if it bends, you move it so that it is no longer straight | Example: The little fern-leaf, bending / Upon the brink, its green reflection greets, / And kisses soft the shadow that it meets / With touch so fine, / The border line / The keenest vision can't define; / So perfect is the blending. From early morn to the fall of the afternoon he would go from fountain to fountain and from portal to portal his lean body so accustomed to bending that he never thought of straightening it, his head bowed as if in prayer."
+      "[bend] v. 弯曲"
     ]
   },
   {
     "name": "benevolent",
     "trans": [
-      "Day 3 | adj. | English: kind, helpful and generous | Example: The company has proved to be a most benevolent employer."
+      "[ba'nevalant] adj. 仁慈的"
     ]
   },
   {
     "name": "bestow",
     "trans": [
-      "Day 3 | v. | English: to give sth to sb, especially to show how much they are respected | Example: Helical swimming, widely understood to confer stability and efficiency in the locomotion of a variety of microscopic organisms—including bacteria, eukaryotic algae, and ciliates—bestows similar advantages, albeit via different propulsive modes, to larger oceanic macroplanktons, such as salps."
+      "[br'stov] v. （将"
     ]
   },
   {
     "name": "betray",
     "trans": [
-      "Day 3 | v. | English: to tell sb or make them aware of a piece of information, a feeling, etc., usually without meaning to | Example: Miranda's reminiscences about her early childhood have a melancholy quality that betrays her discontented view of her current circumstances."
+      "[bI'trer] v. （无意中）泄露信息"
     ]
   },
   {
     "name": "bilateral",
     "trans": [
-      "Day 3 | adj. | English: involving both of two parts or sides of the body or brain | Example: The morphological novelty of echinoderms marine—invertebrates with radial symmetry, usually starlike, around a central point—impedes comparisons with most other animals, in which bilateral symmetry on an anterior-posterior (head to tail) axis through a trunk is typical."
+      "adj. 身体部位-"
     ]
   },
   {
     "name": "biome",
     "trans": [
-      "Day 4 | n. | English: the characteristic plants and animals that exist in a particular type of environment, for example in a forest or desert | Example: Diadromous fish migrate between freshwater and marine biomes during their life cycle."
+      "n. 类似环境条件的植物和动物群落"
     ]
   },
   {
     "name": "bipedal",
     "trans": [
-      "Day 4 | adj. | English: using only two legs for walking Some robots such as Salvius (developed in 2008) and REEM-C (developed in 2013) feature humanoid characteristics like bipedal locomotion so that people will find it easier to interact with them."
+      "[bar'pi:dlbar'pedl] adj. 双足行走的"
     ]
   },
   {
     "name": "bleak",
     "trans": [
-      "Day 4 | adj. | English: exposed, empty, or with no pleasant features | Example: The bleak fields are asleep, / My heart alone wakes;"
+      "[bli:k] adj. 荒凉的"
     ]
   },
   {
     "name": "blend",
     "trans": [
-      "Day 4 | v. | English: to combine with sth in an attractive or effective way | Example: Similarly, Wayuu singer-songwriter Lido Pimienta blended Afro-Indigenous music from Colombia with Latin pop on her album Miss Colombia."
+      "[blend] v. （使）"
     ]
   },
   {
     "name": "block",
     "trans": [
-      "Day 4 | v. | English: to stop sb from going somewhere or seeing sth by standing in front of them or in their way | Example: Is there an available barrier material that can block roots and liquids while allowing fungal strands through?"
+      "[bla:k] v. 堵住"
     ]
   },
   {
     "name": "blossom",
     "trans": [
-      "Day 4 | v. | English: to produce blossom | Example: Night, guardian of dreams, / Now wanders through the land; / The moon, a lily white, / Blossoms within her hand."
+      "['bla:sam] v. 开花"
     ]
   },
   {
     "name": "bolster",
     "trans": [
-      "Day 4 | v. | English: to improve sth or make it stronger | Example: Reducing this kind of subscriber turnover is especially challenging for subscription sellers: customers’ initial enthusiasm for a subscription is often quick to subside, and sellers must thus devise other incentives to bolster retention."
+      "['boolstar] v. 加强"
     ]
   },
   {
     "name": "boorish",
     "trans": [
-      "Day 4 | adj. | English: very unpleasant and rude | Example: Socrates, a sophist, says to a new customer \"I have not seen any man so boorish, nor so impracticable, nor so stupid, nor so forgetful; who, while learning some little petty quibbles, forgets them before he has learned them.”"
+      "['borJ] adj. 粗野的"
     ]
   },
   {
     "name": "boost",
     "trans": [
-      "Day 4 | v. | English: v. to make sth increase, or become better or more successful; n. an increase in sth | Example: [1] In the 1990s, conservationists began planting more than 500,000 native trees in the habitat of the Azores bullfinch to boost the bird's numbers. 2] It's obvious that the selection of Buenaventura by UNESCO has brought awareness to local recipes, cooking practices, and chefs and has provided a boost to the city’s tourism industry."
+      "[bu:st] v.；v.；n. 使增长"
     ]
   },
   {
     "name": "bough",
     "trans": [
-      "Day 4 | n. | English: a large branch of a tree | Example: Adry ravine emerged under boughs / Into the pasture."
+      "[ba0] n. 大树枝"
     ]
   },
   {
     "name": "bounded",
     "trans": [
-      "Day 4 | adj. | English: (of a set) having a bound, esp where a measure is defined in terms of which all the elements of the set, or the differences between all pairs of members, are less than some value, or else all its members lie within some other well-defined set | Example: and leave thou (inexpressibly to unravel) / thou life, with its immensity and fear, / so that, now bounded, now immeasurable, / it is alternately stone in thy and star."
+      "[baondrd] adj. 有界的"
     ]
   },
   {
     "name": "bouquet",
     "trans": [
-      "Day 4 | n. | English: a bunch of flowers arranged in an attractive way so that it can be carried in a ceremony or presented as a gift | Example: [May] dropped her eyes to the immense bouquet of lilies-of-the-valley on her knee, and Newland Archer saw her white-gloved finger-tips touch the flowers softly."
+      "[bu'ker] n. 花束"
     ]
   },
   {
     "name": "branch",
     "trans": [
-      "Day 4 | n. | English: a part of a tree that grows out from the main stem and on which leaves, flowers and fruit grow | Example: Canopy soil is formed in a tree's branches (its canopy) when dead leaves and other falling things collect."
+      "[brentl] n. 树枝"
     ]
   },
   {
     "name": "branch off",
     "trans": [
-      "Day 4 | English: to be joined to another road or river but lead in a different direction | Example: The Chao Phraya River delta is a constantly changing landform made up of a network of distributaries, small channels that branch off from the main river."
+      "分岔"
     ]
   },
   {
     "name": "breach",
     "trans": [
-      "Day 4 | v. | English: If someone or something breaches a barrier, they make an opening in it, usually leaving it weakened or destroyed. | Example: Moreover, the team was surprised to discover that even when the periostracum is breached, pteropods can still mitigate damage by rebuilding the inner shell wall."
+      "[bri:tf] v. 使破开"
     ]
   },
   {
     "name": "breadth",
     "trans": [
-      "Day 4 | n. | English: a wide range (of knowledge, interests, etc.) | Example: The breadth of public art on display in the city can thus satisfy any art lover."
+      "[brcdo] n. （兴趣等的）广泛"
     ]
   },
   {
     "name": "breast",
     "trans": [
-      "Day 4 | n. | English: the top part of the front of your body, below your neck | Example: | rest me deep within the wood, / Drawn by its silent call, / Far from the throbbing crowd of men, / On nature's breast | fall."
+      "[brest] n. 胸部"
     ]
   },
   {
     "name": "breathtaking",
     "trans": [
-      "Day 4 | adj. | English: very exciting or impressive (usually in a pleasant way); very surprising | Example: Giant stone slabs formed the remains of what must once have been a breathtaking structure."
+      "['breoteikm] adj. 激动人心的,惊人的"
     ]
   },
   {
     "name": "bribery",
     "trans": [
-      "Day 4 | n. | English: the giving or taking of bribes | Example: In particular, he thinks oligarchies are particularly susceptible to corruption through bribery."
+      "['braibari] n. 行贿"
     ]
   },
   {
     "name": "brick",
     "trans": [
-      "Day 4 | n. | English: baked clay used for building walls, houses and other buildings; an individual block of this | Example: Maryam Hosseini and her team found that a computer program trained to identify sidewalks in aerial images of Boston could also accurately identify sidewalks in aerial images of Chicago and even distinguished between brick and asphalt."
+      "[brik] n. 砖"
     ]
   },
   {
     "name": "bride",
     "trans": [
-      "Day 4 | n. | English: a woman on her wedding day, or just before or just after it | Example: The sierra is clad in gala colors. Over its inaccessible peaks the opalescent fog settles like a snowy veil on the forehead of a bride."
+      "[brard] n. 新娘"
     ]
   },
   {
     "name": "brink",
     "trans": [
-      "Day 4 | n. | English: the extreme edge of land, for example at the top of a cliff or by a river | Example: The little fern-leaf, bending / Upon the brink, its green reflection greets, / And kisses soft the shadow that it meets / With touch so fine, / The border line / The keenest vision can't define; / So perfect is the blending. broodon fre, WE CARR. BURP RAS) Z232FEX: to think a lot about sth that makes you annoyed, anxious or upset You're not still brooding over what he said, are you?"
+      "[brrgk] n. （峭壁的）边沿"
     ]
   },
   {
     "name": "brood",
     "trans": [
-      "Day 4 | English: to think a lot about sth that makes you annoyed, anxious or upset | Example: You're not still brooding over what he said, are you?"
+      "（担忧或不安的事）"
     ]
   },
   {
     "name": "brusque",
     "trans": [
-      "Day 4 | adj. | English: If you describe a person or their behaviour as brusque, you mean that they deal with things, or say things, quickly and shortly, so that they seem to be rude. | Example: There is no denying that, since he was rather brusque in his ways, he never spared the young authors who asked his advice and read him their productions, but criticized vigorously, even to the verge of insult."
+      "[brAsk] adj. 简短生硬的"
     ]
   },
   {
     "name": "bud",
     "trans": [
-      "Day 4 | n. | English: a-small lump that grows on a plant and from which a flower, leaf or stem develops | Example: | walked slowly beneath the young leaves, drinking in the air, fragrant with the odor of young buds and sap."
+      "[bad] n. 芽,花蕾"
     ]
   },
   {
     "name": "buoy up",
     "trans": [
-      "Day 4 | English: to keep sb/sth floating on water | Example: We are poor plants buoyed up by the air-vessels of our own conceit: alas for us, if we get a few pinches that empty us of that windy self-subsistence! The very capacity for good would go out of us."
+      "使漂浮"
     ]
   },
   {
     "name": "bureaucratic",
     "trans": [
-      "Day 4 | adj. | English: connected with a bureaucracy or bureaucrats and involving complicated official rules which may seem unnecessary | Example: Knowing this can assuage potential investors' worries about bureaucratic minutiae and thereby allow them to instead focus on identifying sound business opportunities."
+      "[bjura'kratk] adj. 官僚主义的"
     ]
   },
   {
     "name": "burst",
     "trans": [
-      "Day 4 | n. | English: n.a short period of a particular activity or strong emotion that often starts suddenly; v. to break open or apart, especially because of pressure from inside; to make sth break in this way [1] Bursts caused by neutron mergers typically last fewer than 2 seconds. | Example: 2] All these things awoke in [Don Custodio] the farther he got from Europe, like the life-giving sap within the sown seed prevented from bursting out by the thick husk."
+      "[b3:rst] n.；n.；v. 使爆开,裂开"
     ]
   },
   {
     "name": "bust",
     "trans": [
-      "Day 4 | v. | English: Vv. to break sth; n. a stone or metal model of a person's head, shoulders and chest | Example: [1] Elephants and other animals, though, have busted the myth that tool use requires hands. 2] According to historical documents, Marietta Strozzi—a young woman who was prominent in fifteenth-century Florentine culture—inspired several artworks, including a portrait bust sculpted by Desiderio da Settignano."
+      "[bAst] v.；n. 石或金属的"
     ]
   },
   {
     "name": "bustling",
     "trans": [
-      "Day 4 | adj. | English: full of people moving about in a busy way | Example: When they debuted in April 1983 as part of the exhibit Children's Art: Identity: New Work from Youth Education Program, the artworks brought vibrant visual texture to the bustling terminals of San Francisco International Airport."
+      "['bAsIn] adj. 熙熙攘攘的"
     ]
   },
   {
     "name": "buttress",
     "trans": [
-      "Day 4 | v. | English: to support or give strength to sb/sth | Example: To that end, certain features such as the ability to respond to voice commands can help to buttress people's feelings of comfort"
+      "['bAtras] v. 支持"
     ]
   },
   {
     "name": "bypass",
     "trans": [
-      "Day 4 | v. | English: to go around or avoid a place | Example: Anew road now bypasses the town."
+      "['balpas] v. 绕过"
     ]
   },
   {
     "name": "calibration",
     "trans": [
-      "Day 4 | n. | English: the act of checking or adjusting (by comparison with a standard) the accuracy of a measuring instrument | Example: The use of OHD requires careful calibration based on a sample's climatic context."
+      "[kalr'brerhn] n. 标定"
     ]
   },
   {
     "name": "candor",
     "trans": [
-      "Day 4 | n. | English: the quality of saying what you think openly and honestly | Example: ‘I don't trust him,’ he said, in a rare moment of candour."
+      "['kendar] n. 坦白"
     ]
   },
   {
     "name": "canoe",
     "trans": [
-      "Day 4 | n. | English: a light narrow boat which you move along in the water with a paddle | Example: Thy warm and land-locked waters swell with an easy motion, / And gently glides the light"
+      "[ka'皿u:] n. 独木舟"
     ]
   },
   {
     "name": "canon",
     "trans": [
-      "Day 4 | n. | English: alist of the books or other works that are generally accepted as the genuine work of a particular writer or as being important | Example: Works from this period make up an outsized proportion of what is considered the canon of Mexican literature, but nineteenth-century writers like Justo Sierra O'Reilly should be considered just as integral to the Mexican literary canon."
+      "['knan] n. （某作家的）"
     ]
   },
   {
     "name": "canonical",
     "trans": [
-      "Day 4 | adj. | English: included in a list of holy books that are accepted as genuine; connected with works of literature that are highly respected | Example: The fact that there is no contemporary evidence that the first audience of Arrival of the Train was alarmed has not stopped the story from becoming canonical, even among film historians."
+      "adj. 经典的"
     ]
   },
   {
     "name": "canopy",
     "trans": [
-      "Day 4 | n. | English: a cover that is fixed or hangs above a bed, seat, etc. as a shelter or decoration | Example: Canopy soil is formed in a tree's branches (its canopy) when dead leaves and other falling things collect."
+      "['kanapi] n. 罩篷,遮篷"
     ]
   },
   {
     "name": "canvas",
     "trans": [
-      "Day 4 | n. | English: a piece of canvas used for painting on; a painting done on a piece of canvas , using oil paints | Example: Hunting Expedition is an important work of Nihonga, or classical Japanese painting. Unlike Wada Eisaku, who adopted traditional European methods such as painting with oil on canvas, Domoto Insh6 embraced traditional Japanese approaches."
+      "['kanvas] n. （帆布）"
     ]
   },
   {
     "name": "canyon",
     "trans": [
-      "Day 4 | n. | English: a deep valley with steep sides of rock | Example: All day long [the soldiers] rode through the canyon, up and down the steep, round hills, dirty and bald as a man’s head, hill after hill in endless succession."
+      "['kanjan] n. 峡谷"
     ]
   },
   {
     "name": "capitalism",
     "trans": [
-      "Day 4 | n. | English: an economic system in which a country's businesses and industry are controlled and run for profit by private owners rather than by the government Fernand Braudel and other historians of capitalism rarely discuss domestic capitalism in Africa before the period of European colonization, implicitly presenting capitalism as external to and imposed on Africa."
+      "['kaprtalrzam] n. 资本主义"
     ]
   },
   {
     "name": "capitalize",
     "trans": [
-      "Day 4 | v. | English: to gain a further advantage for yourself from a situation | Example: The team failed to capitalize on their early lead."
+      "['kaprtalarz] v. 充分利用"
     ]
   },
   {
     "name": "captivate",
     "trans": [
-      "Day 4 | v. | English: to keep sb's attention by being interesting, attractive, etc. | Example: Utilizing vivid pastel colors, overexposed tones, and mirrorlike symmetry to evoke a Socialist- era aesthetic, her photos captivated viewers from Spain to Taiwan."
+      "['kaptrvert] v. 迷住"
     ]
   },
   {
     "name": "captive",
     "trans": [
-      "Day 4 | adj. | English: kept as a prisoner or in a confined space; unable to escape | Example: They found for tucos that daytime is the most active period for wild individuals but not for captive individuals."
+      "['kaptrv] adj. 被关起来的"
     ]
   },
   {
     "name": "capture",
     "trans": [
-      "Day 4 | v. | English: to catch a person or an animal and keep them as a prisoner or in a confined space | Example: In 2016, Gabriela Gonzalez and team announced that a chirping sound captured by Laser Interferometer Gravitational-Wave Observatory antennas was direct evidence of gravitational waves."
+      "['kaptfar] v. 捕捉,捕获"
     ]
   },
   {
     "name": "carnival",
     "trans": [
-      "Day 4 | n. | English: a public festival, usually one that happens at a regular time each year, that involves music and dancing in the streets, for which people wear brightly coloured clothes | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+      "['ka:rnrv(a)l] n. 嘉年华"
     ]
   },
   {
     "name": "carnivorous",
     "trans": [
-      "Day 4 | adj. | English: (of an animal) feeding on other animals. | Example: Oyster mushrooms typically get their nutrients from the damp logs on which they grow, but the fungi are also carnivorous, with the ability to kill and consume microscopic worms known as nematodes."
+      "[ka:r'nrvaras] adj. 食肉的"
     ]
   },
   {
     "name": "carpet",
     "trans": [
-      "Day 4 | n. | English: a thick woven material made of wool, etc. for covering floors or stairs | Example: Agleaming carpet was springing up everywhere."
+      "['ka:rprt] n. 地毯"
     ]
   },
   {
     "name": "carve",
     "trans": [
-      "Day 4 | v. | English: to make objects, patterns, etc. by cutting away material from wood or stone | Example: Carbon dating at the discovery site revealed that the stone was likely carved between 1 and 250 CE."
+      "[ka:rv] v. 雕刻"
     ]
   },
   {
     "name": "cast-iron",
     "trans": [
-      "Day 4 | adj. | English: very strong or certain; that cannot be broken or fail | Example: George, on the other hand, ridiculed the idea of Harris’s having done anything more than eat and sleep, and had a cast-iron opinion that it was he—George himself—who had done all the labour worth speaking of."
+      "adj. 确定不移的"
     ]
   },
   {
     "name": "casual",
     "trans": [
-      "Day 5 | adj. | English: not showing much care or thought; seeming not to be worried; not wanting to show that sth is important to you | Example: A casual description of Scherezade Garcia's 2019 mural Blame It on the Bean: The Power of Coffee can make the work seem unassuming."
+      "['ka3ual] adj. 不经意的,漫不经心的"
     ]
   },
   {
     "name": "catalogue",
     "trans": [
-      "Day 5 | v. | English: to give a list of things connected with a particular person, event, etc. | Example: Researchers catalogued plant seeds found in fecal samples from non-native birds."
+      "['katal3:9] v. 记载"
     ]
   },
   {
     "name": "catalyst",
     "trans": [
-      "Day 5 | n. | English: a substance that makes a chemical reaction happen faster without being changed itself | Example: These devices are silicon-based solar cells coated in chemical catalysts that activate reactions that split water molecules into hydrogen and oxygen gas."
+      "['katalrst] n. 催化剂"
     ]
   },
   {
     "name": "cataract",
     "trans": [
-      "Day 5 | n. | English: amedical condition that affects the lens of the eye and causes a gradual loss of sight | Example: Students in a biology class investigated why individual house mice (Mus musculus) can differ from one another in their susceptibility to cataracts in old age."
+      "n. 白内障"
     ]
   },
   {
     "name": "categorical",
     "trans": [
-      "Day 5 | adj. | English: expressed clearly and in a way that shows that you are very sure about what you are saying | Example: Categorical claims about the original function and significance of the Urfa Man—a statue of a human figure found in what is now Turkey and dating from around 11,000 years ago—should be treated skeptically."
+      "[.keta'93:Ikl] adj. 明确的"
     ]
   },
   {
     "name": "causal",
     "trans": [
-      "Day 5 | adj. | English: connected with the relationship between two things, where one causes the other to happen | Example: The work of Tobias Gerstenberg et al. on tracking eye movements supports a theory that people engage in counterfactual thinking when making causal judgments."
+      "adj. 因果关系的"
     ]
   },
   {
     "name": "cautious",
     "trans": [
-      "Day 5 | adj. | English: being careful about what you say or do, especially to avoid danger or mistakes | Example: Then the banker cautiously broke the seals off the door and put the key in the keyhole."
+      "['k3:[3s] adj. 小心的"
     ]
   },
   {
     "name": "cease",
     "trans": [
-      "Day 5 | v. | English: to stop happening or existing; to stop sth from happening or existing | Example: Whether resigned or not to the verdict of the public, he ceased to write plays and assumed instead the nobler réle of patron to unrecognized authors and artists and to ruined managers."
+      "[si:s] v. （使）停止"
     ]
   },
   {
     "name": "celebrated",
     "trans": [
-      "Day 5 | adj. | English: famous for having good qualities | Example: The following text is adapted from Virginia Woolf's 1919 novel Night and Day. Katharine is the granddaughter of a celebrated poet."
+      "['sclibrertid] adj. 著名的"
     ]
   },
   {
     "name": "celestial",
     "trans": [
-      "Day 5 | adj. | English: of the sky or of heaven | Example: Socrates, a sophist, explains why he studies astronomy while sitting in a basket hanging a few feet off the ground, saying, \"| should not have rightly discovered things celestial if | had not suspended the intellect, and mixed the thought in a subtle form with its kindred air.\""
+      "[53'lestll] adj. 天上的"
     ]
   },
   {
     "name": "census",
     "trans": [
-      "Day 5 | n. | English: the process of officially counting sth, especially a country's population, and recording various facts | Example: Central Vermont's Orange County is among the most rural counties in the United States: the US Census Bureau classified it as 97.2% rural in 2010."
+      "['sensas] n. （官方的）统计"
     ]
   },
   {
     "name": "ceremonious",
     "trans": [
-      "Day 5 | adj. | English: behaving or performed in an extremely formal way | Example: The attorney general made a more ceremonious show of lenity in this particular case."
+      "[sera'mounias] adj. 讲究礼仪的"
     ]
   },
   {
     "name": "chafe",
     "trans": [
-      "Day 5 | v. | English: to feel annoyed and impatient about sth, especially because it limits what you can do | Example: The little conductor stood on tiptoe in an effort to keep one hand on the signal rope, craning his neck in a vain and dissatisfied endeavor to pierce the miasma of the fog. The motorman chafed in his box, thinking of the drudging lot of the laboring man. He registered discontent."
+      "[terf] v. （尤指因受限制而"
     ]
   },
   {
     "name": "chamber",
     "trans": [
-      "Day 5 | n. | English: space in the body, in a plant or in a machine, which is separated from the rest | Example: The scientists put bacteria in petri dishes with two chambers."
+      "['tfemmbar] n. （植物或机器内的）腔;室"
     ]
   },
   {
     "name": "channel",
     "trans": [
-      "Day 5 | n. | English: a deep passage of water in a river or near the coast that can be used as route for ships | Example: As with other river deltas, the Krishna River delta is dynamic: it is a constantly evolving network of channels and strips of land that change in size and shape as the river deposits new sedimentary particles where the river meets the waters of the Bay of Bengal."
+      "['tanl] n. 航道"
     ]
   },
   {
     "name": "chant",
     "trans": [
-      "Day 5 | v. | English: to sing or shout the same words or phrases many times | Example: It's hard to describe Farsi chanting: the way Mom drew her voice out like the notes of a cello as she recited poems by Rumi or Hafez."
+      "[tln] v. 反复唱"
     ]
   },
   {
     "name": "chariot",
     "trans": [
-      "Day 5 | n. | English: an open vehicle with two wheels, pulled by horses, used in ancient times in battle and for racing | Example: There is no Frigate like a Book / To take us Lands away / Nor any Coursers like a Page / Of prancing Poetry— / This Traverse may the poorest take / Without oppress of Toll— / How frugal is the Chariot / That bears the Human soul."
+      "n. （古代用于战斗或比赛的）"
     ]
   },
   {
     "name": "chief",
     "trans": [
-      "Day 5 | n. | English: aleader or ruler of a people or community | Example: lam Ojistoh, | am she, the wife / Of him whose name breathes bravery and life / And courage to the tribe who calls him chief. / | am Ojistoh, his white star, and he / Is land, and lake, and sky—and soul to me."
+      "n. 酋长"
     ]
   },
   {
     "name": "chin",
     "trans": [
-      "Day 5 | n. | English: the part of the face below the mouth and above the neck | Example: [Jim’s father] was shaving this lawn as if it were a priest's chin."
+      "[t[n] n. 下巴"
     ]
   },
   {
     "name": "chip away",
     "trans": [
-      "Day 5 | English: to keep breaking small pieces off sth | Example: When constructing his argument regarding the characteristics of a well-functioning government, Aristotle asserts thar 'Transgression creeps in unperceived and at last ruins the state,’ illustrating this idea with a comparison to frequent small expenditures slowly and almost imperceptibly chipping away at a fortune until it is ultimately depleted."
+      "不停地削"
     ]
   },
   {
     "name": "chorus",
     "trans": [
-      "Day 5 | n. | English: a piece of music, usually part of a larger work, that is written for a choir (= a group of singers) | Example: The sonorous, joyful bells rang again. From within the church, the honeyed voices of a female chorus rose melancholy and grave."
+      "['k3:r3s] n. 合唱曲"
     ]
   },
   {
     "name": "chromosome",
     "trans": [
-      "Day 5 | n. | English: one of the very small structures like threads in the nuclei (= central parts) of animal and plant cells, that carry the genes | Example: Drosophila (fruit files) have generation times of 10-12 days, so seasonal changes in humidity and other environmental conditions can drive seasonal fluctuations in chromosome rearrangements in species such as D. persimilis and D. subobscura."
+      "['kroumasoum] n. 染色体"
     ]
   },
   {
     "name": "chronicle",
     "trans": [
-      "Day 5 | n. | English: a written record of events in the order in which they happened | Example: Siemowit appears in the Gesta principum Polonorum, an authentic chronicle of medieval Polish history written in the 12th century."
+      "['kra:nikl] n. 编年史"
     ]
   },
   {
     "name": "circuit",
     "trans": [
-      "Day 5 | n. | English: The invention in 1958 of the integrated circuit (or microchip) radically altered the semiconductor industry. | Example: The invention in 1958 of the integrated circuit (or microchip) radically altered the semiconductor industry."
+      "['53:rkit] n. 电路"
     ]
   },
   {
     "name": "circulate",
     "trans": [
-      "Day 5 | v. | English: ifa story, an idea, information, etc. circulates or if you circulate it, it spreads or it is passed from one person to another | Example: Although the government of the Soviet Union attempted to suppress Georgi Viadimov's novel Faithful Ruslan, copies of the book circulated in secret among readers in several parts of the country."
+      "['s3:rkjalert] v. 传播"
     ]
   },
   {
     "name": "circumscribe",
     "trans": [
-      "Day 5 | v. | English: to limit sb/sth's freedom, rights, power, etc. | Example: and leave thou (inexpressibly to unravel) / thou life, with its immensity and fear, / so that, now circumscribed, now immeasurable, / it is alternately stone in thy and star."
+      "['83:rkamskraIb] v. 限制"
     ]
   },
   {
     "name": "circumvent",
     "trans": [
-      "Day 5 | v. | English: circumvent sth to find a way of avoiding a difficulty or a rule | Example: They found a way of circumventing the law."
+      "[.s3:Ikam'vent] v. 规避"
     ]
   },
   {
     "name": "citadel",
     "trans": [
-      "Day 5 | n. | English: a place or situation in which an idea, principle, system etc that you think is important is kept safe | Example: I had gazed upon the fortifications and impediments that seemed to keep human beings from entering the citadel of nature, and rashly and ignorantly | had repined."
+      "['sItadel] n. 某事物有保障的地方"
     ]
   },
   {
     "name": "citation",
     "trans": [
-      "Day 5 | n. | English: words or lines taken from a book or a speech For example, a count of other scholars’ citations shows that Boston University economist Marianne Baxter, who studies international finance, is referenced frequently, indicating that her work has been significant in the field."
+      "n. 引用"
     ]
   },
   {
     "name": "citizenry",
     "trans": [
-      "Day 5 | n. | English: all the citizens of a particular town, country, etc. | Example: Some social scientists say that while a desire for cooperation rather than conflict is key to democracy, public understanding of economics is also central to public comprehension of state politics, and if a citizenry is to function, economic issues cannot remain the domain only of experts."
+      "n. 公民"
     ]
   },
   {
     "name": "clad",
     "trans": [
-      "Day 5 | adj. | English: covered in a particular thing | Example: The sierra is clad in gala colors. Over its inaccessible peaks the opalescent fog settles like a snowy veil on the forehead of a bride."
+      "[klad] adj. 覆盖的"
     ]
   },
   {
     "name": "clade",
     "trans": [
-      "Day 5 | n. | English: a group of organisms considered as having evolved from a common ancestor | Example: Some researchers have characterized the flora and fauna of the South Pacific island of Grande Terre as members of clades that inhabited nearby islands before Grande Terre completely emerged 37 million years ago."
+      "n. （进化）分支"
     ]
   },
   {
     "name": "clash",
     "trans": [
-      "Day 5 | v. | English: to be very different and opposed to each other | Example: A two-dimensional photograph, however, cannot capture how a building interacts with its surroundings, whether by complementing, blending in with, or perhaps even clashing with sights and activities nearby."
+      "[klad] v. 相冲突"
     ]
   },
   {
     "name": "classifiable",
     "trans": [
-      "Day 5 | adj. | English: that you can or should classify | Example: Writer Lydia Davis observed that while traditional literary forms, such as the novel, are recognizable as such even as they evolve, there are rarer “intergeneric” forms that might, for example, use elements of both fiction and essays to create something unclassifiable."
+      "['klasrfarabl] adj. 可分类的"
     ]
   },
   {
     "name": "clay",
     "trans": [
-      "Day 5 | n. | English: a type of heavy, sticky earth that becomes hard when it is baked and is used to make things such as pots and bricks | Example: Using a mechanical spear-thrower, he launched spears with Clovis points into mounds of clay—substitutes for the animals’ large bodies."
+      "[kler] n. 黏土"
     ]
   },
   {
     "name": "clergy",
     "trans": [
-      "Day 5 | n. | English: the priests or ministers of a religion, especially of the Christian Church | Example: And by his brother clergy he was regarded as a discreet and agreeable fellow."
+      "['kl3:rd3i] n. 神职人员"
     ]
   },
   {
     "name": "clerical",
     "trans": [
-      "Day 5 | adj. | English: connected with the clergy (= priests) | Example: Colours might have been better chosen and lights more perfectly diffused; but perhaps in doing so the thorough clerical aspect of the whole might have been somewhat marred."
+      "['klerikl] adj. 圣职人员的"
     ]
   },
   {
     "name": "cliff",
     "trans": [
-      "Day 5 | n. | English: a high area of rock with a very steep side, often at the edge of the sea or ocean | Example: Do I behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more deep seclusion; and connect / The landscape with the quiet of the sky."
+      "[kIit] n. 悬崖峭壁"
     ]
   },
   {
     "name": "cling",
     "trans": [
-      "Day 5 | v. | English: to stick to sth | Example: Among the wild rice in the still lagoon. / In monotone the lizard shrills his tune. / The wild goose, homing, seeks a sheltering, / Where rushes grow, and oozing lichens cling."
+      "[k] v. 附着"
     ]
   },
   {
     "name": "clinical trial",
     "trans": [
-      "Day 5 | English: When a new type of drug or medical treatment undergoes clinical trials, it is tested directly on patients to see if it is effective. | Example: The results of randomized clinical trials testing the efficacy of common medical interventions sometimes fail to corroborate conclusions that practitioners reach based on their real-world observations of patients."
+      "临床试验"
     ]
   },
   {
     "name": "clipping",
     "trans": [
-      "Day 5 | n. | English: a piece cut off sth | Example: Although it seems ridiculous and useless to study old newspaper clippings and candy wrappers, these old newspapers, advertising leaflets, posters, and candy wrappers are actually able to evince the shifts in people’s behavior and values in the past and are therefore very valuable for this study."
+      "['klpn] n. 剪下物"
     ]
   },
   {
     "name": "clique",
     "trans": [
-      "Day 5 | n. | English: asmall group of people who spend their time together and do not allow others to join them The great men of culture are those who have had a passion for diffusing, for making prevail, for carrying from one end of society to the other, the best knowledge, the best ideas of their time; who have labored to divest knowledge of all that was harsh, uncouth, difficult, abstract, professional, exclusive; to humanise it, to make it efficient outside the clique of the cultivated and learned, yet still remaining the best knowledge and thought of the time, and a true source, therefore, of sweetness and light."
+      "n. 小集团"
     ]
   },
   {
     "name": "clumsy",
     "trans": [
-      "Day 5 | adj. | English: moving or doing things in a very awkward way | Example: His clumsy fingers couldn't untie the knot."
+      "['klamzi] adj. 笨拙的"
     ]
   },
   {
     "name": "cluster",
     "trans": [
-      "Day 5 | v. | English: to come together in a small group or groups | Example: It is tempting to treat the clustering of information technology firms in Northern California as representative of industrial agglomeration generally."
+      "['klustar] v. 聚集"
     ]
   },
   {
     "name": "coalesce",
     "trans": [
-      "Day 5 | v. | English: to come together to form one larger group, substance, etc. | Example: One popular theory of the origin of the Moon, the \"big whack,\" posits that a protoplanet called Theia collided with Earth, flinging debris into orbit that eventually coalesced into the Moon."
+      "[.koua'les] v. 合并,联合"
     ]
   },
   {
     "name": "coalition",
     "trans": [
-      "Day 5 | n. | English: the act of two or more groups joining together | Example: \"Coalition\" is the term for a group of male lions, and across the Greater Kruger National Park in South Africa, many coalitions vie for territory."
+      "[koo3'Ij(a)] n. 联合"
     ]
   },
   {
     "name": "coarse",
     "trans": [
-      "Day 5 | adj. | English: consisting of relatively large pieces | Example: To characterize the nature of the depositional environment, Frances Rivera-Hernandez et al. analyzed the grain size of Murray Formation sediment, finding that although there are intervals of coarse grains, most of the sediment consists of fine grains that show signs of cracking due to episodic desiccation."
+      "[ko:rs] adj. 大颗粒的"
     ]
   },
   {
     "name": "coherence",
     "trans": [
-      "Day 5 | n. | English: the situation in which all the parts of sth fit together well | Example: For too long, scholars have focused on narrative fragmentation versus coherence, inhibiting inquiry into other points of stylistic correspondence among works that would enrich our understanding of the modernist canon."
+      "[koU'hrans] n. 连贯性"
     ]
   },
   {
     "name": "coherent",
     "trans": [
-      "Day 5 | adj. | English: logical and well organized; easy to understand and clear | Example: Each fails at presenting a wholly coherent vision of art but does not understand why."
+      "[koc'hrant] adj. 合乎逻辑的"
     ]
   },
   {
     "name": "coincide",
     "trans": [
-      "Day 5 | adj. | English: (Of two or more event ) to take place at the same time | Example: Radiocarbon dating can help scientists determine whether the extinction of the giant short- faced bear around 8000 BCE coincided with the arrival of humans in the same region of the Americas."
+      "[koUIn'sard] adj. 同时发生"
     ]
   },
   {
     "name": "collaborate",
     "trans": [
-      "Day 6 | v. | English: to work together with sb in order to produce or achieve sth | Example: Known for the albums Quiet Nights and Milestones, jazz trumpeter Miles Davis collaborated several times with pianist Gil Evans."
+      "[ka'Iebarert] v. 合作"
     ]
   },
   {
     "name": "collaboration",
     "trans": [
-      "Day 6 | n. | English: the act of working with another person or group of people to create or produce sth | Example: It describes the development of a type of scientific collaboration, shows how that type of collaboration has been used in a particular field of study, and then suggests future collaborative projects."
+      "[ka.Iaba'rerhn] n. 合作"
     ]
   },
   {
     "name": "collaborative",
     "trans": [
-      "Day 6 | adj. | English: involving, or done by, several people or groups of people working together | Example: Itis most likely that \"The Senate\" was the product of a collaborative effort between Hamilton and Madison."
+      "[ka'Iabarertrv] adj. 合作的"
     ]
   },
   {
     "name": "collapse",
     "trans": [
-      "Day 6 | n. | English: the action of a building suddenly falling | Example: Like many other genera of wild bees, bumblebees have in recent decades experienced population collapse caused by, among other factors, habitat destruction and climate variation."
+      "[ka'laps] n. 坍塌"
     ]
   },
   {
     "name": "collide",
     "trans": [
-      "Day 6 | v. | English: if two people, vehicles, etc. collide , they crash into each other | Example: When subjects were asked to look at two colliding billiard balls and judge whether one caused or prevented the other's movement through a gate, their eyes looked at where the target ball would have gone if the ball that altered its path did not exist."
+      "[ka'lard] v. 相撞"
     ]
   },
   {
     "name": "collocation",
     "trans": [
-      "Day 6 | n. | English: the act or result of placing or arranging together | Example: The potential for knowledge spillovers, a dominant driver of collocation in this industry, was largely absent from the paint manufacturing industry."
+      "n. 组合"
     ]
   },
   {
     "name": "colonialism",
     "trans": [
-      "Day 6 | n. | English: the practice by which a powerful country controls another country or other countries | Example: In fact the work is a complex, dynamic meditation on gender and the legacy of colonialism that demands serious attention."
+      "n. 殖民主义"
     ]
   },
   {
     "name": "comet",
     "trans": [
-      "Day 6 | n. | English: amass of ice and dust that moves around the sun and looks like a bright star with a tail | Example: The team suggests that scientists have ignored the possibility that something other than a comet fragment could have made the crater."
+      "['ka:nt] n. 彗星"
     ]
   },
   {
     "name": "comfort",
     "trans": [
-      "Day 6 | n. | English: n. the state of being physically relaxed and free from pain; the state of having a pleasant life, with everything that you need v. to make sb who is worried or unhappy feel better by being kind and sympathetic towards them | Example: To that end, certain features such as the ability to respond to voice commands can help to buttress people's feelings of comfort."
+      "['kmfart] n.；n.；v. 舒服,舒适"
     ]
   },
   {
     "name": "comforting",
     "trans": [
-      "Day 6 | adj. | English: making you feel calmer and less worried or unhappy | Example: To this end, certain features such as the ability to respond to voice commands can help to create the comforting semblance of humanity, but a robot that appears too similar to humans can make people feel more unsettled than soothed."
+      "adj. 令人安慰的"
     ]
   },
   {
     "name": "commend",
     "trans": [
-      "Day 6 | v. | English: to praise sb/sth, especially publicly | Example: Ina 2018 article celebrating films depicting the Black experience, critics for the New York Times commended William Greaves's 1968 film Symbiopsychotaxiplasm, Take One and Spike Lee's 1992 film Malcolm X, praising the former as \"a vital artifact of its time\" and the latter as \"electrifying.\""
+      "[ka'mcnd] v. 赞扬"
     ]
   },
   {
     "name": "commentator",
     "trans": [
-      "Day 6 | n. | English: a person who is an expert on a particular subject and talks or writes about it on television or radio, or in a newspaper | Example: While some commentators lauded this development, asserting that such blogs had a welcome transparency missing from traditional news, less sanguine observers countered that such blogs tended to ideological extremes that exacerbated political polarization to problematic levels."
+      "['ka:mantertar] n. 评论员"
     ]
   },
   {
     "name": "commercially",
     "trans": [
-      "Day 6 | adv. | English: considering whether a business or product is making a profit | Example: Though John Crowley, author of Flint and Mirror, is perhaps not as well-known as the most commercially successful American writers of the past fifty years, influential figures have championed his work, including the poet John Hollander and the literary critic Harold Bloom."
+      "[ka'm3:rali] adv. 从商业角度来看"
     ]
   },
   {
     "name": "commission",
     "trans": [
-      "Day 6 | v. | English: to officially ask sb to write, make or create sth or to do a task for you | Example: The first public library became available in Rome in 28 BCE and was soon followed by one commissioned by Emperor Augustus."
+      "[ka'mln] v. 创作或完成"
     ]
   },
   {
     "name": "commitment",
     "trans": [
-      "Day 6 | n. | English: the willingness to work hard and give your energy and time to a job or an activity | Example: To portray Louis Pipestone's strong commitment to collecting signatures for the petition."
+      "[ka'mitmant] n. 对工作或某活动-"
     ]
   },
   {
     "name": "commonplace",
     "trans": [
-      "Day 6 | adj. | English: done very often, or existing in many places, and therefore not unusual | Example: Nowadays, the design is commonplace, found in everything from Eiffel Tower replicas like the one in Rio de Janeiro, Brazil, to structures like the Copenhagen Zoo Tower in Copenhagen, Denmark."
+      "['ka:manpleIs] adj. 普通的"
     ]
   },
   {
     "name": "compelling",
     "trans": [
-      "Day 6 | adj. | English: that makes you think it is true | Example: He and colleagues’ study was not designed in a way that would allow it to produce compelling"
+      "[kam'peln] adj. 令人信服的"
     ]
   },
   {
     "name": "compensate",
     "trans": [
-      "Day 6 | v. | English: to provide sth good to balance or reduce the bad effects of damage, loss, etc | Example: The international Slow Food movement, founded in 1989, promotes universal access to healthy, high-quality food that is produced sustainably by workers who are treated and compensated fairly."
+      "['ka:mpensert] v. 补偿"
     ]
   },
   {
     "name": "competent",
     "trans": [
-      "Day 6 | adj. | English: of a good standard but not very good | Example: Cuttlefish appear to be surprisingly competent at exercising self-control: in a 2021 study conducted by behavioral ecologist Alexandra Schnell, these cephalopods routinely demonstrated restraint by delaying gratification, waiting for a favorite treat instead of instantly devouring a readily available meal."
+      "['ka:mprtant] adj. 合格的,不错的"
     ]
   },
   {
     "name": "complement",
     "trans": [
-      "Day 6 | v. | English: to add to sth in a way that improves it or makes it more attractive | Example: The colors in an Impressionist painting were often chosen to complement the colors of the frame it would be placed in."
+      "['ka:mplrment;'ka:mplrmant] v. 补充,补足"
     ]
   },
   {
     "name": "compliance",
     "trans": [
-      "Day 6 | n. | English: the practice of obeying rules or requests made by people in authority | Example: While bioaccumulation of manufactured nanoparticles may be inherently worrisome, it has been hypothesized that CeO2-NP bioaccumulation in invertebrates like D. polymorpha could serve a valuable proxy role, obviating the need for manufacturers to conduct costly and intrusive sampling of vertebrate species—such as rainbow trout (Oncorhynchus mykiss), commonly used in regulatory compliance testing—for nanoparticle bioaccumulation, as environmental protection laws currently require."
+      "[Kom'plarons] n. 服从"
     ]
   },
   {
     "name": "compliment",
     "trans": [
-      "Day 6 | v. | English: a remark that expresses praise or admiration of sb | Example: Though few critics consider Vasily Grossman's novel Stalingrad—which focuses on the experience of the Soviet Union in the early years of World War —to be as well written as his later book Everything Flows, some compliment it despite the damage wrought by Soviet censors."
+      "['ka:mplmmant] v. 赞扬"
     ]
   },
   {
     "name": "component",
     "trans": [
-      "Day 6 | n. | English: one of several parts of which sth is made | Example: Political blogs with conspicuous ideological alignments became an integral component of US"
+      "[kampounant] n. 组成部分"
     ]
   },
   {
     "name": "composite",
     "trans": [
-      "Day 6 | n. | English: something made by putting together different parts or materials | Example: Aerospace composites containing the nitrogen-treated SiC fiber may have the ability to withstand mechanical stress for a longer period of time than can aerospace composites containing either of the two polymer-derived SiC fibers."
+      "[kam'pa:zat] n. 合成物"
     ]
   },
   {
     "name": "composition",
     "trans": [
-      "Day 6 | n. | English: n.a piece of music or art, or a poem; n. the different parts which sth is made of; the way in which the different parts are organized | Example: [1] The compositions of Delia Derbyshire can yield as many different interpretations as there are people to listen to them. 2] To explain an important study of differences in the composition of Martian soil and the"
+      "[.ka:mpa'zln] n.；n.；n. 作品"
     ]
   },
   {
     "name": "compound",
     "trans": [
-      "Day 6 | v. | English: v. to make sth bad become even worse by causing further damage or problems n. a thing consisting of two or more separate things combined together | Example: [1] The problems were compounded by severe food shortages. 2] Freezers and other cooling technologies use chemical compounds called refrigerants to absorb heat and release cold air."
+      "['ka:mpaond] v.；v.；n. 使恶化"
     ]
   },
   {
     "name": "comprehension",
     "trans": [
-      "Day 6 | n. | English: the ability to understand | Example: Some social scientists say that while a desire for cooperation rather than conflict is key to democracy, public understanding of economics is also central to public comprehension of state politics, and if a citizenry is to function, economic issues cannot remain the domain only of experts."
+      "[.ka:mprr'henh] n. 理解力"
     ]
   },
   {
     "name": "comprehensive",
     "trans": [
-      "Day 6 | adj. | English: including all, or almost all, the items, details, facts, information, etc., that may be concerned | Example: Therefore, if those involved in such efforts want to ensure that a comprehensive range of information is secured, they must incorporate the preservation of songs into their broader efforts to protect Indigenous languages."
+      "[.ka:mprr'henswv] adj. 详尽的"
     ]
   },
   {
     "name": "comprise",
     "trans": [
-      "Day 6 | v. | English: to have sb/sth as parts or members | Example: It clarified that microorganism activity levels in the plant-soil cores varied depending on which microorganism comprised the community."
+      "[kam'prarz] v. 组成"
     ]
   },
   {
     "name": "compulsory",
     "trans": [
-      "Day 6 | adj. | English: that must be done because of a law or a rule | Example: It is compulsory for all motorcyclists to wear helmets."
+      "[kamPAlsari] adj. 必须做的,强制的"
     ]
   },
   {
     "name": "comrade",
     "trans": [
-      "Day 6 | n. | English: a friend or other person that you work with, especially as soldiers during a war | Example: _He was daring, without being rash: prompt, but not thoughtless; firm, without being harsh. Kind and devoted to the company he drilled, he soon won the respect of his superior officers and the love of his comrades."
+      "['ka:mrad] n. 战友"
     ]
   },
   {
     "name": "conceal",
     "trans": [
-      "Day 6 | v. | English: to hide sb/sth | Example: The paintings were concealed beneath a thick layer of plaster."
+      "[kan'si:l] v. 隐藏"
     ]
   },
   {
     "name": "concede",
     "trans": [
-      "Day 6 | v. | English: to admit that sth is true, logical, etc. | Example: It concedes that a finding may not appear to support the main view that the text advances."
+      "[kan'si:d] v. 承认"
     ]
   },
   {
     "name": "conceit",
     "trans": [
-      "Day 6 | n. | English: too much pride in yourself and what you do | Example: We are poor plants buoyed up by the air-vessels of our own conceit: alas for us, if we get a few pinches that empty us of that windy self-subsistence! The very capacity for good would go out of us."
+      "[kan'si:t] n. 骄傲自大"
     ]
   },
   {
     "name": "conceivable",
     "trans": [
-      "Day 6 | adj. | English: that you can imagine or believe | Example: It seemed as if nature had determined to throw every conceivable obstacle in the way of those who should seek to join the two great oceans of the world."
+      "[kan'si:vab(a)] adj. 可想象的,可信的"
     ]
   },
   {
     "name": "conception",
     "trans": [
-      "Day 6 | n. | English: the process of forming an idea or a plan | Example: One person after another rose, and, as with an ill-balanced axe, attempted to hew out his conception of art a little more clearly, and sat down with the feeling that, for some reason which he could not grasp, his strokes had gone awry."
+      "[kan'scphn] n. 构思"
     ]
   },
   {
     "name": "conceptualize",
     "trans": [
-      "Day 6 | v. | English: to form an idea of sth in your mind Rafael Nufiez and colleagues studied how members of the Yupno, an Indigenous group in Papua New Guinea, conceptualize time."
+      "[kan'scptfualarz] v. 构思"
     ]
   },
   {
     "name": "concern oneself with",
     "trans": [
-      "Day 6 | English: to take an interest in sth | Example: | did not concern myself with those things."
+      "（）感兴趣"
     ]
   },
   {
     "name": "concerning",
     "trans": [
-      "Day 6 | adj. | English: If something is concerning, it causes you to feel concerned about it. | Example: However, measurements taken in 2023 showed that the tower was rotating in a concerning way."
+      "[kan'83:1\"] adj. 令人担心的"
     ]
   },
   {
     "name": "concrete",
     "trans": [
-      "Day 6 | adj. | English: adj. based on facts, not on ideas or guesses n. building material that is made by mixing together cement , sand, small stones and water | Example: [1] Itis easier to think in concrete terms rather than in the abstract. 2] When it was tested on images of Brooklyn, it reliably identified sidewalks in the vast majority of cases and even whether sidewalks were concrete or cobblestone."
+      "[ka:nkri:t] adj.；adj.；n. 确实的,具体的"
     ]
   },
   {
     "name": "concur",
     "trans": [
-      "Day 6 | v. | English: to agree | Example: Historians have concurred with each other in this view."
+      "[kan'k3:] v. 赞同"
     ]
   },
   {
     "name": "concurrent",
     "trans": [
-      "Day 6 | adj. | English: existing or happening at the same time | Example: Archaeological evidence of significant increases in clam size and abundance in that area concurrent with the documented past implementation of the method described in the songs supports the conclusion."
+      "[kank3:rant] adj. 同时发生的"
     ]
   },
   {
     "name": "condemn",
     "trans": [
-      "Day 6 | v. | English: to force sb to accept a difficult or unpleasant situation | Example: Now | suddenly find myself plunged into this wilderness [the estate], condemned to see the same stupid people from morning till night and listen to their futile conversations."
+      "[kan'dem] v. 或不愉快的状况"
     ]
   },
   {
     "name": "conduct",
     "trans": [
-      "Day 6 | n. | English: a person's behaviour in a particular place or in a particular situation | Example: It stresses the discrepancy between Mr. Ely's public and private conduct and then alludes to his motivation for hiding his true personality."
+      "[kan'dakt;'ka:ndakt] n. 行为"
     ]
   },
   {
     "name": "confer",
     "trans": [
-      "Day 6 | v. | English: to officially give someone a title etc. | Example: Aany advantages that the transmission strategy used by three-host CLPs may have conferred did not completely offset the negative effects of other temperature driven factors on CLP abundance."
+      "[kan'f3:] v. 赋予"
     ]
   },
   {
     "name": "confess",
     "trans": [
-      "Day 6 | v. | English: to admit sth that you feel ashamed or embarrassed about | Example: And having cleared the ramparts | had to confess the sky was clearing, prior to its winding in the other shroud, night."
+      "[kan'fes] v. 坦白"
     ]
   },
   {
     "name": "confidence level",
     "trans": [
-      "Day 6 | n. | English: ameasure of the reliability of a result. A confidence level of 95 per cent or 0.95 means that there is a probability of at least 95 per cent that the result is reliable | Example: Detailed statistical analysis helped preclude claims of the event's ambiguity, confirming the signal at a confidence level of over 99%."
+      "n. 结果可信度的一种量度,置信级为"
     ]
   },
   {
     "name": "configure",
     "trans": [
-      "Day 6 | v. | English: to arrange sth in a particular way, especially computer equipment; to make equipment or software work in the way that the user prefers | Example: he researchers have concluded that these settlements were culturally linked to Izapa because each of the settlements is the same age and configured in the same manner as Izapa, with a pyramid to the north and a plaza to the south."
+      "v. 设置"
     ]
   },
   {
     "name": "confine",
     "trans": [
-      "Day 6 | v. | English: to keep sb/sth inside the limits of a particular activity, subject, area, etc. | Example: Several advantages—the ability to react strongly with chip components, to avoid interference from other waves, and to be confined within tiny circuits—have positioned acoustic waves as a promising alternative to electrical waves for transmitting data on computer chips."
+      "[kan'fam] v. 限制"
     ]
   },
   {
     "name": "confined",
     "trans": [
-      "Day 6 | adj. | English: small and surrounded by walls or sides | Example: The waters of the Seine are more confined and rough in Paris than they are in the countryside."
+      "adj. 狭窄而围起来的"
     ]
   },
   {
     "name": "conflagration",
     "trans": [
-      "Day 7 | n. | English: a very large fire that destroys a lot of land or buildings | Example: You are cultured and intelligent, [Vanya], and you surely understand that the world is not destroyed by villains and conflagrations, but by hate and malice and all this spiteful tattling."
+      "[.ka:nfla'grerln] n. 大火灾"
     ]
   },
   {
     "name": "conflate",
     "trans": [
-      "Day 7 | v. | English: to put two or more things together to make one new thing | Example: Her letters conflate past and present."
+      "[kan'tlert] v. 合并"
     ]
   },
   {
     "name": "conform to",
     "trans": [
-      "Day 7 | v. | English: to agree with or match sth | Example: The reasons for this characterization may seem irrefutable, but linking Unamuno with the Generation of '98 risks disregarding the subtleties in his style that do not neatly conform to the conventions of this literary movement."
+      "v. 遵守,遵从,服从"
     ]
   },
   {
     "name": "confound",
     "trans": [
-      "Day 7 | v. | English: to confuse and surprise sb | Example: [1] While there are several possible reasons for this, one is that practitioners may overlook confounding variables that account for the results they attribute to the interventions in question. 2] Posed in 1970, McMullen's g-conjecture many mathematicians before yielding to the efforts of Karim Adiprasito, who presented a proof of it in 2018."
+      "[kan'faond] v. 使困惑惊讶"
     ]
   },
   {
     "name": "congestion",
     "trans": [
-      "Day 7 | n. | English: the state of being crowded and full of traffic | Example: Building additional road capacity may seem like an obvious solution to traffic congestion, but numerous studies have cast doubt on the efficacy of that approach."
+      "[kon'd3est[on] n. 塞车"
     ]
   },
   {
     "name": "conjecture",
     "trans": [
-      "Day 7 | n. | English: an opinion or idea that is not based on definite knowledge and is formed by guessing | Example: Before the Mariner 2 mission completed a successful flyby of Venus in 1962, astronomers’ ideas about the planet were little more than conjectures."
+      "[kon'd3ektjar] n. 猜测"
     ]
   },
   {
     "name": "consecutive",
     "trans": [
-      "Day 7 | adj. | English: following one after another in a series, without interruption | Example: The time between consecutive pulses of an RRAT is referred to as a period."
+      "[kan'sekjotwv] adj. 连续不断的"
     ]
   },
   {
     "name": "consensus",
     "trans": [
-      "Day 7 | n. | English: an opinion that all members of a group agree with | Example: Given how little consensus there is among scientists regarding the scope of these categories, this discrepancy shouldn't be surprising: forest researchers regularly dispute one another's classifications."
+      "[kan'sensas] n. 一致的意见"
     ]
   },
   {
     "name": "consequential",
     "trans": [
-      "Day 7 | adj. | English: important; that will have important results | Example: Whether the reign of a French monarch such as Louis VII or Henry V was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy and therefore cannot be understood without a corollary understanding of the characteristics without which the monarch would have been forced to abandon the throne."
+      "[ka:nsI'kwenj(a)l] adj.；V. 重要的"
     ]
   },
   {
     "name": "conservationist",
     "trans": [
-      "Day 7 | n. | English: a person who takes an active part in the protection of the environment | Example: In the 1990s, conservationists began planting more than 500,000 native trees in the habitat of the Azores bullfinch to boost the bird's numbers."
+      "[.ka:nsar'verfanist] n. 自然环境保护主义者"
     ]
   },
   {
     "name": "considerable",
     "trans": [
-      "Day 7 | adj. | English: great in amount, size, importance, etc. | Example: Although Hawaiian literature is highly heterogeneous in many ways, it is also characterized by considerable thematic continuity."
+      "[kan'sIdarabl] adj. 相当多（或大"
     ]
   },
   {
     "name": "console",
     "trans": [
-      "Day 7 | n. | English: a flat surface which contains all the controls and switches for a machine, a piece of electronic equipment, etc. | Example: Portable video game consoles and fitness trackers tend to contain batteries that can't be easily replaced."
+      "['ka:nsool;kan'soul] n. 控制台,操纵台"
     ]
   },
   {
     "name": "conspicuous",
     "trans": [
-      "Day 7 | adj. | English: easy to see or notice | Example: Political blogs with conspicuous ideological alignments became an integral component of US"
+      "[kan'spikjuas] adj. 朋显的"
     ]
   },
   {
     "name": "constellation",
     "trans": [
-      "Day 7 | n. | English: n.a group of related ideas; n. a group of stars that forms a shape in the sky and has a name [1] President Richard Nixon is most famous for his participation in the 1970s Watergate political scandal, a convoluted tale of criminality and eroded ethics involving a constellation of associates such as security operative Jack Caulfield and Attorney General John Mitchell. | Example: 2] Quasars—such as APM 08279+5255, located in the Lynx constellation—are extremely luminous galactic nuclei powered by supermassive black holes."
+      "[ka:nsta'lerhn] n.；n.；n. 群相关的人"
     ]
   },
   {
     "name": "consternation",
     "trans": [
-      "Day 7 | n. | English: aworried, sad feeling after you have received an unpleasant surprise | Example: When she entered [the restaurant] her appearance created no surprise, no consternation, as she had half feared it might."
+      "[ka:nstar'nerln] n. 惊恐"
     ]
   },
   {
     "name": "constitute",
     "trans": [
-      "Day 7 | v. | English: to be considered to be sth | Example: It notes why the two architectural projects described in the text constitute major departures from Barragan's typical style."
+      "['ka:nstrtu:t] v. （被认为或看做）"
     ]
   },
   {
     "name": "constrain",
     "trans": [
-      "Day 7 | v. | English: to restrict or limit sb/sth | Example: Although income of course constrained fuel choice, several factors, including the type of dwelling a household occupies, influenced decisions."
+      "[kan'stremn] v. 约束"
     ]
   },
   {
     "name": "constrained",
     "trans": [
-      "Day 7 | adj. | English: not natural; forced or too controlled But the quality of a more constrained investigation, such as a transportation study seeking only to yield the average number of people per day who use a city's public transportation system, is much less dependent on high levels of funding because such studies are not trying to identify trends over time."
+      "adj. 过于受约束的"
     ]
   },
   {
     "name": "constraint",
     "trans": [
-      "Day 7 | n. | English: a thing that limits or restricts sth, or your freedom to do sth | Example: The work is manifestly a commentary on constraint, but many critics focus on Valdez and the social constraints women faced at the time, which is understandable but Leaves the presence of Valdez's male collaborator Sandoval unexplained."
+      "[kan'streInt] n. 约束"
     ]
   },
   {
     "name": "constrict",
     "trans": [
-      "Day 7 | v. | English: to limit or restrict what sb is able to do Film-makers of the time were constricted by the censors."
+      "[kan'strikt] v. 限制"
     ]
   },
   {
     "name": "consult",
     "trans": [
-      "Day 7 | v. | English: to go to sb for information or advice | Example: One no longer widely read edition is the 1984 \"critical and synoptic edition\" edited by Hans Walter Gabler, which followed French and German editorial theories rather than editorial traditions of the United States and United Kingdom and which was later found to have introduced errors due to Gabler's choice to consult facsimile manuscripts rather than using only originals."
+      "[kan'sAlt] v. 咨询,请教"
     ]
   },
   {
     "name": "contemplate",
     "trans": [
-      "Day 7 | v. | English: to think about whether you should do sth, or how you should do sth | Example: Architects dedicated to this approach carefully contemplate every aspect of their projects from location characteristics and initial materials selection to ultimate interior design choices and building installation."
+      "['ka:ntamplert] v. 考虑,思量"
     ]
   },
   {
     "name": "contemporaneous",
     "trans": [
-      "Day 7 | adj. | English: happening or existing at the same time | Example: Mantle-derived rocks younger than 3.2 billion years contain some material that is not found in older mantle-derived rocks but is found in older and contemporaneous lithospheric rocks."
+      "adj. 同时期的"
     ]
   },
   {
     "name": "contemporary",
     "trans": [
-      "Day 7 | n. | English: a person who lives or lived at the same time as sb else, especially sb who is about the same ag | Example: It explains why the architectural project discussed later in the sentence was highly regarded by Barragan's contemporaries."
+      "[kan'tempareri] n. 同代人"
     ]
   },
   {
     "name": "contempt",
     "trans": [
-      "Day 7 | n. | English: the feeling that sb/sth is without value and deserves no respect at all | Example: Reading [poetry], however, with a perfect contempt for it, one discovers that there is in / it after all, a place for the genuine."
+      "[kan'tempt] n. 轻蔑"
     ]
   },
   {
     "name": "contemptuous",
     "trans": [
-      "Day 7 | adj. | English: feeling or showing that you have no respect for sb/sth | Example: Each is contemptuous of the other attendees but strives to impress them."
+      "[kan'temptfiias] adj. 蔑视的"
     ]
   },
   {
     "name": "contend",
     "trans": [
-      "Day 7 | v. | English: to say that sth is true, especially in an argument | Example: Ghisbain therefore contends that because the responses of bumblebees and other wild bees to environmental threats are not always comparable, researchers need to exercise caution when extrapolating information about wild-bee population declines from bumblebees."
+      "[kan'tend] v. （尤指在争论中）声称"
     ]
   },
   {
     "name": "contender",
     "trans": [
-      "Day 7 | n. | English: a person who takes part in a competition or tries to win sth | Example: A student claims that opening weekend earnings can reliably predict whether a film will be nominated for an Oscar: films that draw large audiences at the beginning of their release are the most likely contenders to earn these coveted award nominations."
+      "n. 竞争者"
     ]
   },
   {
     "name": "content",
     "trans": [
-      "Day 7 | adj. | English: adj. willing to do sth n. the amount of a substance that is contained in sth else | Example: [1] Though there was already talk...of a new Opera House which should compete in costliness and splendour with those of the great European capitals, the world of fashion was still content to reassemble every winter in the shabby red and gold boxes of the sociable old"
+      "['ka:ntcnt;kan'tent] adj.；adj.；n. 愿意的"
     ]
   },
   {
     "name": "contentious",
     "trans": [
-      "Day 7 | adj. | English: likely to cause disagreement between people | Example: Sanctions are expected to be among the most contentious issues."
+      "[kan'tenjas] adj. 可能引起争论的"
     ]
   },
   {
     "name": "contestant",
     "trans": [
-      "Day 7 | n. | English: a person who takes part in a contes | Example: There are persons who go to the theater like the contestants in a mule-race: the last one in, wins, and we know very sensible men who would ascend the scaffold rather than enter a theater before the first act."
+      "[kan'testant] n. 比赛者"
     ]
   },
   {
     "name": "contextualize",
     "trans": [
-      "Day 7 | v. | English: to consider sth in relation to the situation in which it happens or exists | Example: It introduces a trait shared by certain animals in order to contextualize a hypothesis about the origin of that trait that is advanced later in the text."
+      "[kan'tekstfialarz] v. 置于上下文中理解"
     ]
   },
   {
     "name": "continent",
     "trans": [
-      "Day 7 | n. | English: one of the large land masses of the earth such as Europe, Asia or Africa | Example: Some paleontologists thought that a sudden shift toward an arid climate on the Australian continent may have brought about the rapid extinction of several species of large kangaroos around 200,000 years ago."
+      "['ka:ntinant] n. 大陆"
     ]
   },
   {
     "name": "contingent",
     "trans": [
-      "Day 7 | adj. | English: depending on sth that may or may not happen | Example: What a photograph conveys is therefore largely contingent on how it is balanced."
+      "[kan'tndzant] adj. 依情况而定的"
     ]
   },
   {
     "name": "contract",
     "trans": [
-      "Day 7 | v. | English: v. to get an illness; to become less or smaller; v. to become less or smaller; to make sth become less or smaller n. an official written agreement | Example: Itisn't to the fair | came myself, but up to the Five Acre Meadow I'm going, where | have a contract for the hay. We'll get a share of it into tramps [drying stacks] to-day."
+      "['ka:ntrakt] v.；v.；v.；n. 感染"
     ]
   },
   {
     "name": "controversial",
     "trans": [
-      "Day 7 | adj. | English: causing a lot of angry public discussion and disagreement | Example: The experimental group spent a few minutes writing about one of their personal values before they had a group discussion on a controversial topic."
+      "[.ka:ntra'v3:] adj. 有争议的"
     ]
   },
   {
     "name": "controversy",
     "trans": [
-      "Day 7 | n. | English: public discussion and argument about sth that many people strongly disagree about, disapprove of, or are shocked by | Example: It describes an intensely debated scientific controversy that Victor dedicated his life to resolving."
+      "['ka:ntrav3:rsi] n. 争论"
     ]
   },
   {
     "name": "convene",
     "trans": [
-      "Day 7 | v. | English: to arrange for people to come together for a formal meeting | Example: A Board of Inquiry was convened immediately after the accident."
+      "[kan'vi:\"] v. （正式会议）"
     ]
   },
   {
     "name": "convention",
     "trans": [
-      "Day 7 | n. | English: the way in which sth is done that most people in a society expect and consider to be polite or the right way to do it | Example: The reasons for this characterization may seem irrefutable, but linking Unamuno with the Generation of '98 risks disregarding the subtleties in his style that do not neatly conform to the conventions of this literary movement."
+      "[kan'venjn] n. 习俗"
     ]
   },
   {
     "name": "converge",
     "trans": [
-      "Day 7 | v. | English: to move towards a place from different directions and meet | Example: Thousands of supporters converged on London for the rally."
+      "[kan'v3:1d3] v. 汇聚,集中"
     ]
   },
   {
     "name": "convergence",
     "trans": [
-      "Day 7 | n. | English: the process or state of converging | Example: These early quasars developed partly as a result of rare convergences of gases in space."
+      "[kan'v3:rd3ans] n. 汇聚"
     ]
   },
   {
     "name": "convergent",
     "trans": [
-      "Day 7 | adj. | English: to come from different directions and meet at the same point to become one thing | Example: Meredith E. Protas and colleagues have explored how convergent evolution—a phenomenon that occurs when the same trait evolves independently in two reproductively separate lineages—can result from a genetic mechanism shared by both lineages."
+      "[kan'v3:rd3ont] adj. 会聚性的"
     ]
   },
   {
     "name": "conversely",
     "trans": [
-      "Day 7 | adv. | English: ina way that is the opposite or reverse of sth | Example: Conversely, Mulvey proposes that conspicuous editing or an absence of point-of-view shots would induce a more critical stance toward a protagonist."
+      "['ka:nv3:rsli] adv. 反地"
     ]
   },
   {
     "name": "convert",
     "trans": [
-      "Day 7 | v. | English: to change or make sth change from one form, purpose, system, etc. to another | Example: Automated genre classification systems typically struggle to draw distinctions in situations like this, but Yandre Cossa and colleagues solved that problem by converting sound to images and having computers compare features of those images, an approach that demonstrates how much innovation is possible in this field."
+      "[kan'v3:H] v. 转娈"
     ]
   },
   {
     "name": "convey",
     "trans": [
-      "Day 7 | v. | English: to make ideas, feelings, etc. known to sb The Great Wave off Kanagawa's deeper thematic meaning is conveyed to viewers through visual allegory."
+      "[kan'ver] v. 表达"
     ]
   },
   {
     "name": "convoluted",
     "trans": [
-      "Day 7 | adj. | English: extremely complicated and difficult to follow | Example: President Richard Nixon is most famous for his participation in the 1970s Watergate political scandal, a convoluted tale of criminality and eroded ethics involving a constellation of associates such as security operative Jack Caulfield and Attorney General John Mitchell."
+      "['ka:nvalu:td] adj. 错综复杂的"
     ]
   },
   {
     "name": "coordinate",
     "trans": [
-      "Day 7 | v. | English: to organize the different parts of an activity and the people involved in it so that it works well | Example: Maryland should coordinate with other states to protect their native species from invasive species."
+      "[kou'3:rdmnert] v. 使协调"
     ]
   },
   {
     "name": "coordination",
     "trans": [
-      "Day 7 | n. | English: the act of making parts of sth, groups of people, etc. work together in an efficient and organized way | Example: Urban planning expert Francisco Lara-Valencia and colleagues have argued that managing environmental matters along the US-Mexico border requires coordination between the two countries' governments."
+      "[koU.3:rdr'nerhn] n. 协作"
     ]
   },
   {
     "name": "copious",
     "trans": [
-      "Day 7 | adj. | English: in large amounts | Example: New and interesting research conducted by Suleiman A. Al-Sweedan and Moath Alhai is inspired by their observation that though there have been copious studies of the effect of high altitude on blood chemistry, there is a paucity of studies of the effect on blood chemistry of living in locations below sea level, such as the California towns of Salton City and Seeley."
+      "['koopias] adj. 大量的"
     ]
   },
   {
     "name": "corner",
     "trans": [
-      "Day 7 | v. | English: to get a person or an animal into a place or situation from which they cannot escape | Example: Louis Pipestone tended the petition like a garden. He kept it with him at all times. In town, his eyes sharpened when he noticed a tribal member who hadn't yet signed. Wherever they were—at the gas pump, mercantile [general store], at Henry's [Café], on the road, or outside the clinic and hospital—Louis cornered them."
+      "[ko:mnar] v. （人或动物"
     ]
   },
   {
     "name": "corollary",
     "trans": [
-      "Day 8 | n. | English: a situation, an argument or a fact that is the natural and direct result of another one | Example: Whether the reign of a French monarch such as Louis VII or Henry V was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy and therefore cannot be understood without a corollary understanding of the characteristics without which the monarch would have been forced to abandon the throne."
+      "['k:raleri] n.；V. 必然的结果"
     ]
   },
   {
     "name": "corpora",
     "trans": [
-      "Day 8 | n. | English: a collection of written or spoken texts | Example: Text corpora such as the British National Corpus are enormous collections of electronically stored texts that can be used for empirical testing of hypotheses regarding the frequency of typical word usage."
+      "n. （书面或口语的）"
     ]
   },
   {
     "name": "corpus",
     "trans": [
-      "Day 8 | English: a collection of written or spoken texts | Example: If one has a supposition that the word “own” has a high incidence in English, for example, an analysis of a corpus can support that hypothesis by showing that “own” is the eighth most commonly used adjective."
+      "['k3:rp3s] 语料库"
     ]
   },
   {
     "name": "correlate",
     "trans": [
-      "Day 8 | v. | English: if two or more facts, figures, etc. correlate or if a fact, figure, etc. correlates with another, the facts are closely connected and affect or depend on each other | Example: Economists have assumed that companies cluster for the same reasons, but Giulia Faggio et al. found that factors driving agglomeration in some cases are only weakly correlated with agglomeration in others."
+      "['k:ralert] v. 相互关联影响"
     ]
   },
   {
     "name": "correspondence",
     "trans": [
-      "Day 8 | n. | English: a connection between two things; the fact of two things being similar | Example: For too long, scholars have focused on experimental versus conventional poetic forms, inhibiting inquiry into other points of stylistic correspondence among poems that would enrich our understanding of the modernist canon."
+      "[k3:ra'spa:ndans] n. 相关"
     ]
   },
   {
     "name": "corroborate",
     "trans": [
-      "Day 8 | v. | English: to provide evidence or information that supports a statement, theory, etc. | Example: The results of randomized clinical trials testing the efficacy of common medical interventions sometimes fail to corroborate conclusions that practitioners reach based on their real-world observations of patients."
+      "[ka'ra:barcrt] v. 证实"
     ]
   },
   {
     "name": "countenance",
     "trans": [
-      "Day 8 | n. | English: a person's face or their expression | Example: After some trouble [Jim’s father] found the subject of the incident, the broken flower. Turning then, he saw the child lurking at the rear and scanning his countenance."
+      "['kayntanans] n. 面容"
     ]
   },
   {
     "name": "counter",
     "trans": [
-      "Day 8 | v. | English: to reply to sb by trying to prove that what they said is not true | Example: While some commentators lauded this development, asserting that such blogs had a welcome transparency missing from traditional news, less sanguine observers countered that such blogs tended to ideological extremes that exacerbated political polarization to problematic levels."
+      "['kaontar] v. 反驳"
     ]
   },
   {
     "name": "counteract",
     "trans": [
-      "Day 8 | v. | English: to do sth to reduce or prevent the bad or harmful effects of sth | Example: The emphasis on accurately representing the experiences of average working people that is characteristic of the realist style can be seen in The Gleaners, painted by Jean-Francois Millet, which depicts peasants picking stray wheat from a field after the harvest. This style can thus be seen as an effort to counteract what were regarded as the excesses of the romantic style evident in many paintings by Horace Vernet, which instead exaggerated their subjects’ beauty or heroism while hiding all imperfection."
+      "[kaontar'8kt] v. 抵消"
     ]
   },
   {
     "name": "counterbalance",
     "trans": [
-      "Day 8 | v. | English: to have an equal but opposite effect to sth else | Example: Parents’ natural desire to protect their children should be counterbalanced by the child's need for independence."
+      "[kaontarbalans] v. 抵消"
     ]
   },
   {
     "name": "counterfactual",
     "trans": [
-      "Day 8 | adj. | English: relating to or expressing what has not happened or is not the case | Example: The work of Tobias Gerstenberg et al. on tracking eye movements supports a theory that people engage in counterfactual thinking when making causal judgments."
+      "adj. 与事实相反的"
     ]
   },
   {
     "name": "counterintuitive",
     "trans": [
-      "Day 8 | adj. | English: seemingly contrary to common sense | Example: In the 2010s, the price of vintage Teenage Mutant Ninja Turtles action figures rose dramatically, which had the counterintuitive effect of engendering demand."
+      "[kayntarIn'tu:ItVV] adj. 违反直觉的"
     ]
   },
   {
     "name": "counterpart",
     "trans": [
-      "Day 8 | n. | English: a person or thing that has the same position or function as sb/sth else in a different place or situation | Example: The real-world counterparts of other characters in This Side of Paradise are hard to identify."
+      "['kaontarpa:rt] n. 职位（或作用）相当的人"
     ]
   },
   {
     "name": "counterproductive",
     "trans": [
-      "Day 8 | adj. | English: having the opposite effect to the one which was intended | Example: In practice, however, such an attitude is counterproductive."
+      "[kaontarpra'dxktrv] adj. 产生相反效果的"
     ]
   },
   {
     "name": "course",
     "trans": [
-      "Day 8 | n. | English: the direction a river moves in | Example: The bald cypresses spread themselves along the water courses while the willows wept as they always did."
+      "[k3:rs] n. 江河流向"
     ]
   },
   {
     "name": "courser",
     "trans": [
-      "Day 8 | n. | English: a swift horse; steed | Example: There is no Frigate like a Book / To take us Lands away / Nor any Coursers like a Page / Of prancing Poetry—/ This Traverse may the poorest take / Without oppress of Toll— / How frugal is the Chariot / That bears the Human soul."
+      "n. 快马"
     ]
   },
   {
     "name": "coveted",
     "trans": [
-      "Day 8 | adj. | English: You use coveted to describe something that very many people would like to have. | Example: A student claims that opening weekend earnings can reliably predict whether a film will be nominated for an Oscar: films that draw large audiences at the beginning of their release are the most likely contenders to earn these coveted award nominations."
+      "['kvatid] adj. 令人垂涎的"
     ]
   },
   {
     "name": "craft",
     "trans": [
-      "Day 8 | v. | English: to make sth using special skills, especially with your hands | Example: Ina variety of ways, Samuel Kamakau, Kristiana Kahakauwila, and other acclaimed writers have drawn on these stories to craft a rich portrait of the Hawaiian Islands and their people."
+      "[kratt] v. （尤指用手工）"
     ]
   },
   {
     "name": "crane",
     "trans": [
-      "Day 8 | v. | English: to lean or stretch over sth in order to see sth better; to stretch your neck | Example: The little conductor stood on tiptoe in an effort to keep one hand on the signal rope, craning his neck in a vain and dissatisfied endeavor to pierce the miasma of the fog."
+      "[krem] v. （为看得更清楚而"
     ]
   },
   {
     "name": "crater",
     "trans": [
-      "Day 8 | n. | English: a large hole in the ground caused by the explosion of a bomb or by sth large hitting it | Example: Others disagree, partly because there is no known crater from such an impact that dates to the beginning of the period."
+      "['krertar] n. （由炸弹爆炸或巨物撞击形成的）"
     ]
   },
   {
     "name": "credential",
     "trans": [
-      "Day 8 | v. | English: to provide sb with credentials | Example: Conventional theories of rhetoric hold that presenting information as coming from credentialed experts increases that information's credibility."
+      "[kra'denj] v. 提供证明书"
     ]
   },
   {
     "name": "credibility",
     "trans": [
-      "Day 8 | n. | English: the quality that sb/sth has that makes people believe or trust them | Example: Conventional theories of rhetoric hold that presenting information as coming from credentialed experts increases that information’s credibility."
+      "[kreda'biloti] n. 可信性"
     ]
   },
   {
     "name": "credible",
     "trans": [
-      "Day 8 | adj. | English: that can be believed or trusted | Example: It presents a scientific observation, describes a contrast between that observation and other observations, and then explains why those other observations should not be considered credible."
+      "['kredabl] adj. 可信的"
     ]
   },
   {
     "name": "credit",
     "trans": [
-      "Day 8 | n. | English: n. praise or approval because you are responsible for sth good that has happened; v. to believe that sb/sth is of a particular type or quality | Example: [1] Many people worked together to help Buenaventura be recognized by UNESCO, but chefs deserve the most credit for Buenaventura’s selection as a City of Gastronomy. 2] The 2000 production of The Green Bird was the first Broadway show for which Constance Hoffman was credited as a costume designer."
+      "['kredrt] n.；n.；v. 某种类或性质-"
     ]
   },
   {
     "name": "creep",
     "trans": [
-      "Day 8 | v. | English: to move or develop very slowly | Example: Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow's o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+      "[kri:p] v. 非常缓慢地行进"
     ]
   },
   {
     "name": "creep into",
     "trans": [
-      "Day 8 | English: to begin to happen or affect sth | Example: Politicians routinely claim that journalists are biased but while it's true that some journalists allow their own views to creep into their reporting more than others do, most journalists make a good faith effort to be neutral in their reporting."
+      "开始发生"
     ]
   },
   {
     "name": "crew",
     "trans": [
-      "Day 8 | n. | English: all the people working on a ship, plane etc. except the officers who are in charge | Example: All ships with at least 98 cannons had a crew of at least 850 people."
+      "[ku:] n. 全体船员"
     ]
   },
   {
     "name": "criteria",
     "trans": [
-      "Day 8 | n. | English: a standard or principle by which sth is judged, or with the help of which a decision is made | Example: This new measure establishes global criteria used to define three types of settlements (cities, towns, and rural areas) and allows researchers to better understand global urbanization rates."
+      "[krar'tirra] n. 标准"
     ]
   },
   {
     "name": "critique",
     "trans": [
-      "Day 8 | n. | English: n.a piece of written criticism of a set of ideas, a work of art, etc.; v. to write or give your opinion of, or reaction to, a set of ideas, a work of art, etc. | Example: [1] Smith's metaphor of the invisible hand has been interpreted as a model of how individuals acting in their own interest produce aggregate benefits, but it was intended as a subtle critique of the economic theory of mercantilism. 2] Asimov is critiqued for his style, but it is wrong to fault a writer for failing to do what he never intended to do."
+      "[krr'ti:k] n.；n.；v. 评论"
     ]
   },
   {
     "name": "crucible",
     "trans": [
-      "Day 8 | n. | English: a place or situation in which people or ideas are tested severely, often creating sth new or exciting in the process | Example: She went through the crucible of unprecedented adversities and trials of life and came out one of the rare shining lights that beautify the New England sky."
+      "['kru:sIbl] n. 严峻的考验,磨练"
     ]
   },
   {
     "name": "crude",
     "trans": [
-      "Day 8 | adj. | English: in its natural state, before it has been treated with chemicals | Example: The [train] engines of this valley have a whistle, the echoes of which sound like iterated gasps and sobs. | always think of them as crude music."
+      "[kru:d] adj. 天然的"
     ]
   },
   {
     "name": "crust",
     "trans": [
-      "Day 8 | n. | English: a hard layer or surface, especially above or around sth soft or liquid | Example: As the process continues, water from the food's center moves to the crust as long as the crust remains permeable."
+      "[krAst] n. （尤指软物或液体上面"
     ]
   },
   {
     "name": "cryptology",
     "trans": [
-      "Day 8 | n. | English: the science or study of analysing and deciphering codes, ciphers, etc; cryptanalysis | Example: Women like Juanita Moody made important early contributions to the history of US cryptology, a field concerned with secure data communication and storage."
+      "n. 密码学"
     ]
   },
   {
     "name": "culprit",
     "trans": [
-      "Day 8 | n. | English: a person who has done sth wrong or against the law | Example: Every morning, after buying his penny paper at the corner of the Faubourg Saint Honore, he bought two rolls, and then went to his office, like a culprit who is giving himself up to justice."
+      "['Klprt] n. 犯错的人"
     ]
   },
   {
     "name": "cultivate",
     "trans": [
-      "Day 8 | v. | English: to grow plants or crops For thousands of years, O'odham farmers in the Sonoran desert of the southwestern US and northern Mexico have cultivated elderberries and chia seeds"
+      "['kltrvert] v. 种植"
     ]
   },
   {
     "name": "cultivated",
     "trans": [
-      "Day 8 | adj. | English: adj. used to grow crops; adj. having a high level of education and showing good manners [1] As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot. | Example: 2] The great men of culture are those who have had a passion for diffusing, for making prevail, for carrying from one end of society to the other, the best knowledge, the best ideas of their time; who have labored to divest knowledge of all that was harsh, uncouth, difficult, abstract, professional, exclusive; to humanise it, to make it efficient outside the clique of the cultivated and learned, yet still remaining the best knowledge and thought of the time, and a true source, therefore, of sweetness and light."
+      "['kaltrvertid] adj. 用于耕作的"
     ]
   },
   {
     "name": "curator",
     "trans": [
-      "Day 8 | n. | English: a person whose job is to be in charge of the objects or works of art in a museum or art gallery | Example: To encourage that sense of connection, the museum's curators recommend nearby hiking trails and outdoor activities."
+      "['kjurertar] n. （博物馆或美术馆等的）馆长"
     ]
   },
   {
     "name": "currency",
     "trans": [
-      "Day 8 | n. | English: the system of money that a country uses | Example: Because coins with a silver content below 80% were widely considered unsuitable for trade, Elayi et al. speculate that a crisis in confidence in the currency occurred in Sidon around 367 BCE."
+      "['k3:ransi] n. 货币"
     ]
   },
   {
     "name": "current",
     "trans": [
-      "Day 8 | n. | English: the movement of water in the sea or a river; the movement of air in a particular direction | Example: Ocean currents can be powerful and rough, making it difficult for animals to find safe places to hide from predators. The underwater forests slow down the currents."
+      "['k3:rant] n. （海洋或江河的"
     ]
   },
   {
     "name": "curtain",
     "trans": [
-      "Day 8 | n. | English: a thing that covers, hides or protects sth | Example: She has a thick curtain of long, curly hair that practically engulfs her."
+      "['k3:rtn] n. 遮盖物"
     ]
   },
   {
     "name": "customary",
     "trans": [
-      "Day 8 | adj. | English: if sth is customary , it is what people usually do in a particular place or situation Intergenerational Bulgarian female choir group Bistritsa Babi has been working to save customary songs and dances from the Shopluk region of the country since 1939."
+      "['kstameri] adj. 习俗的"
     ]
   },
   {
     "name": "cutlery",
     "trans": [
-      "Day 8 | n. | English: knives, forks and spoons, used for eating and serving food | Example: Guojun He and colleagues studied a food-delivery phone app that is popular in China. The researchers found that having \"no cutlery\" automatically selected influences whether customers request disposable plastic utensils with their food orders."
+      "['ktlari] n. 餐具"
     ]
   },
   {
     "name": "cynical",
     "trans": [
-      "Day 8 | adj. | English: believing that people only do things to help themselves rather than for good or honest reasons | Example: She wanted him to stop being so cool, so detached, so cynical."
+      "['sInikl] adj. 认为人皆自私的"
     ]
   },
   {
     "name": "daring",
     "trans": [
-      "Day 8 | adj. | English: willing to do dangerous or unusual things; involving danger or taking risks | Example: He was daring, without being rash: prompt, but not thoughtless; firm, without being harsh."
+      "['ders] adj. 敢于冒险的"
     ]
   },
   {
     "name": "dart",
     "trans": [
-      "Day 8 | v. | English: to move suddenly and quickly in a particular direction | Example: The sun, already down, was manifest in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+      "[da:tt] v. 猛冲"
     ]
   },
   {
     "name": "daze",
     "trans": [
-      "Day 8 | adj. | English: unable to think clearly, especially because of a shock or because you have been hit on the head The Mole is dazed after briefly meeting a stranger while traveling with a friend."
+      "[derz] adj. （尤因震惊或头部被击-"
     ]
   },
   {
     "name": "dazzle",
     "trans": [
-      "Day 8 | v. | English: to impress sb a lot with your beauty, skill, etc. | Example: There is often a kind of [deceptive] light, playing around such [famous] names, calculated to dazzle and mislead, by their false lustre, until the eye can no longer receive the pure light of Truth, or the mind appreciate real excellence, or intrinsic worth."
+      "['dazl] v. （技能等）"
     ]
   },
   {
     "name": "debatable",
     "trans": [
-      "Day 8 | adj. | English: not certain because people can have different ideas and opinions about the thing being discussed | Example: Mr. French, the senior partner, who sat opposite Kirby, was an older man—a safe guess would have placed him somewhere in the debatable ground between forty and fifty."
+      "[dr'bertabl] adj. 有争议的"
     ]
   },
   {
     "name": "debris",
     "trans": [
-      "Day 8 | n. | English: Debris is pieces from something that has been destroyed or pieces of rubbish or unwanted material that are spread around | Example: One popular theory of the origin of the Moon, the \"big whack,\" posits that a protoplanet called Theia collided with Earth, flinging debris into orbit that eventually coalesced into the Moon."
+      "[da'bri:] n. 碎片"
     ]
   },
   {
     "name": "decidedly",
     "trans": [
-      "Day 8 | adv. | English: definitely and in an obvious way | Example: Ancient Greek and Roman sculpture is sometimes characterized as idealizing human subjects, but in fact there are many Greco-Roman sculptures that depict people in decidedly unflattering ways."
+      "adv. 确实"
     ]
   },
   {
     "name": "decisive",
     "trans": [
-      "Day 9 | adj. | English: able to decide sth quickly and with confidence | Example: Individuals tend to be more decisive if the information flow between the regions is intensified, whereas they make choices more slowly when information flow is reduced."
+      "[dr'saIswv] adj. 坚决的"
     ]
   },
   {
     "name": "dedication",
     "trans": [
-      "Day 9 | n. | English: the hard work and effort that sb puts into an activity or purpose because they think it is important | Example: It emphasizes a character's dedication to her career."
+      "[.dedr'kel] n. 奉献"
     ]
   },
   {
     "name": "default",
     "trans": [
-      "Day 9 | v. | English: v. to fail to do sth that you legally have to do, especially by not paying a debt; n. failure to do sth that must be done by law, especially paying a deb | Example: [1] Although the government regularly defaulted on debt, it ran an even larger overall surplus than did the government of eighteenth-century Britain, which historians consider a model of fiscal virtue. 2] But Drelichman and Voth's unique contribution is their reconstruction of the earliest extant set of annual fiscal records for any sovereign state, which demonstrate that Philip's defaults were caused by short-term liquidity crises, not long-term unsustainable debts."
+      "[dr'f3:It,'di:f3:1t] v.；v.；n. （尤指不偿还债务）"
     ]
   },
   {
     "name": "deference",
     "trans": [
-      "Day 9 | n. | English: behaviour that shows that you respect sb/sth | Example: The women wore veils in deference to the customs of the country."
+      "['defarans] n. 遵从,听从"
     ]
   },
   {
     "name": "define",
     "trans": [
-      "Day 9 | v. | English: to describe or show sth accurately | Example: The little fern-leaf, bending / Upon the brink, its green reflection greets, / And kisses soft the shadow that it meets / With touch so fine, / The border line / The keenest vision can't define; / So perfect is the blending."
+      "[dr'fam] v. 明确"
     ]
   },
   {
     "name": "defunct",
     "trans": [
-      "Day 9 | adj. | English: If something is defunct, it no longer exists or has stopped functioning or operating. | Example: As discussed by scholar Anna Mladentseva, many artworks produced in the mid-1990s to the early 2000s exclusively for exhibition on the internet, such as Sinae Kim's Genesis (2001), have become inaccessible because viewing them requires the use of defunct software (most notably Adobe Flash, discontinued in 2021)."
+      "[dr'fkt] adj. 不再使用的"
     ]
   },
   {
     "name": "defy",
     "trans": [
-      "Day 9 | v. | English: to refuse to obey or show respect for sb in authority, a law, a rule, etc. | Example: Reading is a way of defying the modern world's emphasis on money."
+      "[dr'fa] v. 违抗"
     ]
   },
   {
     "name": "deliberate",
     "trans": [
-      "Day 9 | adj. | English: done on purpose rather than by accident | Example: A city that UNESCO officially names as a City of Gastronomy should still make deliberate efforts to attract visitors to promote its tourism."
+      "[dr'libarat] adj. 故意的"
     ]
   },
   {
     "name": "deliberately",
     "trans": [
-      "Day 9 | adv. | English: done in a way that was planned, not by chance | Example: Barring major archaeological discoveries, we are unlikely to ever have an exhaustive account of ancient Egypt under the female pharaoh Hatshepsut, as much of the evidence of her reign was deliberately destroyed by her successors."
+      "[dr'lbaratli] adv. 故意"
     ]
   },
   {
     "name": "deliberation",
     "trans": [
-      "Day 9 | n. | English: the process of carefully considering or discussing sth | Example: In the story, Mrs. Sommers is depicted as sometimes making decision without conscious deliberation."
+      "[drIiba'rerhn] n. 深思熟虑"
     ]
   },
   {
     "name": "delicate",
     "trans": [
-      "Day 9 | adj. | English: easily damaged or broken | Example: Agleaming carpet was springing up everywhere, that looked too delicate to be trodden upon by rough feet."
+      "['delikat] adj. 脆弱的"
     ]
   },
   {
     "name": "delight",
     "trans": [
-      "Day 9 | v. | English: 0 enjoy doing sth very much, especially sth that makes other people feel embarrassed, uncomfortable, etc. | Example: Each delights in speaking publicly about abstract subjects but detests speaking privately about them."
+      "[dr'lart] v. 为乐"
     ]
   },
   {
     "name": "demarcate",
     "trans": [
-      "Day 9 | v. | English: to mark or establish the limits of sth | Example: The migration's obligate nature is why diadromous fish can be demarcated from those that are merely euryhaline (able to tolerate high salinity)."
+      "v. 的界线"
     ]
   },
   {
     "name": "demeanor",
     "trans": [
-      "Day 9 | n. | English: the way that sb looks or behaves | Example: “The father reflected. After a time he said, ‘Jimmie, come here.’ With an infinite modesty of demeanor the child came forward.”"
+      "[dr'mi:nar] n. 行为"
     ]
   },
   {
     "name": "democracy",
     "trans": [
-      "Day 9 | n. | English: a system of government in which all the people of a country can vote to elect their representatives | Example: Some social scientists say that while a desire for cooperation rather than conflict is key to democracy, public understanding of economics is also central to public comprehension of state politics, and if a citizenry is to function, economic issues cannot remain the domain only of experts."
+      "[drma:krasi] n. 民主制度"
     ]
   },
   {
     "name": "denigrate",
     "trans": [
-      "Day 9 | v. | English: to criticize sb/sth unfairly; to say sb/sth does not have any value or is not important | Example: | didn't intend to denigrate her achievements."
+      "['denigrert] v. 贬低"
     ]
   },
   {
     "name": "denote",
     "trans": [
-      "Day 9 | v. | English: to mean sth | Example: High-entropy alloys (HEAs) have been observed to vary considerably in their resistance to crack propagation, a quality denoted as fracture toughness."
+      "[dr'noot] v. 表示"
     ]
   },
   {
     "name": "denounce",
     "trans": [
-      "Day 9 | v. | English: to strongly criticize sb/sth that you think is wrong, illegal, etc. | Example: She publicly denounced the government's handling of the crisis."
+      "[drnaons] v. 谴责"
     ]
   },
   {
     "name": "depart",
     "trans": [
-      "Day 9 | v. | English: to leave a place, especially to start a trip | Example: Tia Ana had already come into the room several times to see if these guests had departed yet."
+      "[dr'pa:rt] v. 离开"
     ]
   },
   {
     "name": "departure",
     "trans": [
-      "Day 9 | n. | English: an action that is different from what is usual or expected | Example: It notes why the two architectural projects described in the text constitute major departures from Barragan's typical style."
+      "[dr'pa:rtfar] n. 背离"
     ]
   },
   {
     "name": "deplete",
     "trans": [
-      "Day 9 | v. | English: to reduce sth by a large amount so that there is not enough left | Example: When constructing his argument regarding the characteristics of a well-functioning government, Aristotle asserts thar ‘Transgression creeps in unperceived and at last ruins the state,’ illustrating this idea with a comparison to frequent small expenditures slowly and almost imperceptibly chipping away at a fortune until it is ultimately depleted."
+      "[dr'pli:t] v. 大量减少,耗尽"
     ]
   },
   {
     "name": "deploy",
     "trans": [
-      "Day 9 | v. | English: v. to use sth effectively; n. a layer of a substance that has formed naturally underground | Example: Smith deploys this metaphor only once in his economic writings—to make a narrow point about the then-dominant economic theory of mercantilism—and it was largely ignored until some twentieth-century economists eager to secure an intellectual pedigree for their views elevated it to a fully-fledged paradigm."
+      "[dr'ploI] v.；v.；n. （地下自然形成的二"
     ]
   },
   {
     "name": "deposit",
     "trans": [
-      "Day 9 | v. | English: to leave a layer of sth on the surface of sth, especially gradually and over a period of time | Example: [1] As with other river deltas, the Krishna River delta is dynamic: it is a constantly evolving network of channels and strips of land that change in size and shape as the river deposits new sedimentary particles where the river meets the waters of the Bay of Bengal. 2] Deposits of valuable objects, called hoards, have been unearthed in many different parts of Ireland and Northern Ireland."
+      "[drpa:zt] v. 使沉积,使淤积"
     ]
   },
   {
     "name": "deposition",
     "trans": [
-      "Day 9 | n. | English: the natural process of leaving a layer of a substance on rocks or soil; a substance left in this way | Example: The Nile River delta system is located in Northern Egypt, where the river drains into the Mediterranean Sea, and is shaped by interdependent factors: for example, the geography of the coastline influences sedimentary deposition, which over time alters coastal geography."
+      "[depa'zIh] n. 沉积物"
     ]
   },
   {
     "name": "depressing",
     "trans": [
-      "Day 9 | adj. | English: making you feel very sad and without enthusiasm | Example: Perhaps it is a little depressing to inherit not lands but an example of intellectual virtue."
+      "[dr'presn] adj. 令人沮丧的"
     ]
   },
   {
     "name": "depression",
     "trans": [
-      "Day 9 | n. | English: a part of a surface that is lower than the parts around it | Example: Both carbonate dissolution and subsurface salt withdrawal can cause craterlike depressions without the need for a high-velocity impact."
+      "[drprehn] n. 坑"
     ]
   },
   {
     "name": "derive",
     "trans": [
-      "Day 9 | v. | English: to come or develop from sth | Example: Itis hardly an exaggeration to characterize modern Hawaiian literature as having derived from the traditional stories of the Kanaka Maoli, the Native Hawaiian people."
+      "[drrarv] v. 起源于"
     ]
   },
   {
     "name": "descendant",
     "trans": [
-      "Day 9 | n. | English: a person's descendants are their children, their children's children, and all the people who live after them who are related to them | Example: The tarweed's descendants diversifed into distinct species as they adapted to live in the wide variety of habitats found on the Hawaiian Islands."
+      "[dr'sendant] n. 后代"
     ]
   },
   {
     "name": "descent",
     "trans": [
-      "Day 9 | n. | English: a person's family origins | Example: [Katharine's] descent from [a celebrated poet] was no surprise to her."
+      "[dr'scnt] n. 血统"
     ]
   },
   {
     "name": "deserted",
     "trans": [
-      "Day 9 | adj. | English: left by a person or people who do not intend to return | Example: We [people] are creatures of the sun. We love light and life. That is why we crowd into the towns and cities, and the country grows more and more deserted every year."
+      "[dr'z3:rtd] adj. 被遗弃的"
     ]
   },
   {
     "name": "deserving",
     "trans": [
-      "Day 9 | adj. | English: that deserves help, praise, a reward, etc. | Example: Daisy Ashford's novels, which she published as a child, were widely read by contemporaries and are therefore deserving of closer attention."
+      "adj. 值得的,应得的"
     ]
   },
   {
     "name": "desiccation",
     "trans": [
-      "Day 9 | n. | English: the process of becoming completely dry | Example: To characterize the nature of the depositional environment, Frances Rivera-Hernandez et al. analyzed the grain size of Murray Formation sediment, finding that although there are intervals of coarse grains, most of the sediment consists of fine grains that show signs of cracking due to episodic desiccation."
+      "n. 干涸"
     ]
   },
   {
     "name": "designate",
     "trans": [
-      "Day 9 | v. | English: to say officially that sth has a particular character or name | Example: In countries with right-hand traffic, drivers who want to make a left turn at a traffic intersection with stoplights have to wait for either a gap in oncoming traffic or a designated left-turn signal to turn green."
+      "['dezgnert] v. 指定"
     ]
   },
   {
     "name": "designation",
     "trans": [
-      "Day 9 | n. | English: the action of choosing a person or thing for a particular purpose, or of giving them or it a particular status | Example: The country’s designation of the spiraling whitefly as invasive may be appropriate now but not in the future."
+      "[dezg'nerhn] n. 指定"
     ]
   },
   {
     "name": "destitute",
     "trans": [
-      "Day 9 | adj. | English: lacking sth | Example: The knowledge, communicated by the historian and biographer, is analogous to that which we acquire of a country by the map, —minute, perhaps, and accurate, and available for all necessary purposes, but cold and naked, and wholly destitute of the mimic charm produced by landscape painting."
+      "['destrtu:t] adj. 缺乏的"
     ]
   },
   {
     "name": "desultory",
     "trans": [
-      "Day 9 | adj. | English: going from one thing to another, without a definite plan and without enthusiasm | Example: | wandered about in a desultory fashion."
+      "['desalto:ri] adj. 漫无目的的,无条理的,随意的"
     ]
   },
   {
     "name": "detect",
     "trans": [
-      "Day 9 | v. | English: to discover or notice sth, especially sth that is not easy to see, hear, etc | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+      "[dr'tekt] v. 发现"
     ]
   },
   {
     "name": "detection",
     "trans": [
-      "Day 9 | n. | English: the process of detecting sth; the fact of being detected | Example: In 2016, Gabriela Gonzalez and team announced that a chirping sound captured by Laser Interferometer Gravitational-Wave Observatory antennas was direct evidence of gravitational waves, which skeptics had argued would be too faint for detection."
+      "[dr'tekfn] n. 探测"
     ]
   },
   {
     "name": "deterioration",
     "trans": [
-      "Day 9 | n. | English: becoming worse | Example: An image of the Forbidden City thusc onceals the subtle deterioration of the building's materials."
+      "[drtria'rerhn] n. 恶化"
     ]
   },
   {
     "name": "detest",
     "trans": [
-      "Day 9 | v. | English: to hate sb/sth very much | Example: Each delights in speaking publicly about abstract subjects but detests speaking privately about them."
+      "[dr'test] v. 厌恶,讨厌"
     ]
   },
   {
     "name": "detractor",
     "trans": [
-      "Day 9 | n. | English: a person who tries to make sb/sth seem less good or valuable by criticizing it | Example: Although Alfred E. Green's 1950 film The Jackie Robinson Story and Ossie Davis's 1970 film Cotton Comes to Harlem may have had some detractors at the time of their initial release, their place in critics' estimations is now more secure. In 2018, for example, critics for the New York Times described the former as \"irresistible\" and the latter as \"especially pointed.\""
+      "[dr'traktar] n. 诋毁者"
     ]
   },
   {
     "name": "detrimental",
     "trans": [
-      "Day 9 | adj. | English: harmful | Example: Relevant traits or behaviors of the animals were observably different between the exposed group and the otherwise similar but unexposed group, regardless of whether that difference was beneficial or detrimental for the exposed group."
+      "[detrr'mentl] adj. 有害的,不利的"
     ]
   },
   {
     "name": "deviate",
     "trans": [
-      "Day 9 | v. | English: depart from an established course | Example: Domesticated thousands of years ago by Indigenous people in South America, the tomatillo deviates structurally from the wild plant it is descended from."
+      "['di:viert] v. 偏离"
     ]
   },
   {
     "name": "devise",
     "trans": [
-      "Day 9 | v. | English: to invent sth new or a new way of doing sth | Example: Customers’ initial enthusiasm for a subscription is often quick to subside, and sellers must thus devise other incentives to bolster retention. devoteto MAF: MAF: SbF ZR 3CFEMX: to give most of your time, energy, attention, etc. to sb/sth More recently founded US-based institutions devoted to Latino cultures include the Latino Cultural Center."
+      "[dr'varz] v. 想出"
     ]
   },
   {
     "name": "devote to",
     "trans": [
-      "Day 9 | English: to give most of your time, energy, attention, etc. to sb/sth | Example: More recently founded US-based institutions devoted to Latino cultures include the Latino Cultural Center."
+      "献身于"
     ]
   },
   {
     "name": "devour",
     "trans": [
-      "Day 9 | v. | English: v. to eat all of sth quickly, especially because you are very hungry; v. to destroy sb/sth | Example: [1] Cuttlefish appear to be surprisingly competent at exercising self-control: in a 2021 study conducted by behavioral ecologist Alexandra Schnell, these cephalopods routinely demonstrated restraint by delaying gratification, waiting for a favorite treat instead of instantly devouring a readily available meal. 2] Green meadows make rifts in [the woods] here and there, so do little patches of cultivation. But these do not amount to much, for the magnificent woods devour everything."
+      "[dI'vaoar] v.；v.；v. 狼吞虎咽地吃光"
     ]
   },
   {
     "name": "diabolical",
     "trans": [
-      "Day 9 | adj. | English: extremely bad or annoying | Example: How [the sailor] haunted my dreams, | need scarcely tell you. On stormy nights, when the wind shook the four corners of the house and the surf roared along the cove and up the cliffs, | would see him in a thousand forms, and with a thousand diabolical expressions."
+      "adj. 糟糕透顶的"
     ]
   },
   {
     "name": "dialect",
     "trans": [
-      "Day 9 | n. | English: the form of a language that is spoken in one area with grammar, words and pronunciation that may be different from other forms of the same language | Example: A unique dialect, or regional variety, of Spanish is spoken in Puerto Rico."
+      "['daralekt] n. 方言"
     ]
   },
   {
     "name": "diffraction",
     "trans": [
-      "Day 9 | n. | English: In physics, diffraction is a change in the direction of a sound wave or a light wave caused by the presence of an obstacle in its path | Example: All light passing through the hole can only arrive at a single destination, eliminating diffraction and ensuring a clear image."
+      "[dr'frakh] n. （声等的）衍射,绕射"
     ]
   },
   {
     "name": "dim",
     "trans": [
-      "Day 9 | adj. | English: that you cannot remember or imagine clearly [The] Mole stood still a moment, held in thought. As one wakened suddenly from a beautiful dream, who struggles to recall it, and can re-capture nothing but a dim sense of the beauty of it, the beauty!"
+      "[dIm] adj. 不清晰的,模糊的"
     ]
   },
   {
     "name": "diminish",
     "trans": [
-      "Day 10 | v. | English: to become or to make sth become smaller, weaker, etc. | Example: One way to diminish the importance of a scholar’s research is to track how often other scholars refer to that research."
+      "[dr'mIrj] v. 减少"
     ]
   },
   {
     "name": "disastrous",
     "trans": [
-      "Day 10 | adj. | English: very bad, harmful or unsuccessful | Example: Lowering interest rates could have disastrous consequences for the economy."
+      "[dr'zastras] adj. 灾难性的"
     ]
   },
   {
     "name": "discard",
     "trans": [
-      "Day 10 | v. | English: to get rid of sth that you no longer want or need | Example: Cut, bent, and welded from discarded metal materials, the sculptures of London-based Nigerian artist Sokari Douglas Camp are meant to challenge viewers to consider their own relationships to material waste."
+      "[dr'ska:rd] v. 丢弃"
     ]
   },
   {
     "name": "discern",
     "trans": [
-      "Day 10 | v. | English: to know, recognize or understand sth, especially sth that is not obvious | Example: The fossil remains of the individual known as Oase 1, discovered in Romania in 2002, can help paleoanthropologists not only discern steps in the evolution of hominids but also illuminate the Pleistocene epoch generally, revealing important details about the time in which Oase 1 lived."
+      "[dr'83:m] v. 觉察出,识别"
     ]
   },
   {
     "name": "discipline",
     "trans": [
-      "Day 10 | n. | English: a subject that people study or are taught, especially in a university | Example: The team explained that the collaboration between experts in these two disciplines resulted in a more comprehensive approach than independent efforts by experts in either discipline could have achieved."
+      "['drsaplm] n. 知识领域"
     ]
   },
   {
     "name": "disclosure",
     "trans": [
-      "Day 10 | n. | English: the act of making sth known or public that was previously secret or private | Example: In response to concerns that some recent financial crises were exacerbated by consumers misunderstanding risks associated with credit cards, loans, and other financial products, policymakers in many countries have instituted risk-disclosure requirements on sellers of those products."
+      "n. 披露"
     ]
   },
   {
     "name": "discontent",
     "trans": [
-      "Day 10 | n. | English: a feeling of being unhappy because you are not satisfied with a particular situation; sth that makes you have this feeling | Example: To draw attention to individuals’ discontent with the group's conversation about art"
+      "[dIskan'tent] n. 不满"
     ]
   },
   {
     "name": "discontented",
     "trans": [
-      "Day 10 | adj. | English: unhappy because you are not satisfied with your situation | Example: Miranda's reminiscences about her early childhood have a melancholy quality that betrays her discontented view of her current circumstances."
+      "adj. 不满的"
     ]
   },
   {
     "name": "discontinue",
     "trans": [
-      "Day 10 | v. | English: Ifa product is discontinued, the manufacturer stops making it. | Example: Studying wrappers from discontinued candies, menus from nineteenth-century restaurants, and flyers promoting long-forgotten sporting events may seem like a frivolous pursuit, but ephemeral objects like these are useful as markers of cultural change."
+      "v. 停产"
     ]
   },
   {
     "name": "discontinued",
     "trans": [
-      "Day 10 | adj. | English: Ifa product is discontinued, the manufacturer stops making it. | Example: As discussed by scholar Anna Mladentseva, many artworks produced in the mid-1990s to the early 2000s exclusively for exhibition on the internet have become inaccessible because viewing them requires the use of defunct software (most notably Adobe Flash, discontinued in 2021)."
+      "adj. 停止使用的,停产的"
     ]
   },
   {
     "name": "discount",
     "trans": [
-      "Day 10 | v. | English: to think or say that sth is not important or not true | Example: The tendency to group authors together into distinct literary movements often encourages literary scholars to discount subtleties in an author's style."
+      "['diskaont] v. 不重要"
     ]
   },
   {
     "name": "discourse",
     "trans": [
-      "Day 10 | n. | English: along and serious treatment or discussion of a subject in speech or writing | Example: After traveling to the United States and Europe in the early 1930s and immersing himself in a broader architectural discourse, Barragan shifted his style to incorporate principles of modernism, as seen in the Ortega House."
+      "['dIsko:rs] n. 论文"
     ]
   },
   {
     "name": "discreet",
     "trans": [
-      "Day 10 | adj. | English: careful in what you say or do, in order to keep sth secret or to avoid causing embarrassment or difficulty for sb | Example: And by his brother clergy he was regarded as a discreet and agreeable fellow."
+      "[dr'skri:t] adj. 谨慎的"
     ]
   },
   {
     "name": "discrepancy",
     "trans": [
-      "Day 10 | n. | English: a difference between two or more things that should be the same | Example: It stresses the discrepancy between Mr. Ely's public and private conduct and then alludes to his motivation for hiding his true personality."
+      "[dr'skrepansi] n. 不-致"
     ]
   },
   {
     "name": "discrete",
     "trans": [
-      "Day 10 | adj. | English: independent of other things of the same type | Example: Other critics, however, argue that the books should not be thought of as discrete texts with traditional beginnings and endings but as a single incredibly long work, similar to other multivolume stories, such as John Galsworthy's The Forsyte Saga."
+      "[dr'skri:t] adj. 分开的,不连续的"
     ]
   },
   {
     "name": "discretion",
     "trans": [
-      "Day 10 | n. | English: care in what you say or do, in order to keep sth secret or to avoid causing embarrassment to"
+      "[dr'skrej] n. 谨慎"
     ]
   },
   {
     "name": "disdainful",
     "trans": [
-      "Day 10 | adj. | English: showing disdain | Example: She had the air of a queen and gazed disdainfully at the whole house."
+      "adj. 轻视的,蔑视的"
     ]
   },
   {
     "name": "disengage",
     "trans": [
-      "Day 10 | v. | English: to free sb/sth from the person or thing that is holding them or it; to become free | Example: They wished to disengage themselves from these policies."
+      "[.dIsIn'gerd3] v. 脱离"
     ]
   },
   {
     "name": "disguise",
     "trans": [
-      "Day 10 | v. | English: to change your appearance so that people cannot recognize you | Example: The hijackers were heavily disguised."
+      "[dIs'9ar2] v. 伪装"
     ]
   },
   {
     "name": "disingenuous",
     "trans": [
-      "Day 10 | adj. | English: not sincere, especially when you pretend to know less about sth than you really do | Example: It would be disingenuous of me to claim | had never seen it."
+      "[dIsIn'd3enjuas] adj. 不真诚的"
     ]
   },
   {
     "name": "dismiss",
     "trans": [
-      "Day 10 | v. | English: to decide that sb/sth is not important and not worth thinking or talking about | Example: People sometimes dismiss a claim if it comes from a source they regard as self-interested, but from a strictly logical perspective, the source of a claim is irrelevant."
+      "[dIs'mIs] v. 摒弃,不予考虑"
     ]
   },
   {
     "name": "dismissal",
     "trans": [
-      "Day 10 | n. | English: the failure to consider sth as important | Example: Her casual dismissal of the threats seemed irresponsible."
+      "[dIs'mIsl] n. 不予考虑"
     ]
   },
   {
     "name": "disparage",
     "trans": [
-      "Day 10 | v. | English: to suggest that sb/sth is not important or valuable | Example: | don't mean to disparage your achievements."
+      "[dr'sparrd3] v. 贬低,轻视"
     ]
   },
   {
     "name": "disparate",
     "trans": [
-      "Day 10 | adj. | English: essentially different in kind; not allowing comparison | Example: As disparate as their works may seem, commonalities exist between Antonello da Messina, Italian Renaissance painter of the Venetian School; Adriaen Brouwer, Flemish mannerist painter of the Antwerp School; and Jose Guerrero, American abstract painter of the New York School."
+      "['drsparat] adj. 迥然不同的"
     ]
   },
   {
     "name": "disparity",
     "trans": [
-      "Day 10 | n. | English: a difference, especially one connected with unfair treatment | Example: The disparity between these two speeds is not surprising, however, because the features that are most useful for running on land tend to be more limiting on top speeds than the features that are best suited for flying through the air."
+      "[drsparati] n. 尤指因不公正对待引起的二"
     ]
   },
   {
     "name": "dispassionate",
     "trans": [
-      "Day 10 | adj. | English: not influenced by emotion | Example: It primarily works to engage audiences in an interrogation of patriarchy and colonialism, which it does by placing audiences at a distance, thereby encouraging them to be dispassionate as they think critically about the social and political questions raised by the play."
+      "[dIspejanat] adj. 不动感情的"
     ]
   },
   {
     "name": "dispersal",
     "trans": [
-      "Day 10 | English: the process of sending sb/sth in different directions; the process of spreading sth over a wide area | Example: Like many other fruit-eating birds on the Hawaiian island of Oahu, the red-whiskered bulbul helps forest plants spread by dropping seeds from the plants’ fruits in different spots (a"
+      "[dr'sp3:1s1] 分散"
     ]
   },
   {
     "name": "disperse",
     "trans": [
-      "Day 10 | v. | English: to move apart and go away in different directions | Example: She is anxious for the gathering to disperse so that she can ready the space for her own needs."
+      "[dr'8p3:rs] v. 分散"
     ]
   },
   {
     "name": "dispersed",
     "trans": [
-      "Day 10 | adj. | English: Things that are dispersed are situated in many different places, a long way apart from each other. | Example: It took some two hours before the crowd was fully dispersed."
+      "[dr'sp3:Ist] adj. 分散的"
     ]
   },
   {
     "name": "disposable",
     "trans": [
-      "Day 10 | adj. | English: made to be thrown away after use | Example: Guojun He and colleagues studied a food-delivery phone app that is popular in China. The researchers found that having \"no cutlery\" automatically selected influences whether customers request disposable plastic utensils with their food orders."
+      "[dr'spoo2abl] adj. 用后即丢弃的"
     ]
   },
   {
     "name": "dispose of",
     "trans": [
-      "Day 10 | English: to get rid of sb/sth that you do not want or cannot keep | Example: Environmental policy researcher Jessika Richter warns that because new batteries can't be put in once the old ones no longer work, the gadgets stop functioning and are usually disposed of as trash."
+      "去掉"
     ]
   },
   {
     "name": "disproportionate",
     "trans": [
-      "Day 10 | adj. | English: too large or too small when compared with sth else | Example: Less populated rural districts with large tracts of land receive a disproportionate number of seats compared to smaller but more populated urban districts."
+      "[dIspra'P3:rjanat] adj. 不成比例的"
     ]
   },
   {
     "name": "dispute",
     "trans": [
-      "Day 10 | v. | English: to question whether sth is true and valid | Example: Given how little consensus there is among scientists regarding the scope of these categories, this discrepancy shouldn't be surprising: forest researchers regularly dispute one another's classifications."
+      "[dr'spju:t;'dIspju:t] v. 表示异议（或怀疑）"
     ]
   },
   {
     "name": "disregard",
     "trans": [
-      "Day 10 | v. | English: to not consider sth | Example: The reasons for this characterization may seem irrefutable, but linking Unamuno with the Generation of '98 risks disregarding the subtleties in his style that do not neatly conform to the conventions of this literary movement."
+      "[dIsrr'ga:rd] v. 不理会,忽视"
     ]
   },
   {
     "name": "dissect",
     "trans": [
-      "Day 10 | v. | English: to study sth closely and/or discuss it in great detail | Example: He might dissect, anatomize, and give names; but, not to speak of a final cause, causes in their secondary and tertiary grades were utterly unknown to him."
+      "[dr'sektdar'sekt] v. 仔细研究"
     ]
   },
   {
     "name": "disseminate",
     "trans": [
-      "Day 10 | v. | English: to spread information, knowledge, etc. so that it reaches many people | Example: Their findings have been widely disseminated ."
+      "[dr'semmnert] v. 散布"
     ]
   },
   {
     "name": "dissolution",
     "trans": [
-      "Day 10 | n. | English: the process in which sth gradually disappears | Example: These animals are thought to be especially vulnerable to ocean acidification due to calcium carbonate's susceptibility to dissolution at lower pH values."
+      "[dIsa'lu:R] n. 消失"
     ]
   },
   {
     "name": "dissolve",
     "trans": [
-      "Day 10 | v. | English: to make a solid become part of a liquid | Example: In a 2012 study in the United States, Michael E. Berndt and Travis K. Bavin found a positive association between levels of dissolved organic carbon and mercury in bodies of fresh water."
+      "[dr'za:Wv] v. 使（固体）溶解"
     ]
   },
   {
     "name": "distinction",
     "trans": [
-      "Day 10 | n. | English: the quality of being excellent or important | Example: He has the appearance of a distinguished figure, but it is uncertain whether he has accomplished anything to earn distinction."
+      "[dr'strgka] n. 优秀,杰出"
     ]
   },
   {
     "name": "distinctive",
     "trans": [
-      "Day 10 | adj. | English: having a quality or characteristic that makes sth different and easily noticed | Example: Although fewer companies trade their stocks on the Tehran Stock Exchange in Tehran, Iran, than on the stock exchanges in London, Mumbai, or Tokyo, the Tehran Stock Exchange has the advantage of focusing on local companies and thus reflecting economic circumstances that are distinctive to Iran."
+      "[dr'stmktrv] adj. 独特的"
     ]
   },
   {
     "name": "distinguished",
     "trans": [
-      "Day 10 | adj. | English: having an appearance that makes sb look important or that makes people admire or respect them | Example: He has the appearance of a distinguished figure, but it is uncertain whether he has accomplished anything to earn distinction."
+      "[dr'stIgwAt] adj. 显得重要的"
     ]
   },
   {
     "name": "distort",
     "trans": [
-      "Day 10 | v. | English: to change the shape, appearance or sound of sth so that it is strange or not clear | Example: And even the hyperpop artists who don't rely on pitch-shifting, such as Shygirl, often distort their vocals using digital tools."
+      "[dr'sto:rt] v. 使娈形"
     ]
   },
   {
     "name": "distract",
     "trans": [
-      "Day 10 | v. | English: to take sb's attention away from what they are trying to do | Example: Gold, conversely, could distract from the subtleties in a painted scene."
+      "[dr'strekt] v. （注意力）"
     ]
   },
   {
     "name": "distributary",
     "trans": [
-      "Day 10 | n. | English: one of several outlet streams draining a river, esp on a delta The Chao Phraya River delta is a constantly changing landform made up of a network of distributaries, small channels that branch off from the main river."
+      "n. 支流"
     ]
   },
   {
     "name": "diverge",
     "trans": [
-      "Day 10 | v. | English: to be different | Example: Her music diverges from the typical hyperpop sound but doesn't abandon it."
+      "[dar'v3:rd3] v. 分歧"
     ]
   },
   {
     "name": "divergence",
     "trans": [
-      "Day 10 | n. | English: A divergence is a difference between two or more things, attitudes, or opinions. | Example: In harmonious periods and telling phrases the different shades of political opinion, the divergences and disagreements, are adjusted."
+      "[dar'v3:rd3ons] n. 差异"
     ]
   },
   {
     "name": "diversity",
     "trans": [
-      "Day 10 | n. | English: the quality or fact of including a range of many people or things | Example: They found that across the three microbial communities, peak diversity and richness was observed on pine and oak samples placed approximately 125 meters from the shipwrecks."
+      "[dar'v3:rsati;dr'v3:srti] n. 多样性"
     ]
   },
   {
     "name": "divert",
     "trans": [
-      "Day 10 | v. | English: to take sb's thoughts or attention away from sth | Example: Unfortunately, this flood of interesting writing can divert scholarly attention from the fascinating work of nineteenth-century figures like Guillermo Prieto."
+      "[dar'v3:r] v. 转移（某人）"
     ]
   },
   {
     "name": "divest",
     "trans": [
-      "Day 10 | v. | English: to take sth away from sb/sth | Example: The great men of culture are those who have had a passion for diffusing, for making prevail, for carrying from one end of society to the other, the best knowledge, the best ideas of their time; who have labored to divest knowledge of all that was harsh, uncouth, difficult, abstract, professional, exclusive; to humanise it, to make it efficient outside the clique of the cultivated and learned, yet still remaining the best knowledge and thought of the time, and a true source, therefore, of sweetness and light."
+      "v. 使摆脱"
     ]
   },
   {
     "name": "dodge",
     "trans": [
-      "Day 10 | v. | English: to move quickly and suddenly to one side in order to avoid sb/sth | Example: While the others are hopping about in the air, | can dodge under their feet and grab the ball."
+      "[da:d3] v. 闪开"
     ]
   },
   {
     "name": "dogmatic",
     "trans": [
-      "Day 11 | adj. | English: being certain that your beliefs are right and that others should accept them, without paying attention to evidence or other opinions | Example: Political scientists have found that although voters claim to prefer candidates who have nuanced perspectives on issues and who show a willingness to compromise, when asked to compare speeches expressing such views with speeches expressing dogmatic views, voters tend to regard the unyielding rhetoric of the latter more favorably."
+      "[43:9'matk] adj. 自以为是的"
     ]
   },
   {
     "name": "domain",
     "trans": [
-      "Day 11 | n. | English: an area of knowledge or activity; especially one that sb is responsible for | Example: Some social scientists say that while a desire for cooperation rather than conflict is key to democracy, public understanding of economics is also central to public comprehension of state politics, and if a citizenry is to function, economic issues cannot remain the domain only of experts."
+      "[dou'men] n. （活动的）领域"
     ]
   },
   {
     "name": "domestic",
     "trans": [
-      "Day 11 | adj. | English: of or inside a particular country; not foreign or international | Example: Karl Polanyi and other historians of capitalism rarely discuss domestic capitalism in Africa before the period of European colonization."
+      "[da'mestik] adj. 本国的"
     ]
   },
   {
     "name": "domesticate",
     "trans": [
-      "Day 11 | v. | English: to make a wild animal used to living with or working for humans | Example: Maize (corn), another crop domesticated by Indigenous Americans, shows so little resemblance to any wild plant that genetic research was necessary to confirm teosinte grass as its ancestor."
+      "[da'mestikert] v. （动物"
     ]
   },
   {
     "name": "dominant",
     "trans": [
-      "Day 11 | adj. | English: more important, powerful or noticeable than other things | Example: The potential for knowledge spillovers, a dominant driver of collocation in this industry, was largely absent from the paint manufacturing industry."
+      "['da:mmnant] adj. 首要的"
     ]
   },
   {
     "name": "doom",
     "trans": [
-      "Day 11 | v. | English: to make sb/sth certain to fail, suffer, die, etc | Example: The sun, already down, was manifest in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+      "[du:m] v. 注定失败"
     ]
   },
   {
     "name": "downplay",
     "trans": [
-      "Day 11 | v. | English: to make people think that sth is less important than it really is | Example: It downplays the significance of the size difference between the sei whale and the bowhead whale."
+      "[daon'ple] v. 轻描淡写"
     ]
   },
   {
     "name": "doze",
     "trans": [
-      "Day 11 | v. | English: to sleep lightly for a short time | dozed and floated on the clouds of Farsi that blew my way from the front seat of Dayi | Example: Uncle] lamsheed's SUV."
+      "[dovz] v. 打瞌睡"
     ]
   },
   {
     "name": "drain",
     "trans": [
-      "Day 11 | v. | English: to make liquid flow away from sth; to flow away The Nile River delta system is located in Northern Egypt, where the river drains into the Mediterranean Sea."
+      "[drem] v. 流走,流出"
     ]
   },
   {
     "name": "drape",
     "trans": [
-      "Day 11 | v. | English: to hang clothes, materials, etc. loosely on sb/sth | Example: At any rate, it was not without ample consideration that those thick, dark, costly carpets were put down; those embossed, but sombre [wallpapers] hung up; those heavy curtains draped so as to half exclude the light of the sun."
+      "[drem] v. （织物等）悬挂,披"
     ]
   },
   {
     "name": "draw",
     "trans": [
-      "Day 11 | v. | English: to attract or interest sb | Example: lrest me deep within the wood, / Drawn by its silent call, / Far from the throbbing crowd of men, / On nature's breast | fall."
+      "[dro:] v. 吸引"
     ]
   },
   {
     "name": "draw on",
     "trans": [
-      "Day 11 | English: If you draw on or draw upon something such as your skill or experience, you make use of it in order to do something. | Example: Ina variety of ways, Samuel Kamakau, Kristiana Kahakauwila, and other acclaimed writers have drawn on these stories to craft a rich portrait of the Hawaiian Islands and their people. drawing-room /F S23LFEMXL: A drawing room is a room, especially a large room in a large house, where people sit and relax, or entertain guests. By the laity of Milby and its neighbourhood [Mr. Ely] was regarded as a man of quite remarkable powers and learning, who must make a considerable sensation in London pulpits and drawing-rooms on his occasional visit to the metropolis."
+      "利用"
     ]
   },
   {
     "name": "drawing-room",
     "trans": [
-      "Day 11 | English: A drawing room is a room, especially a large room in a large house, where people sit and relax, or entertain guests. | Example: By the laity of Milby and its neighbourhood [Mr. Ely] was regarded as a man of quite remarkable powers and learning, who must make a considerable sensation in London pulpits and drawing-rooms on his occasional visit to the metropolis."
+      "客厅"
     ]
   },
   {
     "name": "dreadful",
     "trans": [
-      "Day 11 | adj. | English: very bad or unpleasant | Example: The Mole saw the wood that had been so dreadful to him in quite a changed aspect."
+      "['dredtl] adj. 令人讨厌的"
     ]
   },
   {
     "name": "drill",
     "trans": [
-      "Day 11 | v. | English: vto teach sb to do sth by making them repeat it a lot of times; v. to make a hole in sth, using a drill | Example: [1] He was daring, without being rash: prompt, but not thoughtless; firm, without being harsh. Kind and devoted to the company he drilled, he soon won the respect of his superior officers and the love of his comrades. 2] Companies involved in petroleum extraction include drilling equipment among their assets."
+      "[drl] v.；v. 打（眼）"
     ]
   },
   {
     "name": "driver",
     "trans": [
-      "Day 11 | n. | English: one of the main things that influence sth or cause it to make progress | Example: The potential for knowledge spillovers, a dominant driver of collocation in this industry, was largely absent from the paint manufacturing industry."
+      "['drarvar] n. 驱动因素"
     ]
   },
   {
     "name": "drudging",
     "trans": [
-      "Day 11 | adj. | English: boring and hard, and taking a lot of time | Example: The motorman chafed in his box, thinking of the drudging lot of the laboring man. He registered discontent."
+      "['drd3巧] adj. 累人的"
     ]
   },
   {
     "name": "dry",
     "trans": [
-      "Day 11 | adj. | English: not interesting | Example: She was reading a book a day in alphabetical order and not skipping the dry ones."
+      "[drar] adj. 干巴巴的,枯燥乏味的"
     ]
   },
   {
     "name": "dull",
     "trans": [
-      "Day 11 | adj. | English: adj. not bright, with a lot of clouds; v. to make a person slower or less lively | Example: [1] The tired cars go grumbling by, / The moaning, groaning cars, / And the old milk carts go rumbling by / Under the same dull stars. 2] The sun, beating down upon [the soldiers], dulled their minds and bodies and presently they were silent."
+      "[dal] adj.；adj.；v. 不明亮的"
     ]
   },
   {
     "name": "duplicate",
     "trans": [
-      "Day 11 | v. | English: to make an exact copy of sth | Example: His task will be to duplicate his success overseas here at home."
+      "['duplikert] v. 复制"
     ]
   },
   {
     "name": "dwindle",
     "trans": [
-      "Day 11 | v. | English: to become gradually less or smaller | Example: Support for the party has dwindled away to nothing."
+      "['dwndl] v. 缩小"
     ]
   },
   {
     "name": "dynamic",
     "trans": [
-      "Day 11 | adj. | English: always changing and making progress | Example: As with other river deltas, the Krishna River delta is dynamic: it is a constantly evolving network of channels and strips of land that change in size and shape as the river deposits new sedimentary particles where the river meets the waters of the Bay of Bengal."
+      "[dar'nanik] adj. 动态的"
     ]
   },
   {
     "name": "ease",
     "trans": [
-      "Day 11 | n. | English: n. lack of difficulty; v. to become or to make sth less unpleasant, painful, severe, etc. | Example: [1] Mr. French, the senior partner, who sat opposite Kirby, was an older man—a safe guess would have placed him somewhere in the debatable ground between forty and fifty; of a good height, as could be seen even from the seated figure, the upper part of which was held erect with the unconscious ease which one associates with military training. 2] Chekhov portrays Helena as trying to ease tensions between Vanya and the professor."
+      "[1:2] n.；n.；v. 不费劲"
     ]
   },
   {
     "name": "eccentric",
     "trans": [
-      "Day 11 | adj. | English: considered by other people to be strange or unusual Although the one exceptional moon orbits in the same direction as the planets spin, its orbit is highly eccentric compared to the rest, which may suggest that it has a different origin than the other 19 moons."
+      "['scntrik] adj. 怪的"
     ]
   },
   {
     "name": "eclipse",
     "trans": [
-      "Day 11 | v. | English: to make sb/sth seem dull or unimportant by comparison | Example: A speaker at a recent children's book publishing conference noted that, while many illustrators do excellent work, in her mind, no one has ever eclipsed work as the illustrator of Under the Sunday Tree."
+      "[I'klps] v. 使相形见绌"
     ]
   },
   {
     "name": "efficacy",
     "trans": [
-      "Day 11 | n. | English: the ability of sth, especially a drug or a medical treatment, to produce the results that are wanted | Example: The results of randomized clinical trials testing the efficacy of common medical interventions sometimes fail to corroborate conclusions that practitioners reach based on their real-world observations of patients."
+      "['efikasi] n. （尤指药物或治疗方法的）"
     ]
   },
   {
     "name": "egocentric",
     "trans": [
-      "Day 11 | adj. | English: thinking only about yourself and not about what other people need or want | Example: Previous research has found a tendency in many cultures to make temporal distinctions using spatial concepts and gestures, particularly along egocentric axes (i.e., relative to the orientation of the speaker)."
+      "[.i:goU'scntrk] adj. 以自我为中心的"
     ]
   },
   {
     "name": "eject",
     "trans": [
-      "Day 11 | v. | English: to push sth out suddenly and with a lot of force | Example: And as Jane X. Luu et al. point out, the singular nature of impact ejection makes it untenable as an account of multiple loss episodes of similar duration over several years."
+      "[I'd3ekt] v. 喷出"
     ]
   },
   {
     "name": "elaborate",
     "trans": [
-      "Day 11 | v. | English: to explain or describe sth in a more detailed way | Example: It elaborates on a potential consequence of Faleiro and colleagues’ reliance on a relatively small sample size."
+      "[I'labarat;I'labarert;I'Iabart] v. 详尽阐述"
     ]
   },
   {
     "name": "electrifying",
     "trans": [
-      "Day 11 | adj. | English: very exciting | Example: Ina 2018 article celebrating films depicting the Black experience, critics for the New York Times commended William Greaves's 1968 film Symbiopsychotaxiplasm, Take One and Spike Lee's 1992 film Malcolm X, praising the former as \"a vital artifact of its time\" and the latter as \"electrifying.\""
+      "adj. 令人兴奋的"
     ]
   },
   {
     "name": "elevation",
     "trans": [
-      "Day 11 | n. | English: the height of a place, especially its height above sea level | Example: To understand how temperature change affects microorganism-mediated cycling of soil nutrients in alpine ecosystems, Eva Kastovska et al, collected plant-soil cores in the Tatra Mountains at elevations around 2,100 meters and transplanted them to elevations of 1,700- 1,800 meters, where the mean air temperature was warmer by 2°C."
+      "[.elr'verln] n. 海拔"
     ]
   },
   {
     "name": "elicit",
     "trans": [
-      "Day 11 | v. | English: (formal) to get information or a reaction from sb, often with difficulty | Example: In their meta-analysis of research on advergames (video games developed to promote products or services), Zeph M.C. van Berlo et al. confirm that such games, though they can elicit player interest, may not facilitate subsequent recall of product and brand information."
+      "[I'IIsrt] v. 引出"
     ]
   },
   {
     "name": "elusive",
     "trans": [
-      "Day 11 | adj. | English: difficult to find, define, or achieve | Example: It was the kind of challenge that would set any art curator’s mind into motion: finding that elusive thread that could link artists as disparate as American abstract painter Anne Ryan, Romanian impressionist painter Micaela Eleutheriade, and Flemish mannerist painter Anthony van Dyck."
+      "[I'lu:sw] adj. 难以捉摸的"
     ]
   },
   {
     "name": "emanate",
     "trans": [
-      "Day 11 | v. | English: to come out from a source | Example: The declination, or celestial latitude, of the Aurigid meteor shower's radiant—the point in the sky from which, to a terrestrial observer, the shower's meteors appear to emanate—is 39 degrees, meaning that its radiant is located 39 degrees north of the celestial equator, in close proximity to the constellation Auriga."
+      "['emanert] v. 散发"
     ]
   },
   {
     "name": "embed",
     "trans": [
-      "Day 11 | v. | English: to fix sth firmly into a substance or solid object | Example: The limited capacity model of motivated mediated message processing developed by Lang provides a means of explaining the finding by van Berlo et al. that players may not readily recollect the brand and product information embedded in advergames."
+      "[Im'bed] v. 牢牢地嵌入"
     ]
   },
   {
     "name": "embossed",
     "trans": [
-      "Day 11 | adj. | English: Ifa surface such as paper or wood is embossed with a design, the design stands up slightly from the surface. | Example: At any rate, it was not without ample consideration that those thick, dark, costly carpets were put down; those embossed, but sombre [wallpapers] hung up; those heavy curtains draped so as to half exclude the light of the sun."
+      "adj. （纸面或木面上）饰有浮凸图案的"
     ]
   },
   {
     "name": "embrace",
     "trans": [
-      "Day 11 | v. | English: to accept an idea, a proposal, a set of beliefs, etc., especially when it is done with enthusiasm | Example: Hunting Expedition is an important work of Nihonga, or classical Japanese painting. Unlike Wada Eisaku, who adopted traditional European methods such as painting with oil on canvas, Domoto Insh6 embraced traditional Japanese approaches."
+      "[I'brers] v. 欣然接受"
     ]
   },
   {
     "name": "emergence",
     "trans": [
-      "Day 11 | n. | English: when something begins to be known or noticed | Example: Documentation of the display in 285 species across 52 families suggests the behavior likely evolved independently multiple times, prompting the team to consider ecological and life- history characteristics with hypothesized associations to the behavior's emergence, including traits related to reproduction investment and future reproduction potential."
+      "[1'm3:rd3ans] n. 出现"
     ]
   },
   {
     "name": "eminence",
     "trans": [
-      "Day 11 | n. | English: the quality of being famous and respected, especially in a profession | Example: Over time, the Aubrey/Maturin series has Jrcquired the same eminence among critics as orks like In Search of Lost Time that have similar structures."
+      "['emnans] n. 著名"
     ]
   },
   {
     "name": "emit",
     "trans": [
-      "Day 11 | English: to send out sth such as light, heat, sound, gas, etc. | Example: To combat predation by Arizona myotis and other insectivorous bats, many moth species, including Cycnia tenera, emit ultrasonic pulses that, in some cases, disrupt the echolocation bats rely on for foraging."
+      "[int] 发出"
     ]
   },
   {
     "name": "empirical",
     "trans": [
-      "Day 11 | adj. | English: based on experiments or experience rather than ideas or theories | Example: Text corpora such as the British National Corpus are enormous collections of electronically stored texts that can be used for empirical testing of hypotheses regarding how pervasive a word is in spoken and written English."
+      "[Im'pIrkl] adj. 实证的"
     ]
   },
   {
     "name": "emulate",
     "trans": [
-      "Day 11 | v. | English: to try to do sth as well as sb else because you admire them | Example: She hopes to emulate her sister's sporting achievements."
+      "['emjulert] v. 努力赶上"
     ]
   },
   {
     "name": "emulsion",
     "trans": [
-      "Day 11 | n. | English: any mixture of liquids that do not normally mix together, such as oil and water; a type of paint used on walls and ceilings that dries without leaving a shiny surface | Example: An emulsifier is a type of compound that serves to stabilize an emulsion—a mixture of two or more liquids that otherwise would not easily blend together."
+      "[I'muIR] n. 乳状液"
     ]
   },
   {
     "name": "enact",
     "trans": [
-      "Day 11 | v. | English: to pass a law | Example: Karam Kang has demonstrated that lobbying does little to alter the probability that a particular energy policy under consideration by the United States Congress will be enacted."
+      "[I'nakt] v. （法律）"
     ]
   },
   {
     "name": "enchantment",
     "trans": [
-      "Day 11 | n. | English: a feeling of great pleasure | Example: A thousand recollections of childhood came over me, awakened by these country odors, and | walked along, permeated with the fragrant, living enchantment, the emotional enchantment of the woods warmed by the sun of June."
+      "n. 狂喜"
     ]
   },
   {
     "name": "encompass",
     "trans": [
-      "Day 11 | v. | English: to include a large number or range of things | Example: A region of the Soviet Union encompassing the present-day city of Sukhumi, Georgia, the Abkhazian-speaking Abkhaz Autonomous Soviet Socialist Republic was in fact only nominally autonomous."
+      "[I'kmpas] v. 包含"
     ]
   },
   {
     "name": "encyclopedia",
     "trans": [
-      "Day 11 | n. | English: a book or set of books giving information about all areas of knowledge or about different areas of one particular subject, usually arranged in alphabetical order | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+      "[m,salkla'pi:dia] n. 百科全书"
     ]
   },
   {
     "name": "end",
     "trans": [
-      "Day 11 | n. | English: an aim or a purpose | Example: To that end, certain features such as the ability to respond to voice commands can help to buttress people's feelings of comfort."
+      "[end] n. 目的"
     ]
   },
   {
     "name": "endeavor",
     "trans": [
-      "Day 11 | n. | English: an attempt to do sth, especially sth new or difficult | Example: The little conductor stood on tiptoe in an effort to keep one hand on the signal rope, craning his neck in a vain and dissatisfied endeavor to pierce the miasma of the fog."
+      "[I'devar] n. （尤指新的或艰苦的）努力"
     ]
   },
   {
     "name": "endure",
     "trans": [
-      "Day 11 | v. | English: to experience and deal with sth that is painful or unpleasant, especially without complaining | Example: Believe me, Anya, believe me! I'm not thirty yet, I'm young, I'm still a student, but | have endured a great deal!"
+      "[m'dur] v. 忍耐"
     ]
   },
   {
     "name": "enduring",
     "trans": [
-      "Day 12 | adj. | English: lasting for a long time | Example: Inan analysis of economic data from 1976 to 1993, Ross Levine and Sara Zervos found that liberalization did not lead to enduring increases in investment in companies based in countries that liberalized."
+      "[In'dorn] adj. 持久的"
     ]
   },
   {
     "name": "enfranchise",
     "trans": [
-      "Day 12 | v. | English: to give sb the right to vote in an election | Example: When contrasting different forms of government, Aristotle holds that ‘oligarchies may last, not from any inherent stability in such forms of government, but because the rulers are on good terms both with the unenfranchised and with the governing classes.\" That is, oligarchic leaders who wish to hold on to power will introduce members of disenfranchised classes into government in a participatory role."
+      "[I'frentfarz] v. 给（某人）选举权"
     ]
   },
   {
     "name": "engaging",
     "trans": [
-      "Day 12 | adj. | English: interesting or pleasant in a way that attracts your attention | Example: Community science, which involves professional scientists collaborating with amateur science enthusiasts to study a topic, is often an effective and engaging way to conduct research."
+      "[I'gerd3n] adj. 有趣的"
     ]
   },
   {
     "name": "engender",
     "trans": [
-      "Day 12 | v. | English: to make a feeling or situation exist | Example: In the 2010s, the price of vintage Teenage Mutant Ninja Turtles action figures rose dramatically, which had the counterintuitive effect of engendering demand."
+      "[n'd3endar] v. 引起"
     ]
   },
   {
     "name": "engraving",
     "trans": [
-      "Day 12 | n. | English: a picture made by cutting a design on a piece of metal and then printing the design on paper | Example: They may have thought of the engravings as something akin to art in our modern sense, but it is entirely possible that they did not—we simply cannot say for certain."
+      "[I'grervn] n. 雕版印刷品"
     ]
   },
   {
     "name": "engulf",
     "trans": [
-      "Day 12 | v. | English: to surround or to cover sb/sth completely | Example: She has a thick curtain of long, curly hair that practically engulfs her."
+      "[I'944] v. 吞没"
     ]
   },
   {
     "name": "enigma",
     "trans": [
-      "Day 12 | n. | English: a person, thing or situation that is mysterious and difficult to understand | Example: His recently published memoirs possibly cast light on this enigma, but given that such details were not provided until after the thirty-page mark, they might as well have remained state secrets."
+      "[I'nigma] n. 令人困惑的处境"
     ]
   },
   {
     "name": "enlist",
     "trans": [
-      "Day 12 | v. | English: to persuade sb to help you or to join you in doing sth | Example: The institute enlisted botanist Janaki Ammal to breed a local variety of sugarcane."
+      "[In'Iist] v. （支持或参与）"
     ]
   },
   {
     "name": "enliven",
     "trans": [
-      "Day 12 | v. | English: to make sth more interesting or more fun | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+      "[I'larvn] v. 使更有生气"
     ]
   },
   {
     "name": "enormous",
     "trans": [
-      "Day 12 | adj. | English: extremely large | Example: Text corpora such as the British National Corpus are enormous collections of electronically stored texts that can be used for empirical testing of hypotheses regarding the frequency of typical word usage."
+      "[工'n3.1m3s] adj. 巨大的"
     ]
   },
   {
     "name": "enroll",
     "trans": [
-      "Day 12 | v. | English: to arrange for yourself or for sb else to officially join a course, school, etc. | Example: Pereira's team enrolled groups of Australian workers in two programs: one that gave employees exercise training (EET) and one that enrolled employees in health promotion seminars (EHP)."
+      "[I'roul] v. 加入,注册"
     ]
   },
   {
     "name": "entail",
     "trans": [
-      "Day 12 | n. | English: to involve sth that cannot be avoided | Example: The job entails a lot of hard work."
+      "[m'terl] n. 牵涉"
     ]
   },
   {
     "name": "entangle",
     "trans": [
-      "Day 12 | v. | English: to involve sb in a difficult or complicated situation | Example: Each becomes entangled in a debate about art, and no one knows how to resolve the debate."
+      "[I't9] v. 使卷入,使陷入"
     ]
   },
   {
     "name": "entertaining",
     "trans": [
-      "Day 12 | adj. | English: interesting and amusing | Example: Many readers find the Aubrey/Maturin novels to be remarkably entertaining despite flaws novels’ structures."
+      "[,entar'teInn] adj. 使人愉快的"
     ]
   },
   {
     "name": "entice",
     "trans": [
-      "Day 12 | n. | English: to persuade sb/sth to go somewhere or to do sth | Example: External shopping cues are a type of marketing that uses obvious messaging—a display featuring a new product, for example, or a “buy one, get one free” offer—to entice consumers to make spontaneous purchases."
+      "[In'tars] n. 诱使"
     ]
   },
   {
     "name": "entreat",
     "trans": [
-      "Day 12 | v. | English: to ask sb to do sth in a serious and often emotional way | Example: Strepsiades encourages his son to learn to be a sophist, saying, “Go, | entreat you, dearest of men, go and be taught.”"
+      "[I'tri:t] v. 乞求"
     ]
   },
   {
     "name": "entrepreneurship",
     "trans": [
-      "Day 12 | n. | English: Entrepreneurship is the state of being an entrepreneur, or the activities associated with being an entrepreneur. | Example: The University of Illinois and the startup accelerator Y Combinator are two of the many institutions offering training programs in entrepreneurship."
+      "n. 企业家精神"
     ]
   },
   {
     "name": "entry",
     "trans": [
-      "Day 12 | n. | English: an item, for example a piece of information, that is written or printed in a dictionary, an account book, a diary, etc. | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+      "['entri] n. （词典等的）"
     ]
   },
   {
     "name": "envision",
     "trans": [
-      "Day 12 | v. | English: to imagine what a situation will be like in the future, especially a situation you intend to work towards | Example: Together, they envisioned a theater company that would nurture and showcase the work of Black theater professionals.]"
+      "[I'VI3n] v. 展望"
     ]
   },
   {
     "name": "ephemera",
     "trans": [
-      "Day 12 | n. | English: things that are important or used for only a short period of time | Example: Studying wrappers from discontinued candies, menus from nineteenth-century restaurants, and flyers promoting long-forgotten sporting events may seem like a frivolous pursuit, but ephemeral objects like these are useful as markers of cultural change."
+      "[I'femara] n. 只在短期内有用的事物"
     ]
   },
   {
     "name": "ephemeral",
     "trans": [
-      "Day 12 | adj. | English: lasting or used for only a short period of time | Example: Studying wrappers from discontinued candies, menus from nineteenth-century restaurants, and flyers promoting long-forgotten sporting events may seem like a frivolous pursuit, but ephemeral objects like these are useful as markers of cultural change."
+      "[I'femaral] adj. 短暂的"
     ]
   },
   {
     "name": "episode",
     "trans": [
-      "Day 12 | n. | English: an event, a situation, or a period of time in sb's life, a novel, etc. that is important or interesting in some way | Example: Asteroid 6478 Gault has experienced intermittent mass loss since at least 2013, but in contrast to some other asteroids with repeated mass-loss episodes, 6478 Gault has not lost mass at its perihelion (the closest point of its orbit to the Sun), and thus the loss is not attributable to solar energy—driven ice vaporization."
+      "['epIsood] n. 事件"
     ]
   },
   {
     "name": "episodic",
     "trans": [
-      "Day 12 | adj. | English: happening occasionally and not at regular intervals | Example: To characterize the nature of the depositional environment, Frances Rivera-Hernandez et al. analyzed the grain size of Murray Formation sediment, finding that although there are intervals of coarse grains, most of the sediment consists of fine grains that show signs of cracking due to episodic desiccation."
+      "[.epr'sa:dik] adj. 偶尔发生的"
     ]
   },
   {
     "name": "epitomize",
     "trans": [
-      "Day 12 | v. | English: to be a perfect example of sth | Example: As epitomized by the Aguilar House in Guadalajara, many of Barragan’s first projects integrated traditional Mexican building techniques into Mediterranean designs."
+      "[Ipitamarz] v. 的典范"
     ]
   },
   {
     "name": "epoch",
     "trans": [
-      "Day 12 | n. | English: a period of time in history, especially one during which important events or changes happen | Example: The fossil remains of the individual known as KNM-KP 271, discovered in Kenya in 1965, can help paleoanthropologists not only identify steps in the evolution of hominids but also illuminate the Pliocene epoch generally, revealing important details about the time in which KNM-KP 271 lived."
+      "['epak] n. 时代"
     ]
   },
   {
     "name": "equalize",
     "trans": [
-      "Day 12 | v. | English: to make things equal in size, quantity, value, etc. in the whole of a place or group | Example: Such measures are needed to equalize wage rates between countries."
+      "['ikwalarz] v. 使平等"
     ]
   },
   {
     "name": "equitable",
     "trans": [
-      "Day 12 | adj. | English: fair and reasonable; treating everyone in an equal way | Example: He has urged them to come to an equitable compromise that gives Hughes his proper due."
+      "['ekwitabl] adj. 公平的"
     ]
   },
   {
     "name": "equivalence",
     "trans": [
-      "Day 12 | n. | English: If there is equivalence between two things, they have the same use, function, size, or value. | Example: Its metaphorical significance derives from the semantic equivalence of the two nouns constituting the difrasismo."
+      "n. （价值等的）相等"
     ]
   },
   {
     "name": "equivalent",
     "trans": [
-      "Day 12 | adj. | English: adj. equal in value, amount, meaning, importance, etc.; n. a thing, amount, word, etc. that is equivalent to sth else | Example: [1] Though not closely related, the hedgehog tenrecs of Madagascar share basic similarities with true hedgehogs, including protective spines, pointed snouts, and small body size—traits the two groups of mammals independently developed in response to equivalent roles in their respective habitats. 2] It doesn't have a clear equivalent in English."
+      "[I'kwrvalant] adj.；adj.；n. 相等的东西"
     ]
   },
   {
     "name": "equivocal",
     "trans": [
-      "Day 12 | adj. | English: not having one clear or definite meaning or intention; able to be understood in more than one way | Example: She gave an equivocal answer, typical of a politician."
+      "[IkwIvak(a)] adj. 模棱两可的"
     ]
   },
   {
     "name": "erect",
     "trans": [
-      "Day 12 | adj. | English: ina vertical position; to build sth | Example: [1] Mr. French, the senior partner, who sat opposite Kirby, was an older man—a safe guess would have placed him somewhere in the debatable ground between forty and fifty; of a good height, as could be seen even from the seated figure, the upper part of which was held erect with the unconscious ease which one associates with military training. 2] At five-thirty the old Panhandle bridge, supported by massive sandstone pillars, stalwart, as when erected fifty years before to serve a generation now passed behind the portals of life, had become a spectral outline against the sky."
+      "[Irekt] adj. 直立的"
     ]
   },
   {
     "name": "erode",
     "trans": [
-      "Day 12 | v. | English: to gradually destroy sth or make it weaker over a period of time | Example: President Richard Nixon is most famous for his participation in the 1970s Watergate political scandal, a convoluted tale of criminality and eroded ethics involving a constellation of associates such as security operative Jack Caulfield and Attorney General John Mitchell."
+      "[I'roud] v. 逐渐毁坏"
     ]
   },
   {
     "name": "erratic",
     "trans": [
-      "Day 12 | adj. | English: not happening at regular times; not following any plan or regular pattern | Example: Entomologists Yash Sondhi and Samuel Fabian have tried to explain why moths fly erratically around light sources at night."
+      "[I'ratk] adj. 不确定的,不规律的"
     ]
   },
   {
     "name": "erroneous",
     "trans": [
-      "Day 12 | adj. | English: not correct; based on wrong information | Example: It could thus erroneously shift the focus of conservation efforts away from M. anniana itself."
+      "[I'rounias] adj. 错误的"
     ]
   },
   {
     "name": "eruption",
     "trans": [
-      "Day 12 | n. | English: an act or instance of erupting Opala in Russia is a caldera, a large cauldron-like hollow that forms shortly after the emptying of a magma chamber in a volcanic eruption."
+      "[I'rphn] n. 喷发"
     ]
   },
   {
     "name": "essential",
     "trans": [
-      "Day 12 | adj. | English: completely necessary; extremely important in a particular situation or for a particular activity | Example: This difference is largely because the features that are essential for running on land restrict top speeds more than the features needed for flying through the air."
+      "[I'senj] adj. 极其重要的"
     ]
   },
   {
     "name": "established",
     "trans": [
-      "Day 12 | adj. | English: respected or given official status because it has existed or been used for a long time | Example: While they might be eager to produce an established classic like Annie, for example, most would be hesitant to stage a work from a relatively unknown playwright."
+      "[I'stablift] adj. 己获确认的"
     ]
   },
   {
     "name": "esteem",
     "trans": [
-      "Day 12 | n. | English: great respect and admiration; a good opinion of sb | Example: This esteem surely helped him to convince France to assist the United States."
+      "[I'sti:m] n. 尊重"
     ]
   },
   {
     "name": "esteemed",
     "trans": [
-      "Day 12 | adj. | English: respected and admired | Example: These characteristic works include his esteemed portraits of poet Seamus Heaney and"
+      "[I'sti:md] adj. 受人尊敬的"
     ]
   },
   {
     "name": "eternity",
     "trans": [
-      "Day 12 | n. | English: time without end, especially life continuing without end after death | Example: A book printed is a record, remaining in every man’s possession, always ready to renew its acquaintance with his memory, and always ready to be produced as an authority or voucher to any reports he makes out of it, and conveys its contents for ages to come, to the eternity of mortal time, when the author is forgotten in his grave."
+      "[I't3:Iati] n. 永恒"
     ]
   },
   {
     "name": "ethereal",
     "trans": [
-      "Day 12 | adj. | English: extremely delicate and light; seeming to belong to another, more spiritual, world | Example: To conclude that this approach accounts for the ethereal qualities now synonymous with the Highwaymen aesthetic is tempting but inaccurate."
+      "[I'Orrial] adj. 优雅的,超凡的"
     ]
   },
   {
     "name": "eventful",
     "trans": [
-      "Day 12 | adj. | English: full of things that happen, especially exciting, important or dangerous things | Example: Whether the reign of a French monarch such as Louis VII or Henry V was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy."
+      "[I'ventfl] adj.；V. 充满大事的"
     ]
   },
   {
     "name": "evince",
     "trans": [
-      "Day 12 | v. | English: to show clearly that you have a feeling or quality | Example: Although it seems ridiculous and useless to study old newspaper clippings and candy wrappers, these old newspapers, advertising leaflets, posters, and candy wrappers are actually able to evince the shifts in people’s behavior and values in the past and are therefore very valuable for this study."
+      "[I'vins] v. 表明"
     ]
   },
   {
     "name": "evocative",
     "trans": [
-      "Day 12 | adj. | English: making you think of or remember a strong image or feeling, in a pleasant way Evocative of African sculpture and American and Scandinavian folk art, these portraits feature flat, deliberately oversimplified figures in a vibrant but limited color palette."
+      "[I'va:katw] adj. 引起记忆的"
     ]
   },
   {
     "name": "evoke",
     "trans": [
-      "Day 12 | v. | English: to bring a feeling, a memory or an image into your mind | Example: Utilizing vivid pastel colors, overexposed tones, and mirrorlike symmetry, Svarbova's photographs evoke a Socialist-era aesthetic that she describes as \"minimalistic but also futuristic.\""
+      "[I'vouk] v. 记忆或形象"
     ]
   },
   {
     "name": "evolutionary",
     "trans": [
-      "Day 12 | adj. | English: relating to or denoting the process by which different kinds of living organisms are believed to have developed from earlier forms | Example: Michael G. Campana and colleagues relied on historical DNA (hDNA)—genomic data incidentally preserved in specimens housed in natural history collections—to investigate the evolutionary origins of a fungal pathogen affecting bats."
+      "[.eva'lu:joneri] adj. 进化的"
     ]
   },
   {
     "name": "exacerbate",
     "trans": [
-      "Day 12 | v. | English: to make sth worse, especially a disease or problem While some commentators lauded this development, asserting that such blogs had a welcome transparency missing from traditional news, less sanguine observers countered that such blogs tended to ideological extremes that exacerbated political polarization to problematic levels."
+      "[Ig'zasarbert] v. 使恶化"
     ]
   },
   {
     "name": "exactitude",
     "trans": [
-      "Day 12 | n. | English: the quality of being very accurate and exact | Example: Ecologist Exequiel Ezcurra and colleagues found that the inhabitants of the Mexica empire used natural landmarks to track time with a high degree of exactitude."
+      "[Ig'zaktitu:d] n. 精准"
     ]
   },
   {
     "name": "exaggerate",
     "trans": [
-      "Day 12 | v. | English: to make sth seem larger, better, worse or more important than it really is | Example: Clements and colleagues caution that relying on such a relatively small sample size can increase the potential for biased analysis. Such analysis, in turn, can contribute to reports of exaggerated effects."
+      "[Ig'zad3arert] v. 夸张"
     ]
   },
   {
     "name": "exalted",
     "trans": [
-      "Day 12 | adj. | English: of high rank, position or great importance | Example: It should not be considered essential to the interest and value of biography, that its subject be of exalted rank, or illustrious name."
+      "[Ig'Z:Itid] adj. 地位高的,显赫的"
     ]
   },
   {
     "name": "excavate",
     "trans": [
-      "Day 13 | v. | English: to dig in the ground to look for old buildings or objects that have been buried for a long time | Example: Archaeologist Christiana Kohler and her team excavated the Egyptian tomb of Queen Merneith, the wife of a First Dynasty pharaoh."
+      "['ekskavcrt] v. （古物二"
     ]
   },
   {
     "name": "exceptional",
     "trans": [
-      "Day 13 | adj. | English: unusually good The National Heritage Fellowship was created to publicly recognize exceptional folk and traditional artists in the United States."
+      "[l'sepjonl] adj. 杰出的,优秀的"
     ]
   },
   {
     "name": "excessive",
     "trans": [
-      "Day 13 | adj. | English: greater than what seems reasonable or appropriate | Example: They complained about the excessive noise coming from the upstairs flat."
+      "[I'seswv] adj. 过分的"
     ]
   },
   {
     "name": "exclude",
     "trans": [
-      "Day 13 | v. | English: to deliberately not include sth in what you are doing or considering | Example: Fernandez and colleagues excluded all pathways other than the CMN by using barriers to keep the plants’ root systems separate while allowing mycorrhizal strands through—a crucial step Wahbi and colleagues' study did not take."
+      "[正'sklu:d] v. 不包括"
     ]
   },
   {
     "name": "exclusive",
     "trans": [
-      "Day 13 | adj. | English: only to be used by one particular person or group; only given to one particular person or group | Example: But most minor planets are given only an identification number, both because there are over 500,000 such bodies known at present and because any name chosen needs to be exclusive to that body: no two minor planets are allowed to have the same name."
+      "[I'sklu:sw] adj. 专用的"
     ]
   },
   {
     "name": "exclusively",
     "trans": [
-      "Day 13 | adv. | English: Exclusively is used to refer to situations or activities that involve only the thing or things mentioned, and nothing else. | Example: Today, the mobile application Instagram is thought of exclusively as a photo- and video- sharing program."
+      "[i'sklu:swvli] adv. 排他地,独占地"
     ]
   },
   {
     "name": "exemplar",
     "trans": [
-      "Day 13 | n. | English: a person or thing that is a good or typical example of sth | Example: They viewed their new building as an exemplar of taste."
+      "n. 典范"
     ]
   },
   {
     "name": "exemplify",
     "trans": [
-      "Day 13 | v. | English: exemplify sth to be a typical example of sth; exemplify sth to give an example in order to make sth clearer | Example: Historians argue that Morris's repudiation of industrialization is manifest in the Kelmscott editions' use of handmade materials and intricate ornamentation reminiscent of medieval manuscripts: these meticulously handcrafted elements exemplify the artistry involved."
+      "[Ig'zemplifar] v. 的典型,举例说明"
     ]
   },
   {
     "name": "exhaustion",
     "trans": [
-      "Day 13 | n. | English: suffering from physical/mental/nervous exhaustion | Example: In her shopping-cart stroller she exercised to exhaustion, bouncing for hours to develop her leg muscles."
+      "[Ig'Z3:stfon] n. 精疲力尽"
     ]
   },
   {
     "name": "exhaustive",
     "trans": [
-      "Day 13 | adj. | English: including everything possible; very thorough or complete | Example: Barring major archaeological discoveries, we are unlikely to ever have an exhaustive account of ancient Egypt under the female pharaoh Hatshepsut, as much of the evidence of her reign was deliberately destroyed by her successors."
+      "[Ig'ZD:stw] adj. 详尽的"
     ]
   },
   {
     "name": "exile",
     "trans": [
-      "Day 13 | n. | English: the state of being sent to live in another country that is not your own, especially for political reasons or as a punishment | Example: When ye plead for the wrecked and fallen, / The exile from far-distant shores, / Remember that men are still wasting / Life's crimson around your own doors."
+      "['eksarl,'cgzall] n. 放逐"
     ]
   },
   {
     "name": "exorbitant",
     "trans": [
-      "Day 13 | adj. | English: much too high | Example: No amount of justification, however, is likely to persuade some drivers who believe the current toll is exorbitant."
+      "[I9'z3:rbitont] adj. 高得离谱的"
     ]
   },
   {
     "name": "expectancy",
     "trans": [
-      "Day 13 | n. | English: the state of expecting or hoping that sth, especially sth good or exciting, will happen | Example: They hypothesized that performance expectancy (how much the use of a service is perceived to benefit the consumer) would be positively correlated with users’ intentions to adopt premium versions."
+      "[正'spektansi] n. 期待"
     ]
   },
   {
     "name": "expedition",
     "trans": [
-      "Day 13 | n. | English: an organized journey with a particular purpose, especially to find out about a place that is not well known | Example: Louise Arner Boyd, who led several scientific expeditions off the coast of Greenland in the 1930s, undoubtedly accomplished much, but to gain a lasting place in our historical memory, there is little that can prevail over being the first to do something."
+      "[.ekspa'drln] n. 远征,探险,考察"
     ]
   },
   {
     "name": "expenditure",
     "trans": [
-      "Day 13 | n. | English: the act of spending or using money; an amount of money spent | Example: When constructing his argument regarding the characteristics of a well-functioning government, Aristotle asserts thar 'Transgression creeps in unperceived and at last ruins the state,’ illustrating this idea with a comparison to frequent small expenditures slowly and almost imperceptibly chipping away at a fortune until it is ultimately depleted."
+      "[ik'spendrtfar] n. 花费"
     ]
   },
   {
     "name": "expense",
     "trans": [
-      "Day 13 | n. | English: the money that you spend on sth | Example: This is a valuable service since the time and expense necessary to find individual investors might otherwise be prohibitive for these companies."
+      "[I'spens] n. 费用"
     ]
   },
   {
     "name": "expertise",
     "trans": [
-      "Day 13 | n. | English: expert knowledge or skill in a particular subject, activity or job | Example: Despite the education specialist's hesitancy about her expertise on the subject in general, she found that she could speak authoritatively about the works of author Mildred Pitts Walter, particularly Justin and the Best Biscuits in the World, which she had used effectively in classroom instruction for many years."
+      "[.eksp3:r'ti:z] n. 专门知识"
     ]
   },
   {
     "name": "explicable",
     "trans": [
-      "Day 13 | adj. | English: that can be explained or understood | Example: This discrepancy is explicable in terms of OFT: the monkeys’ greater reliance on vision means that higher lunar intensity benefits them more than it benefits the bats."
+      "adj. 可解释的"
     ]
   },
   {
     "name": "exploit",
     "trans": [
-      "Day 13 | v. | English: to use sth well in order to gain as much from it as possible | Example: It may seem that the optimal strategy for an animal pursuing prey or escaping predators is to move at maximal speed, but the energy expense of exploiting full speed capacity can disfavor such a strategy even in escape contexts."
+      "[』'sploit] v. 运用"
     ]
   },
   {
     "name": "expound",
     "trans": [
-      "Day 13 | v. | English: to explain sth by talking about it in detail | Example: It provides a general statement about the career of a particular architect, highlights a transition in that career, and then expounds on the ways that transition is evident in the architect's work."
+      "[i'spaond] v. 详解"
     ]
   },
   {
     "name": "exquisite",
     "trans": [
-      "Day 13 | adj. | English: delicate and sensitive | Example: Like this alabaster box whose art / Is frail as a cassia-flower, is my heart, / Carven with delicate dreams and wrought / With many a subtle and exquisite thought."
+      "[Ik'skwrzit;'ekskwizt] adj. 微妙的,敏感的"
     ]
   },
   {
     "name": "extant",
     "trans": [
-      "Day 13 | adj. | English: still in existence | Example: But Drelichman and Voth's unique contribution is their reconstruction of the earliest extant set of annual fiscal records for any sovereign state, which demonstrate that Philip's defaults were caused by short-term liquidity crises, not long-term unsustainable debts."
+      "[ek'stant;'ekstant] adj. 现存的"
     ]
   },
   {
     "name": "extend",
     "trans": [
-      "Day 13 | v. | English: to make sth longer or larger The fog extended its tentacles over city and river gradually obliterating traces of familiar landscapes."
+      "[I'stend] v. 使延伸,扩展"
     ]
   },
   {
     "name": "extended",
     "trans": [
-      "Day 13 | adj. | English: long or longer than usual or expected | Example: It makes an extended comparison of nature to human emotions."
+      "[I'stcndrd] adj. 延长了的,扩展了的"
     ]
   },
   {
     "name": "extension",
     "trans": [
-      "Day 13 | n. | English: the act of making sth longer or larger; the thing that is made longer and larger | Example: Postcranial skeletal pneumaticity (PSP) refers to the presence of extensions of an animal's lungs and air sacs inside its bones."
+      "[』'stenhn] n. 延伸"
     ]
   },
   {
     "name": "extensive",
     "trans": [
-      "Day 13 | adj. | English: great in amount | Example: In an extensive review of existing literature, Lena de Framond and team cataloged the prevalence of broken-wing display—a defensive behavior observed in Charadrius semipalmatus (semipalmated plover) and many other species—throughout the Aves class."
+      "[止'stensrv] adj. 大量的"
     ]
   },
   {
     "name": "extinguish",
     "trans": [
-      "Day 13 | v. | English: to make a fire stop burning or a light stop shining | Example: The sun, already down, was manifest in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+      "[i'stngwIJ] v. 熄灭"
     ]
   },
   {
     "name": "extract",
     "trans": [
-      "Day 13 | v. | English: to remove or obtain a substance from sth, for example by using an industrial or a chemical process | Example: And now, dear reader, a word with you. What is done cannot be undone. We cannot unravel this web of iniquity, and extract justice from this mass of cruel wrongs."
+      "['ekstrakt] v. 提取"
     ]
   },
   {
     "name": "extraneous",
     "trans": [
-      "Day 13 | adj. | English: not directly connected with the particular situation you are in or the subject you are dealing with | Example: We do not want any extraneous information on the page."
+      "[正'strcInias] adj. 无关的"
     ]
   },
   {
     "name": "extraordinary",
     "trans": [
-      "Day 13 | adj. | English: not normal or ordinary; greater or better than usual There is no doubt that Irving Langmuir must have proved himself to be extraordinarily adept at understanding some of the most advanced concepts in the field of chemistry"
+      "[I'stro:rdoneri] adj. 非凡的"
     ]
   },
   {
     "name": "extrapolate",
     "trans": [
-      "Day 13 | v. | English: to estimate sth or form an opinion about sth, using the facts that you have now and that are valid for one situation and supposing that they will be valid for the new one | Example: It is tempting to treat the clustering of information technology firms in Northern California as representative of industrial agglomeration generally, but Guilia Faggio et al. caution against extrapolating from this one example"
+      "[Ik'strapalert] v. 推断"
     ]
   },
   {
     "name": "extricate",
     "trans": [
-      "Day 13 | v. | English: to escape or enable sb to escape from a difficult situation | Example: He had managed to extricate himself from most of his official duties."
+      "['ekstrkert] v. 摆脱,脱离"
     ]
   },
   {
     "name": "exuberant",
     "trans": [
-      "Day 13 | adj. | English: full of energy, excitement and happiness | Example: In a 2018 article about films depicting the experiences of Black Americans, critics for the New York Times praise Madeline Anderson's 1970 film | Am Somebody as \"galvanizing\" and Reginald Hudlin's 1990 film House Party as \"exuberant.\""
+      "[I9'zu:barant] adj. 精力充沛的"
     ]
   },
   {
     "name": "fabrication",
     "trans": [
-      "Day 13 | n. | English: a product of fabrication; especcially LIE, FALSEHOOD | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+      "n. 虚构的信息"
     ]
   },
   {
     "name": "facade",
     "trans": [
-      "Day 13 | n. | English: the front of a building | Example: The sloping tile roofs and picturesque facade of Mission San Luis Rey de Francia in Oceanside, California, exemplify the Spanish contribution to Californian architecture, an influence that is palpable throughout the state"
+      "[f'sa:d] n. （建筑物的）"
     ]
   },
   {
     "name": "facilitate",
     "trans": [
-      "Day 13 | v. | English: to make an action or a process possible or easier | Example: In their meta-analysis of research on advergames (video games developed to promote products or services), Zeph M.C. van Berlo et al. confirm that such games, though they can elicit player interest, may not facilitate subsequent recall of product and brand information."
+      "[f'srlrtert] v. 促进"
     ]
   },
   {
     "name": "facsimile",
     "trans": [
-      "Day 13 | n. | English: an exact copy of sth | Example: One no longer widely read edition is the 1984 “critical and synoptic edition\" edited by Hans Walter Gabler, which followed French and German editorial theories rather than editorial traditions of the United States and United Kingdom and which was later found to have introduced errors due to Gabler's choice to consult facsimile manuscripts rather than using only originals."
+      "[fak'sImali] n. 摹本"
     ]
   },
   {
     "name": "fade away",
     "trans": [
-      "Day 13 | English: to disappear gradually | Example: [The] Mole stood still a moment, held in thought. As one wakened suddenly from a beautiful dream, who struggles to recall it, and can re-capture nothing but a dim sense of the beauty of it, the beauty! Till that, too, fades away in its turn."
+      "逐渐消失"
     ]
   },
   {
     "name": "faint",
     "trans": [
-      "Day 13 | adj. | English: that cannot be clearly seen, heard or smelt | Example: In 2016, Gabriela Gonzalez and team announced that a chirping sound captured by Laser Interferometer Gravitational-Wave Observatory antennas was direct evidence of gravitational waves, which skeptics had argued would be too faint for detection."
+      "[fcInt] adj. 微弱的,不清楚的"
     ]
   },
   {
     "name": "fair",
     "trans": [
-      "Day 13 | n. | English: a type of entertainment in a field or park at which farm animals and products are shown and take part in competitions Mrs. Tarpey, Bartley, and Mrs. Fallon have been buying and selling goods at the local fair."
+      "[fer] n. 集市"
     ]
   },
   {
     "name": "fame",
     "trans": [
-      "Day 13 | n. | English: the state of being known and talked about by many people | Example: These masterpieces deserve as much fame as Joplin's biggest hits."
+      "[feIm] n. 名声"
     ]
   },
   {
     "name": "fashion",
     "trans": [
-      "Day 13 | v. | English: to make or shape sth, especially with your hands But culture indefatigably tries, not to make what each raw person may like, the rule by which he fashions himself."
+      "['fa] v. 塑造"
     ]
   },
   {
     "name": "fate",
     "trans": [
-      "Day 13 | n. | English: the power that is believed to control everything that happens and that cannot be stopped or change | Example: I'm as hungry as the winter, I'm ill, I'm shaken... and where haven't | been—fate has tossed me everywhere!"
+      "[fert] n. 命运"
     ]
   },
   {
     "name": "fauna",
     "trans": [
-      "Day 13 | n. | English: all the animals living in an area or in a particular period of history | Example: Some researchers have characterized the flora and fauna of the South Pacific island of Grande Terre as members of clades that inhabited nearby islands before Grande Terre"
+      "['13:13] n. 动物群"
     ]
   },
   {
     "name": "feasible",
     "trans": [
-      "Day 13 | adj. | English: that is possible and likely to be achieved | Example: Expanding the scope of such studies is unlikely to be feasible."
+      "['丘:23b] adj. 可行的"
     ]
   },
   {
     "name": "feature",
     "trans": [
-      "Day 13 | v. | English: to include a particular person or thing as a special feature | Example: Propped on the window ledge, it featured a portrait of Great-Great-Grandmother Rosita as a young woman."
+      "['fi:tjar] v. 为特色"
     ]
   },
   {
     "name": "feline",
     "trans": [
-      "Day 13 | n. | English: acat; an animal of the cat family | Example: Researchers hypothesize that this difference between the two feline species may be partly due to a U-shaped bone in their throats."
+      "['f:lamn] n. 猫科动物"
     ]
   },
   {
     "name": "fence",
     "trans": [
-      "Day 13 | n. | English: a-structure made of wood or wire supported with posts that is put between two areas of land as a boundary , or around a garden yard, field, etc. to keep animals in, or to keep people and animals out | Example: He surveyed the fence, and all gladness left him and a deep melancholy settled down upon his spirit. Thirty yards of board fence nine feet high."
+      "[fens] n. 栅栏"
     ]
   },
   {
     "name": "fern",
     "trans": [
-      "Day 13 | n. | English: a plant with large delicate leaves and no flowers that grows in wet areas or is grown in a pot. There are many types of fern. | Example: The little fern-leaf, bending / Upon the brink, its green reflection greets, / And kisses soft the shadow that it meets / With touch so fine, / The border line / The keenest vision can't define; / So perfect is the blending."
+      "n. 蕨类植物"
     ]
   },
   {
     "name": "fertile",
     "trans": [
-      "Day 13 | adj. | English: that plants grow well in | Example: Natural humidity, which renders irrigation unnecessary or reduces its importance in the northern reaches of California, gradually decreases toward the sun-scorched but nonetheless fertile valleys of the southern part of the state."
+      "['f3:r] adj. 肥沃的"
     ]
   },
   {
     "name": "festoon",
     "trans": [
-      "Day 14 | n. | English: achain of lights, coloured paper, flowers, etc., used to decorate sth | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+      "[fe'stu:\"] n. 彩灯,花彩"
     ]
   },
   {
     "name": "fictionalize",
     "trans": [
-      "Day 14 | v. | English: to write a book or make a film/movie about a true story, but changing some of the details, characters, etc. | Example: Fitzgerald merely fictionalized true events."
+      "['fjanalarz] v. （真人真事）改编成小说"
     ]
   },
   {
     "name": "fictitious",
     "trans": [
-      "Day 14 | adj. | English: invented by sb rather than true | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+      "[fik'tjas] adj. 虚构的"
     ]
   },
   {
     "name": "fidelity",
     "trans": [
-      "Day 14 | n. | English: the quality of being accurate | Example: Historians’ fidelity to the truth often results in work that is less engaging than it could be."
+      "[f'deloti] n. 准确性"
     ]
   },
   {
     "name": "figurative",
     "trans": [
-      "Day 14 | adj. | English: used in a way that is different from the usual meaning, in order to create a particular mental picture | Example: They provide examples, one literal and one figurative, of a change that the speaker describes throughout the text."
+      "['figjaratrv] adj. 比喻的"
     ]
   },
   {
     "name": "figure",
     "trans": [
-      "Day 14 | n. | English: a person of the type mentioned | Example: It describes a writer's successful career, presents two literary figures who were supporters of that writer's career, and explains why the writer was able to achieve what he did."
+      "['figjar] n. 人物"
     ]
   },
   {
     "name": "filter",
     "trans": [
-      "Day 14 | v. | English: v. to pass liquid, light, etc. through a special device, especially to remove sth that is not wanted; n. a device containing paper, sand, chemicals, etc. that a liquid or gas is passed through in order to remove any materials that are not wanted | Example: [1] Like all species of baleen whales, the humpback whale feeds on tiny creatures known as krill by filtering water through bristlelike keratin structures called baleen plates. 2] In one study, Vivek Nityananda and his team fitted mantises' faces with two different color filters, one covering each eye, much like the filters in 3D glasses once worn at movies."
+      "['fltar] v.；v.；n. 过滤"
     ]
   },
   {
     "name": "finite",
     "trans": [
-      "Day 14 | adj. | English: having a definite limit or fixed size | Example: This phenomenon can be explained by the finite nature of cognitive capacity as it is articulated in Annie Lang's limited capacity model of motivated mediated message processing."
+      "['faInart] adj. 有限制的"
     ]
   },
   {
     "name": "firm",
     "trans": [
-      "Day 14 | adj. | English: adj. fairly hard; not easy to press into a different shape; adj. not likely to change | Example: He was daring, without being rash: prompt, but not thoughtless; firm, without being harsh."
+      "[f3:Im] adj. 坚固的"
     ]
   },
   {
     "name": "fiscal",
     "trans": [
-      "Day 14 | adj. | English: connected with government or public money, especially taxes | Example: Although the government regularly defaulted on debt, it ran an even larger overall surplus than did the government of eighteenth-century Britain, which historians consider a model of fiscal virtue."
+      "['fiskl] adj. 财政的"
     ]
   },
   {
     "name": "fling",
     "trans": [
-      "Day 14 | v. | English: to throw sb/sth somewhere with force | Example: One popular theory of the origin of the Moon, the \"big whack,\" posits that a protoplanet called Theia collided with Earth, flinging debris into orbit that eventually coalesced into the Moon."
+      "[{] v. 扔"
     ]
   },
   {
     "name": "flora",
     "trans": [
-      "Day 14 | n. | English: the plants of a particular area, type of environment or period of time | Example: Some researchers have characterized the flora and fauna of the South Pacific island of Grande Terre as members of clades that inhabited nearby islands before Grande Terre"
+      "['fl3:ra] n. 植物群"
     ]
   },
   {
     "name": "flourish",
     "trans": [
-      "Day 14 | v. | English: to develop quickly and be successful or common | Example: Some historians suggest that Maya mathematicians inherited it from the Olmec civilization, which flourished in the region 2,400-3,600 years ago."
+      "['+13:可] v. 繁荣"
     ]
   },
   {
     "name": "fluctuation",
     "trans": [
-      "Day 14 | n. | English: the quality of being unsteady and subject to changes | Example: Having an ample reserve of stored energy can mitigate the effects of fluctuations in solar energy collection caused by unpredictable shifts in cloud cover and haze. flyer on. 1) CO) 8 S232: a small sheet of paper that advertises a product or an event and is given to a large number of people Studying wrappers from discontinued candies, menus from nineteenth-century restaurants, and flyers promoting long-forgotten sporting events may seem like a frivolous pursuit, but ephemeral objects like these are useful as markers of cultural change."
+      "[fluktfu'erhn] n. 起伏"
     ]
   },
   {
     "name": "flyer",
     "trans": [
-      "Day 14 | n. | English: a small sheet of paper that advertises a product or an event and is given to a large number of people | Example: Studying wrappers from discontinued candies, menus from nineteenth-century restaurants, and flyers promoting long-forgotten sporting events may seem like a frivolous pursuit, but ephemeral objects like these are useful as markers of cultural change."
+      "n. （广告）传单"
     ]
   },
   {
     "name": "folk",
     "trans": [
-      "Day 14 | n. | English: people in general | Example: The National Heritage Fellowship was created to publicly recognize exceptional folk and"
+      "[fouk] n. 人们"
     ]
   },
   {
     "name": "folklore",
     "trans": [
-      "Day 14 | n. | English: the traditions and stories of a country or community | Example: This style has exerted a decisive influence on authors around the world, including Olga Tokarczuk, whose 1996 novel Primeval and Other Times resembles classic magical realist novels in its juxtaposition of literary realism with folklore—namely, that of Poland."
+      "['foUkl3:r] n. 民俗"
     ]
   },
   {
     "name": "forage",
     "trans": [
-      "Day 14 | v. | English: to search for food | Example: The bird species Myiobius barbatus (the bearded flycatcher), which forages in relatively dense vegetation, and Platyrinchus saturatus (the cinnamon-crested spadebill), which forages in open areas or low-density vegetation, share territory in French Guiana with Thainnomanes caesius (the cinereous antshrike), which emits a loud alarm call when it detects predators."
+      "['f3:r1d3] v. （食"
     ]
   },
   {
     "name": "forecast",
     "trans": [
-      "Day 14 | n. | English: n.a statement about what will happen in the future, based on information that is available now; v. to say what you think will happen in the future based on information that you have now | Example: [1] Researchers Youran Fu and Marshall Fisher have found that combining sellers' own data with information gathered from social media can dramatically improve the accuracy of such forecasts—by 24 to 57 percent in the cases they directly studied. 2] Businesses selling clothing and other fashion items face obstacles in trying to forecast how much product to order: tastes and styles change quickly, while manufacturing clothing takes a significant amount of time."
+      "['f3:rkast] n.；n.；v. 预测"
     ]
   },
   {
     "name": "foresight",
     "trans": [
-      "Day 14 | n. | English: the ability to predict what is likely to happen and to use this to prepare for the future | Example: She had had the foresight to prepare herself financially in case of an accident."
+      "['fo:rsart] n. 先见之明"
     ]
   },
   {
     "name": "forestall",
     "trans": [
-      "Day 14 | v. | English: to prevent sth from happening or sb from doing sth by doing sth first | Example: As having the effect of forestalling consideration of the full stylistic dimensions of poetry written in the period"
+      "[f:工'8t3:1] v. 预先阻止"
     ]
   },
   {
     "name": "forge",
     "trans": [
-      "Day 14 | v. | English: to shape metal by heating it in a fire and hitting it with a hammer; to make an object in this way | Example: Poetry can forge connections between people from different cultures."
+      "[f:rd3] v. 锻造,制作"
     ]
   },
   {
     "name": "fortification",
     "trans": [
-      "Day 14 | n. | English: a tower, wall, gun position, etc. built to defend a place against attack | Example: | had gazed upon the fortifications and impediments that seemed to keep human beings from entering the citadel of nature, and rashly and ignorantly | had repined."
+      "[.f:rtrfi'kerln] n. 防御工事"
     ]
   },
   {
     "name": "fortune",
     "trans": [
-      "Day 14 | n. | English: a large amount of money | Example: When constructing his argument regarding the characteristics of a well-functioning government, Aristotle asserts thar ‘Transgression creeps in unperceived and at last ruins the state,’ illustrating this idea with a comparison to frequent small expenditures slowly and almost imperceptibly chipping away at a fortune until it is ultimately depleted."
+      "['f:Itjan] n. 大笔的钱"
     ]
   },
   {
     "name": "foster",
     "trans": [
-      "Day 14 | v. | English: to encourage sth to develop | Example: Ata conference for aspiring children's book authors, Candy Dawson Boyd, author of such lauded works as Circle of Gold, was the subject of a presentation that was intended specifically to foster insight into the techniques of successful authors so that attendees could use that understanding to improve their own work."
+      "['fa:sta] v. 培养"
     ]
   },
   {
     "name": "fracture",
     "trans": [
-      "Day 14 | v. | English: to break or crack; to make sth break or crack | Example: Researchers investigated the timing of the transition from a stagnant lid regime to a tectonic plate regime, in which the lithosphere is fractured into dynamic plates that in turn allow lithospheric and mantle material to mix. fracturing on. why 327%: If something such as a bone is fractured or fractures, it gets a crack or break in it. Many chondrites experience aqueous alteration as a result of exposure to fluids, as well as fracturing, veining, and localized melting due to collisions with other objects."
+      "['fraktjar] v. 使断裂,破裂"
     ]
   },
   {
     "name": "fracturing",
     "trans": [
-      "Day 14 | n. | English: If something such as a bone is fractured or fractures, it gets a crack or break in it. | Example: Many chondrites experience aqueous alteration as a result of exposure to fluids, as well as fracturing, veining, and localized melting due to collisions with other objects."
+      "n. 断裂"
     ]
   },
   {
     "name": "fragile",
     "trans": [
-      "Day 14 | adj. | English: easily broken or damaged | Example: A gleaming carpet was springing up everywhere, that looked too fragile to be trodden upon by rough feet."
+      "['frad3l] adj. 易碎的"
     ]
   },
   {
     "name": "fragment",
     "trans": [
-      "Day 14 | n. | English: a small part of sth that has broken off or comes from sth larger | Example: The team suggests that scientists have ignored the possibility that something other than a comet fragment could have made the crater."
+      "['fragmant;fregment] n. 碎片"
     ]
   },
   {
     "name": "fragmentation",
     "trans": [
-      "Day 14 | n. | English: the process or state of breaking or being broken into small or separate parts | Example: For too long, scholars have focused on narrative fragmentation versus coherence, inhibiting inquiry into other points of stylistic correspondence among works that would enrich our understanding of the modernist canon."
+      "[.fragmen'terhn] n. 分裂"
     ]
   },
   {
     "name": "fragrant",
     "trans": [
-      "Day 14 | adj. | English: having a pleasant smell | walked slowly beneath the young leaves, drinking in the air, fragrant with the odor of young buds and sap."
+      "['frergrant] adj. 芳香的"
     ]
   },
   {
     "name": "frail",
     "trans": [
-      "Day 14 | adj. | English: weak; easily damaged or broken | Example: Like this alabaster box whose art / Is frail as a cassia-flower, is my heart, / Carven with delicate dreams and wrought / With many a subtle and exquisite thought."
+      "[frerl] adj. 脆弱的"
     ]
   },
   {
     "name": "fraudulent",
     "trans": [
-      "Day 14 | adj. | English: intended to cheat sb, usually in order to make money illegally | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few entries that knowledgeable readers should have realized were fraudulent, such as those for the town of Stone Ridge, Maryland, and the 18th-century forestry magnate Guillermo Garcia, persisted on the site for many years before they were finally recognized as falsehoods and deleted."
+      "['+3:d33lant] adj. 欺骗的"
     ]
   },
   {
     "name": "frigate",
     "trans": [
-      "Day 14 | n. | English: a small fast ship in the navy that travels with other ships in order to protect them | Example: There is no Frigate like a Book / To take us Lands away / Nor any Coursers like a Page / Of prancing Poetry— / This Traverse may the poorest take / Without oppress of Toll— / How frugal is the Chariot / That bears the Human soul."
+      "n. （小型）"
     ]
   },
   {
     "name": "frivolous",
     "trans": [
-      "Day 14 | adj. | English: silly or amusing, especially when such behaviour is not suitable | Example: Studying wrappers from discontinued candies, menus from nineteenth-century restaurants, and flyers promoting long-forgotten sporting events may seem like a frivolous pursuit, but ephemeral objects like these are useful as markers of cultural change."
+      "['frrvalas] adj. 愚蠢的"
     ]
   },
   {
     "name": "frugal",
     "trans": [
-      "Day 14 | adj. | English: using only as much money or food as is necessary | Example: There is no Frigate like a Book / To take us Lands away / Nor any Coursers like a Page / Of prancing Poetry— / This Traverse may the poorest take / Without oppress of Toll— / How frugal is the Chariot / That bears the Human soul."
+      "['fru:9] adj. 节约的"
     ]
   },
   {
     "name": "fry",
     "trans": [
-      "Day 14 | v. | English: to cook sth in hot fat or oil; to be cooked in hot fat or oil | Example: Many Indian snack foods, such as bhatoora and paneer pakora, acquire their flavor from being fried in oil."
+      "[fra] v. 油炸"
     ]
   },
   {
     "name": "fully-fledged",
     "trans": [
-      "Day 14 | adj. | English: Fully-fledged means complete or fully developed. | Example: Smith deploys this metaphor only once in his economic writings—to make a narrow point about the then-dominant economic theory of mercantilism—and it was largely ignored until some twentieth-century economists eager to secure an intellectual pedigree for their views elevated it to a fully-fledged paradigm."
+      "[.fuli'tled3d] adj. 充分发展的"
     ]
   },
   {
     "name": "fume",
     "trans": [
-      "Day 14 | n. | English: Fumes are the unpleasant and often unhealthy smoke and gases that are produced by fires or by things such as chemicals, fuel, or cooking. | Example: | think Québec City needs more streets like Rue du Petit-Champlain, not more streets full of loud cars spewing exhaust fumes into the air."
+      "[tu:皿] n. （难闻且常有害的）"
     ]
   },
   {
     "name": "funeral",
     "trans": [
-      "Day 14 | n. | English: a ceremony, usually a religious one, for burying or cremating | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+      "['fu:naral] n. 葬礼"
     ]
   },
   {
     "name": "fungal",
     "trans": [
-      "Day 14 | adj. | English: of or caused by fungus | Example: Is there an available barrier material that can block roots and liquids while allowing fungal strands through?"
+      "['f4gl] adj. 真菌的"
     ]
   },
   {
     "name": "fungi",
     "trans": [
-      "Day 14 | n. | English: any plant without leaves, flowers or green colouring, usually growing on other plants or on decaying matter. Mushrooms and mildew are both fungi. | Example: The researchers studied two wooden shipwrecks in the Gulf of Mexico by placing pieces of pine and oak between zero and 200 meters away from each shipwreck to collect samples of three kinds of microbes: bacteria, archaea, and fungi."
+      "['fundzar;'fu] n. （的复数形式）"
     ]
   },
   {
     "name": "furrow",
     "trans": [
-      "Day 14 | n. | English: a long narrow cut in the ground, especially one made by a plough for planting seeds in | Example: As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot."
+      "n. 犁沟"
     ]
   },
   {
     "name": "fuse",
     "trans": [
-      "Day 14 | v. | English: when one thing fuses with another, or two things fuse or are fused , they are joined together to form a single thing Schiller thought works could be classified as either naive (seeking to describe reality) or sentimental (seeking to develop ideas), Little, Big fuses both modes of writing."
+      "[#u:2] v. （使）融合"
     ]
   },
   {
     "name": "fusion",
     "trans": [
-      "Day 14 | n. | English: the process or result of joining two or more things together to form one | Example: Mosques often reflect multiple architectural styles, resulting in a unique fusion of those influences, as in the case of the Sheikh Zayed Mosque, which combines elements from the Persian, Mughal, and Moorish styles."
+      "['5u:3] n. 融合"
     ]
   },
   {
     "name": "futile",
     "trans": [
-      "Day 14 | adj. | English: having no purpose because there is no chance of success | Example: Professor Serebrakoff says to Helena, “I am used to my library and the lecture hall and to the esteem and admiration of my colleagues. Now | suddenly find myself plunged into this wilderness (the cottage), condemned to see the same stupid people from morning till night and listen to their futile conversations.”"
+      "['tu:t] adj. 徒劳的"
     ]
   },
   {
     "name": "gadget",
     "trans": [
-      "Day 14 | n. | English: a small tool or device that does sth useful | Example: Environmental policy researcher Jessika Richter warns that because new batteries can't be put in once the old ones no longer work, the gadgets stop functioning and are usually disposed of as trash."
+      "['gad3t] n. 小器具"
     ]
   },
   {
     "name": "galactic",
     "trans": [
-      "Day 14 | adj. | English: relating to a galaxy | Example: Using the Stratospheric Observatory for Infrared Astronomy (SOFIA), a team of astronomers mapped out the magnetic field of G47, one of the Milky Way's galactic bones (dense clouds of gas and dust that run through the middle of the arm of a spiral galaxy)."
+      "adj. 银河的"
     ]
   },
   {
     "name": "gallop",
     "trans": [
-      "Day 14 | n. | English: the fastest speed at which a horse can run, with a stage in which all four feet are off the ground together | Example: They spurred their horses to a gallop as if in that mad race they laid claims of possession to the earth."
+      "['galop] n. （马的）飞奔"
     ]
   },
   {
     "name": "galvanize",
     "trans": [
-      "Day 14 | v. | English: to make sb take action by shocking them or by making them excited | Example: In a 2018 article about films depicting the experiences of Black Americans, critics for the New York Times praise Madeline Anderson's 1970 film | Am Somebody as \"galvanizing\" and Reginald Hudlin's 1990 film House Party as \"exuberant.\""
+      "['galvanarz] v. 使兴奋,使震惊"
     ]
   },
   {
     "name": "gasp",
     "trans": [
-      "Day 15 | n. | English: a quick deep breath, usually caused by a strong emotion | Example: The [train] engines of this valley have a whistle, the echoes of which sound like iterated gasps and sobs. | always think of them as crude music."
+      "[g8sP] n. （常指由强烈情感引起的）"
     ]
   },
   {
     "name": "gathering",
     "trans": [
-      "Day 15 | adj. | English: adj. If there is gathering darkness, the light is gradually decreasing, usually because it is nearly night. n. a meeting of people for a particular purpose | Example: [1] Guiding himself by the sound, he made his way through the gathering darkness to the foot of an old beech tree. 2] The text makes which point about the people at the gathering?"
+      "['9803r] adj.；adj.；n. （进入黑夜）"
     ]
   },
   {
     "name": "gaudy",
     "trans": [
-      "Day 15 | adj. | English: too brightly coloured in a way that lacks taste | Example: But there were vacant seats here and there, and into one of them she was ushered, between brilliantly dressed women who had gone there to kill time and eat candy and display their gaudy attire."
+      "['93:di] adj. 俗艳的,花哨的"
     ]
   },
   {
     "name": "gaze",
     "trans": [
-      "Day 15 | v. | English: to look steadily at sb/sth for a long time, either because you are very interested or surprised, or because you are thinking of sth else | Example: | had gazed upon the fortifications and impediments that seemed to keep human beings from entering the citadel of nature, and rashly and ignorantly | had repined."
+      "[gerz] v. 凝视"
     ]
   },
   {
     "name": "gender",
     "trans": [
-      "Day 15 | n. | English: the fact of being male or female | Example: In fact the work is a complex, dynamic meditation on gender and the legacy of colonialism that demands serious attention."
+      "['d3endor] n. 性别"
     ]
   },
   {
     "name": "generic",
     "trans": [
-      "Day 15 | adj. | English: shared by, including or typical of a whole group of things; not specific | Example: If \"Kleenex\" were judged to have become a generic term, as \"cellophane\" was, other companies would be free to use it to promote similar products, making it harder for Kimberly- Clark to stand out from competitors."
+      "[433'nerk] adj. 普通的"
     ]
   },
   {
     "name": "generous",
     "trans": [
-      "Day 15 | adj. | English: giving or willing to give freely; given freely | Example: It was generous of him to offer to pay for us both."
+      "['dzenaras] adj. 慷慨的"
     ]
   },
   {
     "name": "genome",
     "trans": [
-      "Day 15 | n. | English: the complete set of genes in a cell or living thing | Example: Instead, success in fields like chemistry is usually achieved through direct cooperation with other experts, as was the case for Jennifer Doudna, who was among those awarded for “the development of a method for genome editing.”"
+      "['d3i:noum] n. 基因组"
     ]
   },
   {
     "name": "gentility",
     "trans": [
-      "Day 15 | n. | English: very good manners and behaviour; the fact of belonging to a high social class | Example: Newland Archer felt himself distinctly the superior of these chosen specimens of old New York gentility; he had probably read more, thought more, and even seen a good deal more of the world, than any other man of the number."
+      "[d3en'tlati] n. 高贵的身份"
     ]
   },
   {
     "name": "genuine",
     "trans": [
-      "Day 15 | adj. | English: sincere and honest; that can be trusted | Example: \"Reading [poetry], however, with a perfect contempt for it, one discovers that there is in / it after all, a place for the genuine.\""
+      "['dzenjum] adj. 真诚的"
     ]
   },
   {
     "name": "genus",
     "trans": [
-      "Day 15 | n. | English: a group into which animals, plants, etc. that have similar characteristics are divided, smaller than a family and larger than a species | Example: The discoverers of the minor planet 1227 Geranium named it after the plant genus that includes cranesbills."
+      "['d3i:n3s] n. （动植物的）属"
     ]
   },
   {
     "name": "geography",
     "trans": [
-      "Day 15 | n. | English: the way in which the physical features of a place are arranged The Nile River delta system is located in Northern Egypt, where the river drains into the for example, the geography of the coastline influences sedimentary deposition, which over time alters coastal geography."
+      "[d3i'a:groti] n. 地形,地势,地貌"
     ]
   },
   {
     "name": "geometric",
     "trans": [
-      "Day 15 | adj. | English: of geometry ; of or like the lines, shapes, etc. used in geometry , especially because of having regular shapes or lines | Example: The project's unadorned geometric forms, typical of the modernist aesthetic, contrasted with the historically inspired architecture seen in his earlier projects in Guadalajara, such as the"
+      "[d3i:3'metrk] adj. 几何的"
     ]
   },
   {
     "name": "germinate",
     "trans": [
-      "Day 15 | v. | English: when the seed of a plant germinates or is germinated , it starts to grow | Example: Can field mustard plants grow on Mars? Can pea plants? You might think the answer to these questions is obviously no, but researchers in the Netherlands recently showed that the seeds of many common plant species can germinate in soil designed to simulate Martian conditions, as long as water is supplied."
+      "['433:Immnert] v. 使一"
     ]
   },
   {
     "name": "giggle",
     "trans": [
-      "Day 15 | v. | English: to laugh in a silly way because you are amused, embarrassed or nervous | Example: They usually spent the entire day in the attic, playing dolls and giggling."
+      "['gIgl] v. 窘迫或紧张而"
     ]
   },
   {
     "name": "gimmick",
     "trans": [
-      "Day 15 | n. | English: an unusual trick or unnecessary device that is intended to attract attention or to persuade people to buy sth | Example: Today, the Michelin Guide is widely known as the arbiter of fine dining, but when it was created in 1900, it was little more than a marketing gimmick."
+      "['gImk] n. （为引人注意或诱人购买而搞的"
     ]
   },
   {
     "name": "give free rein to",
     "trans": [
-      "Day 15 | English: to give sb complete freedom of action; to allow a feeling to be expressed freely | Example: Padre Florentino, who was an accomplished musician, was improvising, and, as he was alone, gave free rein to the sadness in his heart."
+      "不加约束"
     ]
   },
   {
     "name": "gleaming",
     "trans": [
-      "Day 15 | adj. | English: shining brightly | Example: A gleaming carpet was springing up everywhere."
+      "['gli:\"n] adj. 明亮的"
     ]
   },
   {
     "name": "glide",
     "trans": [
-      "Day 15 | v. | English: to move smoothly and quietly, especially as though it takes no effort | Example: Thy warm and land-locked waters swell with an easy motion, / And gently glides the light"
+      "[glad] v. 滑行,滑动,掠过"
     ]
   },
   {
     "name": "grasp",
     "trans": [
-      "Day 15 | v. | English: to understand sth completely | Example: One person after another rose, and, as with an ill-balanced axe, attempted to hew out his conception of art a little more clearly, and sat down with the feeling that, for some reason which he could not grasp, his strokes had gone awry."
+      "[grasp] v. 理解"
     ]
   },
   {
     "name": "gratification",
     "trans": [
-      "Day 15 | n. | English: the state of feeling pleasure when sth goes well for you or when your desires are satisfied; sth that gives you pleasure | Example: Cuttlefish appear to be surprisingly competent at exercising self-control: in a 2021 study conducted by behavioral ecologist Alexandra Schnell, these cephalopods routinely demonstrated restraint by delaying gratification, waiting for a favorite treat instead of instantly devouring a readily available meal."
+      "n. 满足"
     ]
   },
   {
     "name": "grave",
     "trans": [
-      "Day 15 | v. | English: n.a place in the ground where a dead person is buried; adj. serious in manner, as if sth sad, important or worrying has just happened | Example: [1] A book printed is a record, remaining in every man’s possession, always ready to renew its acquaintance with his memory, and always ready to be produced as an authority or voucher to any reports he makes out of it, and conveys its contents for ages to come, to the eternity of mortal time, when the author is forgotten in his grave. 2] The sonorous, joyful bells rang again. From within the church, the honeyed voices of a female chorus rose melancholy and grave."
+      "[grerv;gra:v] v.；n.；adj. 坟墓"
     ]
   },
   {
     "name": "gravely",
     "trans": [
-      "Day 15 | adv. | English: toa degree that gives cause for alarm | Example: Before Juchipila was lost from sight, Valderrama got off his horse, bent down, kneeled, and gravely kissed the ground."
+      "['grervli] adv. 严肃地"
     ]
   },
   {
     "name": "gravitas",
     "trans": [
-      "Day 15 | n. | English: the quality of being serious | Example: Finally, and adding much-needed gravitas, was Sir Winston Day, whose features seemed moulded to adorn a bust, or possibly a stamp, and whose forehead was so evidently bulging with grey matter that it would have been impertinent to inquire too closely into the actual achievements his half century of public service had produced."
+      "n. 庄重"
     ]
   },
   {
     "name": "gravitational wave",
     "trans": [
-      "Day 15 | n. | English: a wave propagated in a gravitational field, predicted to occur as a result of an accelerating mass | Example: In 2016, Gabriela Gonzalez and team announced that a chirping sound captured by Laser Interferometer Gravitational-Wave Observatory antennas was direct evidence of gravitational waves."
+      "n. 引力波"
     ]
   },
   {
     "name": "grid",
     "trans": [
-      "Day 15 | n. | English: a pattern of straight lines, usually crossing each other to form squares | Example: Hydrologist Yonghong Yi and her colleagues modeled seasonal changes in net CO2 in Alaska in a landscape grid of 1 square kilometer (km2) cells and again in a grid of 10 km2 cells, which are finer resolutions than most models of net CO2 have achieved."
+      "[grid] n. 网格"
     ]
   },
   {
     "name": "grief",
     "trans": [
-      "Day 15 | n. | English: a feeling of great sadness, especially when sb dies | Example: Mercedes, being not quite seventeen, her grief at parting from Clarence was wild, vehement and all-absorbing."
+      "n. 悲伤"
     ]
   },
   {
     "name": "groan",
     "trans": [
-      "Day 15 | v. | English: to make a long deep sound because you are annoyed, upset or in pain, or with pleasure | Example: [The wagon] bumps, and groans, and shakes as it crosses the railroad track."
+      "[groun] v. 呻吟"
     ]
   },
   {
     "name": "grooved",
     "trans": [
-      "Day 15 | adj. | English: having a groove or several grooves | Example: Researchers have long hypothesized that woolly mammoths were hunted to extinction in North America by humans using spears with grooved tips known as Clovis points."
+      "[gru:vd] adj. 有槽的"
     ]
   },
   {
     "name": "grossly",
     "trans": [
-      "Day 15 | adv. | English: extremely | Example: MOMA claims the video presentations are only for games that would be impractical to display in a playable form, but video games are an inherently interactive medium, a feature that is grossly absent in a video-only presentation."
+      "['grousli] adv. 极度地;非常"
     ]
   },
   {
     "name": "growl",
     "trans": [
-      "Day 15 | v. | English: to say sth in a low angry voice | Example: Itis your duty to make peace [with Professor Serebrakoff], and not to growl at everything."
+      "[graol] v. 发出低沉的怒吼"
     ]
   },
   {
     "name": "grudging",
     "trans": [
-      "Day 15 | adj. | English: given or done unwillingly | Example: He could not help feeling a grudging admiration for the old lady."
+      "adj. 勉强的"
     ]
   },
   {
     "name": "hallmark",
     "trans": [
-      "Day 15 | n. | English: a feature or quality that is typical of sb/sth | Example: Certain features are almost always included in the designs of mosques, like the minaret (or tower), which is considered to be a hallmark of mosques architecture."
+      "['h3:Ima:以] n. 特征"
     ]
   },
   {
     "name": "halt",
     "trans": [
-      "Day 15 | v. | English: to stop; to make sb/sth stop | Example: Then, hurriedly, [the soldiers] took the Juchipila canyon northward, without halting to rest until nightfall."
+      "[h3:4t] v. （使"
     ]
   },
   {
     "name": "haphazard",
     "trans": [
-      "Day 15 | adj. | English: not organized well | Example: Set in a world where science fiction tropes exist as everyday realities, Charles Yu’s 2010 novel How to Live Safely in a Science Fictional Universe traces a time traveler’s quest to find his father. Because the journey at the novel’s center is so haphazard, with the protagonist ricocheting chaotically across time, the reader often wonders whether the pair will ever be reunited."
+      "[hap'hazard] adj. 无秩序的"
     ]
   },
   {
     "name": "harbinger",
     "trans": [
-      "Day 15 | n. | English: asign that shows that sth is going to happen soon, often sth bad | Example: The November air stung my cheeks, a harbinger of winter."
+      "['ha:rbInd3or] n. （常指坏的）预兆,兆头"
     ]
   },
   {
     "name": "harsh",
     "trans": [
-      "Day 15 | adj. | English: cruel, severe and unkind | Example: He was daring, without being rash: prompt, but not thoughtless; firm, without being harsh."
+      "adj. 残酷的"
     ]
   },
   {
     "name": "hasty",
     "trans": [
-      "Day 15 | adj. | English: said, made or done very quickly, especially when this has bad results | Example: She did not wish to act hastily, to do anything she might afterward regret."
+      "['hersti] adj. 匆忙的"
     ]
   },
   {
     "name": "hatchling",
     "trans": [
-      "Day 15 | n. | English: a baby bird or animal which has just come out of its shell Based on observations made over three years, scientists concluded that temperatures at the site likely confer reproductive benefits and that the site is used exclusively for reproduction—6,000 M.robustus adults, hatchlings, and eggs were observed at the garden, but no juveniles were present."
+      "['hatfln] n. 刚出壳的雏鸟"
     ]
   },
   {
     "name": "haunt",
     "trans": [
-      "Day 15 | v. | English: to continue to cause problems for sb for a long time | Example: How [the sailor] haunted my dreams, | need scarcely tell you. On stormy nights, when the wind shook the four corners of the house and the surf roared along the cove and up the cliffs, | would see him in a thousand forms, and with a thousand diabolical expressions."
+      "[I3:nt] v. 长期不断地缠扰"
     ]
   },
   {
     "name": "haunted",
     "trans": [
-      "Day 15 | adj. | English: believed to be visited by ghosts | Example: He'd be a hero among his friends if he was the first boy to cross the haunted gates!"
+      "adj. 闹鬼的"
     ]
   },
   {
     "name": "havoc",
     "trans": [
-      "Day 15 | n. | English: a situation in which there is a lot of damage, destruction or confusion | Example: On March 23, 2021, a gust of wind wreaked havoc on global trade."
+      "['havak] n. 灾难"
     ]
   },
   {
     "name": "haze",
     "trans": [
-      "Day 15 | n. | English: air that is difficult to see through because it contains very small drops of water, especially caused by hot weather | Example: Having an ample reserve of stored energy can mitigate the effects of fluctuations in solar energy collection caused by unpredictable shifts in cloud cover and haze."
+      "n. （尤指热天引起的"
     ]
   },
   {
     "name": "heritage",
     "trans": [
-      "Day 15 | n. | English: the history, traditions and qualities that a country or society has had for many years and that are considered an important part of its character | Example: It summarizes the career of a particular architect, states how that architect's heritage influenced his career choice, and then emphasizes the impact of that architect's career."
+      "['hertid3] n. 遗产"
     ]
   },
   {
     "name": "hesitancy",
     "trans": [
-      "Day 15 | n. | English: the state or quality of being slow or uncertain in doing or saying sth Despite the education specialist's hesitancy about her expertise on the subject in general, she found that she could speak authoritatively about the works of author Mildred Pitts Walter, particularly Justin and the Best Biscuits in the World, which she had used effectively in classroom instruction for many years."
+      "['hezitonsi] n. 犹豫"
     ]
   },
   {
     "name": "hesitant",
     "trans": [
-      "Day 15 | adj. | English: slow to speak or act because you feel uncertain, embarrassed or unwilling | Example: So while they might be eager to produce an established classic like Annie, for example, most would be hesitant to stage a work from a relatively unknown playwright."
+      "['heztant] adj. 犹豫的"
     ]
   },
   {
     "name": "heterogeneous",
     "trans": [
-      "Day 15 | adj. | English: consisting of many different kinds of people or things | Example: Although Hawaiian literature is highly heterogeneous in many ways, it is also characterized by considerable thematic continuity."
+      "[hetara'd3i:nias] adj. 由很多种类组成的"
     ]
   },
   {
     "name": "hew",
     "trans": [
-      "Day 15 | v. | English: to make or shape sth large by cutting One person after another rose, and, as with an ill-balanced axe, attempted to hew out his conception of art a little more clearly, and sat down with the feeling that, for some reason which he could not grasp, his strokes had gone awry."
+      "[hju:] v. 某种形状"
     ]
   },
   {
     "name": "hideous",
     "trans": [
-      "Day 15 | adj. | English: very ugly or unpleasant | Example: The whole experience had been like some hideous nightmare."
+      "['Idias] adj. 令人厌恶的"
     ]
   },
   {
     "name": "hitherto",
     "trans": [
-      "Day 15 | adv. | English: until now; until the particular time you are talking about | Example: The vast majority of invertebrate species found in a recent survey of the CCZ were hitherto unknown to scientists."
+      "[hudar't:] adv. 迄今为止"
     ]
   },
   {
     "name": "hive",
     "trans": [
-      "Day 16 | n. | English: a structure made for bees to live in | Example: Honeybee hives consist mainly of hexagonal (six-sided) units called cells, in which queens lay eggs."
+      "[harv] n. 蜂房,蜂箱"
     ]
   },
   {
     "name": "hoard",
     "trans": [
-      "Day 16 | n. | English: acollection of money, food, valuable objects, etc., especially one that sb keeps in a secret place so that other people will not find or steal it | Example: And although the period is known as the Bronze Age, some hoards, like the Fittleworth hoard, contained decorative objects made of gold."
+      "[h3:rd] n. （贵重物品等的）贮存"
     ]
   },
   {
     "name": "hoax",
     "trans": [
-      "Day 16 | n. | English: an act intended to make sb believe sth that is not true, especially sth unpleasant | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+      "[hooks] n. 骗局"
     ]
   },
   {
     "name": "hollow",
     "trans": [
-      "Day 16 | adj. | English: having a hole or empty space inside | Example: Holes, hollows, pools, pitfalls, and other menaces to the wayfarer were vanishing fast."
+      "['ha:loo] adj. 空心的"
     ]
   },
   {
     "name": "hominid",
     "trans": [
-      "Day 16 | n. | English: a human, or a creature that lived in the past which humans developed from | Example: The fossil remains of the individual known as KNM-KP 271, discovered in Kenya in 1965, can help paleoanthropologists not only identify steps in the evolution of hominids but also illuminate the Pliocene epoch generally, revealing important details about the time in which KNM-KP 271 lived."
+      "['ha:mInd] n. 人科动物"
     ]
   },
   {
     "name": "homogeneity",
     "trans": [
-      "Day 16 | n. | English: the quality of being homogeneous | Example: The results showed that the genetic homogeneity of M. anniana decreased over time."
+      "[hoUmoUd3a'ni:ati] n. 同种"
     ]
   },
   {
     "name": "homogeneous",
     "trans": [
-      "Day 16 | adj. | English: consisting of things or people that are all the same or all of the same type | Example: Previous research has shown that plant species with a narrow geographical range tend to be more genetically homogeneous than plant species with extensive ranges are."
+      "[hoUma'd3i:nias] adj. 同种类的"
     ]
   },
   {
     "name": "horizontal",
     "trans": [
-      "Day 16 | adj. | English: Horizontal gene transfer involves the exchange of genetic material between organisms not in a parent-offspring relationship."
+      "[I3:II'za:ntl] adj. 水平的"
     ]
   },
   {
     "name": "horrid",
     "trans": [
-      "Day 16 | adj. | English: very unpleasant or unkind | Example: I'm really getting quite fond of the big room, all but that horrid [wall] paper."
+      "adj. 非常讨厌的"
     ]
   },
   {
     "name": "hull",
     "trans": [
-      "Day 16 | n. | English: the main, bottom part of a ship, that goes in the wate | Example: Marine archaeologists have found much of the wooden hull of a sixteenth-century ship in a flooded quarry in southeast England. humanoid on. (AHBA; BAR 3230: a machine or creature that looks and behaves like a human Some robots such as Salvius (developed in 2008) and REEM-C (developed in 2013) feature humanoid characteristics like bipedal locomotion so that people will find it easier to interact with them."
+      "[hl] n. 船身"
     ]
   },
   {
     "name": "humanoid",
     "trans": [
-      "Day 16 | n. | English: a machine or creature that looks and behaves like a human | Example: Some robots such as Salvius (developed in 2008) and REEM-C (developed in 2013) feature humanoid characteristics like bipedal locomotion so that people will find it easier to interact with them."
+      "n. 仿真机器人"
     ]
   },
   {
     "name": "humid",
     "trans": [
-      "Day 16 | adj. | English: warm and damp Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow's o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+      "['hju:md] adj. 温暖潮湿的"
     ]
   },
   {
     "name": "hushed",
     "trans": [
-      "Day 16 | adj. | English: quiet because nobody is talking; much quieter than usual | Example: Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow's o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+      "[hAt] adj. 寂静的"
     ]
   },
   {
     "name": "husk",
     "trans": [
-      "Day 16 | n. | English: the dry outer covering of nuts, fruits and seeds, especially of grain | Example: All these things awoke in [Don Custodio] the farther he got from Europe, like the life-giving sap within the sown seed prevented from bursting out by the thick husk."
+      "[hsk] n. （果实和种子的）外壳"
     ]
   },
   {
     "name": "hydraulic",
     "trans": [
-      "Day 16 | adj. | English: connected with hydraulic systems | Example: The irrigation system developed by the Hohokam people in the 7th century CE in what is now known as central Arizona was simple but applied hydraulic engineering design features that are still used today."
+      "[har'dr3:] adj. 与水利系统有关的"
     ]
   },
   {
     "name": "hyphae",
     "trans": [
-      "Day 16 | n. | English: any of the filaments that constitute the body (mycelium) of a fungus | Example: Effects of this thermoregulation were not limited to the fungi's fruiting bodies and root-like hyphae: temperature reductions were observed in the air immediately surrounding the mushrooms."
+      "n. （真菌的）菌丝"
     ]
   },
   {
     "name": "identical",
     "trans": [
-      "Day 16 | adj. | English: similar in every detail | Example: The many editions of James Joyce's 1922 novel Ulysses are not textually identical, and scholars debate which versions reflect Joyce's authorial intent."
+      "[ar'dentik(a)l] adj. 完全同样的"
     ]
   },
   {
     "name": "identify",
     "trans": [
-      "Day 16 | v. | English: to recognize sb/sth and be able to say who or what they are | Example: Since molecular analysis does not require distinguishing subtle physiological differences, it is more likely to properly distinguish between morphologically similar but distinct invertebrate species than is the method used to identify Prionospio branchilucida."
+      "[ar'dentifa] v. 确认"
     ]
   },
   {
     "name": "ideological",
     "trans": [
-      "Day 16 | adj. | English: Ideological means relating to principles or beliefs. | Example: Political blogs with conspicuous ideological alignments became an integral component of US media in the early 2000s."
+      "adj. 意识形态的"
     ]
   },
   {
     "name": "idiosyncratic",
     "trans": [
-      "Day 16 | adj. | English: somewhat unusual. | Example: She still appeared to be an idiosyncratic figure."
+      "[.IdiasH] adj. 怪异的"
     ]
   },
   {
     "name": "ignorantly",
     "trans": [
-      "Day 16 | adj. | English: lacking knowledge or information about sth; not educated | Example: | had gazed upon the fortifications and impediments that seemed to keep human beings from entering the citadel of nature, and rashly and ignorantly | had repined."
+      "adj. 无知的,愚昧的"
     ]
   },
   {
     "name": "illusory",
     "trans": [
-      "Day 16 | adj. | English: not real, although seeming to be | Example: First impressions can often prove illusory."
+      "[I'lu:sari] adj. 虚假的"
     ]
   },
   {
     "name": "illustration",
     "trans": [
-      "Day 16 | n. | English: a drawing or picture in a book, magazine, etc. especially one that explains sth | Example: Whether Carmen Lomas Garza is creating small paintings and illustrations or large public artworks—such as Baile, a copper cutout of traditional Mexican dance in the San Francisco International Airport—she is inspired by direct experience, drawing from memories of her childhood in Texas or details of her current surroundings in California."
+      "[.Ilo'strerhn] n. （杂志等中的）"
     ]
   },
   {
     "name": "imitator",
     "trans": [
-      "Day 16 | n. | English: a person or thing that copies sb/sth else | Example: The band's success has inspired hundreds of would-be imitators."
+      "['Itertar] n. 模仿者"
     ]
   },
   {
     "name": "immense",
     "trans": [
-      "Day 16 | adj. | English: extremely large or great | Example: Much like the continents themselves, the variety of native languages in the Americas is immense."
+      "[Imens] adj. 巨大的"
     ]
   },
   {
     "name": "immensity",
     "trans": [
-      "Day 16 | n. | English: the large size of sth | Example: The men threw out their chests as if to breathe the widening horizon, the immensity of the sky, the blue from the mountains and the fresh air, redolent with the various odors of the sierra."
+      "[I'mensati] n. 巨大"
     ]
   },
   {
     "name": "immerse",
     "trans": [
-      "Day 16 | v. | English: to become or make sb completely involved in sth | Example: After traveling to the United States and Europe in the early 1930s and immersing himself in a broader architectural discourse, Barragan shifted his style to incorporate principles of modernism, as seen in the Ortega House."
+      "[I'm3:rs] v. 深陷于"
     ]
   },
   {
     "name": "immortal",
     "trans": [
-      "Day 16 | adj. | English: that lives or lasts for ever | Example: The most learned philosopher knew little more. He had partially unveiled the face of Nature, but her immortal lineaments were still a wonder and a mystery."
+      "[I'm3:rtl] adj. 永世的"
     ]
   },
   {
     "name": "immutable",
     "trans": [
-      "Day 16 | adj. | English: that cannot be changed; that will never change | Example: Willpower isn't some immutable trait we're either born with or not."
+      "[I'mju:tabl] adj. 不可改娈的,永恒不娈的"
     ]
   },
   {
     "name": "impact",
     "trans": [
-      "Day 16 | n. | English: the act of one object hitting another; the force with which this happens | Example: And as Jane X. Luu et al. point out, the singular nature of impact ejection makes it untenable as an account of multiple loss episodes of similar duration over several years."
+      "['Ipakt] n. 撞击"
     ]
   },
   {
     "name": "impart",
     "trans": [
-      "Day 16 | v. | English: to give a particular quality to sth; | Example: To convey the speaker's longing for the ocean to impart a sense of inner tranquility"
+      "[Ipa:t] v. （某性质）赋予"
     ]
   },
   {
     "name": "impartial",
     "trans": [
-      "Day 16 | adj. | English: not supporting one person or group more than another | Example: Culture's duty is to impartially determine which ideas are most useful to a society."
+      "[ImIpa:r[(a)] adj. 公正的"
     ]
   },
   {
     "name": "impede",
     "trans": [
-      "Day 16 | v. | English: to delay or stop the progress of sth | Example: The morphological novelty of echinoderms marine—invertebrates with radial symmetry, usually starlike, around a central point—impedes comparisons with most other animals."
+      "[I'pi:d] v. 阻碍"
     ]
   },
   {
     "name": "impediment",
     "trans": [
-      "Day 16 | n. | English: something that delays or stops the progress of sth | Example: I had gazed upon the fortifcations and impediments that seemed to keep human beings from entering the citadel of nature, and rashly and ignorantly | had repined."
+      "[Imn'pedrant] n. 妨碍"
     ]
   },
   {
     "name": "imperative",
     "trans": [
-      "Day 16 | adj. | English: (formal) very important and needing immediate attention or action; | Example: Itis absolutely imperative that we finish by next week."
+      "[Iperatrv] adj. 重要紧急的"
     ]
   },
   {
     "name": "imperceptible",
     "trans": [
-      "Day 16 | adj. | English: very small and therefore unable to be seen | Example: When constructing his argument regarding the characteristics of a well-functioning government, Aristotle asserts thar 'Transgression creeps in unperceived and at last ruins the state,’ illustrating this idea with a comparison to frequent small expenditures slowly and almost imperceptibly chipping away at a fortune until it is ultimately depleted."
+      "[Ipar'septabl] adj. 无法察觉的"
     ]
   },
   {
     "name": "impertinent",
     "trans": [
-      "Day 16 | adj. | English: rude and not showing respect for sb who is older or more important | Example: Finally, and adding much-needed gravitas, was Sir Winston Day, whose features seemed moulded to adorn a bust, or possibly a stamp, and whose forehead was so evidently bulging with grey matter that it would have been impertinent to inquire too closely into the actual achievements his half century of public service had produced."
+      "[Im'p3:rtnant] adj. 粗鲁无礼的,不敬的"
     ]
   },
   {
     "name": "impervious",
     "trans": [
-      "Day 16 | adj. | English: not allowing a liquid or gas to pass through | Example: A barrier that is impervious to both roots and fungal strands is necessary to evaluate nutrient transfer via a CMN."
+      "[I'P3:rvias] adj. 不能渗透的"
     ]
   },
   {
     "name": "implausible",
     "trans": [
-      "Day 16 | adj. | English: not seeming reasonable or likely to be true | Example: These early quasars developed partly as a result of rare convergences of gases in space without the need for ultraviolet backgrounds or other extreme and implausible environmental conditions."
+      "adj. 似乎不合情理的"
     ]
   },
   {
     "name": "implement",
     "trans": [
-      "Day 16 | v. | English: to make sth that has been officially decided start to happen or be used | Example: Kwaxsistalla WathI'thla, a song keeper for the Kwakwaka'wakw people in Canada, collaborated with ethnobiologist Dana Lepofsky et al., sharing songs referencing terraced intertidal clam gardens the people implemented in the past to foster healthy development of a dietary staple."
+      "['Impllmant;'Ipla.mcnt] v. 执行,实施"
     ]
   },
   {
     "name": "implication",
     "trans": [
-      "Day 16 | n. | English: a possible effect or result of an action or a decision | Example: It likely has broad implications for other species of fish besides Sparus aurata."
+      "[.Implr'kerln] n. 可能的影响"
     ]
   },
   {
     "name": "implicit",
     "trans": [
-      "Day 16 | adj. | English: suggested without being directly expressed | Example: Fernand Braudel and other historians of capitalism rarely discuss domestic capitalism in Africa before the period of European colonization, implicitly presenting capitalism as external to and imposed on Africa."
+      "[Im'plisrt] adj. 含蓄的"
     ]
   },
   {
     "name": "impose on",
     "trans": [
-      "Day 16 | English: to force sb/sth to have to deal with sth that is difficult or unpleasant | Example: Fernand Braudel and other historians of capitalism rarely discuss domestic capitalism in Africa before the period of European colonization, implicitly presenting capitalism as external to and imposed on Africa."
+      "迫使"
     ]
   },
   {
     "name": "imposing",
     "trans": [
-      "Day 16 | adj. | English: impressive to look at | Example: The Istiqlal Mosque in Jakarta, Indonesia, is a massive mosque that can accommodate approximately 200,000 people at once, making it an imposing sight to behold."
+      "[Im'poUzN] adj. 壮观的"
     ]
   },
   {
     "name": "impracticable",
     "trans": [
-      "Day 16 | adj. | English: impossible or very difficult to do; not practical in a particular situation | Example: Socrates, a sophist, says to a new customer \"I have not seen any man so boorish, nor so impracticable, nor so stupid, nor so forgetful; who, while learning some little petty quibbles, forgets them before he has learned them.”"
+      "adj. 不切实际的"
     ]
   },
   {
     "name": "impractical",
     "trans": [
-      "Day 16 | adj. | English: not sensible or realistic | Example: Because any name given to a minor planet needs to be unique to that body, naming each would be impractical."
+      "[Im'praktikl] adj. 不现实的"
     ]
   },
   {
     "name": "impress",
     "trans": [
-      "Day 16 | v. | English: if a person or thing impresses you, you feel admiration for them or it | Example: Each is contemptuous of the other attendees but strives to impress them."
+      "[Im'pres] v. 留下深刻的好印象"
     ]
   },
   {
     "name": "impression",
     "trans": [
-      "Day 16 | n. | English: an idea, a feeling or an opinion that you get about sb/sth, or that sb/sth gives you | Example: The speaker lists various impressions people might have of her and then explains why they don't matter to her."
+      "[Im'preh] n. 印象"
     ]
   },
   {
     "name": "improvise",
     "trans": [
-      "Day 16 | v. | English: to invent music, the words in a play, a statement, etc. while you are playing or speaking, instead of planning it in advance Padre Florentino, who was an accomplished musician, was improvising, and, as he was alone, gave free rein to the sadness in his heart."
+      "['Ipravarz] v. 即兴创作"
     ]
   },
   {
     "name": "impurity",
     "trans": [
-      "Day 16 | n. | English: a substance that is present in small amounts in another substance, making it dirty or of poor quality | Example: Every few days, Abuela Evila washed Elida's hair with lemon water because, according to her, lemon juice cleans the impurities of the hair and makes it shiny and healthy."
+      "[Im'pjuroti] n. 杂质"
     ]
   },
   {
     "name": "inaccessible",
     "trans": [
-      "Day 17 | adj. | English: difficult or impossible to reach or to get | Example: As discussed by scholar Anna Mladentseva, many artworks produced in the mid-1990s to the early 2000s exclusively for exhibition on the internet have become inaccessible because viewing them requires the use of defunct software."
+      "[Inak'8283b(3)1] adj. 难以达到的"
     ]
   },
   {
     "name": "inadvertently",
     "trans": [
-      "Day 17 | adv. | English: by accident; without intending to | Example: Those studying the works of Antonio Machado, for instance, may inadvertently overlook nuances in his work by focusing only on the most obvious ways in which his style"
+      "[.Iad'v3:rtntli] adv. 不经意地"
     ]
   },
   {
     "name": "inarguable",
     "trans": [
-      "Day 17 | adj. | English: that nobody can disagree with | Example: Although Polish folklore clearly informs the style and occasionally antirealistic plot of Primeval and Other Times, the novel also shows the inarguable influence of the magical realist tradition of Latin America."
+      "[In'a:rgjuabl] adj. 不容争辩的"
     ]
   },
   {
     "name": "inattention",
     "trans": [
-      "Day 17 | n. | English: lack of attention | Example: So as long as a listener's interpretation isn't willfully absurd or the result of inattention, it is difficult to justify the claim that the listener has misunderstood the piece."
+      "n. 不注意"
     ]
   },
   {
     "name": "incentive",
     "trans": [
-      "Day 17 | n. | English: something that encourages you to do sth | Example: Reducing this kind of subscriber turnover is especially challenging for subscription sellers: customers’ initial enthusiasm for a subscription is often quick to subside, and sellers must thus devise other incentives to bolster retention."
+      "[I'sentwv] n. 激励"
     ]
   },
   {
     "name": "incidence",
     "trans": [
-      "Day 17 | n. | English: the extent to which sth happens or has an effect | Example: If one has a supposition that the word “own” has a high incidence in English, for example, an analysis of a corpus can support that hypothesis by showing that “own” is the eighth most commonly used adjective."
+      "['InsIdans] n. 发生率"
     ]
   },
   {
     "name": "incident",
     "trans": [
-      "Day 17 | n. | English: something that happens, especially sth unusual or unpleasant After some trouble [Jim’s father] found the subject of the incident, the broken flower. Turning then, he saw the child lurking at the rear and scanning his countenance."
+      "['Insidant] n. 事件"
     ]
   },
   {
     "name": "inconclusive",
     "trans": [
-      "Day 17 | adj. | English: not leading to a definite decision or result | Example: Research has so far proved inconclusive."
+      "[Inkanklu:sw] adj. 非决定性的,不确定的"
     ]
   },
   {
     "name": "incongruity",
     "trans": [
-      "Day 17 | n. | English: The incongruity of something is its strangeness when considered together with other aspects of a situation. | Example: Mauricio Drelichman and Hans-Joachim Voth's analysis of the overall debt and revenue of the government of philip (who ruled an empire including Spain and Sicily from 1556 to 1598) found an intriguing incongruity."
+      "[Inkan'gru:ati] n. 不协调"
     ]
   },
   {
     "name": "incongruous",
     "trans": [
-      "Day 17 | adj. | English: strange, and not suitable in a particular situation | Example: Researchers Haley R. Dolton et al. found that its body temperature remains 1.0 to 1.5°C above ambient, which is incongruous with that classification."
+      "[I'ka:ngruas] adj. 不相称的"
     ]
   },
   {
     "name": "inconsequential",
     "trans": [
-      "Day 17 | adj. | English: not important or worth considering | Example: While recent scholarship has undermined claims that the works of twelfth-century Islamic philosopher Ibn Rushd were inconsequential to other Muslim philosophers of his time, it is indisputable that his location in the Muslim-ruled area of what is now Spain meant that his works were primarily available thousands of miles west of the era’s center of Islamic thought."
+      "[I,ka:nsr'kwenjl] adj. 不重要的"
     ]
   },
   {
     "name": "inconsistent",
     "trans": [
-      "Day 17 | adj. | English: if two statements, etc. are inconsistent , or one is inconsistent with the other, they cannot both be true because they give the facts in a different way | Example: It describes a behavioral pattern displayed by Mohol bushbabies that is inconsistent with how they would be expected to respond to high lunar intensity based on benefits and costs."
+      "[Ikan'sIstant] adj. 不一致的"
     ]
   },
   {
     "name": "inconspicuous",
     "trans": [
-      "Day 17 | adj. | English: not attracting attention; not easy to notice | Example: I'll try to be as inconspicuous as possible."
+      "[Inkan'splkjuas] adj. 不引人注目的"
     ]
   },
   {
     "name": "incorporate",
     "trans": [
-      "Day 17 | v. | English: to include sth so that it forms a part of sth | Example: For example, Inuit singer-songwriter Tanya Tagaq incorporated Inuit throat singing into electronic music on her album Tongues."
+      "[In'ko:rparert] v. 包括在内"
     ]
   },
   {
     "name": "incremental",
     "trans": [
-      "Day 17 | adj. | English: Incremental is used to describe something that increases in value or worth, often by a regular amount. | Example: Because these effects are incremental and can generally be repaired (though at some cost), structures in southern and central Georgia are typically not built to resist them."
+      "[Inkra'mantl] adj. 递增的"
     ]
   },
   {
     "name": "incubation",
     "trans": [
-      "Day 17 | n. | English: the hatching of eggs Based on their review of those traits, the team concluded that incubation duration and capacity for multiple broods are more strongly associated with the use of broken-wing display than the number of parental incubators is."
+      "[.Jkju'berln] n. 孵化"
     ]
   },
   {
     "name": "incubator",
     "trans": [
-      "Day 17 | n. | English: a machine like a box where eggs are kept warm until the young birds are born Based on their review of those traits, the team concluded that incubation duration and capacity for multiple broods are more strongly associated with the use of broken-wing display than the number of parental incubators is."
+      "['Ikjubertar] n. 孵化器"
     ]
   },
   {
     "name": "indefatigable",
     "trans": [
-      "Day 17 | adj. | English: never giving up or getting tired of doing sth | Example: But culture indefatigably tries, not to make what each raw person may like, the rule by which he fashions himself."
+      "[.Idr'fetigobl] adj. 不屈不挠的"
     ]
   },
   {
     "name": "indefatigably",
     "trans": [
-      "Day 17 | adv. | English: determined and never giving up | Example: But culture indefatigably tries, not to make what each raw person may like the rule by which he fashions himself; but to draw ever nearer to a sense of what is indeed beautiful, graceful, and becoming, and to get the raw person to like that."
+      "[.Indr'fatigabli] adv. 不屈不挠地"
     ]
   },
   {
     "name": "index",
     "trans": [
-      "Day 17 | n. | English: a system that shows the level of prices and wages, etc. so that they can be compared with those of a previous date | Example: Utilizing the Index of Waterbird Community Integrity (IWCl), on which a high score corresponds to high community integrity, the researchers found that bulkheads are more strongly negatively correlated with waterbird community integrity than is riprap."
+      "['mdeks] n. （物价和工资等的）指数"
     ]
   },
   {
     "name": "indication",
     "trans": [
-      "Day 17 | n. | English: a remark or sign that shows that sth is happening or what sb is thinking or feeling | Example: Indications that the film is of high quality, such as an Oscar nomination, can dramatically boost public interest in the film and thus its overall earnings, even with a relatively modest opening weekend performance."
+      "[.Indr'kerhn] n. 表明,标示"
     ]
   },
   {
     "name": "indicative",
     "trans": [
-      "Day 17 | adj. | English: (formal) showing or suggesting sth | Example: It would be a mistake to treat the relative inflation rates of Jamaica and Qatar as indicative of an inherent shortcoming in democratic institutions with regard to control over inflation."
+      "[In'dikatm] adj. 表明,标示"
     ]
   },
   {
     "name": "indices",
     "trans": [
-      "Day 17 | n. | English: a sign or measure that sth else can be judged by | Example: Focusing on two characteristics that are positive indices of grammatical complexity, fusion (when new phonemes arise from the merger of previously distinct ones) and informativity (languages' capacity for meaningful variation), Olena Shcherbakova and colleagues conducted a quantitative analysis for more than 1,300 languages and claim the outcome is inconsistent with the LNH."
+      "n. 指标,度量"
     ]
   },
   {
     "name": "indigenous",
     "trans": [
-      "Day 17 | adj. | English: belonging to a particular place rather than coming to it from somewhere else | Example: Indigenous songs can be repositories of ecological information, from Yi songs about the natural environment to Tlingit songs about wildlife encounters."
+      "[I'drd3onas] adj. 土生土长的"
     ]
   },
   {
     "name": "indisputable",
     "trans": [
-      "Day 17 | adj. | English: that is true and cannot be disagreed with or denied | Example: The evidence that would indisputably prove that either Hamilton or Madison was the sole author of \"The Senate\" has been lost."
+      "[.Idr'spju:tabl] adj. 不容置疑的"
     ]
   },
   {
     "name": "indistinct",
     "trans": [
-      "Day 17 | adj. | English: that cannot be seen, heard or remembered clearly | Example: Elizabeth Catlett's sculpture Recognition (1970) shows two African American figures with rounded, indistinct features."
+      "[.Idr'stnkt] adj. 不清楚的"
     ]
   },
   {
     "name": "indoctrinate",
     "trans": [
-      "Day 17 | v. | English: to force sb to accept a particular belief or set of beliefs and not allow them to consider any others | Example: They had been indoctrinated from an early age with their parents’ beliefs."
+      "[I'da:ktrmncrt] v. 信仰或学说"
     ]
   },
   {
     "name": "induce",
     "trans": [
-      "Day 17 | v. | English: to cause sth | Example: Some ethicists challenge the concept of personal character, claiming that if it were meaningful, situational factors could not, as they clearly can, induce behavior contrary to that character."
+      "[I'du:s] v. 引起"
     ]
   },
   {
     "name": "indulgent",
     "trans": [
-      "Day 17 | adj. | English: tending to allow sb to have or do whatever they want His indulgent mother was willing to let him do anything he wanted."
+      "[m'dald3ont] adj. 纵容的"
     ]
   },
   {
     "name": "ineffectual",
     "trans": [
-      "Day 17 | adj. | English: If someone or something is ineffectual, they fail to do what they are expected to do or are trying to do. | Example: Karam Kang has demonstrated that lobbying does little to alter the probability that a particular energy policy under consideration by the United States Congress will be enacted, but lobbying is not as ineffectual as this finding seems to suggest."
+      "[.Inr'fektjial] adj. 无效的"
     ]
   },
   {
     "name": "ineligible",
     "trans": [
-      "Day 17 | adj. | English: not having the necessary qualifications to have or to do sth | Example: They were ineligible to remain in the U.S."
+      "[I'elid3abl] adj. 不符合资格的"
     ]
   },
   {
     "name": "ineluctable",
     "trans": [
-      "Day 17 | adj. | English: that you cannot avoid | Example: Malthus's theories are about the ineluctable tendency of populations to exceed resources."
+      "[.Ir'Iktabl] adj. 无可避免的"
     ]
   },
   {
     "name": "inextricable",
     "trans": [
-      "Day 17 | adj. | English: too closely linked to be separated | Example: Although the literary works of David Malo and Lee Cataluna have universal appeal, they are also inextricable from the Hawaiian literary tradition in which both authors work and that stretches back to the traditional stories of the Kanaka Maoli, the Native Hawaiian people."
+      "[.Iik'strkabl.In'ekstrikabl] adj. 无法分开的"
     ]
   },
   {
     "name": "infamous",
     "trans": [
-      "Day 17 | adj. | English: well known for being bad or evil | Example: Richard Nixon is commonly linked with an infamous historical event, but this overshadows some of his notable achievements."
+      "['Infamas] adj. 臭名昭著的"
     ]
   },
   {
     "name": "infant",
     "trans": [
-      "Day 17 | n. | English: a baby or very young child | Example: Hypothesizing that lullabies, characterized by their slow tempos, are universally calming to infants, Constance M. Bainbridge and colleagues played a lullaby sung in the Scottish Gaelic language and a non-lullaby sung in the Seri language to a group of infants."
+      "['Infant] n. 婴儿"
     ]
   },
   {
     "name": "infer",
     "trans": [
-      "Day 17 | v. | English: to reach an opinion or decide that sth is true on the basis of information that is available | Example: To infer PSP from fossils, researchers look for indicators such as large foramina (holes in bones)."
+      "[I'f3:] v. 推断"
     ]
   },
   {
     "name": "inferior",
     "trans": [
-      "Day 17 | adj. | English: not good or not as good as sb/sth else | Example: It undermines the idea that a practical approach to understanding natural phenomena is inferior to a scientific approach."
+      "[I'firiar] adj. 较差的"
     ]
   },
   {
     "name": "inferiority",
     "trans": [
-      "Day 17 | n. | English: the state of not being as good as sb/sth else | Example: Singly [the men around Newland] betrayed their inferiority: but grouped together they represented ‘New York,’ and the habit of masculine solidarity made him accept their doctrine on all the issues called moral."
+      "n. 低等,劣等"
     ]
   },
   {
     "name": "infinite",
     "trans": [
-      "Day 17 | adj. | English: without limits; without end The father reflected. After a time he said, ‘Jimmie, come here.’ With an infinite modesty of demeanor the child came forward."
+      "['Infinat] adj. 无限的"
     ]
   },
   {
     "name": "inflation",
     "trans": [
-      "Day 17 | n. | English: a general rise in the prices of services and goods in a particular country, resulting in a fall in the value of money; the rate at which this happens | Example: The Netherlands, which, according to international indices, has relatively strong democratic institutions and low intranational income inequality, experienced an inflation rate of 2.63% in 2019."
+      "[I'flerln] n. 通货膨胀"
     ]
   },
   {
     "name": "infraction",
     "trans": [
-      "Day 17 | n. | English: an act of breaking a rule or law By suggesting that whatever infractions Luttrell might have committed are outweighed by the cultural value of the Luttrell Psalter"
+      "[In'frakjn] n. 犯规"
     ]
   },
   {
     "name": "infrastructure",
     "trans": [
-      "Day 17 | n. | English: the basic systems and services that are necessary for a country or an organization to run smoothly, for example buildings, transport and water and power supplies | Example: Vancouver, Canada, has installed engineered structures along 75% of its shoreline to protect infrastructure from storm surges and other hazards, a practice known as shoreline hardening."
+      "['Infrastraktjar] n. 基础设施,基础建设"
     ]
   },
   {
     "name": "ingenious",
     "trans": [
-      "Day 17 | adj. | English: having a lot of clever new ideas and good at inventing things | Example: She's very ingenious when it comes to finding excuses."
+      "[In'd3i:nias] adj. 机敏的"
     ]
   },
   {
     "name": "ingest",
     "trans": [
-      "Day 17 | v. | English: to take food, drugs, etc. into your body, usually by swallowing | Example: Mammoth tusks grew in sequential layers, incorporating ingested minerals and organics, and so each ivory stratum reflects the ratio of strontium isotopes (87Sr/86Sr) in the local environment."
+      "[I'd3est] v. 摄入"
     ]
   },
   {
     "name": "inherent",
     "trans": [
-      "Day 17 | adj. | English: that is a basic or permanent part of sb/sth and that cannot be removed | Example: Zoo chimpanzees in Sweden and other mid-latitude countries tend to synthesize less vitamin D than they are inherently capable of synthesizing."
+      "[m'herant,In'hrant] adj. 固有的"
     ]
   },
   {
     "name": "inherit",
     "trans": [
-      "Day 17 | v. | English: to receive money, property, etc. from sb when they die | Example: Perhaps it is a little depressing to inherit not lands but an example of intellectual virtue."
+      "[m'hert] v. 继承"
     ]
   },
   {
     "name": "inhibit",
     "trans": [
-      "Day 17 | v. | English: to prevent sth from happening or make it happen more slowly or less frequently than normal | Example: For too long, scholars have focused on experimental versus conventional poetic forms, inhibiting inquiry into other points of stylistic correspondence among poems that would enrich our understanding of the modernist canon."
+      "[m'hbrt] v. 阻止"
     ]
   },
   {
     "name": "iniquity",
     "trans": [
-      "Day 17 | n. | English: the fact of being very unfair or wrong; sth that is very unfair or wrong | Example: And now, dear reader, a word with you. What is done cannot be undone. We cannot unravel this web of iniquity, and extract justice from this mass of cruel wrongs."
+      "[I'nkwati] n. 很不正当（的事）"
     ]
   },
   {
     "name": "initiative",
     "trans": [
-      "Day 17 | n. | English: anew plan for dealing with a particular problem or for achieving a particular purpose | Example: Conservationists worldwide are working to protect ecosystems from habitat destruction and biodiversity loss, and in many cases, initiatives that rely on natural features or processes can help address such challenges."
+      "[I'nfatwv] n. 倡议"
     ]
   },
   {
     "name": "innate",
     "trans": [
-      "Day 17 | adj. | English: a quality or a feeling that you have when you are born | Example: Modularity of mind is the notion that the mind is at least partly composed of innate neural structures (modules) that perform fast, necessary tasks."
+      "[Inert] adj. 先天的"
     ]
   },
   {
     "name": "inquire",
     "trans": [
-      "Day 18 | v. | English: ask for information from someone moulded to adorn a bust, or possibly a stamp, and whose forehead was so evidently bulging with grey matter that it would have been impertinent to inquire too closely into the actual achievements his half century of public service had produced."
+      "[I'kwaIar] v. 询问,打听"
     ]
   },
   {
     "name": "insert",
     "trans": [
-      "Day 18 | v. | English: to put sth into sth else or between two things | Example: They would encourage engineers in southern and central Georgia to insert vapor barriers between new structures' foundations and the surrounding soil."
+      "[I'83:t] v. 插入,嵌入"
     ]
   },
   {
     "name": "insight",
     "trans": [
-      "Day 18 | n. | English: the ability to see and understand the truth about people or situations | Example: At aconference for aspiring children's book authors, Candy Dawson Boyd, author of such lauded works as Circle of Gold, was the subject of a presentation that was intended specifically to foster insight into the techniques of successful authors so that attendees could use that understanding to improve their own work."
+      "['mnsart] n. 洞察力"
     ]
   },
   {
     "name": "instability",
     "trans": [
-      "Day 18 | n. | English: the quality of a situation in which things are likely to change or fail suddenly | Example: Instead, Luu et al. are likely correct that 6478 Gault is shedding mass due to rotational instability."
+      "n. 不稳定"
     ]
   },
   {
     "name": "install",
     "trans": [
-      "Day 18 | v. | English: to fix equipment or furniture into position so that it can be used | Example: Janet Echelman is a sculptor and fiber artist. She has installed giant sculptures all over the world."
+      "[m'8t3:] v. 安装"
     ]
   },
   {
     "name": "instantly",
     "trans": [
-      "Day 18 | adj. | English: immediately | Example: Cuttlefish appear to be surprisingly competent at exercising self-control: in a 2021 study conducted by behavioral ecologist Alexandra Schnell, these cephalopods routinely demonstrated restraint by delaying gratification, waiting for a favorite treat instead of instantly devouring a readily available meal."
+      "['Instantli] adj. 立即"
     ]
   },
   {
     "name": "insult",
     "trans": [
-      "Day 18 | n. | English: a remark or an action that is said or done in order to offend sb | Example: There is no denying that, since he was rather brusque in his ways, he never spared the young authors who asked his advice and read him their productions, but criticized vigorously, even to the verge of insult."
+      "[I'SAIt;'IsAIt] n. 侮辱"
     ]
   },
   {
     "name": "insuperable",
     "trans": [
-      "Day 18 | adj. | English: that cannot be dealt with successfully | Example: Insuperable though it seemed to many mathematicians, the Marden tameness conjecture, posed in 1974, eventually yielded to the efforts of lan Agol, who presented a proof of it in 2004."
+      "[I'su:p3r3b(3)] adj. 无法克服的"
     ]
   },
   {
     "name": "insurmountable",
     "trans": [
-      "Day 18 | adj. | English: that cannot be dealt with successfully | Example: Most of the recently discovered minor planets, however, are given only an identification number, largely due to there being over 500,000 such bodies known at present, which makes the already challenging task of finding a unique name for each nearly insurmountable."
+      "[Insar'maUntabl] adj. 无法克服的,难以解决的"
     ]
   },
   {
     "name": "intact",
     "trans": [
-      "Day 18 | adj. | English: complete and not damaged | Example: Victoria L. Peck and colleagues recently found that the periostracum (a protective coating on pteropods' outer shells) prevents this dissolution when intact."
+      "[m'tekt] adj. 完好无损的"
     ]
   },
   {
     "name": "intangible",
     "trans": [
-      "Day 18 | adj. | English: that exists but that is difficult to describe, understand or measure Stars form in cloudlike swirls of gas and dust that cannot be touched, but astrophysicist Nia she uses simulation data and sophisticated 3D printers to produce interactive models of these stellar nurseries."
+      "[I'tand33b1] adj. 难以形容"
     ]
   },
   {
     "name": "integral",
     "trans": [
-      "Day 18 | adj. | English: being an essential part of sth | Example: Works from this period make up an outsized proportion of what is considered the canon of Mexican literature, but nineteenth-century writers like Justo Sierra O'Reilly should be considered just as integral to the Mexican literary canon."
+      "['Intigral;In'tegral] adj. 作为整体所必需的"
     ]
   },
   {
     "name": "integrate",
     "trans": [
-      "Day 18 | v. | English: to combine two or more things so that they work together; to combine with sth else in this way | Example: As epitomized by the Aguilar House in Guadalajara, many of Barragan's first projects integrated traditional Mexican building techniques into Mediterranean designs."
+      "['Intrgrert] v. 合并,成为一体"
     ]
   },
   {
     "name": "integrated",
     "trans": [
-      "Day 18 | adj. | English: in which many different parts are closely connected and work successfully together | Example: The invention in 1958 of the integrated circuit (or microchip) radically altered the semiconductor industry."
+      "adj. 各部分密切协调的,综合的"
     ]
   },
   {
     "name": "intelligible",
     "trans": [
-      "Day 18 | adj. | English: that can be easily understood | Example: Semantic relations among the two nouns and the concept they signify can be tenuous, as in the previous example, such that difrasismos are often only intelligible according to the conceptual associations observed in Aztec ceremonial culture."
+      "[m'telrd3abl] adj. 易懂的,容易理解的"
     ]
   },
   {
     "name": "intense",
     "trans": [
-      "Day 18 | adj. | English: very great; very strong | Example: Do | behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more intense seclusion; and connect / The landscape with the quiet of the sky."
+      "[In'tens] adj. 十分强烈的"
     ]
   },
   {
     "name": "intent",
     "trans": [
-      "Day 18 | n. | English: what you intend to do | Example: The many editions of James Joyce's 1922 novel Ulysses are not textually identical, and scholars debate which versions reflect Joyce's authorial intent."
+      "[I'tent] n. 目的,意图"
     ]
   },
   {
     "name": "intentional",
     "trans": [
-      "Day 18 | adj. | English: done deliberately | Example: Without an intentional effort to promote the city's food scene, many current and potential visitors to Buenaventura may not even be aware that it’s home to uniquely delicious food."
+      "[In'tenjan(a)l] adj. 故意的"
     ]
   },
   {
     "name": "interactive",
     "trans": [
-      "Day 18 | adj. | English: that allows information to be passed continuously and in both directions between a computer and the person who uses it | Example: Stars form in cloudlike swirls of gas and dust that cannot be touched, but astrophysicist Nia Imara believes these formations need not remain completely intangible to researchers: she uses simulation data and sophisticated 3D printers to produce interactive models of these stellar nurseries."
+      "[Intar'aktrv] adj. 人机对话的"
     ]
   },
   {
     "name": "intercede",
     "trans": [
-      "Day 18 | v. | English: to speak to sb in order to persuade them to show pity on sb else or to help settle an argument | Example: They interceded with the authorities on behalf of the detainees."
+      "[Intar'si:d] v. （为某人）"
     ]
   },
   {
     "name": "interdependent",
     "trans": [
-      "Day 18 | adj. | English: People or things that are interdependent all depend on each other. The Nile River delta system is located in Northern Egypt, where the river drains into the for example, the geography of the coastline influences sedimentary deposition, which over time alters coastal geography."
+      "adj. 相互依赖的"
     ]
   },
   {
     "name": "interference",
     "trans": [
-      "Day 18 | n. | English: the act of interfering | Example: Several advantages—the ability to react strongly with chip components, to avoid interference from other waves, and to be confined within tiny circuits—have positioned acoustic waves as a promising alternative to electrical waves for transmitting data on computer chips."
+      "[Intar'frans] n. 干扰"
     ]
   },
   {
     "name": "intergeneric",
     "trans": [
-      "Day 18 | adj. | English: involving more than one genus (= a group of plants or animals that are all related to each other) | Example: Writer Lydia Davis observed that while traditional literary forms, such as the novel, are recognizable as such even as they evolve, there are rarer “intergeneric” forms that might, for example, use elements of both fiction and essays to create something unclassifiable."
+      "adj. 属间的"
     ]
   },
   {
     "name": "intermediary",
     "trans": [
-      "Day 18 | n. | English: a person or an organization that helps other people or organizations to make an agreement by being a means of communication between them M. robustus leave the Octopus Garden upon reaching an intermediary stage of development."
+      "[.Intar'mi:dicri] n. 中间人"
     ]
   },
   {
     "name": "intermittent",
     "trans": [
-      "Day 18 | adj. | English: stopping and starting often over a period of time, but not regularly | Example: Asteroid 6478 Gault has experienced intermittent mass loss since at least 2013."
+      "[Intar'mItant] adj. 断断续续的"
     ]
   },
   {
     "name": "interplay",
     "trans": [
-      "Day 18 | v. | English: the way in which two or more things or people affect each other | Example: The Limén technique, developed by Mexican-born dancer and choreographer Jose Limon, is known for its emphasis on breath control and its interplay of weight and weightlessness."
+      "['Intorple] v. 相互影响"
     ]
   },
   {
     "name": "intervention",
     "trans": [
-      "Day 18 | n. | English: the act of becoming involved in an argument, fight, or other difficult situation in order to change what happens | Example: The results of randomized clinical trials testing the efficacy of common medical interventions sometimes fail to corroborate conclusions that practitioners reach based on their real-world observations of patients."
+      "[Itar'venjn] n. 干预"
     ]
   },
   {
     "name": "intricate",
     "trans": [
-      "Day 18 | adj. | English: having a lot of different parts and small details that fit together The unusual structure that O'Brian uses for Master and Commander makes it one of his most intricate books."
+      "['Intrkat;Intrikrt] adj. 错综复杂的"
     ]
   },
   {
     "name": "intriguing",
     "trans": [
-      "Day 18 | adj. | English: very interesting because of being unusual or not having an obvious answer | Example: Mauricio Drelichman and Hans-Joachim Voth's analysis of the overall debt and revenue of the government of philip (who ruled an empire including Spain and Sicily from 1556 to 1598) found an intriguing incongruity."
+      "[I'tri:gn] adj. 引人入胜的"
     ]
   },
   {
     "name": "intrinsic",
     "trans": [
-      "Day 18 | adj. | English: belonging to or part of the real nature of sth/sb | Example: There is often a kind of [deceptive] light, playing around such [famous] names, calculated to dazzle and mislead, by their false lustre, until the eye can no longer receive the pure light of Truth, or the mind appreciate real excellence, or intrinsic worth."
+      "[In'trInzik,I'trInsik] adj. 固有的"
     ]
   },
   {
     "name": "intrusive",
     "trans": [
-      "Day 18 | adj. | English: too noticeable, direct, etc. in a way that is disturbing or annoying While bioaccumulation of manufactured nanoparticles may be inherently worrisome, it has been hypothesized that CuO-NP bioaccumulation in invertebrates like L. stagnalis could serve a valuable proxy role, obviating the need for manufacturers to conduct costly and intrusive sampling of vertebrate species—such as African clawed frogs (Xenopus laevis), commonly used in regulatory compliance testing—for nanoparticle bioaccumulation, as environmental protection laws currently require."
+      "[m'trl:sv] adj. 侵入的"
     ]
   },
   {
     "name": "invalidate",
     "trans": [
-      "Day 18 | v. | English: to prove that an idea, a story, an argument, etc. is wrong | Example: It has been largely invalidated by results obtained from similar studies."
+      "[皿'vclrdert] v. 证明"
     ]
   },
   {
     "name": "invariably",
     "trans": [
-      "Day 18 | adv. | English: always | Example: As they sat down they turned almost invariably to the person sitting next them."
+      "[I'veriabli] adv. 始终如一地"
     ]
   },
   {
     "name": "inventive",
     "trans": [
-      "Day 18 | adj. | English: having the ability to create or design new things or to think originally | Example: The early British postal system required the cost of mail delivery to be paid upon receipt, a system which encouraged inventive strategies by the intended recipient to avoid payment."
+      "[I'ventw] adj. 有创造力的"
     ]
   },
   {
     "name": "inverse",
     "trans": [
-      "Day 18 | adj. | English: opposite in amount or position to sth else | Example: Biologist Ari Martinez and colleagues, who studied the ecological community the species share, hypothesized that there is an inverse relationship between birds’ field of vision while foraging and their sensitivity to alarm calls from neighboring species."
+      "[.皿'v3:rs] adj. 相反的"
     ]
   },
   {
     "name": "invertebrate",
     "trans": [
-      "Day 18 | n. | English: any animal with no backbone , for example a worm | Example: The vast majority of invertebrate species found in a recent survey of the CCZ were hitherto unknown to scientists, and sampling for animal life has been highly concentrated in the eastern part of the zone."
+      "[I'v3:rtibrat] n. 无脊椎动物"
     ]
   },
   {
     "name": "iridescent",
     "trans": [
-      "Day 18 | adj. | English: showing many bright colours that seem to change in different lights | Example: Itis made of iridescent multicolored LED domes."
+      "[.III'desnt] adj. 色彩斑斓闪耀的"
     ]
   },
   {
     "name": "irradiance",
     "trans": [
-      "Day 18 | n. | English: a measurement of the amount of light that comes from sth | Example: Since UVB exposure enables vertebrates to synthesize vitamin D, this raises questions about how chimpanzees in mid-latitude zoos are affected by the lower and more variable UVB irradiance in those locations."
+      "n. 辐照度"
     ]
   },
   {
     "name": "irrefutable",
     "trans": [
-      "Day 18 | adj. | English: that cannot be proved wrong and that must therefore be accepted | Example: The reasons for this characterization may seem irrefutable, but linking Unamuno with the Generation of '98 risks disregarding the subtleties in his style that do not neatly conform to the conventions of this literary movement."
+      "adj. 无可辩驳的,不能否认的"
     ]
   },
   {
     "name": "irrelevant",
     "trans": [
-      "Day 18 | adj. | English: not important to or connected with a situation People sometimes dismiss a claim if it comes from a source they regard as self-interested, but from a strictly logical perspective, the source of a claim is irrelevant."
+      "[I'relavant] adj. 无关紧要的,不相关的"
     ]
   },
   {
     "name": "irreproachable",
     "trans": [
-      "Day 18 | adj. | English: free from fault and impossible to criticize She welcomed her unexpected visitor with irreproachable politeness."
+      "[.II'prootf3b(a)l] adj. 无可指责的"
     ]
   },
   {
     "name": "irresistible",
     "trans": [
-      "Day 18 | adj. | English: s0 attractive that you feel you must have it | Example: Although Alfred E. Green's 1950 film The Jackie Robinson Story and Ossie Davis's 1970 film Cotton Comes to Harlem may have had some detractors at the time of their initial release, their place in critics' estimations is now more secure. In 2018, for example, critics for the New York Times described the former as \"irresistible\" and the latter as \"especially pointed.\""
+      "[.II'zIstabl] adj. 极诱人的,忍不住想要的"
     ]
   },
   {
     "name": "irresolvable",
     "trans": [
-      "Day 18 | adj. | English: not able to be resolved into parts or elements | Example: The question of whether the people of the time understood the paintings as something akin to art in your modern sense or in some other way entirely is irresolvable: we will never be able to answer it."
+      "[.II'zblvabal] adj. 不能解决的"
     ]
   },
   {
     "name": "isolate",
     "trans": [
-      "Day 18 | v. | English: to separate sb/sth physically or socially from other people or things | Example: They found that during harmless simulated attacks on isolated caterpillars, 33% of the tested species produced sound, which ranged from clicks in Actias luna to whistles in Phyllosphingia dissimilis."
+      "['aIsalert] v. 使一"
     ]
   },
   {
     "name": "isolated",
     "trans": [
-      "Day 18 | adj. | English: without much contact with other people or other countrie | Example: They found that during harmless simulated attacks on isolated caterpillars, 33% of the tested species produced sound, which ranged from clicks in Actias luna to chirps in Schausiella santarosensis."
+      "['aIsalertid] adj. 弧立的"
     ]
   },
   {
     "name": "isotope",
     "trans": [
-      "Day 18 | n. | English: one of two or more forms of a chemical element which have the same number of protons but a different number of neutrons in their atoms. They have different physical properties (= characteristics) but the same chemical ones | Example: Mammoth tusks grew in sequential layers, incorporating ingested minerals and organics, and so each ivory stratum reflects the ratio of strontium isotopes (87Sr/86Sr) in the local environment."
+      "['aIsatoUp] n. 同位素"
     ]
   },
   {
     "name": "iterate",
     "trans": [
-      "Day 18 | v. | English: to say or do again; repeat | Example: The [train] engines of this valley have a whistle, the echoes of which sound like iterated gasps and sobs. | always think of them as crude music."
+      "['Itarert] v. 重复说"
     ]
   },
   {
     "name": "jointly",
     "trans": [
-      "Day 18 | adj. | English: involving two or more people together | Example: Often, the Nobel Prize in Chemistry is given to a single person, such as Frederick Sanger in 1958. But sometimes the Nobel Committee wants to reward work attributed to two or three individuals, in which case, the award is given jointly."
+      "['d3oIntli] adj. 联合的,共同的"
     ]
   },
   {
     "name": "judicial",
     "trans": [
-      "Day 18 | adj. | English: connected with a court, a judge or legal judgement | Example: Jordan's constitution, enacted in 1952, contains just one of the six constitutional features that enhance judicial independence, as identified by legal scholars James Melton and Tom Ginsburg."
+      "[d3u'drll] adj. 司法的"
     ]
   },
   {
     "name": "juggler",
     "trans": [
-      "Day 18 | n. | English: a person who juggles , especially an entertainer | Example: To illustrate Albert Einstein's special theory of relativity, picture two jugglers: one juggling on a steadily moving parade float, the other juggling while standing still on a sidewalk."
+      "['d3Aglar] n. 玩杂耍的人"
     ]
   },
   {
     "name": "justification",
     "trans": [
-      "Day 19 | n. | English: a good reason why sth exists or is done | Example: No amount of justification, however, is likely to persuade some drivers who believe the current toll is exorbitant."
+      "[.d3Astrfi'kerhn] n. 正当理由"
     ]
   },
   {
     "name": "juxtaposition",
     "trans": [
-      "Day 19 | n. | English: The juxtaposition of two contrasting objects, images, or ideas is the fact that they are placed together or described together, so that the differences between them are emphasized. | Example: This style has exerted a decisive influence on authors around the world, including Olga Tokarczuk, whose 1996 novel Primeval and Other Times resembles classic magical realist novels in its juxtaposition of literary realism with folklore—namely, that of Poland."
+      "n. 并列"
     ]
   },
   {
     "name": "keen",
     "trans": [
-      "Day 19 | n. | English: highly developed | Example: The little fern-leaf, bending / Upon the brink, its green reflection greets, / And kisses soft the shadow that it meets / With touch so fine, / The border line / The keenest vision can't define; / So perfect is the blending."
+      "[ki:n] n. 敏锐的"
     ]
   },
   {
     "name": "laborious",
     "trans": [
-      "Day 19 | adj. | English: taking a lot of time and effort | Example: She was not thinking at all. She seemed for the time to be taking a rest from that laborious and fatiguing function and to have abandoned herself to some mechanical impulse that directed her actions and freed her of responsibility."
+      "[la'b3:rias] adj. 耗时费力的"
     ]
   },
   {
     "name": "lagoon",
     "trans": [
-      "Day 19 | n. | English: a lake of salt water that is separated from the sea by a reef or an area of rock or sand | Example: Among the wild rice in the still lagoon. / In monotone the lizard shrills his tune. / The wild goose, homing, seeks a sheltering, / Where rushes grow, and oozing lichens cling."
+      "[13'9u:\"] n. 环礁湖"
     ]
   },
   {
     "name": "landscape",
     "trans": [
-      "Day 19 | n. | English: everything you can see when you look across a large area of land, especially in the country | Example: The fog extended its tentacles over city and river gradually obliterating traces of familiar landscapes."
+      "['landskemp] n. （陆上;尤指乡村的）风景"
     ]
   },
   {
     "name": "lane",
     "trans": [
-      "Day 19 | n. | English: a narrow road in the country | Example: As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot."
+      "[lem] n. （乡间）小路"
     ]
   },
   {
     "name": "languid",
     "trans": [
-      "Day 19 | adj. | English: moving slowly in an elegant manner, not needing energy or effort | Example: The sun, already down, was manifest in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+      "['langwd] adj. 慢悠悠的,慵懒的"
     ]
   },
   {
     "name": "larynx",
     "trans": [
-      "Day 19 | n. | English: the area at the top of the throat that contains the vocal cords | Example: Rusty-spotted cats, which are much smaller than jaguars, have a rigid hyoid that rumbles when the cat’s larynx vibrates, resulting in a purr."
+      "['larmks] n. 喉"
     ]
   },
   {
     "name": "latitude",
     "trans": [
-      "Day 19 | n. | English: the distance of a place north or south of the equator (= the line around the world dividing north and south) , measured in degrees | Example: Across the orders in the study, deceptive antipredator displays are observed in approximately 34% of species with brooding ranges of 0°-30° absolute latitude and approximately 60% of species with brooding ranges of 50°-80° absolute latitude."
+      "['latitu:d] n. 维度"
     ]
   },
   {
     "name": "laud",
     "trans": [
-      "Day 19 | v. | English: to praise sb/sth | Example: While some commentators lauded this development, asserting that such blogs had a welcome transparency missing from traditional news, less sanguine observers countered that such blogs tended to ideological extremes that exacerbated political polarization to problematic levels."
+      "[13:4] v. 赞美"
     ]
   },
   {
     "name": "launch",
     "trans": [
-      "Day 19 | v. | English: v. to start an activity, especially an organized one v. to send sth such as a spacecraft , weapon, etc. into space, into the sky or through water | Example: [1] A group of 80 attackers launched an all-out assault just before dawn. 2] Since the Hubble Space Telescope was launched into space in 1990, astronauts have needed to complete regular missions to repair the telescope and keep it working smoothly."
+      "[I:n] v.；v.；v. （尤指有组织的活动）"
     ]
   },
   {
     "name": "lay",
     "trans": [
-      "Day 19 | adj. | English: not having expert knowledge or professional qualifications in a particular subject As Rachana Kamtekar observes, this argument is difficult to reconcile with our lay conception we expect a person of helpful character to be frequently helpful, not sporadically helpful."
+      "[ler] adj. 外行的,非专业的"
     ]
   },
   {
     "name": "layout",
     "trans": [
-      "Day 19 | n. | English: the way in which the parts of sth such as the page of a book, a garden or a building are arranged | Example: In a study, data scientist Sam K. Hui and colleagues found that this effect can also be achieved with a less obvious cue: rearranging a store’s layout."
+      "['leraot] n. 布局"
     ]
   },
   {
     "name": "lean",
     "trans": [
-      "Day 19 | adj. | English: adj. difficult and not producing much money, food, etc.; v. to bend or move from a vertical position | Example: [1] And when the wind is from the South, soil of my homeland falls like a fertile shower upon"
+      "[li:n] adj.；adj.；v. 贫乏的"
     ]
   },
   {
     "name": "ledge",
     "trans": [
-      "Day 19 | n. | English: a narrow flat shelf fixed to a wall, especially one below a window Propped on the window ledge, it featured a portrait of Great-Great-Grandmother Rosita as a young woman."
+      "[led3] n. 窗台"
     ]
   },
   {
     "name": "legacy",
     "trans": [
-      "Day 19 | n. | English: money or property that is given to you by sb when they die | Example: In fact the work is a complex, dynamic meditation on gender and the legacy of colonialism that demands serious attention."
+      "['legasi] n. 遗产"
     ]
   },
   {
     "name": "legitimacy",
     "trans": [
-      "Day 19 | n. | English: the quality or state of being legitimate | Example: Whether the reign of a French monarch such as Louis VII or Henry V was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy and therefore cannot be understood without a corollary understanding of the characteristics without which the monarch would have been forced to abandon the throne."
+      "n.；V. 合法性"
     ]
   },
   {
     "name": "legitimate",
     "trans": [
-      "Day 19 | adj. | English: for which there is a fair and acceptable reason Duchamp's Fountain did just that, raising the question of whether displaying any object in an art gallery could be said to transform the object—even, as Duchamp's sculpture was, a urinal—into a legitimate work of art."
+      "[Ir'd3Itmat] adj. 正当合理的"
     ]
   },
   {
     "name": "liability",
     "trans": [
-      "Day 19 | n. | English: the amount of money that a person or company owes | Example: But petroleum extraction is a very carbon-intensive industry, so as social attitudes increasingly favor using less carbon intensive sources of energy, demand for petroleum falls and the drilling equipment will eventually, or even suddenly, become a liability as reduced petroleum prices make it more difficult to recover the expense of maintaining such equipment."
+      "[.lara'brloti] n. 欠债"
     ]
   },
   {
     "name": "lichen",
     "trans": [
-      "Day 19 | n. | English: avery small grey or yellow plant that spreads over the surface of rocks, walls and trees and does not have any flowers | Example: Among the wild rice in the still lagoon. / In monotone the lizard shrills his tune. / The wild goose, homing, seeks a sheltering, / Where rushes grow, and oozing lichens cling."
+      "['lalkan,'Iitjon] n. 地衣"
     ]
   },
   {
     "name": "liftoff",
     "trans": [
-      "Day 19 | n. | English: a vertical takeoff by an aircraft or a rocket vehicle or missile | Example: The Apollo Moon landings (1969-1972) brought charged particle detectors and equipment too heavy for liftoff to the Moon and produced large amounts of data, much of which was stored on outdated technologies."
+      "n. 发射"
     ]
   },
   {
     "name": "ligament",
     "trans": [
-      "Day 19 | n. | English: a strong band of tissue in the body that connects bones and supports organs and keeps them in position | Example: By contrast, jaguars have a somewhat flexible hyoid, and the bone is attached to the skull with a stretchy ligament that rusty-spotted cats lack."
+      "['Igamant] n. 韧带"
     ]
   },
   {
     "name": "light",
     "trans": [
-      "Day 19 | v. | English: to make sth start to burn | Example: The sun, already down, was manifest in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+      "[lart] v. 过去式和过去分词都是"
     ]
   },
   {
     "name": "lighthearted",
     "trans": [
-      "Day 19 | adj. | English: free from care, anxiety, or seriousness | Example: | wanted to be brave, eager, confident, at ease, lighthearted."
+      "['lartha:rtd] adj. 无忧无虑的"
     ]
   },
   {
     "name": "lineage",
     "trans": [
-      "Day 19 | n. | English: the series of families that sb comes from originally | Example: Meredith E. Protas and colleagues have explored how convergent evolution—a phenomenon that occurs when the same trait evolves independently in two reproductively separate lineages—can result from a genetic mechanism shared by both lineages."
+      "['Imiid3] n. 世系"
     ]
   },
   {
     "name": "lineament",
     "trans": [
-      "Day 19 | n. | English: a feature of your face | Example: He had partially unveiled the face of Nature, but her immortal lineaments were still a wonder and a mystery."
+      "['Iniamant] n. 容貌"
     ]
   },
   {
     "name": "linger",
     "trans": [
-      "Day 19 | v. | English: to stay somewhere for longer because you do not want to leave; to spend a long time doing sth | Example: As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot."
+      "['Igar] v. 逗留"
     ]
   },
   {
     "name": "liquidity",
     "trans": [
-      "Day 19 | n. | English: the state of owning things of value that can easily be exchanged for cash | Example: But Drelichman and Voth's unique contribution is their reconstruction of the earliest extant set of annual fiscal records for any sovereign state, which demonstrate that Philip's defaults were caused by short-term liquidity crises, not long-term unsustainable debts."
+      "[Ir'kwIdati] n. 资产流动性"
     ]
   },
   {
     "name": "livestock",
     "trans": [
-      "Day 19 | n. | English: the animals kept on a farm, for example cows or sheep | Example: The flavor of meat from livestock differs across species (from pig to chicken to cow), and is also influenced by farming conditions and the breeds and genders of animals."
+      "['larvsta:k] n. 家畜"
     ]
   },
   {
     "name": "livid",
     "trans": [
-      "Day 19 | adj. | English: extremely angry | Example: The sun, already down, was manifest in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+      "adj. 暴怒的,狂怒的"
     ]
   },
   {
     "name": "loan",
     "trans": [
-      "Day 19 | n. | English: money that an organization such as a bank lends and sb borrows | Example: The bank went on to provide home loans and savings opportunities to thousands of Black families over the following decades."
+      "[loon] n. 贷款"
     ]
   },
   {
     "name": "lobby",
     "trans": [
-      "Day 19 | v. | English: to try to influence a politician or the government and, for example, persuade them to support or oppose a change in the law | Example: Karam Kang has demonstrated that lobbying does little to alter the probability that a particular energy policy under consideration by the United States Congress will be enacted."
+      "['la:bi] v. （从政者或政府"
     ]
   },
   {
     "name": "locomotion",
     "trans": [
-      "Day 19 | n. | English: movement or the ability to move | Example: Some robots such as Salvius (developed in 2008) and REEM-C (developed in 2013) feature humanoid characteristics like bipedal locomotion so that people will find it easier to interact with them."
+      "[.looka'moojn] n. 移动（力）"
     ]
   },
   {
     "name": "lodge",
     "trans": [
-      "Day 19 | v. | English: to become fixed or stuck somewhere | Example: On March 23, 2021, a gust of wind wreaked havoc on global trade. Ever Given, an international shipping container vessel, became lodged in Egypt's Suez Canal, a major"
+      "[la:d3] v. （被）固定"
     ]
   },
   {
     "name": "lofty",
     "trans": [
-      "Day 19 | adj. | English: very high and impressive Do | behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more deep seclusion; and connect / The landscape with the quiet of the sky."
+      "['I:fi] adj. 巍峨高耸的"
     ]
   },
   {
     "name": "long for",
     "trans": [
-      "Day 19 | English: to want sth very much especially if it does not seem likely to happen soon | Example: Then we sit and sob, and long for the gas-lit streets, and the sound of human voices, and the answering throb of human life."
+      "渴望"
     ]
   },
   {
     "name": "longing",
     "trans": [
-      "Day 19 | n. | English: a strong feeling of wanting sth/sb | Example: To convey the speaker's longing for the ocean to impart a sense of inner tranquility"
+      "['13:n] n. 渴望"
     ]
   },
   {
     "name": "longitudinal",
     "trans": [
-      "Day 19 | adj. | English: going downwards rather than across | Example: One reason for this discrepancy is that historians of capitalism tend to focus on longitudinal economic data drawn from archival records, which do not exist for much of precolonial Africa."
+      "adj. 纵向的"
     ]
   },
   {
     "name": "lot",
     "trans": [
-      "Day 19 | n. | English: a person's luck or situation in life | Example: The motorman chafed in his box, thinking of the drudging lot of the laboring man. He registered discontent."
+      "[la:t] n. 生活状况"
     ]
   },
   {
     "name": "lullaby",
     "trans": [
-      "Day 19 | n. | English: a soft gentle song sung to make a child go to sleep | Example: Just let me drift far out from toil and care, / Where lapping of the waves shall be the sound, / Which mingled with the winds that gently bear / Me on between a peaceful sea and sky, /To make my soothing slumberous lullaby."
+      "['Ilaba] n. 摇篮曲"
     ]
   },
   {
     "name": "luminous",
     "trans": [
-      "Day 19 | adj. | English: shining in the dark; giving out light | Example: Quasars—such as APM 08279+5255, located in the Lynx constellation—are extremely luminous galactic nuclei powered by supermassive black holes."
+      "['lu:mInas] adj. 发光的"
     ]
   },
   {
     "name": "lunar",
     "trans": [
-      "Day 19 | adj. | English: connected with the moon | Example: This discrepancy is explicable in terms of OFT: the monkeys’ greater reliance on vision means that higher lunar intensity benefits them more than it benefits the bats."
+      "['lu:nar] adj. 月球的"
     ]
   },
   {
     "name": "lung",
     "trans": [
-      "Day 19 | n. | English: either of the two organs in the chest that you use for breathing | Example: Postcranial skeletal pneumaticity (PSP) refers to the presence of extensions of an animal's lungs and air sacs inside its bones."
+      "[u] n. 肺"
     ]
   },
   {
     "name": "lurk",
     "trans": [
-      "Day 19 | v. | English: to wait somewhere secretly, especially because you are going to do sth bad or illegal | Example: After some trouble [Jim’s father] found the subject of the incident, the broken flower. Turning then, he saw the child lurking at the rear and scanning his countenance."
+      "[13:呔] v. 埋伏"
     ]
   },
   {
     "name": "magistrate",
     "trans": [
-      "Day 19 | n. | English: an official who acts as a judge in the lowest courts of law | Example: Every state should be so administered and so regulated by law that its magistrates cannot possibly make money."
+      "['madgIstrert] n. 地方执法官"
     ]
   },
   {
     "name": "magnetic field",
     "trans": [
-      "Day 19 | English: an area around a magnet or magnetic object, where there is a force that will attract some metals towards it | Example: Whereas crayfish can detect fields emitted by household electronics, those are many times stronger than the fields created by water moving through Earth's magnetic field, which sharks are sensitive enough to detect."
+      "磁场"
     ]
   },
   {
     "name": "magnify",
     "trans": [
-      "Day 19 | v. | English: to make sth look bigger than it really is, for example by using a lens or microscope | Example: The tendency to group authors together into distinct literary movements often encourages literary scholars to magnify subtleties in an author's style."
+      "['magnrfa] v. 放大"
     ]
   },
   {
     "name": "magnitude",
     "trans": [
-      "Day 19 | n. | English: the great size or importance of sth; the degree to which sth is large or important | Example: Both sharks and crayfish can detect electrical fields around them, but the magnitude of their sensitivities differs substantially."
+      "['megntu:d] n. （重要性等）"
     ]
   },
   {
     "name": "make off with",
     "trans": [
-      "Day 19 | English: If you make off with something, you steal it and take it away with you. | Example: Most infamously, he participated in what was essentially a private war against Sempringham Priory, a monastery near his manor, even making off with 500 pounds' worth of monastery property during a raid."
+      "偷走"
     ]
   },
   {
     "name": "malice",
     "trans": [
-      "Day 20 | n. | English: a feeling of hatred for sb that causes a desire to harm them | Example: You are cultured and intelligent, [Vanya], and you surely understand that the world is not destroyed by villains and conflagrations, but by hate and malice and all this spiteful tattling."
+      "['malIs] n. 恶意"
     ]
   },
   {
     "name": "mandatory",
     "trans": [
-      "Day 20 | adj. | English: required by law | Example: But naming a minor planet is not mandatory; whether to assign it a name is entirely the choice of whoever discovers it."
+      "['mandoto:ri] adj. 强制的,法定的,义务的"
     ]
   },
   {
     "name": "manifest",
     "trans": [
-      "Day 20 | adj. | English: easy to see or understand | Example: [Katharine's] descent from [a celebrated poet] was no surprise to her, but matter for satisfaction, until, as the years wore on, certain drawbacks made themselves very manifest."
+      "['manfest] adj. 明显的"
     ]
   },
   {
     "name": "manipulate",
     "trans": [
-      "Day 20 | v. | English: to control or use sth in a skilful way | Example: A number of artists associated with hyperpop, a movement in electronic music that emerged in the 2010s, aggressively manipulate their recorded voice."
+      "[ma'npjulert] v. 操作,使用"
     ]
   },
   {
     "name": "manor",
     "trans": [
-      "Day 20 | n. | English: a large country house surrounded by land that belongs to it | Example: Most infamously, he participated in what was essentially a private war against Sempringham Priory, a monastery near his manor, even making off with 500 pounds' worth of monastery property during a raid."
+      "n. 庄园宅地"
     ]
   },
   {
     "name": "mantle",
     "trans": [
-      "Day 20 | n. | English: the part of the earth below the crust and surrounding the core | Example: Until recently, Theia was notional, but researcher Qian Yuan and colleagues now claim to have identified pieces of the protoplanet in the lowermost section of Earth's mantle."
+      "['mentl] n. 地幔"
     ]
   },
   {
     "name": "mar",
     "trans": [
-      "Day 20 | v. | English: to damage or spoil sth good | Example: Colours might have been better chosen and lights more perfectly diffused; but perhaps in doing so the thorough clerical aspect of the whole might have been somewhat marred."
+      "[ma:] v. 破坏,损坏"
     ]
   },
   {
     "name": "margin",
     "trans": [
-      "Day 20 | n. | English: the empty space at the side of a written or printed page | Example: Douglass observed that the concept of an \"interactive\" text is much older than technologists assume, extending back to the first time readers scratched notes into a text's margins."
+      "['ma:rd3mn] n. 页边空白"
     ]
   },
   {
     "name": "marginal",
     "trans": [
-      "Day 20 | adj. | English: small and not important | Example: While they were used in a study that made an important scientific discovery, they are generally of marginal value as sources of genomic data. marvels on. AFAR: wea: AWE 322: wonderful results or things that have been achieved Hi) ‘a]: Her stockings and boots and well-fitting gloves had worked marvels in her bearing—had given her a feeling of assurance, a sense of belonging to the well-dressed multitude."
+      "['ma:rdzInl] adj. 微不足道的"
     ]
   },
   {
     "name": "marvels",
     "trans": [
-      "Day 20 | n. | English: wonderful results or things that have been achieved Her stockings and boots and well-fitting gloves had worked marvels in her bearing—had given her a feeling of assurance, a sense of belonging to the well-dressed multitude."
+      "n. 不平凡的成果"
     ]
   },
   {
     "name": "masculine",
     "trans": [
-      "Day 20 | adj. | English: having the qualities or appearance considered to be typical of men; connected with or like men | Example: Singly [the men around Newland] betrayed their inferiority: but grouped together they represented ‘New York,’ and the habit of masculine solidarity made him accept their doctrine on all the issues called moral."
+      "['meskjalm] adj. 男子汉的"
     ]
   },
   {
     "name": "mass loss",
     "trans": [
-      "Day 20 | English: the loss of the quantity of material that sth contains | Example: Asteroid 6478 Gault has experienced intermittent mass loss since at least 2013, but in contrast to some other asteroids with repeated mass-loss episodes, 6478 Gault has not lost mass at its perihelion (the closest point of its orbit to the Sun), and thus the loss is not attributable to solar energy—driven ice vaporization."
+      "质量损失"
     ]
   },
   {
     "name": "mass production",
     "trans": [
-      "Day 20 | n. | English: Mass production is the production of something in large quantities, especially by machine. | Example: In fact, some historians argue that it fundamentally transformed the industry by enabling it to take advantage of mass production methods for the first time."
+      "n. 大批量生产"
     ]
   },
   {
     "name": "massive",
     "trans": [
-      "Day 20 | adj. | English: extremely large or serious | Example: The Al-Fattah Al-Aleem Mosque in the New Administrative Capital, Egypt, is a massive mosque that can accommodate approximately 17,000 people at once."
+      "['masw] adj. 巨大的"
     ]
   },
   {
     "name": "meadow",
     "trans": [
-      "Day 20 | n. | English: a field covered in grass, used especially for hay | Example: It was the end of Paris, the beginning of the country, and behind the double row of arches the Seine, suddenly spreading out as though it had regained space and liberty, became all at once the peaceful river which flows through the plains, alongside the wooded hills, amid the meadows, along the edge of the forests."
+      "['medod] n. 草地"
     ]
   },
   {
     "name": "meager",
     "trans": [
-      "Day 20 | adj. | English: small in quantity and poor in quality | Example: She supplements her meagre income by cleaning at night."
+      "['mi:gar] adj. 少量且劣质的"
     ]
   },
   {
     "name": "means",
     "trans": [
-      "Day 20 | n. | English: n. the money that a person has; n. an action, an object or a system by which a result is achieved; a way of achieving or doing sth | Example: [1] Literature can metaphorically transport people to new places regardless of their means. 2] | aim to create a clear sense of the character and the world they inhabit. Sometimes this means adhering to the historical period's style, but frequently, as in stagings of A Midsummer Night's Dream, some flexibility is required to communicate an idea to the audience."
+      "[mi:nz] n.；n.；n. 财富;钱财"
     ]
   },
   {
     "name": "mediate",
     "trans": [
-      "Day 20 | v. | English: to influence sth and/or make it possible for it to happen | Example: Rather than being an arbitrary stylistic choice, hyperpop's persistent modification of the voice functions as a commentary on how digital technology mediates human experience today."
+      "['mi:diert] v. 的发生"
     ]
   },
   {
     "name": "mediocre",
     "trans": [
-      "Day 20 | adj. | English: not very good; of only average standard | Example: Isaac Asimov, author of Nemesis and The Stars, Like Dust, is highly regarded despite his mediocre writing style."
+      "[.mni:di'oukar] adj. 平庸的,普通的"
     ]
   },
   {
     "name": "meditation",
     "trans": [
-      "Day 20 | n. | English: the practice of thinking deeply in silence, especially for religious reasons or in order to make your mind calm | Example: In fact the work is a complex, dynamic meditation on gender and the legacy of colonialism that demands serious attention."
+      "[.medr'terlhn] n. 沉思"
     ]
   },
   {
     "name": "mediterranean",
     "trans": [
-      "Day 20 | adj. | English: connected with the Mediterranean Sea or the countries and regions that surround it; typical of this area | Example: It lends support to an argument about the Mediterranean design aesthetic that is made in the previous sentence."
+      "[medIta'relnian] adj. 地中海的"
     ]
   },
   {
     "name": "melancholy",
     "trans": [
-      "Day 20 | n. | English: a deep feeling of sadness that lasts for a long time and often cannot be explained | Example: He surveyed the fence, and all gladness left him and a deep melancholy settled down upon his spirit."
+      "['melanka:li] n. 忧郁"
     ]
   },
   {
     "name": "menace",
     "trans": [
-      "Day 20 | n. | English: a person or thing that causes, or may cause, serious damage, harm or danger | Example: Holes, hollows, pools, pitfalls, and other menaces to the wayfarer were vanishing fast."
+      "['menas] n. 危险的人或物"
     ]
   },
   {
     "name": "mercantilism",
     "trans": [
-      "Day 20 | n. | English: the economic theory that trade increases wealth | Example: Smith's metaphor of the invisible hand has been interpreted as a model of how individuals acting in their own interest produce aggregate benefits, but it was intended as a subtle critique of the economic theory of mercantilism."
+      "n. （认为商业可增加财富）"
     ]
   },
   {
     "name": "merger",
     "trans": [
-      "Day 20 | n. | English: the act of joining two or more organizations or businesses into one | Example: Bursts caused by neutron mergers typically last fewer than 2 seconds."
+      "['13:1d331] n. 合并"
     ]
   },
   {
     "name": "metabolic",
     "trans": [
-      "Day 20 | adj. | English: relating to a person's or animal's metabolism | Example: Some scientists have hypothesized that this capability evolved because it imposes a lower metabolic cost than does the alternative mechanism of producing chemicals that render moths noxious to bats."
+      "[.meta'ba:Iik] adj. 新陈代谢的"
     ]
   },
   {
     "name": "metaphorical",
     "trans": [
-      "Day 20 | adj. | English: connected with or containing metaphors | Example: Literature can metaphorically transport people to new places regardless of their means."
+      "adj. 隐喻的,比喻性的"
     ]
   },
   {
     "name": "methodology",
     "trans": [
-      "Day 20 | n. | English: aset of methods and principles used to perform a particular activity | Example: It introduces a research team's study of urban neighborhoods, describes an aspect of the study's methodology, and suggests a potential application of the team's research."
+      "[.mega'da:lod3i] n. 方法论"
     ]
   },
   {
     "name": "meticulous",
     "trans": [
-      "Day 20 | adj. | English: paying careful attention to every detail Historians argue that Morris's repudiation of industrialization is manifest in the Kelmscott editions' use of handmade materials and intricate ornamentation reminiscent of medieval these meticulously handcrafted elements exemplify the artistry involved."
+      "[ma'tjalas] adj. 小翼翼的"
     ]
   },
   {
     "name": "metropolis",
     "trans": [
-      "Day 20 | n. | English: a large important city (often the capital city of a country or region) | Example: By the laity of Milby and its neighbourhood [Mr. Ely] was regarded as a man of quite remarkable powers and learning, who must make a considerable sensation in London pulpits and drawing-rooms on his occasional visit to the metropolis."
+      "[na'tra:palIs] n. 大都市"
     ]
   },
   {
     "name": "metropolitan",
     "trans": [
-      "Day 20 | adj. | English: connected with a large or capital city | Example: Often, governments will report a value for the city proper (including only residents within the city limits) and another for the larger metropolitan area (including residents from nearby places beyond the city limits). miasma on. 5 SRMERIAVEE 3230: amass of air that is dirty and smells unpleasant The little conductor stood on tiptoe in an effort to keep one hand on the signal rope, craning his neck in a vain and dissatisfied endeavor to pierce the miasma of the fog."
+      "[mctra'Pa:Itan] adj. 大城市的"
     ]
   },
   {
     "name": "miasma",
     "trans": [
-      "Day 20 | n. | English: amass of air that is dirty and smells unpleasant | Example: The little conductor stood on tiptoe in an effort to keep one hand on the signal rope, craning his neck in a vain and dissatisfied endeavor to pierce the miasma of the fog."
+      "n. 污浊难闻的空气"
     ]
   },
   {
     "name": "microbe",
     "trans": [
-      "Day 20 | n. | English: an extremely small living thing that you can only see under a microscope and that may cause disease The researchers studied two wooden shipwrecks in the Gulf of Mexico by placing pieces of pine and oak between zero and 200 meters away from each shipwreck to collect samples of bacteria, archaea, and fungi."
+      "['malkroob] n. 微生物"
     ]
   },
   {
     "name": "microbial",
     "trans": [
-      "Day 20 | adj. | English: Microbial means relating to or caused by microbes. | Example: Rachel Mugge and colleagues were particularly curious about the effects of wooden shipwrecks on seafloor microbial communities."
+      "[mar'krobral] adj. 微生物的"
     ]
   },
   {
     "name": "microchip",
     "trans": [
-      "Day 20 | n. | English: avery small piece of a material that is a semiconductor , used to carry a complicated electronic circuit | Example: The invention in 1958 of the integrated circuit (or microchip) radically altered the semiconductor industry."
+      "n. 芯片"
     ]
   },
   {
     "name": "mimic",
     "trans": [
-      "Day 20 | v. | English: to copy the way sb speaks, moves, behaves, etc., especially in order to make other people laugh | Example: Artificial leaves are a developing renewable energy technology that mimics the process of photosynthesis in plants."
+      "['mIlik] v. 模仿"
     ]
   },
   {
     "name": "mingle",
     "trans": [
-      "Day 20 | v. | English: to combine or make one thing combine with another | Example: Just let me drift far out from toil and care, / Where lapping of the waves shall be the sound, / Which mingled with the winds that gently bear / Me on between a peaceful sea and sky, /To make my soothing slumberous lullaby."
+      "['mgl] v. 混合"
     ]
   },
   {
     "name": "minimalistic",
     "trans": [
-      "Day 20 | adj. | English: using the using the smallest range of materials and colours possible, and only very simple shapes or forms | Example: Scholarship today overrepresents formal experimentation, such as William Carlos Williams's use of minimalistic, image-based structures, well beyond the degree to which it actually influenced US poetry during the modernist period (roughly 1900-1945)."
+      "adj. 极简化的"
     ]
   },
   {
     "name": "mining",
     "trans": [
-      "Day 20 | n. | English: the process of getting coal and other minerals from under the ground; the industry involved in this | Example: The Clarion-Clipperton Zone (CCZ) is an expanse of abyssal plain and seamounts (underwater mountains) between Hawai'i and Mexico in which mining is permitted. minor planet on. /)4{7# MEM: asteroid The discoverers of the minor planet 1227 Geranium named it after the plant genus that includes cranesbills."
+      "['maInn] n. 采矿"
     ]
   },
   {
     "name": "minor planet",
     "trans": [
-      "Day 20 | n. | English: asteroid | Example: The discoverers of the minor planet 1227 Geranium named it after the plant genus that includes cranesbills."
+      "小行星"
     ]
   },
   {
     "name": "mint",
     "trans": [
-      "Day 20 | v. | English: to make a coin from metal | Example: An analysis by Alain Elayi and colleagues of coins minted in Sidon in the fifth and fourth centuries BCE reveals a change in their composition over time."
+      "[mInt] v. 铸（币）"
     ]
   },
   {
     "name": "minute",
     "trans": [
-      "Day 20 | adj. | English: very detailed, careful and thorough | Example: The knowledge, communicated by the historian and biographer, is analogous to that which we acquire of a country by the map, —minute, perhaps, and accurate, and available for all necessary purposes, but cold and naked, and wholly destitute of the mimic charm produced by landscape painting."
+      "['mInt] adj. 细致入微的,详细的"
     ]
   },
   {
     "name": "minutiae",
     "trans": [
-      "Day 20 | n. | English: very small details | Example: Knowing this can assuage potential investors' worries about bureaucratic minutiae and thereby allow them to instead focus on identifying sound business opportunities."
+      "[mI'nu:jii:,I1'nu:jia] n. 微小的细节"
     ]
   },
   {
     "name": "miraculous",
     "trans": [
-      "Day 20 | adj. | English: like a miracle ; completely unexpected and very lucky | Example: Behind the Lamassu, more columns sprouted from the ground like ancient trees in a petrified forest, forty feet tall, spindly but still miraculously upright."
+      "[mr'rekjalas] adj. 不可思议的"
     ]
   },
   {
     "name": "misanthropic",
     "trans": [
-      "Day 20 | adj. | English: hating and avoiding other people | Example: He was paranoid, self-obsessed and misanthropic."
+      "[.mIsan'Ora:pIk] adj. 厌世的,不愿与别人交往的"
     ]
   },
   {
     "name": "mischievous",
     "trans": [
-      "Day 20 | adj. | English: causing trouble, such as damaging sb's reputation | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+      "['mIstfivas] adj. 恶意的"
     ]
   },
   {
     "name": "misconstrue",
     "trans": [
-      "Day 20 | v. | English: to understand sb's words or actions wrongly | Example: She of course is complaining that her comments were sort of misconstrued."
+      "[mIskan'stru:] v. 误解"
     ]
   },
   {
     "name": "mitigate",
     "trans": [
-      "Day 20 | v. | English: to make sth less harmful, serious, etc. | Example: Having an ample reserve of stored energy can mitigate the effects of fluctuations in solar energy collection caused by unpredictable shifts in cloud cover and haze."
+      "['mtgert] v. 减轻,缓和"
     ]
   },
   {
     "name": "mock",
     "trans": [
-      "Day 20 | v. | English: to laugh at sb/sth in an unkind way, especially by copying what they say or do | Example: He's always mocking my French accent."
+      "[ma:k] v. 嘲笑"
     ]
   },
   {
     "name": "mollusk",
     "trans": [
-      "Day 20 | n. | English: A mollusk is an animal such as a snail, clam, or octopus which has a soft body. Many types of mollusc have hard shells to protect them. | Example: With a shell that measured 1.7 meters, the extinct mollusk Parapuzosia seppenradensis is the largest ammonite in the fossil record."
+      "['ma:lask] n. 软体动物"
     ]
   },
   {
     "name": "momentous",
     "trans": [
-      "Day 21 | adj. | English: very important or serious, especially because there may be important results | Example: The prime minister called the eve of the Games “a truly momentous day for our country\"."
+      "[moU'mcntas] adj. 重要的"
     ]
   },
   {
     "name": "monarch",
     "trans": [
-      "Day 21 | n. | English: a person who rules a country, for example a king or a quee | Example: Whether the reign of a French monarch such as Louis VII or Henry V was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy and therefore cannot be understood without a corollary understanding of the characteristics without which the monarch would have been forced to abandon the throne."
+      "['ma:nark;'ma:na:I] n.；V. 君主"
     ]
   },
   {
     "name": "monastery",
     "trans": [
-      "Day 21 | n. | English: A monastery is a building or collection of buildings in which monks live. | Example: Most infamously, he participated in what was essentially a private war against Sempringham Priory, a monastery near his manor, even making off with 500 pounds’ worth of monastery property during a raid."
+      "['ma:nastcri] n. 修道院"
     ]
   },
   {
     "name": "monetize",
     "trans": [
-      "Day 21 | v. | English: to establish as the legal tender of a country Do you actually want to monetize your blog?"
+      "v. 使货币化"
     ]
   },
   {
     "name": "monotone",
     "trans": [
-      "Day 21 | n. | English: a dull sound or way of speaking in which the tone and volume remain the same and therefore seem boring | Example: Among the wild rice in the still lagoon. / In monotone the lizard shrills his tune. / The wild goose, homing, seeks a sheltering, / Where rushes grow, and oozing lichens cling."
+      "n. 单调"
     ]
   },
   {
     "name": "monotonous",
     "trans": [
-      "Day 21 | adj. | English: never changing and therefore boring | Example: They suggest Caravan's dismay about being trapped in a job that has become exceedingly monotonous."
+      "[a'na:tanas] adj. 单调乏味的"
     ]
   },
   {
     "name": "monotony",
     "trans": [
-      "Day 21 | n. | English: boring lack of variety | Example: In his solitary retreat on the shore of the sea, whose mobile surface was visible through the open windows, extending outward until it mingled with the horizon, Padre Florentino was relieving the monotony by playing on his harmonium sad and melancholy tunes, to which the sonorous roar of the surf and the sighing of the treetops of the neighboring wood served as accompaniments."
+      "[ma'na:tani] n. 单调乏味"
     ]
   },
   {
     "name": "morphological",
     "trans": [
-      "Day 21 | adj. | English: relating to the form or structure of things | Example: The morphological novelty of echinoderms marine—invertebrates with radial symmetry, usually starlike, around a central point—impedes comparisons with most other animals, in which bilateral symmetry on an anterior-posterior (head to tail) axis through a trunk is typical."
+      "[.m3:rfa'la:d3ik] adj. 形态学的"
     ]
   },
   {
     "name": "mortal",
     "trans": [
-      "Day 21 | n. | English: a human, especially an ordinary person with little power or influence | Example: Indeed, what mortal is there of us, who would find his satisfaction enhanced by an opportunity of comparing the picture he presents to himself of his own doings, with the picture they make on the mental retina of his neighbours?"
+      "['m3:rtl] n. 凡人"
     ]
   },
   {
     "name": "mosque",
     "trans": [
-      "Day 21 | n. | English: a building in which Muslims worship | Example: The Al-Fattah Al-Aleem Mosque in the New Administrative Capital, Egypt, is a massive mosque that can accommodate approximately 17,000 people at once."
+      "[ma:sk] n. 清真寺"
     ]
   },
   {
     "name": "moss",
     "trans": [
-      "Day 21 | n. | English: avery small green or yellow plant without flowers that spreads over damp surfaces, rocks, trees, etc. | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+      "[13:5] n. 地衣,苔藓"
     ]
   },
   {
     "name": "motif",
     "trans": [
-      "Day 21 | n. | English: a design or a pattern used as a decoration | Example: Linda Lomahaftewa often assembles compositions out of motifs common in the ceramics and other traditional arts of the Hopi Tribe."
+      "[moU'ti:廿装饰图案英文释义:designorapatternusedasadecoration例句:LindaLomahaftewaoftenassemblescompositionsoutofmotifscommonintheceramicsandothertraditionalartsoftheHopiTribe_mound[maond] n. 土墩"
     ]
   },
   {
     "name": "mound",
     "trans": [
-      "Day 21 | n. | English: a large pile of earth or stones | Example: Using a mechanical spear-thrower, he launched spears with Clovis points into mounds of clay—substitutes for the animals’ large bodies."
+      "[maond] n. 土墩"
     ]
   },
   {
     "name": "mourn",
     "trans": [
-      "Day 21 | v. | English: to feel and show sadness because sb has died | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+      "[13:m] v. （因失去"
     ]
   },
   {
     "name": "mournful",
     "trans": [
-      "Day 21 | adj. | English: very sad | Example: Notes long, full, mournful as a prayer, yet still vigorous, escaped from the old instrument."
+      "['m3:rntl] adj. 忧伤的"
     ]
   },
   {
     "name": "mule",
     "trans": [
-      "Day 21 | n. | English: an animal that has a horse and a donkey as parents, used especially for carrying loads | Example: There are persons who go to the theater like the contestants in a mule-race: the last one in, wins, and we know very sensible men who would ascend the scaffold rather than enter a theater before the first act."
+      "[mju:] n. 骡子"
     ]
   },
   {
     "name": "multifaceted",
     "trans": [
-      "Day 21 | adj. | English: having many different aspects to be considered | Example: In The Future of Nostalgia, Svetlana Boym offers readers a multifaceted exploration of the concept of nostalgia."
+      "[.mAlti'fasrtd] adj. 多方面的"
     ]
   },
   {
     "name": "multitude",
     "trans": [
-      "Day 21 | n. | English: a large crowd of people | Example: Her stockings and boots and well-fitting gloves had worked marvels in her bearing—had given her a feeling of assurance, a sense of belonging to the well-dressed multitude."
+      "['mAltitu:d] n. 人群"
     ]
   },
   {
     "name": "municipality",
     "trans": [
-      "Day 21 | n. | English: a town, city or district with its own local government; the group of officials who govern it | Example: For example, the Puerto Rican municipality of Hatillo has also been called \"the Blue Coast of Puerto Rico,\" a nickname that alludes to what the area is well known for: the pristine blue ocean that surrounds it."
+      "n. 自治市"
     ]
   },
   {
     "name": "musing",
     "trans": [
-      "Day 21 | n. | English: a period of thinking carefully about sth or telling people your thoughts about it | Example: So shrewd an observer is Shnagon, a lady-in-waiting to Empress Teishi, that her book's musings on tenth-century Japanese courtly life fascinate readers a thousand years later."
+      "['mju:Z] n. 沉思"
     ]
   },
   {
     "name": "musty",
     "trans": [
-      "Day 21 | adj. | English: smelling damp and unpleasant because of a lack of fresh air | Example: | sauntered along, forgetful of musty papers, of the offices, of my chief, my colleagues, my documents, and thinking of the good things that were sure to come to me, of all the veiled unknown contained in the future."
+      "adj. 有霉味的"
     ]
   },
   {
     "name": "mutable",
     "trans": [
-      "Day 21 | adj. | English: that can change; likely to change | Example: The Fly River delta is a remarkably mutable landscape."
+      "adj. 会娈的"
     ]
   },
   {
     "name": "mutation",
     "trans": [
-      "Day 21 | n. | English: a process in which the genetic material of a person, a plant or an animal changes in structure when it is passed on to children, etc., causing different physical characteristics to develop; a change of this kind | Example: The genetic mutation exists in an ancestor of domestic dogs dating to 53,000 years ago."
+      "[mju:'terhn] n. （生物物种的）娈异"
     ]
   },
   {
     "name": "mute",
     "trans": [
-      "Day 21 | v. | English: to make the sound of sth, especially a musical instrument, quieter or softer, sometimes using amute | Example: “The wooing kestrel.” | said, “mutes his mating-note / To please the harmony of this sweet silence.”"
+      "[mju:t] v. 减弱声音"
     ]
   },
   {
     "name": "myopic",
     "trans": [
-      "Day 21 | adj. | English: If you describe someone as myopic, you are critical of them because they seem unable to realize that their actions might have negative consequences. | Example: Despite stated claims of global relevance, much major research on income inequality performed in the 2010s suffered from a myopic focus on a few countries in North America and Western Europe, partly due to limited data availability."
+      "[maI'a:p] adj. 目光短浅的"
     ]
   },
   {
     "name": "myth",
     "trans": [
-      "Day 21 | n. | English: something that many people believe but that does not exist or is false | Example: Elephants and other animals, though, have busted the myth that tool use requires hands."
+      "[mIo] n. 错误的观点"
     ]
   },
   {
     "name": "naked",
     "trans": [
-      "Day 21 | adj. | English: expressed strongly and not hidden | Example: The knowledge, communicated by the historian and biographer, is analogous to that which we acquire of a country by the map, —minute, perhaps, and accurate, and available for all necessary purposes, but cold and naked, and wholly destitute of the mimic charm produced by landscape painting."
+      "['nerkd] adj. 毫不掩饰的"
     ]
   },
   {
     "name": "neatly",
     "trans": [
-      "Day 21 | adv. | English: tidy and carefully arranged | Example: Difference in cell size results in a construction problem—it's hard to neatly connect sections of small cells to sections of large cells—that worsens as the difference increases."
+      "['ni:tli] adv. 整齐地"
     ]
   },
   {
     "name": "nebulous",
     "trans": [
-      "Day 21 | adj. | English: not clear | Example: Our knowledge of the Pliocene epoch and the lives of the hominids during this time was once nebulous."
+      "['nebjalas] adj. 模糊的"
     ]
   },
   {
     "name": "nectar",
     "trans": [
-      "Day 21 | n. | English: a sweet liquid that is produced by flowers and collected by bees for making honey | Example: In a 2021 paper, zoologist Guillaume Ghisbain notes that bumblebees are among the relatively few wild-bee genera that display social behaviors and dietary generalism (ability to obtain nectar and pollen from a diversity of plant species), two traits that are associated with increased resilience to some specific environmental changes."
+      "['nektar] n. 花蜜"
     ]
   },
   {
     "name": "negligible",
     "trans": [
-      "Day 21 | adj. | English: of very little importance or size and not worth considering | Example: Seira et al. asserted that such effects may nevertheless be worth pursuing, given the negligible cost of messaging."
+      "['neglrd3abl] adj. 微不足道的"
     ]
   },
   {
     "name": "neutron star",
     "trans": [
-      "Day 21 | n. | English: Aneutron star is a star that has collapsed under the weight of its own gravity. The recently observed gamma ray burst GRB 230307A lasted for 200 seconds, an oddity for a burst generated by the merger of neutron stars."
+      "n. 中子星"
     ]
   },
   {
     "name": "nocturnal",
     "trans": [
-      "Day 21 | adj. | English: active at night | Example: Though many other nocturnal mammals respond to lunar intensity variations similarly to greater short-nosed fruit bats, mongoose lemurs (Eulemur mongoz) display the opposite pattern, as their heavy reliance on visual foraging results in a different balance of reward and risk."
+      "[na:k't3:1n] adj. 夜间活动的"
     ]
   },
   {
     "name": "nominally",
     "trans": [
-      "Day 21 | adv. | English: in name only | Example: The present-day city of Yoshkar-Ola, Russia, was the capital of the Mari Autonomous Soviet Socialist Republic, one of many nominally autonomous republics within the Soviet Union."
+      "adv. 名义上地"
     ]
   },
   {
     "name": "nomination",
     "trans": [
-      "Day 21 | n. | English: the act of suggesting or choosing sb as a candidate in an election, or for a job or an award; the fact of being suggested for this | Example: A-student claims that opening weekend earnings can reliably predict whether a film will be nominated for an Oscar: films that draw large audiences at the beginning of their release are the most likely contenders to earn these coveted award nominations."
+      "[.na:mr'nerln] n. 提名"
     ]
   },
   {
     "name": "nonetheless",
     "trans": [
-      "Day 21 | adv. | English: despite this fact | Example: This approach has some limits—data from Places API tend to be restricted to places that are customer-facing—but the data set nonetheless provides an extremely reliable source to study colocation patterns of neighborhood amenities."
+      "[unda'les] adv. 尽管如此"
     ]
   },
   {
     "name": "norms",
     "trans": [
-      "Day 21 | n. | English: standards of behaviour that are typical of or accepted within a particular group or society | Example: They can register shifts in norms, values, and concerns that traditional objects of historical inquiry may not."
+      "[n:Imnz] n. 标准行为"
     ]
   },
   {
     "name": "notable",
     "trans": [
-      "Day 21 | adj. | English: deserving to be noticed or to receive attention; important | Example: British painter Peter Edwards has a reputation for painting portraits of notable figures from a variety of different fields."
+      "['nootabl] adj. 显著的"
     ]
   },
   {
     "name": "notional",
     "trans": [
-      "Day 21 | adj. | English: based on a guess, estimate or theory; not existing in reality Until recently, Theia was notional, but researcher Qian Yuan and colleagues now claim to have identified pieces of the protoplanet in the lowermost section of Earth's mantle."
+      "adj. 猜测的,估计的"
     ]
   },
   {
     "name": "notorious",
     "trans": [
-      "Day 21 | adj. | English: well known for being bad | Example: The fact that this genus has not been observed in eastern and western Coahuila has been attributed to a lack of appropriate habitat, but much of the landscape in this area is notoriously inaccessible."
+      "[noU'to:rias] adj. 臭名昭著的"
     ]
   },
   {
     "name": "noxious",
     "trans": [
-      "Day 21 | adj. | English: poisonous or harmful Some scientists have hypothesized that this capability evolved because it imposes a lower metabolic cost than does the alternative mechanism of producing chemicals that render moths noxious to bats."
+      "['na:kjas] adj. 有毒的"
     ]
   },
   {
     "name": "nuance",
     "trans": [
-      "Day 21 | n. | English: a very slight difference in meaning, sound, colour or sb's feelings that is not usually very obvious | Example: Those studying the works of Antonio Machado, for instance, may inadvertently overlook nuances in his work by focusing only on the most obvious ways in which his style"
+      "['nu:a:ns] n. 细微差别"
     ]
   },
   {
     "name": "nuanced",
     "trans": [
-      "Day 21 | adj. | English: characterized by subtle shades of meaning or expression | Example: Political scientists have found that although voters claim to prefer candidates who have nuanced perspectives on issues and who show a willingness to compromise, when asked to compare speeches expressing such views with speeches expressing dogmatic views, voters tend to regard the unyielding rhetoric of the latter more favorably."
+      "['nu:.a:nst] adj. 有细微差别的"
     ]
   },
   {
     "name": "nuclei",
     "trans": [
-      "Day 21 | n. | English: the central part of sth around which other parts are located or collected Quasars—such as APM 08279+5255, located in the Lynx constellation—are extremely luminous galactic nuclei powered by supermassive black holes."
+      "n. （的复数形式）"
     ]
   },
   {
     "name": "nullify",
     "trans": [
-      "Day 21 | v. | English: to make sth lose its effect or power Economist Jingting Fan argues that the effects of international trade may display spatial variation at sub-national levels. For instance, imported goods may reduce expenses for a country's average consumer, but for consumers living far from ports, high intranational transport costs could nullify the price advantages associated with imports."
+      "['ulrfa] v. 使无效"
     ]
   },
   {
     "name": "nurture",
     "trans": [
-      "Day 21 | v. | English: to help sb/sth to develop and be successful | Example: Although fewer companies trade their stocks on the Cambodia Securities Exchange in Phnom Penh, Cambodia, than on the stock exchanges in London, Mumbai, or Tokyo, the Cambodia Securities Exchange has the advantage of being able to nurture relatively small companies in Cambodia."
+      "['n3:Itfar] v. 扶持"
     ]
   },
   {
     "name": "oar",
     "trans": [
-      "Day 21 | n. | English: along pole with a flat blade at one end that is used for rowing a boat | Example: Thy warm and land-locked waters swell with an easy motion, / And gently glides the light"
+      "[3:] n. 船桨"
     ]
   },
   {
     "name": "obedience",
     "trans": [
-      "Day 21 | n. | English: the fact that people or animals do what they are told to do | Example: But she had been trained to obedience, and her battles with the spirit always took place after she carefully locked her bedroom door."
+      "[3'bi:dians] n. 服从"
     ]
   },
   {
     "name": "objective",
     "trans": [
-      "Day 21 | n. | English: n. something that you are trying to achieve; adj. not influenced by personal feelings or opinions; considering only facts | Example: [1] The algorithm gave them an objective way to identify neighborhoods. 2] It illustrates the assertion that peace is a subjective state rather than an objective one."
+      "[ab'd3ektwv] n.；n.；adj. 目标"
     ]
   },
   {
     "name": "obligate",
     "trans": [
-      "Day 21 | adj. | English: biologically essential for survival | Example: The migration's obligate nature is why diadromous fish can be demarcated from those that are merely euryhaline (able to tolerate high salinity)."
+      "['ablr,gert] adj. （生）"
     ]
   },
   {
     "name": "obligated",
     "trans": [
-      "Day 22 | adj. | English: having a moral or legal duty to do sth | Example: He felt obligated to help."
+      "adj. 有义务的,有责任的,必须的"
     ]
   },
   {
     "name": "obliterate",
     "trans": [
-      "Day 22 | v. | English: to remove all signs of sth, either by destroying or covering it completely | Example: The fog extended its tentacles over city and river gradually obliterating traces of familiar landscapes."
+      "[3'blitarert] v. 毁掉"
     ]
   },
   {
     "name": "oblivious",
     "trans": [
-      "Day 22 | adj. | English: not aware of sth | Example: He drove off, oblivious of the damage he had caused."
+      "[3'blrvias] adj. 不知道的"
     ]
   },
   {
     "name": "obscure",
     "trans": [
-      "Day 22 | v. | English: v. to make it difficult to see, hear or understand sth; adj. difficult to understand | Example: [1] Thus, in the case of Cannon's generation, the identification of an abstract painting as Indigenous art tends to obscure the Indigenous origins of certain motifs associated with Abstract Expressionism. 2] May herself could not understand [Newland's] obscure reluctance to fall in with so reasonable and pleasant a way of spending the summer."
+      "[3b'skjur] v.；v.；adj. 使模糊,使隐晦,使费解"
     ]
   },
   {
     "name": "obscurity",
     "trans": [
-      "Day 22 | n. | English: difficult to understand | Example: Its apparent obscurity can be resolved when considered in the proper cultural context."
+      "[ab'skjuroti] n. 默默无闻"
     ]
   },
   {
     "name": "observatory",
     "trans": [
-      "Day 22 | n. | English: a special building from which scientists watch the stars, the weather, etc | Example: In 2016, Gabriela Gonzalez and team announced that a chirping sound captured by Laser Interferometer Gravitational-Wave Observatory antennas was direct evidence of gravitational waves."
+      "n. 天文台"
     ]
   },
   {
     "name": "obsolete",
     "trans": [
-      "Day 22 | adj. | English: no longer used because sth new has been invented | Example: Its primary methods for analyzing fiction written in the period are growing obsolete as computer technology advances."
+      "[.a:bsa'li:t] adj. 过时的"
     ]
   },
   {
     "name": "obstacle",
     "trans": [
-      "Day 22 | n. | English: a situation, an event, etc. that makes it difficult for you to do or achieve sth | Example: It seemed as if nature had determined to throw every conceivable obstacle in the way of those who should seek to join the two great oceans of the world."
+      "['a:bstakl] n. 障碍"
     ]
   },
   {
     "name": "obstruct",
     "trans": [
-      "Day 22 | v. | English: to prevent sb/sth from doing sth or making progress, especially when this is done deliberately | Example: They were charged with obstructing the police in the course of their duty."
+      "[3b'strakt] v. 故意"
     ]
   },
   {
     "name": "obviate",
     "trans": [
-      "Day 22 | v. | English: to remove a problem or the need for sth | Example: While bioaccumulation of manufactured nanoparticles may be inherently worrisome, it has been hypothesized that CeO2-NP bioaccumulation in invertebrates like D. polymorpha could serve a valuable proxy role, obviating the need for manufacturers to conduct costly and intrusive sampling of vertebrate species—such as rainbow trout (Oncorhynchus mykiss), commonly used in regulatory compliance testing—for nanoparticle bioaccumulation, as environmental protection laws currently require."
+      "['a:bviert] v. 消除"
     ]
   },
   {
     "name": "occasional",
     "trans": [
-      "Day 22 | adj. | English: happening or done sometimes but not often | Example: By the laity of Milby and its neighbourhood [Mr. Ely] was regarded as a man of quite remarkable powers and learning, who must make a considerable sensation in London pulpits and drawing-rooms on his occasional visit to the metropolis."
+      "[3'ker3anl] adj. 偶尔的"
     ]
   },
   {
     "name": "occurrence",
     "trans": [
-      "Day 22 | n. | English: something that happens or exists | Example: To describe a regular occurrence from Grande's childhood"
+      "[3'k3:rans] n. 发生的事情"
     ]
   },
   {
     "name": "oddity",
     "trans": [
-      "Day 22 | n. | English: a person or thing that is strange or unusual | Example: The recently observed gamma ray burst GRB 230307A lasted for 200 seconds, an oddity for a burst generated by the merger of neutron stars."
+      "['a:dati] n. 古怪反常的人"
     ]
   },
   {
     "name": "odor",
     "trans": [
-      "Day 22 | n. | English: asmell, especially one that is unpleasant | Example: | walked slowly beneath the young leaves, drinking in the air, fragrant with the odor of young buds and sap."
+      "['oudar] n. 气味"
     ]
   },
   {
     "name": "offset",
     "trans": [
-      "Day 22 | v. | English: to use one cost, payment or situation in order to cancel or reduce the effect of another | Example: Any advantages that the transmission strategy used by three-host CLPs may have conferred did not completely offset the negative effects of other temperature driven factors on CLP abundance."
+      "['3:fset] v. 抵消"
     ]
   },
   {
     "name": "offspring",
     "trans": [
-      "Day 22 | n. | English: a child of a particular person or couple | Example: Horizontal gene transfer involves the exchange of genetic material between organisms not in a parent-offspring relationship."
+      "['3:fspr] n. 后代"
     ]
   },
   {
     "name": "oligarchy",
     "trans": [
-      "Day 22 | n. | English: a form of government in which only a small group of people hold all the power | Example: Aristotle observes that different forms of government can fall in different ways—for example, oligarchies might grant power to military leaders during wartime who refuse to relinquish that power during peacetime—but some methods of preserving order apply across all forms of government. ontiptoe HF BER# 3232: standing or walking on the front part of your foot, with your heels off the ground, in order to make yourself taller or to move very quietly The little conductor stood on tiptoe in an efort to keep one hand on the signal rope, craning his neck in a vain and dissatisfed endeavor to pierce the miasma of the fog. on/to the verge of sth/of doing sth Big 327%: very near to the moment when sb does sth or sth happens There is no denying that, since he was rather brusque in his ways, he never spared the young authors who asked his advice and read him their productions, but criticized vigorously, even to the verge of insult."
+      "n. 寡头政治"
     ]
   },
   {
     "name": "on tiptoe",
     "trans": [
-      "Day 22 | English: standing or walking on the front part of your foot, with your heels off the ground, in order to make yourself taller or to move very quietly | Example: The little conductor stood on tiptoe in an efort to keep one hand on the signal rope, craning his neck in a vain and dissatisfed endeavor to pierce the miasma of the fog. on/to the verge of sth/of doing sth Big 327%: very near to the moment when sb does sth or sth happens"
+      "蹑手蹑脚"
     ]
   },
   {
     "name": "on/to the verge of sth/of doing sth",
     "trans": [
-      "Day 22 | English: very near to the moment when sb does sth or sth happens | Example: There is no denying that, since he was rather brusque in his ways, he never spared the young authors who asked his advice and read him their productions, but criticized vigorously, even to the verge of insult."
+      "即将"
     ]
   },
   {
     "name": "ongoing",
     "trans": [
-      "Day 22 | adj. | English: continuing to exist or develop | Example: The student, however, claims that ultimately audiences of the time preferred resolution and closure over ongoing tension."
+      "['a:ngoun] adj. 仍在进行的"
     ]
   },
   {
     "name": "ooze",
     "trans": [
-      "Day 22 | v. | English: ifa thick liquid oozes from a place, or if sth oozes a thick liquid, the liquid flows from the place slowly Among the wild rice in the still lagoon. / In monotone the lizard shrills his tune. / The wild goose, homing, seeks a sheltering, / Where rushes grow, and oozing lichens cling."
+      "[\":2] v. 渗出,慢慢流出"
     ]
   },
   {
     "name": "opalescent",
     "trans": [
-      "Day 22 | adj. | English: changing colour like an opal The sierra is clad in gala colors. Over its inaccessible peaks the opalescent fog settles like a snowy veil on the forehead of a bride."
+      "[oUpa'les(a)nt] adj. 色彩娈幻的"
     ]
   },
   {
     "name": "opportune",
     "trans": [
-      "Day 22 | n. | English: suitable for doing a particular thing, so that it is likely to be successfu | Example: The offer could not have come at a more opportune moment."
+      "[apar't:\"] n. 恰当的"
     ]
   },
   {
     "name": "oppressive",
     "trans": [
-      "Day 22 | adj. | English: treating people in a cruel and unfair way and not giving them the same freedom, rights, etc. as other people | Example: Because coins with a silver content below 80% were widely considered unsuitable for trade, Elayi et al. speculate that a crisis in confidence in the currency occurred in Sidon around 367 BCE, which was likely relieved—despite Sidon's persistent oppressive financial obligations—as a result of Ba’al&illem II's successor Abd'aStart I's decision to keep the amount of silver in Sidonian coins consistent with that in coins minted in 367 BCE but decrease their weight."
+      "[a'preswv] adj. 压迫的"
     ]
   },
   {
     "name": "optimal",
     "trans": [
-      "Day 22 | adj. | English: the best possible; producing the best possible results | Example: The predictive model, which incorporates this algorithm, is sure to be invaluable in determining the optimal mix of a city's amenities."
+      "['a:ptrmal] adj. 最佳的"
     ]
   },
   {
     "name": "orbit",
     "trans": [
-      "Day 22 | n. | English: a curved path followed by a planet or an object as it moves around another planet, star, moon, etc. | Example: One popular theory of the origin of the Moon, the \"big whack,\" posits that a protoplanet called Theia collided with Earth, flinging debris into orbit that eventually coalesced into the Moon."
+      "['3:rbrt] n. （天体等运行的）"
     ]
   },
   {
     "name": "ornamental",
     "trans": [
-      "Day 22 | adj. | English: used as decoration rather than for a practical purpose | Example: Extensive travels abroad later sparked an engagement with modernist and functionalist aesthetics—styles whose emphasis on utility and whose repudiation of traditional architecture's more ornamental elements are readily apparent in Barragan's house in Calle Guadiana."
+      "[.3:mamcntl] adj. 装饰性的"
     ]
   },
   {
     "name": "ornamentation",
     "trans": [
-      "Day 22 | n. | English: the use of objects, designs, etc. to decorate sth Historians argue that Morris's repudiation of industrialization is manifest in the Kelmscott editions' use of handmade materials and intricate ornamentation reminiscent of medieval these meticulously handcrafted elements exemplify the artistry involved."
+      "[.3:mamen'teln] n. 装饰"
     ]
   },
   {
     "name": "orthodox",
     "trans": [
-      "Day 22 | adj. | English: following generally accepted beliefs | Example: Orthodox economists believe that a recession is now inevitable."
+      "['3:rgada:ks] adj. 正统的"
     ]
   },
   {
     "name": "outgrow",
     "trans": [
-      "Day 22 | v. | English: to grow too big to be able to wear or fit into sth | Example: The young trees had not outgrown their [planter] boxes then. V Street [in Washington, DC] was lined with them."
+      "[,aot'grov] v.；V. 增长得容不进"
     ]
   },
   {
     "name": "outlay",
     "trans": [
-      "Day 22 | n. | English: the money that you have to spend in order to start a new project | Example: The success of the fitness study likely requires significantly less financial outlay than that needed for CLSA-ELCV."
+      "['aotler] n. 开支"
     ]
   },
   {
     "name": "outnumber",
     "trans": [
-      "Day 22 | v. | English: to be greater in number than sb/sth | Example: Night-blooming jessamine shrubs and other non-native forest plants only recently began to outnumber native forest plants in the wild."
+      "[.aUt'umbar] v. （在数量上）压倒"
     ]
   },
   {
     "name": "outpouring",
     "trans": [
-      "Day 22 | n. | English: a large amount of sth produced in a short time | Example: Literary production in the period after the Mexican Revolution (which lasted from 1910-1920) was prolific, with writers like Octavio Paz contributing to the outpouring of poetry, fiction, essays, and more."
+      "['aUtp3:r] n. 涌现"
     ]
   },
   {
     "name": "outright",
     "trans": [
-      "Day 22 | adv. | English: clearly and completely | Example: While some of her recordings conform to the model perfected by 100 gecs, others reject it outright."
+      "adv. 完全彻底"
     ]
   },
   {
     "name": "outsized",
     "trans": [
-      "Day 22 | adj. | English: exceptionally large | Example: Works from this period make up an outsized proportion of what is considered the canon of Mexican literature, but nineteenth-century writers like Justo Sierra O'Reilly should be considered just as integral to the Mexican literary canon."
+      "['aotsarzd] adj. 超大型的,极大的"
     ]
   },
   {
     "name": "outstrip",
     "trans": [
-      "Day 22 | v. | English: to become larger, more important, etc. than sb/sth | Example: Consumers’ expectations for reduced delivery times may be outstripping what is viable for delivery companies to provide."
+      "[.aot'strp] v. （或重要等）"
     ]
   },
   {
     "name": "outweigh",
     "trans": [
-      "Day 22 | v. | English: to be greater or more important than sth | Example: By suggesting that whatever infractions Luttrell might have committed are outweighed by the"
+      "[aot'weI] v. 重于"
     ]
   },
   {
     "name": "overdue",
     "trans": [
-      "Day 22 | adj. | English: that should have happened or been done before now | Example: The naming of Buenaventura as a City Gastronomy was long overdue, given the city’s delicious food."
+      "[oUvar'du:] adj. 早该发生的"
     ]
   },
   {
     "name": "overflow",
     "trans": [
-      "Day 22 | v. | English: to be so full that the contents go over the sides | Example: | guess this means Pops is overflowing with riches because ever since | can remember | was never without a book within reach."
+      "[.oovar'flod] v. 溢出"
     ]
   },
   {
     "name": "overlook",
     "trans": [
-      "Day 22 | v. | English: to fail to see or notice sth | Example: While there are several possible reasons for this, one is that practitioners may overlook confounding variables that account for the results they attribute to the interventions in question."
+      "[.ouvar'luk] v. 未注意到"
     ]
   },
   {
     "name": "overreach",
     "trans": [
-      "Day 22 | v. | English: to fail by trying to achieve more than is possible | Example: In making these promises, the company had clearly overreached itself."
+      "v. 贪功致败"
     ]
   },
   {
     "name": "oversee",
     "trans": [
-      "Day 22 | v. | English: to watch sb/sth and make sure that a job or an activity is done correctly | Example: The text recounts Mukerjee's early training in the social scientific disciplines and then lists social policies whose implementation Mukerjee oversaw."
+      "[.oovar'si:] v. 监督"
     ]
   },
   {
     "name": "overshadow",
     "trans": [
-      "Day 22 | v. | English: to make sb/sth seem less important, or successful | Example: Richard Nixon is commonly linked with an infamous historical event, but this overshadows some of his notable achievements."
+      "[.oUvarJadov] v. 使黯然失色"
     ]
   },
   {
     "name": "overstate",
     "trans": [
-      "Day 22 | v. | English: to say sth in a way that makes it seem more important than it really is | Example: It may overstate the effect of ocean acidification on the behavior of Sparus aurata."
+      "[.oUVar'stcrt] v. 夸大"
     ]
   },
   {
     "name": "overstock",
     "trans": [
-      "Day 22 | v. | English: to buy or make more of sth than you need or can sell | Example: Better predictions mean demand is easier to meet without retailers becoming overstocked."
+      "v. 库存过多（货物）"
     ]
   },
   {
     "name": "overturn",
     "trans": [
-      "Day 22 | v. | English: to officially decide that a legal decision etc. is not correct, and to make it no longer valid | Example: It states a long-standing scientific assumption and then shows how recent research has overturned that assumption."
+      "[OUVar't3:m] v. 推翻"
     ]
   },
   {
     "name": "overwhelmed",
     "trans": [
-      "Day 22 | v. | English: to be so bad or so great that a person cannot deal with it; to give too much of a thing to a person | Example: We were overwhelmed by requests for information."
+      "[,ova'welmd] v. 压垮,使应接不暇"
     ]
   },
   {
     "name": "painstaking",
     "trans": [
-      "Day 22 | adj. | English: needing a lot of care, effort and attention to detail | Example: Over the course of three years, Reiniger and her collaborators painstakingly made more than 250,000 individual images of hand-cut paper silhouettes and repeatedly had to invent entirely new methods and tools to create the special effects Reiniger envisioned."
+      "['pcInztenks] adj. 煞费苦心的"
     ]
   },
   {
     "name": "palatable",
     "trans": [
-      "Day 22 | adj. | English: having a pleasant or acceptable taste | Example: Nicholas T. Homziak et al. investigated the acoustic properties of moths' ultrasonic responses to audio of bat echolocation and then assessed the palatability of the ultrasound- producing moths."
+      "['palatabl] adj. 可口的"
     ]
   },
   {
     "name": "palatial",
     "trans": [
-      "Day 22 | adj. | English: very large and impressive, like a palace | Example: The whole of Manhattan Island is turned into a city of skyscrapers, churches and palatial residences."
+      "[p3'lerll] adj. 宫殿般的"
     ]
   },
   {
     "name": "pale",
     "trans": [
-      "Day 23 | adj. | English: having skin that is almost white; having skin that is whiter than usual because of illness, a strong emotion, etc. | Example: Yes, the great cloud was ravelling, discovering here and there a pale and dying sky."
+      "[perl] adj. 苍白的"
     ]
   },
   {
     "name": "palpable",
     "trans": [
-      "Day 23 | adj. | English: that is easily noticed by the mind or the senses | Example: The sloping tile roofs and picturesque facade of Mission San Luis Rey de Francia in Oceanside, California, exemplify the Spanish contribution to Californian architecture, an influence that is palpable throughout the state"
+      "['palpabl] adj. 易于察觉的"
     ]
   },
   {
     "name": "paradigm",
     "trans": [
-      "Day 23 | n. | English: a typical example or pattern of sth | Example: Smith deploys this metaphor only once in his economic writings—to make a narrow point about the then-dominant economic theory of mercantilism—and it was largely ignored until some twentieth-century economists eager to secure an intellectual pedigree for their views elevated it to a fully-fledged paradigm."
+      "['paradamm] n. 典范"
     ]
   },
   {
     "name": "parallel",
     "trans": [
-      "Day 23 | n. | English: similar features | Example: F. Scott Fitzgerald's 1920 novel This Side of Paradise contains elements drawn from Fitzgerald's own life—there are many parallels between the experiences of the novel's protagonist, Amory Blaine, and those of Fitzgerald."
+      "['peralel] n. 相似特征"
     ]
   },
   {
     "name": "parcel",
     "trans": [
-      "Day 23 | n. | English: something that is wrapped in paper or put into a thick envelope so that it can be sent by mail, carried easily, or given as a present | Example: She handed the girl a five-dollar bill and waited for her change and for her parcel. What a very small parcel it was!"
+      "['pa:rs(a)] n. 包裹"
     ]
   },
   {
     "name": "parlor",
     "trans": [
-      "Day 23 | n. | English: aroom ina private house for sitting in, entertaining visitors, etc. | Example: The front parlor had always been her special province, as she used it for her little school."
+      "客厅"
     ]
   },
   {
     "name": "partfrom",
     "trans": [
-      "Day 23 | v. | English: if a person parts from another person, or two people part , they leave each other | Example: Mercedes, being not quite seventeen, her grief at parting from Clarence was wild, vehement and all-absorbing."
+      "v. 离开,分别"
     ]
   },
   {
     "name": "partition",
     "trans": [
-      "Day 23 | v. | English: to divide sth into parts The room is partitioned into three sections."
+      "[pa:r'tln] v. 分割,使分裂"
     ]
   },
   {
     "name": "pasture",
     "trans": [
-      "Day 23 | n. | English: and covered with grass that is suitable for feeding animals on | Example: A dry ravine emerged under boughs / Into the pasture."
+      "['pastjar] n. 牧场,草地"
     ]
   },
   {
     "name": "pathogen",
     "trans": [
-      "Day 23 | n. | English: a thing that causes disease | Example: An understanding of how to prevent horizontal gene transfer might result in the mitigation of dangerous pathogens (organisms that cause disease)."
+      "['padad3on] n. 病原体"
     ]
   },
   {
     "name": "patron",
     "trans": [
-      "Day 23 | n. | English: a person who uses a particular shop/store, restaurant, etc. | Example: It conveys the urgency some theater patrons feel to be the first ones to arrive at a performance."
+      "['pertron] n. 顾客"
     ]
   },
   {
     "name": "patronage",
     "trans": [
-      "Day 23 | n. | English: the support, especially financial, that is given to a person or an organization by a patron | Example: As modern scholar Fabio Fernandes notes, however, these two traditions aren't as distinct as they seem, as both the emperor and the private library owners viewed their libraries as extensions of their personal patronage, just on vasty differing scales."
+      "['patranrd3,'pertranId3] n. 资助,赞助"
     ]
   },
   {
     "name": "pavement",
     "trans": [
-      "Day 23 | n. | English: the surface of a road | Example: Civil engineer Jay X. Wang has noted that the effects of expansive soil appear slowly in the form of gradually growing cracks in foundations, walls, and pavements."
+      "['pervmant] n. 路面"
     ]
   },
   {
     "name": "peak",
     "trans": [
-      "Day 23 | adj. | English: used to describe the highest level of sth, or a time when the greatest number of people are doing sth or using sth | Example: They found that across the three microbial communities, peak diversity and richness was observed on pine and oak samples placed approximately 125 meters from the shipwrecks."
+      "[pi:k] adj. 高峰时期的"
     ]
   },
   {
     "name": "peasant",
     "trans": [
-      "Day 23 | n. | English: (especially in the past, or in poorer countries) a farmer who owns or rents a small piece of land | Example: The emphasis on accurately representing the experiences of average working people that is characteristic of the realist style can be seen in The Gleaners, painted by Jean-Francois Millet, which depicts peasants picking stray wheat from a field after the harvest."
+      "['pcznt] n. （尤指昔日或贫穷国家的）"
     ]
   },
   {
     "name": "peculiar",
     "trans": [
-      "Day 23 | adj. | English: strange or unusual, especially in a way that is unpleasant or worrying | Example: [The soldiers] entered the streets of Juchipila as the church bells rang, loud and joyfully, with that peculiar tone that thrills every mountaineer."
+      "[pr'kju:liar] adj. 怪异的"
     ]
   },
   {
     "name": "pedestrian",
     "trans": [
-      "Day 23 | n. | English: a person walking in the street and not travelling in a vehicle | Example: Some cities track pedestrian activity to map their sidewalks."
+      "[Pa'destrion] n. 行人"
     ]
   },
   {
     "name": "pedigree",
     "trans": [
-      "Day 23 | n. | English: a person's family history or the background of sth, especially when this is impressive | Example: Smith deploys this metaphor only once in his economic writings—to make a narrow point about the then-dominant economic theory of mercantilism—and it was largely ignored until some twentieth-century economists eager to secure an intellectual pedigree for their views elevated it to a fully-fledged paradigm."
+      "['pedrgri:] n. 家谱"
     ]
   },
   {
     "name": "peer review",
     "trans": [
-      "Day 23 | English: the evaluation by fellow specialists of research that someone has done in order to assess its suitability for publication or further development | Example: For Carson's album, dubbed a “mixtap/e/ssay,” peer review involved both scholars and rap artists."
+      "同行评审"
     ]
   },
   {
     "name": "penetrate",
     "trans": [
-      "Day 23 | v. | English: to go into or through sth | Example: The projectiles generally penetrated only a few inches into the clay, an amount insufficient to have harmed most woolly mammoths."
+      "['penatrert] v. 穿过"
     ]
   },
   {
     "name": "perceptible",
     "trans": [
-      "Day 23 | adj. | English: great enough for you to notice it | Example: The sun, already down, was perceptible in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+      "[par'septab] adj. 可察觉到的"
     ]
   },
   {
     "name": "perceptive",
     "trans": [
-      "Day 23 | adj. | English: having or showing the ability to see or understand things quickly, especially things that are not obvious | Example: It helps explain why some people are especially perceptive of the social dynamics at theaters."
+      "[par'septrv] adj. 理解力强的"
     ]
   },
   {
     "name": "peripheral",
     "trans": [
-      "Day 23 | adj. | English: adj. in the outer area of something, or relating to this area; adj. not as important as the main aim, part, etc. of sth | Example: [1] Because Xoconochco’s location within the empire was so peripheral, cacao and other trade goods produced there could reach the capital only after a long overland journey. 2] It establishes a contrast between the aesthetic qualities of works by artists who were central to a movement introduced earlier in the text and those of an artist who was more peripheral to that movement."
+      "[pa'rfaral] adj. （在）边缘的"
     ]
   },
   {
     "name": "periphery",
     "trans": [
-      "Day 23 | n. | English: If something is on the periphery of an area, place, or thing, it is on the edge of it _ The way in which individual elements are balanced within a photographic image tends to symmetry tends to give the elements equal importance, asymmetry emphasizes differences, and radial balance (organizing the elements around a central point) emphasizes the center over the periphery."
+      "[pa'nfari] n. 边缘"
     ]
   },
   {
     "name": "permanent",
     "trans": [
-      "Day 23 | adj. | English: lasting for a long time or for all time in the future; existing all the time | Example: Since its founding, it has acquired more than 4,800 objects for its permanent collection."
+      "['p3:manant] adj. 永恒的"
     ]
   },
   {
     "name": "permeability",
     "trans": [
-      "Day 23 | n. | English: the state or quality of being permeable | Example: However, any barrier used must allow the thread-like hyphae of a CMN to pass through, and this permeability would also allow liquids through."
+      "n. 渗透性"
     ]
   },
   {
     "name": "permeable",
     "trans": [
-      "Day 23 | adj. | English: allowing a liquid or gas to pass through | Example: As the process continues, water from the food's center moves to the crust as long as the crust remains permeable."
+      "['P3:Imiabl] adj. 可渗透的"
     ]
   },
   {
     "name": "permeate",
     "trans": [
-      "Day 23 | v. | English: to spread to every part of an object or a place | Example: A thousand recollections of childhood came over me, awakened by these country odors, and | walked along, permeated with the fragrant, living enchantment, the emotional enchantment of the woods warmed by the sun of June."
+      "['P3:Iiert] v. 渗透"
     ]
   },
   {
     "name": "permissible",
     "trans": [
-      "Day 23 | adj. | English: acceptable according to the law or a particular set of rules | Example: Under current astronomical conventions, it is permissible for the discoverers to name their discoveries, but they are not required to do so; whether to assign a minor planet a name is entirely the choice of whoever discovers it."
+      "[Par'mIsab(a)] adj. 允许的"
     ]
   },
   {
     "name": "perpetrate",
     "trans": [
-      "Day 23 | v. | English: to commit a crime or do sth wrong or evil | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few fictitious entries, such as those for the country singer-songwriter Joseph G. Williams and the Jamaican bird allegedly known as the Salvadorian Magpie, persisted on the site for many years before they were finally recognized as fabrications and deleted."
+      "v. 犯（罪）"
     ]
   },
   {
     "name": "perpetual",
     "trans": [
-      "Day 23 | adj. | English: never ending or changing | Example: Remarkable for anticipating and amplifying cultural perceptions of Florida that became pervasive in the public consciousness, paintings by the Highwaymen are readily identifiable by the natural iconography—placid inland rivers, windswept palm trees—that McLendon and colleagues perpetually revisited."
+      "[par'petfual] adj. 永久的"
     ]
   },
   {
     "name": "perplexed",
     "trans": [
-      "Day 23 | adj. | English: If you are perplexed, you feel confused and slightly worried by something because you do not understand it. | Example: Ever since fossilized remains of this species were discovered in 1895, scientists have been perplexed by its size."
+      "[parplekst] adj. 困惑不解的"
     ]
   },
   {
     "name": "persist",
     "trans": [
-      "Day 23 | v. | English: to continue to exist | Example: For centuries, people in Ireland and Northern Ireland have been finding deposits of valuable objects, called hoards, that earlier people buried. These discoveries have persisted into the 2000s."
+      "[par'sIst] v. 持续存在"
     ]
   },
   {
     "name": "persistent",
     "trans": [
-      "Day 23 | adj. | English: adj. determined to do sth despite difficulties, especially when other people are against you and think that you are being annoying or unreasonable; adj. continuing for a long period of time without interruption, or repeated frequently, especially in a way that is annoying and cannot be stopped | Example: [1] Rather than being an arbitrary stylistic choice, hyperpop's persistent modification of the voice functions as a commentary on how digital technology mediates human experience today. 2] a crisis in confidence in the currency occurred in Sidon around 367 BCE, which was likely relieved—despite Sidon's persistent oppressive financial obligations—as a result of Ba‘alsillem II's successor Abd'a&tart I's decision to keep the amount of silver in Sidonian coins consistent with that in coins minted in 367 BCE but decrease their weight."
+      "[par'sIstant] adj. 坚持不懈的"
     ]
   },
   {
     "name": "personage",
     "trans": [
-      "Day 23 | n. | English: an important or famous person | Example: Few of the personages of past times (except such as have gained renown in fireside legends as well as in written history) are anything but mere names to their successors."
+      "['P3:IsanId3] n. 要人"
     ]
   },
   {
     "name": "perspective",
     "trans": [
-      "Day 23 | n. | English: a particular attitude towards sth; a way of thinking about sth | Example: People sometimes dismiss a claim if it comes from a source they regard as self-interested, but from a strictly logical perspective, the source of a claim is irrelevant."
+      "[par'spektwv] n. 态度,思考方法"
     ]
   },
   {
     "name": "persuasive",
     "trans": [
-      "Day 23 | adj. | English: able to persuade sb to do or believe sth | Example: In the play, Aristophanes satirizes sophists as teaching students how to be persuasive without regard for what is morally good."
+      "[par'swCIsIV] adj. 有说服力的"
     ]
   },
   {
     "name": "pervasive",
     "trans": [
-      "Day 23 | adj. | English: existing in all parts of a place or thing | Example: Text corpora such as the British National Corpus are enormous collections of electronically stored texts that can be used for empirical testing of hypotheses regarding how pervasive a"
+      "[par'veIsw] adj. 普遍的"
     ]
   },
   {
     "name": "petition",
     "trans": [
-      "Day 23 | v. | English: v. to make a formal request to sb in authority, especially by sending them a petition; n. a written document signed by a large number of people that asks sb in a position of authority to do or change sth | Example: [1] Local residents have successfully petitioned against the siting of a prison in their area. 2] Louis Pipestone is collecting signatures for a petition from fellow members of the Turtle Mountain Band of Chippewa on the tribe's reservation in North Dakota."
+      "[p3't] v.；v.；n. 请愿"
     ]
   },
   {
     "name": "petrified",
     "trans": [
-      "Day 23 | adj. | English: petrified trees, insects, etc. have died and been changed into stone over a very long period of time | Example: Behind the Lamassu, more columns sprouted from the ground like ancient trees in a petrified forest, forty feet tall, spindly but still miraculously upright."
+      "adj. 石化的"
     ]
   },
   {
     "name": "petroleum",
     "trans": [
-      "Day 23 | n. | English: mineral oil that is found under the ground or the sea and is used to produce petrol/gas, paraffin , diesel oil, etc. | Example: Companies involved in petroleum extraction include drilling equipment among their assets."
+      "[p3'trooliam] n. 石油"
     ]
   },
   {
     "name": "pharaoh",
     "trans": [
-      "Day 23 | n. | English: a ruler of ancient Egypt | Example: Archaeologist Christiana Kohler and her team excavated the Egyptian tomb of Queen Merneith, the wife of a First Dynasty pharaoh."
+      "n. （古埃及国王）"
     ]
   },
   {
     "name": "pierce",
     "trans": [
-      "Day 23 | v. | English: to force a way through a barrier The little conductor stood on tiptoe in an effort to keep one hand on the signal rope, craning his neck in a vain and dissatisfied endeavor to pierce the miasma of the fog."
+      "[PIrs] v. 冲破"
     ]
   },
   {
     "name": "pigment",
     "trans": [
-      "Day 23 | n. | English: a substance that exists naturally in people, animals and plants and gives their skin, leaves, etc. a particular colour | Example: For instance, Démoto produced Hunting Expedition by applying color pigments to a silk screen."
+      "['pigmant] n. 色素"
     ]
   },
   {
     "name": "pile",
     "trans": [
-      "Day 23 | v. | English: to put sth on/into sth; to load sth with sth | Example: \"I'm going to have one of these gorgeous oranges,\" said Mrs. Wilkins, staying where she was and reaching across to a black bowl piled with them."
+      "[paJl] v. 放置"
     ]
   },
   {
     "name": "pillar",
     "trans": [
-      "Day 23 | n. | English: alarge round stone, metal or wooden post that is used to support a bridge, the roof of a building, etc., especially when it is also decorative | Example: At five-thirty the old Panhandle bridge, supported by massive sandstone pillars, stalwart, as when erected fifty years before to serve a generation now passed behind the portals of life, had become a spectral outline against the sky."
+      "['pilar] n. 柱子"
     ]
   },
   {
     "name": "pique",
     "trans": [
-      "Day 23 | v. | English: to make sb annoyed or upset | Example: As time went on, [Avey's] indifference to things began to pique me; | was ambitious. | left [our small hometown] earlier than she did."
+      "[pi:k] v. 使愤怒"
     ]
   },
   {
     "name": "pitch",
     "trans": [
-      "Day 23 | n. | English: how high or low a sound is, especially a musical note | Example: Her combination of dense synthesizer arrangements and metallic percussion with vocals electronically shifted in pitch above her natural range exemplifies the hyperpop sound."
+      "[pitl] n. （尤指乐音的）音高"
     ]
   },
   {
     "name": "pitfall",
     "trans": [
-      "Day 23 | n. | English: a danger or difficulty, especially one that is hidden or not obvious at first | Example: Holes, hollows, pools, pitfalls, and other menaces to the wayfarer were vanishing fast."
+      "['PItf3:] n. 陷阱"
     ]
   },
   {
     "name": "placate",
     "trans": [
-      "Day 23 | v. | English: to make sb feel less angry about sth The concessions did little to placate the students."
+      "['plerkert] v. 安抚"
     ]
   },
   {
     "name": "placid",
     "trans": [
-      "Day 24 | adj. | English: calm and peaceful, with very little movemen | Example: Remarkable for anticipating and amplifying cultural perceptions of Florida that became pervasive in the public consciousness, paintings by the Highwaymen are readily identifiable by the natural iconography—placid inland rivers, windswept palm trees—that McLendon and colleagues perpetually revisited."
+      "['plasrd] adj. 平静的"
     ]
   },
   {
     "name": "plague",
     "trans": [
-      "Day 24 | v. | English: to cause pain or trouble to sb/sth over a period of time | Example: These studies are plagued by insufficient sample sizes, a lack of control groups, and failures to establish pretraining baselines for the measured attributes of participants."
+      "[plerg] v. 困扰"
     ]
   },
   {
     "name": "plateau",
     "trans": [
-      "Day 24 | v. | English: to stay at a steady level after a period of growth or progress | Example: In a study of zoo chimpanzees in Swenden and other mid-latitude countries, Sophie Moittié and colleagues found not only that chimpanzees' vitamin D levels correlate with UVB irradiance but also that vitamin D levels show no evidence of plateauing as UVB irradiance reaches its highest local levels."
+      "[pla'too] v. 在一段时期的发展后"
     ]
   },
   {
     "name": "plausible",
     "trans": [
-      "Day 24 | adj. | English: reasonable and likely to be true | Example: It introduces a natural phenomenon, refutes two potential explanations for that phenomenon, and then presents a third explanation for that phenomenon that the author regards as plausible."
+      "['p3:23b1] adj. 有道理的"
     ]
   },
   {
     "name": "playwright",
     "trans": [
-      "Day 24 | n. | English: a person who writes plays for the theatre, television or radio | Example: While they might be eager to produce an established classic like Annie, for example, most would be hesitant to stage a work from a relatively unknown playwright."
+      "['plelrart] n. 剧作家"
     ]
   },
   {
     "name": "plod",
     "trans": [
-      "Day 24 | v. | English: to walk slowly with heavy steps, especially because you are tired | Example: | remember [the sailor] as if it were yesterday, as he came plodding to the inn door, his sea- chest following behind him in a hand-barrow."
+      "[pla:d] v. 艰难地行走"
     ]
   },
   {
     "name": "plot",
     "trans": [
-      "Day 24 | n. | English: a small piece of land that is used or intended for a special purpose | Example: As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot."
+      "[pla:t] n. （专用的）小块土地"
     ]
   },
   {
     "name": "plough",
     "trans": [
-      "Day 24 | v. | English: to dig and turn over a field or other area of land with a plough | Example: As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot."
+      "[plao] v. 耕（地）"
     ]
   },
   {
     "name": "plunge",
     "trans": [
-      "Day 24 | v. | English: the act of becoming involved in a situation or activity | Example: Now | suddenly find myself plunged into this wilderness [the estate], condemned to see the same stupid people from morning till night and listen to their futile conversations."
+      "[plnd3] v. 经历"
     ]
   },
   {
     "name": "poetry",
     "trans": [
-      "Day 24 | n. | English: acollection of poems; poems in general | Example: The late-period pieces of James Tate arguably fit this description, since they straddle the line between prose and poetry."
+      "['pouatri] n. 诗歌"
     ]
   },
   {
     "name": "polarize",
     "trans": [
-      "Day 24 | v. | English: to separate or make people separate into two groups with completely opposite opinions While some commentators lauded this development, asserting that such blogs had a welcome transparency missing from traditional news, less sanguine observers countered that such blogs tended to ideological extremes that exacerbated political polarization to problematic levels."
+      "[poolararz] v. 两极化,截然对立"
     ]
   },
   {
     "name": "pollen",
     "trans": [
-      "Day 24 | n. | English: fine powder, usually yellow, that is formed in flowers and carried to other flowers of the same kind by the wind or by insects, to make those flowers produce seeds | Example: In a 2021 paper, zoologist Guillaume Ghisbain notes that bumblebees are among the relatively few wild-bee genera that display social behaviors and dietary generalism (ability to obtain nectar and pollen from a diversity of plant species), two traits that are associated with increased resilience to some specific environmental changes."
+      "['pa:lan] n. 花粉"
     ]
   },
   {
     "name": "pollinate",
     "trans": [
-      "Day 24 | v. | English: to put pollen into a flower or plant so that it produces seeds | Example: The first phase of their study involved shielding some cucumber plants to prevent insects from pollinating them, resulting in those plants having 40 to 90 percent lower crop production than plants that were pollinated normally."
+      "['pa:lanert] v. 授粉"
     ]
   },
   {
     "name": "polling",
     "trans": [
-      "Day 24 | n. | English: the act of asking questions as part of an opinion poll | Example: There are many famous examples of election pollsters making inaccurate predictions in presidential elections. But neuroscientist and election pollster Sam Wang has said that these prediction failures should not lead campaigns to neglect election polling entirely."
+      "n. 民意测验"
     ]
   },
   {
     "name": "pollster",
     "trans": [
-      "Day 24 | n. | English: a person who makes or asks the questions in an opinion poll | Example: There are many famous examples of election pollsters making inaccurate predictions in presidential elections."
+      "n. 民意调查员"
     ]
   },
   {
     "name": "polymer",
     "trans": [
-      "Day 24 | n. | English: a natural or artificial substance consisting of large molecules (= groups of atoms) that are made from combinations of small simple molecules | Example: Chemists Mare A. Meyers and Andrew Grazela studied the mass and heat transfer processes that occur when foods are fried in batters containing hydrocolloids, polymers that become viscous or gel-like in water."
+      "['pa:Iimar] n. 聚合物"
     ]
   },
   {
     "name": "populous",
     "trans": [
-      "Day 24 | adj. | English: where a large number of people live | Example: While other even-toed ungulate species, such as the water buffalo (Bubalus bubalis), are among the most populous animal species on earth, the Przewalski's gazelle (Procapra przewalskii) has a total population between 700 and 800 individuals."
+      "adj. 人口众多的"
     ]
   },
   {
     "name": "port",
     "trans": [
-      "Day 24 | n. | English: aplace where ships load and unload goods or shelter from storms | Example: For instance, imported goods may reduce expenses for a country's average consumer, but for consumers living far from ports, high intranational transport costs could nullify the price advantages associated with imports."
+      "[P3:rt] n. 港口"
     ]
   },
   {
     "name": "portal",
     "trans": [
-      "Day 24 | n. | English: a large, impressive gate or entrance to a building | Example: At five-thirty the old Panhandle bridge, supported by massive sandstone pillars, stalwart, as when erected fifty years before to serve a generation now passed behind the portals of life, had become a spectral outline against the sky."
+      "['p3:rtl] n. 壮观的大门"
     ]
   },
   {
     "name": "posit",
     "trans": [
-      "Day 24 | v. | English: to suggest or accept that sth is true so that it can be used as the basis for an argument or discussion | Example: One popular theory of the origin of the Moon, the \"big whack,\" posits that a protoplanet called Theia collided with Earth, flinging debris into orbit that eventually coalesced into the Moon."
+      "['pa:2t] v. 假设"
     ]
   },
   {
     "name": "possess",
     "trans": [
-      "Day 24 | v. | English: to have or own sth | Example: Possessing an outstanding collection of public art, Chicago has everything from monumental sculptures like Anish Kapoor's Cloud Gate at sites like Millennium Park to innovative street art like Amuse 126's mural High Tide located on South State Street."
+      "[p'2es] v. 拥有"
     ]
   },
   {
     "name": "possession",
     "trans": [
-      "Day 24 | n. | English: something that you own or have with you at a particular time | Example: A book printed is a record, remaining in every man’s possession, always ready to renew its acquaintance with his memory."
+      "[p3'2eh] n. 个人财产"
     ]
   },
   {
     "name": "postulate",
     "trans": [
-      "Day 24 | v. | English: to suggest or accept that sth is true so that it can be used as the basis for a theory, etc. | Example: They postulated a 500-year lifespan for a plastic container."
+      "['pa:stjalert;'pa:stjalat] v. 假定"
     ]
   },
   {
     "name": "practicality",
     "trans": [
-      "Day 24 | n. | English: the quality of being suitable, or likely to be successfu | Example: Ihave doubts about the practicality of their proposal."
+      "n. 可行性"
     ]
   },
   {
     "name": "practically",
     "trans": [
-      "Day 24 | adv. | English: almost; very nearly | Example: She has a thick curtain of long, curly hair that practically engulfs her."
+      "['prektikli] adv. 几乎"
     ]
   },
   {
     "name": "practitioner",
     "trans": [
-      "Day 24 | n. | English: Doctors are sometimes referred to as practitioners or medical practitioners. | Example: The results of randomized clinical trials testing the efficacy of common medical interventions sometimes fail to corroborate conclusions that practitioners reach based on their real-world observations of patients."
+      "[prak'tjonar] n. 行医者"
     ]
   },
   {
     "name": "prance",
     "trans": [
-      "Day 24 | v. | English: to move with high steps | Example: There is no Frigate like a Book / To take us Lands away / Nor any Coursers like a Page / Of prancing Poetry— / This Traverse may the poorest take / Without oppress of Toll— / How frugal is the Chariot / That bears the Human soul."
+      "v. （马）腾跃"
     ]
   },
   {
     "name": "prayer",
     "trans": [
-      "Day 24 | n. | English: a fixed form of words that you can say when you speak to God | Example: Notes long, full, mournful as a prayer, yet still vigorous, escaped from the old instrument."
+      "[prer] n. 祈祷文,经文"
     ]
   },
   {
     "name": "precariousness",
     "trans": [
-      "Day 24 | n. | English: being unsettled or in doubt or dependent on chance | Example: Yet the conclave is likely to do little to change perceptions about the precariousness of world oil markets."
+      "[prr'keriasnas] n. 不稳定"
     ]
   },
   {
     "name": "precaution",
     "trans": [
-      "Day 24 | n. | English: something that is done in advance in order to prevent problems or to avoid danger | Example: Fernandez and colleagues took the necessary precaution of separating the plants’ root systems (thereby excluding root-to-root transmission)."
+      "[prr'ko:血] n. 预防措施"
     ]
   },
   {
     "name": "precede",
     "trans": [
-      "Day 24 | v. | English: to happen before sth or come before sth/sb in order | Example: His resignation was preceded by weeks of speculation."
+      "[prr'si:d] v. 之前发生"
     ]
   },
   {
     "name": "precedent",
     "trans": [
-      "Day 24 | n. | English: a similar action or event that happened earlier | Example: There is no precedent for a disaster of this scale."
+      "['presidant] n. 先例"
     ]
   },
   {
     "name": "precipitate",
     "trans": [
-      "Day 24 | v. | English: If something precipitates an event or situation, usually a bad one, it causes it to happen suddenly or sooner than normal. | Example: In the 2010s, the price of vintage My Little Pony figures rose dramatically, which had the counterintuitive effect of precipitating demand."
+      "[prr'sIpItert] v. 的仓促发生"
     ]
   },
   {
     "name": "precipitation",
     "trans": [
-      "Day 24 | n. | English: rain, snow, etc. that falls; the amount of this that falls | Example: Persad and her colleagues concluded that concentration of precipitation into fewer events would result in a higher number of dry days, triggering more irrigation."
+      "[PrISIPI'terln] n. 降水"
     ]
   },
   {
     "name": "preclude",
     "trans": [
-      "Day 24 | v. | English: (formal) to prevent sth from happening or sb from doing sth | Example: Based on the texts, the author of Text 2 would most likely want to know if Friedrich and colleagues took steps to preclude which potential objection to the finding described in Text 1?"
+      "[prr'klu:d] v. 阻止"
     ]
   },
   {
     "name": "precursor",
     "trans": [
-      "Day 24 | n. | English: (formal) a person or thing that comes before sb/sth similar and that leads to or influences its development | Example: But Nixon’s legacy is complex: he has been praised for his role in affirming the sovereignty of tribal nations, and he once made an attempt at reforming United States health care policy that is arguably a precursor to the Affordable Care Act, which became law during the Barack Obama administration."
+      "[pri'k3:rsar] n. 先驱"
     ]
   },
   {
     "name": "predate",
     "trans": [
-      "Day 24 | v. | English: exist or occur at a date earlier than | Example: John lliffe and other Africanist scholars have shown, however, that in parts of Africa, institutionally protected private land ownership, the existence of salaried labor, and other features of capitalism predated colonization."
+      "[.pri:'dert] v. 在日期上早于（先于）"
     ]
   },
   {
     "name": "predominantly",
     "trans": [
-      "Day 24 | adv. | English: mostly; mainly | Example: During Rome's republican period, which ended in the first century BCE., libraries were predominantly owned by wealthy individuals who tightly controlled access to their book collections."
+      "[prr'da:mlnantli] adv. 多数情况下"
     ]
   },
   {
     "name": "preeminent",
     "trans": [
-      "Day 24 | adj. | English: more important, powerful, or capable than other people or things in the group | Example: Long attributed to Jacques-Louis David, the preeminent Neoclassical painter of his day, the 1801 painting Marie Josephine Charlotte du Val d'Ognes gained fresh attention in the 1990s."
+      "[pri'emnant] adj. 卓越的"
     ]
   },
   {
     "name": "preliminary",
     "trans": [
-      "Day 24 | adj. | English: happening before a more important action or event | Example: It provided preliminary evidence that microorganism mediated nutrient cycling was accelerated in the transplanted cores."
+      "[prr'IImneri] adj. 初步的"
     ]
   },
   {
     "name": "premiere",
     "trans": [
-      "Day 24 | v. | English: to perform a play or piece of music or show a film/movie to an audience for the first time; to be performed or shown to an audience for the first time | Example: A revised version of the musical premiered on Broadway in 2019, in a larger production."
+      "v. 首次公演"
     ]
   },
   {
     "name": "premium",
     "trans": [
-      "Day 24 | adj. | English: of high quality | Example: They hypothesized that performance expectancy (how much the use of a service is perceived to benefit the consumer) would be positively correlated with users' intentions to adopt premium versions."
+      "['pri:miam] adj. 优质的"
     ]
   },
   {
     "name": "preoccupation",
     "trans": [
-      "Day 24 | n. | English: a state of thinking about sth continuously; sth that you think about frequently or for a long time | Example: Becoming overstocked is the main preoccupation of sellers trying to forecast demand for fashion items."
+      "[pri,a:kjuperlh] n. 盘算"
     ]
   },
   {
     "name": "prerogative",
     "trans": [
-      "Day 24 | n. | English: a right or advantage belonging to a particular person or group because of their importance or social positio | Example: By giving these restive republics the right to assert their prerogatives, President Mikhail Gorbachev likely hastened the Soviet Union's breakup."
+      "[prr'ra:gatrv] n. 特权"
     ]
   },
   {
     "name": "presage",
     "trans": [
-      "Day 24 | v. | English: to be a warning or sign that sth will happen, usually sth unpleasant | Example: The dawn's loud chorus seemed to presage a bright hot summer's day."
+      "['presid3] v. 预兆"
     ]
   },
   {
     "name": "preserve",
     "trans": [
-      "Day 24 | v. | English: to keep a particular quality, feature, etc.; to make sure that sth is kept | Example: This material breaks down, becoming canopy soil. Canopy soil helps preserve healthy nutrient cycling (how nutrients move through the environment) in rainforests."
+      "[Prr'z3:w] v. 保护,维护"
     ]
   },
   {
     "name": "prestige",
     "trans": [
-      "Day 24 | n. | English: the respect and admiration that sb/sth has because of their social position, or what they have done | Example: Widespread admiration of these works has helped Edwards gain substantial prestige as an artist."
+      "[Pre'sti:3] n. 声望"
     ]
   },
   {
     "name": "presumptuous",
     "trans": [
-      "Day 24 | adj. | English: too confident, in a way that shows a lack of respect for other people | Example: It would be presumptuous to judge what the outcome will be."
+      "[prr'ZAIptfiias] adj. 自负的"
     ]
   },
   {
     "name": "presuppose",
     "trans": [
-      "Day 24 | v. | English: to accept sth as true or existing and act on that basis, before it has been proved to be true | Example: By broadly agreeing with the claim but objecting that the timelines it presupposes conflicts with the findings of the genetic analysis conducted by Storey's team"
+      "[pri:sa'povz] v. 假设"
     ]
   },
   {
     "name": "pretend",
     "trans": [
-      "Day 24 | v. | English: to behave in a particular way, in order to make other people believe sth that is not true | Example: She pretended to be examining their texture, which the clerk assured her was excellent."
+      "[prr'tend] v. 假装"
     ]
   },
   {
     "name": "pretentious",
     "trans": [
-      "Day 25 | adj. | English: trying to appear important, intelligent, etc. in order to impress other people | Example: They are decorated in a style that the narrator considers pretentious."
+      "[prr'tenjas] adj. 自命不凡的"
     ]
   },
   {
     "name": "prevail over",
     "trans": [
-      "Day 25 | English: to be accepted, especially after a struggle or an argument | Example: Louise Arner Boyd, who led several scientific expeditions off the coast of Greenland in the 1930s, undoubtedly accomplished much, but to gain a lasting place in our historical memory, there is little that can prevail over being the first to do something."
+      "战胜,压倒"
     ]
   },
   {
     "name": "prevalence",
     "trans": [
-      "Day 25 | n. | English: the fact or condition of being prevalent; commonness | Example: Meanwhile, Cynthia C. Steiner and colleagues have investigated how convergence occurs through different genetic mechanisms, but the relative prevalence of convergence through shared and different genetic processes is still poorly understood."
+      "['prevalans] n. 流行,盛行"
     ]
   },
   {
     "name": "prevalent",
     "trans": [
-      "Day 25 | adj. | English: that exists or is very common at a particular time or in a particular place | Example: These are currently used throughout the United States and are especially prevalent in California."
+      "['prevalant] adj. 普遍存在的"
     ]
   },
   {
     "name": "prey",
     "trans": [
-      "Day 25 | v. | English: to hunt and kill another animal for food | Example: Andrew S. Gale, and colleagues concluded that P.seppenradensis may have evolved from P.leptophylla and gradually increased in size as larger ammonites were better able to escape being preyed on by mosasaurs."
+      "[prer] v. 捕食;猎获"
     ]
   },
   {
     "name": "priest",
     "trans": [
-      "Day 25 | n. | English: a person who is qualified to perform religious duties and ceremonies in the Roman Catholic, Anglican and Orthodox Churches | Example: [Jim's father] was shaving this lawn as if it were a priest's chin."
+      "[pri:st] n. （东正教的）神父"
     ]
   },
   {
     "name": "primate",
     "trans": [
-      "Day 25 | n. | English: any animal that belongs to the group of mammals that includes humans, apes and monkeys | Example: Fora long time, people thought tool use was unique to primates."
+      "[praImert;'prarmat] n. 灵长目动物"
     ]
   },
   {
     "name": "principal",
     "trans": [
-      "Day 25 | adj. | English: most important; main | Example: This led the anthropologist to conclude that hunters using spears with Clovis points likely weren't the principal drivers of the extinction."
+      "['prmnsapl] adj. 最主要的"
     ]
   },
   {
     "name": "prioritize",
     "trans": [
-      "Day 25 | v. | English: to put tasks, problems, etc. in order of importance, so that you can deal with the most important first | Example: Parents of small children likely prioritize other factors over a product's environmental sustainability when making purchasing decisions."
+      "[prar'3:ratarz] v. 按重要性排列"
     ]
   },
   {
     "name": "pristine",
     "trans": [
-      "Day 25 | adj. | English: not developed or changed in any way; left in its original condition For example, the Puerto Rican municipality of Hatillo has also been called \"the Blue Coast of the pristine blue ocean that surrounds it."
+      "['prIsti:n] adj. 处于原始状态的"
     ]
   },
   {
     "name": "proceed",
     "trans": [
-      "Day 25 | v. | English: to move or travel in a particular direction | Example: At busy intersections, this often causes a backup of vehicles waiting to turn left or being prevented from proceeding by left-turning vehicles in front of them."
+      "[proo'si:d] v. 行进"
     ]
   },
   {
     "name": "proclaim",
     "trans": [
-      "Day 25 | v. | English: to publicly and officially tell people about sth important | Example: Ba’al8illem II's successor Abd'a8tart | decided to proclaim that the percentage of silver in coins suitable for trade would be raised to a threshold higher than 80%."
+      "[pra'klem] v. （正式）宣告"
     ]
   },
   {
     "name": "prodigious",
     "trans": [
-      "Day 25 | adj. | English: very large or powerful and causing surprise or admiration | Example: That his work is enjoyable despite this is a testament to his prodigious imagination—even if people read his books only for the ideas, they will have plenty to consider."
+      "[pra'drd33s] adj. 巨大的,伟大的"
     ]
   },
   {
     "name": "profound",
     "trans": [
-      "Day 25 | adj. | English: very great | Example: But historical fiction can be used to explore profound themes and complex characters—in fact, many writers find that writing about the past gives them a creative freedom they'd lack if they wrote about the present."
+      "[pra'faond] adj. 深远的"
     ]
   },
   {
     "name": "prohibitive",
     "trans": [
-      "Day 25 | adj. | English: so high that it prevents people from buying sth or doing sth | Example: This is a valuable service since the time and expense necessary to find individual investors might otherwise be prohibitive for these companies."
+      "[pra'hbatrv;DroU'hbatwv] adj. 贵得买不起的"
     ]
   },
   {
     "name": "projectile",
     "trans": [
-      "Day 25 | n. | English: any object that is thrown as a weapon | Example: The projectiles generally penetrated only a few inches into the clay, an amount insufficient to have harmed most woolly mammoths."
+      "[pra'dzekt(a)l] n. （作为武器的）"
     ]
   },
   {
     "name": "proliferation",
     "trans": [
-      "Day 25 | n. | English: the sudden increase in the number or amount of sth; a large number of a particular thing | Example: Blatt concluded that in Hemingway's oeuvre, there is a negative correlation between -ly adverb proliferation and perceived literary merit."
+      "[Pra,IIfa'rerfn] n. 激增"
     ]
   },
   {
     "name": "prolific",
     "trans": [
-      "Day 25 | adj. | English: producing many works | Example: Literary production in the period after the Mexican Revolution (which lasted from 1910-1920) was prolific, with writers like Octavio Paz contributing to the outpouring of poetry, fiction, essays, and more."
+      "[pra'Iifik] adj. 创作丰富的"
     ]
   },
   {
     "name": "prolong",
     "trans": [
-      "Day 25 | n. | English: to make sth last longer | Example: These scientists therefore imply that prolonged deep sleep is likely advantageous in ways that have yet to be discovered."
+      "[pra'13:] n. 延长"
     ]
   },
   {
     "name": "prolonged",
     "trans": [
-      "Day 25 | adj. | English: continuing for a long time | Example: A lake existed at the Murray Formation for a prolonged period, though the lake occasionally experienced drying and there were periods in which one or more streams were present."
+      "[pra'Io:nd] adj. 持久的"
     ]
   },
   {
     "name": "prominence",
     "trans": [
-      "Day 25 | n. | English: the state of being important, well known or noticeable | Example: Originating in the traditional stories of the Kanaka Maoli, the Native Hawaiian people, the literature of Hawaii has a rich history that was later brought to international prominence by"
+      "n. 突出"
     ]
   },
   {
     "name": "prominent",
     "trans": [
-      "Day 25 | adj. | English: important or well known | Example: In contrast, the prominent Indigenous practitioners of abstract painting during the mid- twentieth century, such as the Kiowa artist T.C. Cannon, typically aligned their compositional strategies with Abstract Expressionism—a school of painting dominated by European American artists—instead of with traditionally nonrepresentational forms of Indigenous art."
+      "['pra:mmant] adj. 著名的"
     ]
   },
   {
     "name": "promote",
     "trans": [
-      "Day 25 | v. | English: to help sell a product, service, etc. or make it more popular by advertising it or offering it at a special price | Example: As amember of Indigenous Photograph, artist Tshepiso Mabula ka Ndogngeni (Xhosa) can promote her work more broadly than she could without the organization's reach."
+      "[pra'mout] v. 推广"
     ]
   },
   {
     "name": "prompt",
     "trans": [
-      "Day 25 | v. | English: v. to make sb decide to do sth; to cause sth to happen adj. acting without delay | Example: [1] While the potential for knowledge spillovers can prompt agglomeration, collocation among tube manufacturers occurs for different reasons. prompt, but not thoughtless; firm, without being harsh."
+      "[pra:mpt] v.；v.；adj. 敏捷的"
     ]
   },
   {
     "name": "pronounced",
     "trans": [
-      "Day 25 | adj. | English: very noticeable, obvious or strongly expressed | Example: This was the case for both separation problems and dog rivalry but was especially pronounced for attachment and attention-seeking, which can be seen when a dog solicits affection or attention."
+      "[pra'naonst] adj. 显著的"
     ]
   },
   {
     "name": "prop",
     "trans": [
-      "Day 25 | v. | English: to support an object by leaning it against sth, or putting sth under it etc.; to support a person in the same way | Example: Propped on the window ledge, it featured a portrait of Great-Great-Grandmother Rosita as a young woman."
+      "[pra:卫] v. 支持"
     ]
   },
   {
     "name": "propel",
     "trans": [
-      "Day 25 | v. | English: to move, drive or push sth forward or in a particular direction | Example: Occurring in the constellation Virgo, 60 million light-years from Earth, the transient yet powerful blast propelled particles and debris into space at extremely high speeds."
+      "[pra'pel] v. 推动"
     ]
   },
   {
     "name": "property",
     "trans": [
-      "Day 25 | n. | English: n.a quality or characteristic that sth has; n. a thing or things that are owned by sb; a possession or possessions | Example: [1] To assist with the development of new water-repellant materials for aviation and other applications, a team including both engineers and entomologists conducted a study of the water-repellant properties of cicada wings. 2] Most infamously, he participated in what was essentially a private war against Sempringham Priory, a monastery near his manor, even making off with 500 pounds’ worth of monastery property during a raid."
+      "['pra:parti] n.；n.；n. 特性"
     ]
   },
   {
     "name": "proposal",
     "trans": [
-      "Day 25 | n. | English: a formal suggestion or plan; the act of making a suggestion | Example: As Kang herself notes, lobbying can shape which policy proposals members of Congress bring forward for consideration in the first place."
+      "[pra'poozl] n. 提议,建议"
     ]
   },
   {
     "name": "propriety",
     "trans": [
-      "Day 25 | n. | English: moral and social behaviour that is considered to be correct and acceptable | Example: There was an air of heaviness about the rooms which might have been avoided without any sacrifice of propriety."
+      "[pra'prarati] n. 得体的举止"
     ]
   },
   {
     "name": "prose",
     "trans": [
-      "Day 25 | n. | English: writing that is not poetry | Example: The late-period pieces of James Tate arguably fit this description, since they straddle the line between prose and poetry."
+      "[Provz] n. 散文"
     ]
   },
   {
     "name": "protagonist",
     "trans": [
-      "Day 25 | n. | English: the main character in a play, film/movie or book | Example: F. Scott Fitzgerald's 1920 novel This Side of Paradise contains elements drawn from Fitzgerald's own life—there are many parallels between the experiences of the novel's protagonist, Amory Blaine, and those of Fitzgerald."
+      "[pra'taganist] n. （电影书的）"
     ]
   },
   {
     "name": "proton",
     "trans": [
-      "Day 25 | n. | English: a substance with a positive electric charge that forms part of the nucleus | Example: In the periodic table, an element's atomic number indicates the number of protons in an atom of that element."
+      "[prouta:\"] n. 质子"
     ]
   },
   {
     "name": "protoplanet",
     "trans": [
-      "Day 25 | n. | English: a planet in its early stages of evolution by the process of accretion | Example: One popular theory of the origin of the Moon, the \"big whack,\" posits that a protoplanet called Theia collided with Earth, flinging debris into orbit that eventually coalesced into the Moon."
+      "n. 原行星"
     ]
   },
   {
     "name": "prototype",
     "trans": [
-      "Day 25 | n. | English: the first design of sth from which other forms are copied or developed Though slight, the reductions inspired an air-cooling device; using approximately 400 grams of mushrooms, the team's prototype lowered the air temperature in a controlled environment by 10°C in forty minutes."
+      "['proutatafp] n. 雏形,最初形态"
     ]
   },
   {
     "name": "provincial",
     "trans": [
-      "Day 25 | n. | English: a person who lives in or comes from a part of the country that is not near the capital city | Example: She had the air of a queen and gazed disdainfully at the whole house, as if to say, \"I've come later than all of you, you crowd of upstarts and provincials, I've come later than you!\""
+      "[pra'vInjI] n. 乡巴佬"
     ]
   },
   {
     "name": "provocative",
     "trans": [
-      "Day 25 | adj. | English: intended to make people angry or upset; intended to make people argue about sth | Example: He doesn't really mean that—he's just being deliberately provocative."
+      "[pra'va:katrv] adj. 挑衅的,煽动性的,激起争端的"
     ]
   },
   {
     "name": "provoke",
     "trans": [
-      "Day 25 | v. | English: to cause a particular reaction or have a particular effect | Example: Physical aspects of musicians’ brains may suppress the hedonic response to music at volumes that provoke the hedonic response in nonmusicians."
+      "[pra'vouk] v. 激起"
     ]
   },
   {
     "name": "proximity",
     "trans": [
-      "Day 25 | n. | English: the state of being near sb/sth in distance or time | Example: It is caused by something other than the parks’ proximity to residents."
+      "[pra:k'sImati] n. 接近"
     ]
   },
   {
     "name": "proxy",
     "trans": [
-      "Day 25 | n. | English: a person who has been given the authority to represent sb else While bioaccumulation of manufactured nanoparticles may be inherently worrisome, it has been hypothesized that CeO2-NP bioaccumulation in invertebrates like D. polymorpha could serve a valuable proxy role."
+      "['pra:ksi] n. 代理人,代表"
     ]
   },
   {
     "name": "prudence",
     "trans": [
-      "Day 25 | n. | English: Prudence is care and good sense that someone shows when making a decision or taking action. | Example: Western businessmen are showing remarkable prudence in investing in the region."
+      "['pru:dns] n. 谨慎"
     ]
   },
   {
     "name": "pseudonymous",
     "trans": [
-      "Day 25 | adj. | English: having or using a false or assumed name | Example: The Federalist Papers are a collection of 85 essays written by Alexander Hamilton, john jay, and James Madison. They were published pseudonymously in the New York Packet and other New York newspapers in 1787-88 and argue that New Yorkers should vote to ratify the proposed United States Constitution."
+      "adj. 用假名的"
     ]
   },
   {
     "name": "publicity",
     "trans": [
-      "Day 25 | n. | English: the attention that is given to sb/sth by newspapers, television, etc. | Example: Though it does not guarantee a book's commercial success, publicity can play a big role in that success"
+      "[PAb'Iisati] n. 宣传,报道"
     ]
   },
   {
     "name": "pulpit",
     "trans": [
-      "Day 25 | n. | English: a small platform in a church that is like a box and is high above the ground, where a priest, etc. stands to speak to the people | Example: By the laity of Milby and its neighbourhood [Mr. Ely] was regarded as a man of quite remarkable powers and learning, who must make a considerable sensation in London pulpits and drawing-rooms on his occasional visit to the metropolis."
+      "[polprt] n. 小讲坛"
     ]
   },
   {
     "name": "pupil",
     "trans": [
-      "Day 25 | n. | English: the small round black area at the centre of the eye | Example: Bainbridge and colleagues also measured pupil size, as pupils typically become larger when a stimulus captures a person's attention."
+      "['pju:pl] n. 瞳孔"
     ]
   },
   {
     "name": "putative",
     "trans": [
-      "Day 25 | adj. | English: believed to be the person or thing mentioned | Example: Eighteenth-century economist Adam Smith is famed for his metaphor of the invisible hand, which he putatively used to illustrate a robust model of how individuals produce aggregate benefits by pursuing their own economic interests."
+      "['pju:tatw] adj. 推定的"
     ]
   },
   {
     "name": "puzzle",
     "trans": [
-      "Day 25 | v. | English: to make sb feel confused because they do not understand sth | Example: May is puzzled by Newland's lack of enthusiasm for Newport"
+      "['PAZI] v. 使困惑"
     ]
   },
   {
     "name": "qualify",
     "trans": [
-      "Day 25 | v. | English: v. to add sth to a previous statement to make the meaning less strong or less general; v. to have the right qualities to be described as a particular thing | Example: [1] It qualifies an earlier description of Mr. Verloc. 2] Each qualifying party is awarded a number of seats proportional to the number of votes it received."
+      "['kwa:Irfar] v.；v.；v. 使所说的话语气减弱"
     ]
   },
   {
     "name": "qualm",
     "trans": [
-      "Day 25 | n. | English: a feeling of doubt or worry about whether what you are doing is righ | Example: To justify the speaker's qualms about being transported by the ocean to a quiet destination"
+      "[kwa:m,kwD:皿] n. 疑虑"
     ]
   },
   {
     "name": "quantity",
     "trans": [
-      "Day 25 | n. | English: an amount or a number of sth | Example: It draws a distinction between the overall size of the sei whale and the relatively small quantity of krill it can consume per day."
+      "[\"kwa:ntati] n. 数量"
     ]
   },
   {
     "name": "quarry",
     "trans": [
-      "Day 26 | n. | English: a place where large amounts of stone, etc. are dug out of the ground | Example: Marine archaeologists have found much of the wooden hull of a sixteenth-century ship in a flooded quarry in southeast England."
+      "['kwa:ri] n. 采石场"
     ]
   },
   {
     "name": "quibble",
     "trans": [
-      "Day 26 | n. | English: asmall complaint or criticism, especially one that is not important | Example: Socrates, a sophist, says to a new customer \"I have not seen any man so boorish, nor so impracticable, nor so stupid, nor so forgetful; who, while learning some little petty quibbles, forgets them before he has learned them.\""
+      "['kwibl] n. 牢骚,小意见"
     ]
   },
   {
     "name": "quintessential",
     "trans": [
-      "Day 26 | adj. | English: representing a perfect or typical example of something. | Example: Google's introduction of the Chrome web browser in 2008 is a quintessential instance of brand extension—the company leveraged its brand recognition as an internet search provider to enter a product category where it had not previously competed."
+      "[.kwIntr'scnj] adj. 典型的"
     ]
   },
   {
     "name": "quiver",
     "trans": [
-      "Day 26 | n. | English: a-slight movement in part of your body | Example: | sang, with a strange quiver in my voice, a promise-song."
+      "['kwrvar] n. 微颤"
     ]
   },
   {
     "name": "radically",
     "trans": [
-      "Day 26 | adv. | English: ina radical or extreme mamner | Example: The invention in 1958 of the integrated circuit (or microchip) radically altered the semiconductor industry."
+      "['redikli] adv. 彻底地"
     ]
   },
   {
     "name": "raid",
     "trans": [
-      "Day 26 | n. | English: n. an attack on a building, etc. in order to commit a crime; v. to enter a place, usually using force, and steal from it | Example: [1] Most infamously, he participated in what was essentially a private war against Sempringham Priory, a monastery near his manor, even making off with 500 pounds’ worth of monastery property during a raid. 2] By agreeing that though the law might have permitted Luttrell to do so, Luttrell was wrong to have raided Sempringham Priory"
+      "[rerd] n.；n.；v. 抢劫"
     ]
   },
   {
     "name": "rampart",
     "trans": [
-      "Day 26 | n. | English: a high wide wall of stone or earth with a path on top, built around a castle, town, etc. to defend it In the text, Molloy has arrived at the town ramparts, an elevated walkway atop the city walls."
+      "n. 壁垒"
     ]
   },
   {
     "name": "rash",
     "trans": [
-      "Day 26 | adj. | English: doing sth that may not be sensible without first thinking about the possible results | Example: | had gazed upon the fortifications and impediments that seemed to keep human beings from entering the citadel of nature, and rashly and ignorantly | had repined."
+      "[ra] adj. 轻率的"
     ]
   },
   {
     "name": "ratify",
     "trans": [
-      "Day 26 | v. | English: to make an agreement officially valid by voting for or signing it | Example: The Federalist Papers are a collection of 85 essays written by Alexander Hamilton, john jay, and James Madison. They were published pseudonymously in the New York Packet and other New York newspapers in 1787-88 and argue that New Yorkers should vote to ratify the proposed United States Constitution."
+      "['ratrfa] v. 正式批准"
     ]
   },
   {
     "name": "rationalize",
     "trans": [
-      "Day 26 | v. | English: to find or try to find a logical reason to explain sth | Example: He further rationalized his activity by convincing himself that he was actually promoting peace."
+      "['rj(a)nalarz] v. 进行合理解释"
     ]
   },
   {
     "name": "rave",
     "trans": [
-      "Day 26 | v. | English: to shout in a loud and emotional way at sb because you are angry with them | Example: And while outside the tempest is raving o'er the ocean, / And the ship is madly driving on some lone and desert shore."
+      "[rew] v. 咆哮,怒吼"
     ]
   },
   {
     "name": "ravelling",
     "trans": [
-      "Day 26 | v. | English: to separate or undo the texture of | Example: Yes, the great cloud was ravelling, discovering here and there a pale and dying sky."
+      "v. 拆开"
     ]
   },
   {
     "name": "ravine",
     "trans": [
-      "Day 26 | n. | English: a deep and narrow valley with steep sides | Example: A dry ravine emerged under boughs / Into the pasture."
+      "[ra'vi:n] n. 沟壑"
     ]
   },
   {
     "name": "readily",
     "trans": [
-      "Day 26 | adv. | English: quickly and without difficulty | Example: Cuttlefish appear to be surprisingly competent at exercising self-control: in a 2021 study conducted by behavioral ecologist Alexandra Schnell, these cephalopods routinely demonstrated restraint by delaying gratification, waiting for a favorite treat instead of instantly devouring a readily available meal."
+      "['redili] adv. 轻而易举地"
     ]
   },
   {
     "name": "rear",
     "trans": [
-      "Day 26 | n. | English: the back part of sth | Example: After some trouble [Jim’s father] found the subject of the incident, the broken flower. Turning then, he saw the child lurking at the rear and scanning his countenance."
+      "[rr] n. 后部"
     ]
   },
   {
     "name": "rebuke",
     "trans": [
-      "Day 26 | n. | English: an expression of strong disapproval | Example: He were expecting a rebuke for some neglect of duty of which he might have been guilty."
+      "[II'bjuk] n. 指责"
     ]
   },
   {
     "name": "rebut",
     "trans": [
-      "Day 26 | v. | English: to say or prove that a statement or criticism is false | Example: It considers and rebuts an interpretation of the effect of a painting technique mentioned earlier in the text on the perception of work by a group of artists."
+      "[rI'bAt] v. 反驳"
     ]
   },
   {
     "name": "recalcitrant",
     "trans": [
-      "Day 26 | adj. | English: unwilling to obey rules or follow instructions; difficult to control | Example: The danger is that recalcitrant local authorities will reject their responsibilities."
+      "[Ir'kalsitrant] adj. 不服从指挥的"
     ]
   },
   {
     "name": "reception",
     "trans": [
-      "Day 26 | n. | English: the type of welcome that is given to sb/sth | Example: The reception of Keshni Kashyap's book Tina's Mouth has been very positive."
+      "[rr'sepjn] n. 反应"
     ]
   },
   {
     "name": "reciprocate",
     "trans": [
-      "Day 26 | v. | English: to behave or feel towards sb in the same way as they behave or feel towards you | Example: In habitats with limited nutrients, certain fungus species grow on the roots of trees, engaging in mutually beneficial relationships known as ectomycorrhizae: in this symbiotic exchange, the tree provides the fungus with carbon, a nutrient necessary for both species, and the fungus reciprocate by enhancing the tree’s ability to absorb nitrogen, another key nutrient, from the soil."
+      "[r'slprakert] v. 回报"
     ]
   },
   {
     "name": "recite",
     "trans": [
-      "Day 26 | v. | English: to say a poem, piece of literature, etc. that you have learned, especially to an audience | Example: It's hard to describe Farsi chanting: the way Mom drew her voice out like the notes of a cello as she recited poems by Rumi or Hafez."
+      "[rr'sat] v. 背诵,吟诵"
     ]
   },
   {
     "name": "reckon with",
     "trans": [
-      "Day 26 | English: to consider or treat sb/sth as a serious opponent, problem , etc. | Example: Any assessment of the state of contemporary poetry must reckon with the professionalization of the field."
+      "认真处理"
     ]
   },
   {
     "name": "reckoning",
     "trans": [
-      "Day 26 | n. | English: the act of calculating sth, especially in a way that is not very exact | Example: The banker, spoilt and frivolous, with millions beyond his reckoning, was delighted at the bet."
+      "['rekann] n. 估算"
     ]
   },
   {
     "name": "recommend",
     "trans": [
-      "Day 26 | v. | English: to tell sb that sth is good or useful, or that sb would be suitable for a particular job, etc. | Example: The reception of Hena Khan's book Amina's Song has been very good. Many reviewers, booksellers, and librarians have recommended the book, and it won the Asian/Pacific American Award for Literature."
+      "[reka'mend] v. 推荐"
     ]
   },
   {
     "name": "reconcile",
     "trans": [
-      "Day 26 | v. | English: to find an acceptable way of dealing with two or more ideas, needs, etc. that seem to be opposed to each other | Example: As Rachana Kamtekar observes, this argument is difficult to reconcile with our lay conception of character: we expect a person of helpful character to be frequently helpful, not sporadically helpful."
+      "['rckansall] v. 使和谐一致"
     ]
   },
   {
     "name": "reconstitute",
     "trans": [
-      "Day 26 | v. | English: to form an organization or a group again in a different wa | Example: The group reconstituted itself as a political party."
+      "[.ri:'ka:nstitu:t] v. 重组"
     ]
   },
   {
     "name": "recount",
     "trans": [
-      "Day 26 | v. | English: (formal) to tell sb about sth, especially sth that you have experienced | Example: The speaker presents herself as fiercely independent and then recounts scenarios that demonstrate that independence."
+      "[II'kaont] v. 讲述,叙述"
     ]
   },
   {
     "name": "recreational",
     "trans": [
-      "Day 26 | adj. | English: connected with activities that people do for enjoyment when they are not working | Example: As urbanist Mariela Alfonzo argues, our understanding of individuals’ decision-making about whether to walk is insufficiently robust: some studies emphasize the role of climate conditions, others the role of recreational amenities, and so on, but walking decisions are made in complex contexts in which multiple conditions and needs inform individuals’ choices."
+      "[rekri'erjanl] adj. 娱乐的"
     ]
   },
   {
     "name": "rectify",
     "trans": [
-      "Day 26 | v. | English: to put right sth that is wrong | Example: As they sat down they turned almost invariably to the person sitting next them, and rectified and continued what they had just said in public."
+      "['rektrfar] v. 矫正"
     ]
   },
   {
     "name": "recurrent",
     "trans": [
-      "Day 26 | adj. | English: that happens again and again | Example: Poverty is a recurrent theme in her novels."
+      "[Ir'k3:rat] adj. 反复出现的"
     ]
   },
   {
     "name": "reduplication",
     "trans": [
-      "Day 26 | n. | English: the process or an instance of redoubling | Example: This phenomenon, in which an element of a root word is repeated, sometimes with modification, within another word that is related to the root word, is called reduplication."
+      "[IIdjupla'kelon] n. 重复"
     ]
   },
   {
     "name": "reference",
     "trans": [
-      "Day 26 | v. | English: to refer to sth; to provide a book, etc. with references | Example: For example, a count of other scholars’ citations shows that Boston University economist Marianne Baxter, who studies international finance, is referenced frequently, indicating that her work has been significant in the field."
+      "['refrans] v. 查阅,参考"
     ]
   },
   {
     "name": "reflective",
     "trans": [
-      "Day 26 | adj. | English: typical of a particular situation or thing; showing the state or nature of sth | Example: It may lead to conclusions that are not reflective of all the amenities in a given neighborhood"
+      "[rr'tlektwv] adj. 典型的,代表性的"
     ]
   },
   {
     "name": "refute",
     "trans": [
-      "Day 26 | v. | English: to prove that sth is wrong | Example: It introduces a natural phenomenon, refutes two potential explanations for that phenomenon, and then presents a third explanation for that phenomenon that the author regards as plausible."
+      "[II'fju:t] v. 驳斥"
     ]
   },
   {
     "name": "regard",
     "trans": [
-      "Day 26 | n. | English: respect or admiration for sb | Example: It conveys how Mr. Ely initially established a positive reputation among his colleagues and then recounts the events that led them to alter their regard."
+      "[r'ga:rd] n. 尊重"
     ]
   },
   {
     "name": "register",
     "trans": [
-      "Day 26 | v. | English: to show or express a feeling | Example: The motorman chafed in his box, thinking of the drudging lot of the laboring man. He registered discontent."
+      "['redgIstar] v. 流露出,表达出"
     ]
   },
   {
     "name": "regulate",
     "trans": [
-      "Day 26 | v. | English: to control the speed, pressure, temperature, etc. in a machine or system | Example: The researchers determined that among dogs as a whole, there are many different variations of the gene that regulates the production of IGF-1 (insulin growth factor 1), a hormone that promotes growth."
+      "['regjulert] v. 调节"
     ]
   },
   {
     "name": "rehabilitate",
     "trans": [
-      "Day 26 | v. | English: to begin to consider that sb is good or acceptable after a long period during which they were considered bad or unacceptable | Example: Instead of engaging in unproductive debates, it should work to rehabilitate the reputations of neglected modernist works."
+      "[.ri:a'brlitert] v. 的名誉"
     ]
   },
   {
     "name": "rehearse",
     "trans": [
-      "Day 26 | v. | English: to prepare in your mind or practise privately what you are going to do or say to sb | Example: | made a mental map and located myself upon it. At night in bed | rehearsed the small world’s scheme and set challenges: Find the store using backyards only. Imagine a route from the school to my friend’s house."
+      "[r'13:1s] v. 默默地练习"
     ]
   },
   {
     "name": "reign",
     "trans": [
-      "Day 26 | n. | English: the period during which a king, queen, emperor , etc. rules | Example: Barring major archaeological discoveries, we are unlikely to ever have an exhaustive account of ancient Egypt under the female pharaoh Hatshepsut, as much of the evidence of her reign was deliberately destroyed by her successors."
+      "[remn] n. 君主统治时期"
     ]
   },
   {
     "name": "rejuvenate",
     "trans": [
-      "Day 26 | v. | English: to make something work much better or become much better again | Example: Although inhabiting a home surrounded by fanciful features such as those designed by Gins and Arakawa can be rejuvenating, it is unsustainable."
+      "[Ir'd3u:vanert] v. 使恢复活力"
     ]
   },
   {
     "name": "relief",
     "trans": [
-      "Day 26 | n. | English: a way of decorating wood, stone, etc. by cutting designs into the surface of it so that some parts stick out more than others; a design that is made in this way | Example: The Roc-aux-Sorciers frieze—a group of relief carvings of animals found in what is now France and dating from around 14,000 years ago—is sometimes said to be emotionally powerful despite its age."
+      "n. 浮雕作品"
     ]
   },
   {
     "name": "relieve",
     "trans": [
-      "Day 26 | v. | English: to make a problem less serious | Example: Not only does additional road capacity often fail to relieve congestion, but it can also make traffic worse by encouraging more people to drive."
+      "[rI'li:v] v. （问题的严重性）"
     ]
   },
   {
     "name": "relinquish",
     "trans": [
-      "Day 26 | v. | English: to stop having sth, especially when this happens unwillingly | Example: Oligarchies might grant power to military leaders during wartime who refuse to relinquish that power during peacetime."
+      "[r'IkwJ] v. 尤指不情愿地"
     ]
   },
   {
     "name": "reluctant",
     "trans": [
-      "Day 26 | adj. | English: hesitating before doing sth because you do not want to do it or because you are not sure that it is the right thing to do | Example: Miranda's doubts about the accuracy of one recollection of a place other than the island are clouding her judgment and seem to be making her reluctant to explore her recollection of traveling to the island."
+      "[Ir'Iktant] adj. 不愿意的"
     ]
   },
   {
     "name": "remarkable",
     "trans": [
-      "Day 26 | adj. | English: unusual or surprising in a way that causes people to take notice | Example: By the laity of Milby and its neighbourhood [Mr. Ely] was regarded as a man of quite remarkable powers and learning, who must make a considerable sensation in London pulpits and drawing-rooms on his occasional visit to the metropolis."
+      "[rr'ma:rkabl] adj. 非凡的"
     ]
   },
   {
     "name": "reminiscence",
     "trans": [
-      "Day 26 | n. | English: the act of remembering things that happened in the pas | Example: Miranda's reminiscences about her early childhood have a melancholy quality that betrays her discontented view of her current circumstances."
+      "n. 回忆"
     ]
   },
   {
     "name": "reminiscent of",
     "trans": [
-      "Day 26 | English: reminding you of sb/sth | Example: Historians argue that Morris's repudiation of industrialization is manifest in the Kelmscott editions' use of handmade materials and intricate ornamentation reminiscent of medieval manuscripts: these meticulously handcrafted elements exemplify the artistry involved."
+      "使回忆起"
     ]
   },
   {
     "name": "render",
     "trans": [
-      "Day 26 | v. | English: to cause sb/sth to be in a particular state or condition | Example: Some scientists have hypothesized that this capability evolved because it imposes a lower metabolic cost than does the alternative mechanism of producing chemicals that render moths noxious to bats."
+      "['rendar] v. 使成为,使娈得"
     ]
   },
   {
     "name": "renounce",
     "trans": [
-      "Day 26 | n. | English: to state officially that you are no longer going to keep a title, position, etc. | Example: Vanya says to Professor Serebrakoff, \"This place [the country estate] could never have been bought had | not renounced my inheritance in favor of my sister [the professor's late wife], whom | deeply loved—and what is more, | worked for ten years like an ox, and paid off the debt.\""
+      "[II'naons] n. 宣布放弃"
     ]
   },
   {
     "name": "renown",
     "trans": [
-      "Day 27 | n. | English: fame and respect because of sth you have done that people admire | Example: Few of the personages of past times (except such as have gained renown in fireside legends as well as in written history) are anything but mere names to their successors."
+      "[II'naon] n. 名誉,声望"
     ]
   },
   {
     "name": "repellant",
     "trans": [
-      "Day 27 | adj. | English: adj. not letting a particular substance, especially water, pass through it; adj. very unpleasant; causing strong dislike | Example: [1] To assist with the development of new water-repellant materials for aviation and other applications, a team including both engineers and entomologists conducted a study of the water-repellant properties of cicada wings. 2] “The color is repellant, almost revolting; a smouldering unclean yellow, strangely faded by the slow-turning sunlight.”"
+      "adj. 的"
     ]
   },
   {
     "name": "repine",
     "trans": [
-      "Day 27 | v. | English: to feel sad or complain about something, especially a bad situation | Example: | had gazed upon the fortifcations and impediments that seemed to keep human beings from entering the citadel of nature, and rashly and ignorantly | had repined."
+      "[II'pamn] v. 抱怨"
     ]
   },
   {
     "name": "replica",
     "trans": [
-      "Day 27 | n. | English: copy that is not the original | Example: Built at a scale of 1:110, the Eiffel Tower in Baku, Azerbaijan, is one of many replicas of the famous Eiffel Tower in Paris, France."
+      "['replka] n. 复制品"
     ]
   },
   {
     "name": "replicate",
     "trans": [
-      "Day 27 | v. | English: to copy sth exactly | Example: Correlations in a country between languages and regions where they are spoken can replicate themselves in a new country to which the original country's citizens emigrate."
+      "['replikert] v. 复制"
     ]
   },
   {
     "name": "repository",
     "trans": [
-      "Day 27 | n. | English: a place where sth is stored in large quantities | Example: Indigenous songs can be repositories of ecological information, from Yi songs about the natural environment to Tlingit songs about wildlife encounters."
+      "[Ir'pa:zato:ri] n. 仓库,贮藏室"
     ]
   },
   {
     "name": "representative",
     "trans": [
-      "Day 27 | adj. | English: typical of a particular group of people | Example: It is tempting to treat the clustering of information technology firms in Northern California as representative of industrial agglomeration generally."
+      "[.reprr'zcntatrv] adj. 有代表性的"
     ]
   },
   {
     "name": "repress",
     "trans": [
-      "Day 27 | v. | English: to try not to have or show an emotion, a feeling, etc. In a discussion of the study, a student hypothesizes that small breeds of dogs (for example, Havaneses) must share a version that represses IGF-1 production that would otherwise confer larger body size."
+      "[II'pres] v. 抑制,压制"
     ]
   },
   {
     "name": "reprieve",
     "trans": [
-      "Day 27 | v. | English: adelay before sth bad happens | Example: Campaigners have won a reprieve for the hospital threatened with closure."
+      "[rr'pri:v] v. 延缓"
     ]
   },
   {
     "name": "repudiate",
     "trans": [
-      "Day 27 | v. | English: to refuse to accept sth | Example: Seminole/Muscogee director Sterlin Harjo repudiates television’s tendency to situate Native characters in the distant past."
+      "[Ir'pju:diert] v. 拒绝"
     ]
   },
   {
     "name": "repudiation",
     "trans": [
-      "Day 27 | n. | English: the act of repudiating the state of being repudiated; especially the refusal of public authorities or acknowledge or pay a debt Historians argue that Morris's repudiation of industrialization is manifest in the Kelmscott editions' use of handmade materials and intricate ornamentation reminiscent of medieval these meticulously handcrafted elements exemplify the artistry involved."
+      "[IIPju:di'erf(a)n] n. 否认"
     ]
   },
   {
     "name": "reputation",
     "trans": [
-      "Day 27 | n. | English: the opinion that people have about what sb/sth is like, based on what has happened in the past | Example: British painter Peter Edwards has a reputation for painting portraits of notable figures from a variety of different fields."
+      "[.repju'terhn] n. 名誉,名声"
     ]
   },
   {
     "name": "requisite",
     "trans": [
-      "Day 27 | adj. | English: necessary for a particular purpose | Example: As a result, this lovely region is atrociously poor and its few scattered farms provide just the requisite number of red roofs to set off the velvety green of the woods."
+      "['rekwrzrt] adj. 必需的"
     ]
   },
   {
     "name": "resemblance",
     "trans": [
-      "Day 27 | English: the fact of being or looking similar to sb/sth | Example: Maize (corn), another crop domesticated by Indigenous Americans, shows so little resemblance to any wild plant that genetic research was necessary to confirm teosinte grass as its ancestor."
+      "[rI'zcmblans] 相似"
     ]
   },
   {
     "name": "resemble",
     "trans": [
-      "Day 27 | v. | English: to look like or be similar to another person or thing | Example: Summer squash, another domesticated crop from the Americas, doesn’t closely resemble any wild plant"
+      "[r'zembl] v. 看起来像"
     ]
   },
   {
     "name": "reservation",
     "trans": [
-      "Day 27 | n. | English: an area of land in the US that is kept separate for Native Americans to live in | Example: Louis Pipestone is collecting signatures for a petition from fellow members of the Turtle Mountain Band of Chippewa on the tribe's reservation in North Dakota."
+      "[.rezar'verhn] n. 美国为土著美洲人划出的-"
     ]
   },
   {
     "name": "reserve",
     "trans": [
-      "Day 27 | n. | English: n.a supply of sth that is available to be used in the future or when it is needed v. to keep sth for sb/sth, so that it cannot be used by any other person or for any other reason | Example: [1] Having an ample reserve of stored energy can mitigate the effects of fluctuations in solar energy collection caused by unpredictable shifts in cloud cover and haze. 2] These seats are reserved for special guests."
+      "[Ir'23:w] n.；n.；v. 储备（量）"
     ]
   },
   {
     "name": "resilience",
     "trans": [
-      "Day 27 | n. | English: the ability of people or things to feel better quickly after sth unpleasant, such as shock, injury, etc. In a 2021 paper, zoologist Guillaume Ghisbain notes that bumblebees are among the relatively few wild-bee genera that display social behaviors and dietary generalism (ability to obtain nectar and pollen from a diversity of plant species), two traits that are associated with increased resilience to some specific environmental changes."
+      "[rI'zllians] n. 快速恢复的能力"
     ]
   },
   {
     "name": "resolve",
     "trans": [
-      "Day 27 | v. | English: to find an acceptable solution to a problem or difficulty | Example: Each becomes entangled in a debate about art, and no one knows how to resolve the debate."
+      "[II'za:lv] v. （问题或困难二"
     ]
   },
   {
     "name": "resonance",
     "trans": [
-      "Day 27 | n. | English: the power to bring images, feelings, etc. into the mind of the person reading or listening; the images, etc. produced in this way | Example: Itis the link of shared humanity with the artist across so many centuries that gives the Roc- aux-Sorciers frieze such resonance."
+      "['rezanans] n. 激发联想的力量"
     ]
   },
   {
     "name": "respective",
     "trans": [
-      "Day 27 | adj. | English: belonging or relating separately to each of the people or things already mentioned | Example: Though not closely related, the hedgehog tenrecs of Madagascar share basic similarities with true hedgehogs, including protective spines, pointed snouts, and small body size—traits the two groups of mammals independently developed in response to equivalent roles in their respective habitats."
+      "[Ir'spektrv] adj. 分别的,各自的"
     ]
   },
   {
     "name": "resplendent",
     "trans": [
-      "Day 27 | adj. | English: brightly coloured in an impressive way | Example: The pine green is resplendent."
+      "[r'splendant] adj. 华丽的"
     ]
   },
   {
     "name": "restraint",
     "trans": [
-      "Day 27 | n. | English: the quality of behaving calmly and with control | Example: Cuttlefish appear to be surprisingly competent at exercising self-control: in a 2021 study conducted by behavioral ecologist Alexandra Schnell, these cephalopods routinely demonstrated restraint by delaying gratification, waiting for a favorite treat instead of instantly devouring a readily available meal."
+      "[rI'strcrnt] n. 克制"
     ]
   },
   {
     "name": "retain",
     "trans": [
-      "Day 27 | v. | English: to continue to have sth | Example: \"Coyote\" changed in meaning significantly when English borrowed the word from Spanish, whereas \"iguana\" retained its original meaning."
+      "[rr'temn] v. 保留"
     ]
   },
   {
     "name": "retention",
     "trans": [
-      "Day 27 | n. | English: the action of keeping sth rather than losing it or stopping it | Example: Reducing this kind of subscriber turnover is especially challenging for subscription sellers: customers’ initial enthusiasm for a subscription is often quick to subside, and sellers must thus devise other incentives to bolster retention."
+      "[II'tenjn] n. 保持,保留"
     ]
   },
   {
     "name": "retentive",
     "trans": [
-      "Day 27 | adj. | English: able to store facts and remember things easily | Example: She had a good sense of logic, a strong power of concentration, and a remarkably retentive and visualizing memory."
+      "[Ir'tentwv] adj. 有记性的"
     ]
   },
   {
     "name": "retina",
     "trans": [
-      "Day 27 | n. | English: a layer of tissue at the back of the eye that is sensitive to light and sends signals to the brain about what is seen | Example: Indeed, what mortal is there of us, who would find his satisfaction enhanced by an opportunity of comparing the picture he presents to himself of his own doings, with the picture they make on the mental retina of his neighbours?"
+      "['retrna] n. 视网膜"
     ]
   },
   {
     "name": "retiree",
     "trans": [
-      "Day 27 | n. | English: a person who has stopped working because of their age | Example: Proposals to raise the age at which retirees begin receiving government transfers of funds are generally discussed in terms of the effects on transfer recipients."
+      "[IItara'ri:] n. 退休人员"
     ]
   },
   {
     "name": "retreat",
     "trans": [
-      "Day 27 | n. | English: a movement away from a place or an enemy because of danger or defeat | Example: If instead the giant short-faced bear died out before humans could have altered its habitat, that suggests that its extinction was the result of some other factor, such as change in sea levels as a result of glaciers retreating."
+      "[rr'tri:t] n. 撤退"
     ]
   },
   {
     "name": "retrieve",
     "trans": [
-      "Day 27 | v. | English: to bring or get sth back, especially from a place where it should not be | Example: The cognitive abilities of monkeys given problems requiring little dexterity, such as sliding a panel to retrieve food, were judged by the same criteria as were those of monkeys given physically demanding problems, such as unscrewing a bottle and inserting a straw."
+      "[I'tri:v] v. 取回,索回"
     ]
   },
   {
     "name": "retroactive",
     "trans": [
-      "Day 27 | adj. | English: Ifa decision or action is retroactive, it is intended to take effect from a date in the past. Itisn't yet clear whether the new law can actually be applied retroactively."
+      "[.retroo'aktw] adj. （决定或行为）有追溯效力的"
     ]
   },
   {
     "name": "revelation",
     "trans": [
-      "Day 27 | n. | English: a fact that people are made aware of, especially one that has been secret and is surprising While hDNA has yielded many revelations about evolutionary history, it is relatively underused due to a shortage of specimens from the appropriate time periods."
+      "[.reva'lerln] n. 被暴露的真相"
     ]
   },
   {
     "name": "reverence",
     "trans": [
-      "Day 27 | n. | English: (formal) a feeling of great respect or admiration for sb/sth | Example: In the United States, historians of the American Revolution once had a tendency to approach their subject with reverence."
+      "['revarans] n. 尊敬"
     ]
   },
   {
     "name": "reverential",
     "trans": [
-      "Day 27 | adj. | English: full of respect or admiration | Example: His name was always mentioned in almost reverential tones."
+      "adj. 恭敬的"
     ]
   },
   {
     "name": "revise",
     "trans": [
-      "Day 27 | v. | English: to change your opinions or plans, for example because of sth you have learned | Example: However, new evidence that the change in conditions occurred well before those species went extinct is forcing paleontologists to revise that hypothesis."
+      "[Ir'varz] v. 修改"
     ]
   },
   {
     "name": "revolt",
     "trans": [
-      "Day 27 | v. | English: to take violent action against the people in power | Example: The peasants threatened to revolt."
+      "[rI'voolt] v. （当权者）"
     ]
   },
   {
     "name": "revolting",
     "trans": [
-      "Day 27 | adj. | English: extremely unpleasant | Example: “I'm really getting quite fond of the big room, all but that horrid [wall] paper.”"
+      "adj. 令人作眍的,极其讨厌的"
     ]
   },
   {
     "name": "rhetoric",
     "trans": [
-      "Day 27 | n. | English: the skill of using language in speech or writing in a special way that influences or entertains people | Example: Political scientists have found that although voters claim to prefer candidates who have nuanced perspectives on issues and who show a willingness to compromise, when asked to compare speeches expressing such views with speeches expressing dogmatic views, voters tend to regard the unyielding rhetoric of the latter more favorably."
+      "['retarik] n. 修辞"
     ]
   },
   {
     "name": "ribbon",
     "trans": [
-      "Day 27 | n. | English: anarrow strip of material, used to tie things or for decoration | Example: During many historic New York City parades, including the 1924 ticker-tape parade for US Olympic champions, the ribbonlike swirls descending on the scene were paper spools from \"tickers,\" telegraph machines that were used to transmit stock prices."
+      "['rban] n. （用于捆绑或装饰的）"
     ]
   },
   {
     "name": "rift",
     "trans": [
-      "Day 27 | n. | English: a large crack or opening in the ground, rocks or clouds | Example: Green meadows make rifts in [the woods] here and there, so do little patches of cultivation."
+      "[IIft] n. 裂缝"
     ]
   },
   {
     "name": "rigid",
     "trans": [
-      "Day 27 | adj. | English: stiff and difficult to move or bend | Example: Both ocelots and jaguars have U-shaped hyoid bones, but ocelots' hyoids are rigid whereas aguars’ hyoids are flexible."
+      "['rid3Id] adj. 不弯曲的"
     ]
   },
   {
     "name": "ripple",
     "trans": [
-      "Day 27 | v. | English: to move or to make sth move in very small waves He watches his father raise a kite within minutes into the wind, so high that Gogol must tip his head back in order to see, a rippling speck against the sky."
+      "['rpl] v. 如波浪般起伏"
     ]
   },
   {
     "name": "rival",
     "trans": [
-      "Day 27 | n. | English: n.a person, group, or organization that you compete with in sport, business, a fight etc; v. to be as good, impressive, etc. as sb/sth else | Example: [1] One such theory points to various primary sources that indicate an escalation in infighting among rival factions in the society that coincided with increasing droughts. 2] It was a city of only 250,000 or 300,000 inhabitants; now it is a metropolis rivaling London in population, wealth and commerce."
+      "['rawl] n.；n.；v. 相匹敌"
     ]
   },
   {
     "name": "rivalry",
     "trans": [
-      "Day 27 | n. | English: a state in which two people, companies, etc. are competing for the same thing | Example: This was the case for both separation problems and dog rivalry but was especially pronounced for attachment and attention-seeking, which can be seen when a dog solicits affection or attention."
+      "['ramvlri] n. 竞争"
     ]
   },
   {
     "name": "roar",
     "trans": [
-      "Day 27 | n. | English: aloud deep sound made by an animal, especially a lion , or by sb's voice | Example: In his solitary retreat on the shore of the sea, whose mobile surface was visible through the open windows, extending outward until it mingled with the horizon, Padre Florentino was relieving the monotony by playing on his harmonium sad and melancholy tunes, to which the sonorous roar of the surf and the sighing of the treetops of the neighboring wood served as accompaniments."
+      "[r3:] n. 咆哮"
     ]
   },
   {
     "name": "robust",
     "trans": [
-      "Day 27 | adj. | English: strong and not likely to fail or become weak | Example: Although Smith is famed for his metaphor of the invisible hand, the metaphor was largely ignored until economists in the twentieth century came to realize that the metaphor was a robust model that anticipated their own views."
+      "[roc'bAst] adj. 强劲的"
     ]
   },
   {
     "name": "rotation",
     "trans": [
-      "Day 27 | n. | English: the action of an object moving in a circle around a central fixed point Instead, Luu et al. are likely correct that 6478 Gault is shedding mass due to rotational instability."
+      "[roo'terhn] n. 旋转"
     ]
   },
   {
     "name": "rough",
     "trans": [
-      "Day 27 | adj. | English: not gentle or careful; violent | Example: [1] A gleaming carpet was springing up everywhere, that looked too delicate to be trodden upon by rough feet. 2] Ocean currents can be powerful and rough, making it difficult for animals to find safe places to hide from predators. The underwater forests slow down the currents."
+      "[ruf] adj. 粗暴的,猛烈的"
     ]
   },
   {
     "name": "route",
     "trans": [
-      "Day 27 | n. | English: away that you follow to get from one place to another | Example: Haworth and Schramm asked adult bike riders questions about their level of experience, reasons for riding a bike, and route preferences."
+      "[ru:traot] n. 路线"
     ]
   },
   {
     "name": "rudimentary",
     "trans": [
-      "Day 27 | adj. | English: dealing with only the most basic matters or ideas | Example: The method used in 1920 by the US Geological Survey to calculate the geographic center of Louisiana, involving a cardboard cutout of the state and a piece of string, seems rudimentary today."
+      "[.ru:drmentri] adj. 基础的"
     ]
   },
   {
     "name": "rumble",
     "trans": [
-      "Day 28 | v. | English: to make a long deep sound or series of sounds | Example: Iberian lynxes, which are much smaller than lions, have a rigid hyoid that rumbles when the cat's larynx vibrates."
+      "['r4mb(a)l] v. 发出隆隆声"
     ]
   },
   {
     "name": "rural",
     "trans": [
-      "Day 28 | adj. | English: connected with or like the countryside | Example: The Last Report on the Miracles at Little No Horse is a 2001 novel by Ojibwe writer Louise Erdrich. It explores how historical events affect families on a reservation in rural North Dakota."
+      "['roral] adj. 乡村的"
     ]
   },
   {
     "name": "sac",
     "trans": [
-      "Day 28 | n. | English: a part inside the body of a person, an animal or a plant, that is shaped like a bag, has thin skin around it, and contains liquid or air | Example: Postcranial skeletal pneumaticity (PSP) refers to the presence of extensions of an animal's lungs and air sacs inside its bones."
+      "[sak] n. （动植物体内的）囊,液囊"
     ]
   },
   {
     "name": "sacred",
     "trans": [
-      "Day 28 | adj. | English: connected with God or a god; considered to be holy | Example: Home is home, to the lowly as well as the great: and no rank, or color, destroys its sacred character, its power over the mind, and the affections."
+      "['scrkrd] adj. 神圣的"
     ]
   },
   {
     "name": "salient",
     "trans": [
-      "Day 28 | adj. | English: most important or noticeable | Example: In this case, players’ cognitive resources are directed foremost toward the advergame's mechanics, leaving little or no capacity for encoding and storing the information the advertiser intends to be salient."
+      "['selliant] adj. 最重要的"
     ]
   },
   {
     "name": "saline",
     "trans": [
-      "Day 28 | adj. | English: containing salt | Example: The migration's obligate nature is why diadromous fish can be demarcated from those that are merely euryhaline (able to tolerate high salinity)."
+      "['sclli:n] adj. 含盐的"
     ]
   },
   {
     "name": "sanction",
     "trans": [
-      "Day 28 | n. | English: official permission or approval for an action or a change | Example: These changes will require the sanction of the court."
+      "['sankf] n. 批准"
     ]
   },
   {
     "name": "sanguine",
     "trans": [
-      "Day 28 | adj. | English: cheerful and confident about the future | Example: While some commentators lauded this development, asserting that such blogs had a welcome transparency missing from traditional news, less sanguine observers countered that such blogs tended to ideological extremes that exacerbated political polarization to problematic levels."
+      "['sangw] adj. 充满信心的,乐观的"
     ]
   },
   {
     "name": "sap",
     "trans": [
-      "Day 28 | n. | English: the liquid in a plant or tree that carries food to all its parts | Example: | walked slowly beneath the young leaves, drinking in the air, fragrant with the odor of young buds and sap."
+      "[s8p] n. （植物体内运送养分的）液"
     ]
   },
   {
     "name": "satiate",
     "trans": [
-      "Day 28 | v. | English: to give sb so much of sth that they do not feel they want any more | Example: From sculptures like Mird's Chicago by Joan Miré, found at Brunswick Plaza, to street art like Justus Roe's mural South Shore on South Exchange Avenue, Chicago offers an array of works to satiate the tastes of art lovers."
+      "['serliert] v. 满足"
     ]
   },
   {
     "name": "satirize",
     "trans": [
-      "Day 28 | v. | English: to use satire to show the faults in a person, an organization, a system, etc. | Example: In the play, Aristophanes satirizes sophists as teaching students how to be persuasive without regard for what is morally good."
+      "['satararz] v. 讽刺"
     ]
   },
   {
     "name": "saturation",
     "trans": [
-      "Day 28 | n. | English: the degree to which something has been mixed into something else | Example: Contrasting a high saturation color palette against dark paper and stoneware, Atlanta-based artist Jina Moon creates fused pieces, wherein Korean folk art, Western contemporary art, and global popular culture mix."
+      "[.sat3'rerln] n. 饱和度"
     ]
   },
   {
     "name": "saunter",
     "trans": [
-      "Day 28 | v. | English: to walk in a slow relaxed way | Example: | sauntered along, forgetful of musty papers, of the offices, of my chief, my colleagues, my documents, and thinking of the good things that were sure to come to me, of all the veiled unknown contained in the future."
+      "['s3.ntar] v. 悠闲地走"
     ]
   },
   {
     "name": "scandal",
     "trans": [
-      "Day 28 | n. | English: behaviour or an event that people think is morally or legally wrong and causes public feelings of shock or anger | Example: President Richard Nixon is most famous for his participation in the 1970s Watergate political scandal, a convoluted tale of criminality and eroded ethics involving a constellation of associates such as security operative Jack Caulfield and Attorney General John Mitchell."
+      "['skandl] n. 丑闻"
     ]
   },
   {
     "name": "scarcely",
     "trans": [
-      "Day 28 | adv. | English: only just; almost not | Example: How [the sailor] haunted my dreams, | need scarcely tell you. On stormy nights, when the wind shook the four corners of the house and the surf roared along the cove and up the cliffs, | would see him in a thousand forms, and with a thousand diabolical expressions."
+      "['skersli] adv. 几乎不"
     ]
   },
   {
     "name": "scatter",
     "trans": [
-      "Day 28 | v. | English: to move or to make people or animals move very quickly in different directions | Example: Other bird species than M. barbatus also showed a tendency to freeze in place or scatter into vegetation when Martinez and colleagues played T. caesius alarm calls."
+      "['skatar] v. 散开"
     ]
   },
   {
     "name": "scattered",
     "trans": [
-      "Day 28 | adj. | English: spread far apart over a wide area or over a long period of time | Example: It was a scattered sort of a fair. If we didn't expect more, we got less."
+      "['skatard] adj. 零散的"
     ]
   },
   {
     "name": "scenario",
     "trans": [
-      "Day 28 | n. | English: a description of how things might happen in the future | Example: The speaker presents herself as fiercely independent and then recounts scenarios that demonstrate that independence."
+      "[sa'nriov] n. 设想"
     ]
   },
   {
     "name": "scene",
     "trans": [
-      "Day 28 | n. | English: a view that you see | Example: Do | behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more deep seclusion; and connect / The landscape with the quiet of the sky."
+      "[si:n] n. 景象"
     ]
   },
   {
     "name": "scope",
     "trans": [
-      "Day 28 | n. | English: the range of things that a subject, an organization, an activity, etc. deals with | Example: Given how little consensus there is among scientists regarding the scope of these categories, this discrepancy shouldn't be surprising: forest researchers regularly dispute one another's classifications."
+      "[skoup] n. 范围"
     ]
   },
   {
     "name": "scrupulous",
     "trans": [
-      "Day 28 | adj. | English: careful about paying attention to every detail | Example: The grey Prince Albert was scrupulously buttoned about his form, and a shiny top hat replaced the felt of the afternoon."
+      "['skru:pjalas] adj. 一丝不苟的"
     ]
   },
   {
     "name": "scrutinize",
     "trans": [
-      "Day 28 | v. | English: to look at or examine sb/sth carefully The statement was carefully scrutinized before publication."
+      "['skru:tanarz] v. 仔细检查"
     ]
   },
   {
     "name": "seam",
     "trans": [
-      "Day 28 | n. | English: a line along which two edges of cloth, etc. are joined or sewn together | Example: _Babou hummed to himself as he smoothed out my shoulder seams and rested his hands on them."
+      "[si:皿] n. （缝合两块布等的）线缝,接缝"
     ]
   },
   {
     "name": "secluded",
     "trans": [
-      "Day 28 | adj. | English: quiet and private; not used or disturbed by other people | Example: Do | behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more deep seclusion; and connect / The landscape with the quiet of the sky."
+      "[sI'klu:did] adj. 僻静的,不受打扰的"
     ]
   },
   {
     "name": "seclusion",
     "trans": [
-      "Day 28 | n. | English: the state of being private or of having little contact with other people | Example: Do | behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more deep seclusion; and connect / The landscape with the quiet of the sky."
+      "[sI'klu:3(3] n. 隐居,与世隔绝"
     ]
   },
   {
     "name": "secretive",
     "trans": [
-      "Day 28 | adj. | English: tending or liking to hide your thoughts, feelings, ideas, etc. from other people | Example: Maya civilization was highly secretive about its intellectual achievements."
+      "['si:kratrv] adj. （情感等）"
     ]
   },
   {
     "name": "sediment",
     "trans": [
-      "Day 28 | n. | English: the solid material that settles at the bottom of a liquid | Example: When it is exposed to air and water, wood rots quickly unless it is protected by sediment that shields it from oxygen."
+      "['scdrmant] n. 沉淀物"
     ]
   },
   {
     "name": "sedimentary",
     "trans": [
-      "Day 28 | adj. | English: connected with or formed from the sand, stones, mud, etc. that settle at the bottom of lakes, etc. | Example: The Nile River delta system is located in Northern Egypt, where the river drains into the Mediterranean Sea, and is shaped by interdependent factors: for example, the geography of the coastline influences sedimentary deposition, which over time alters coastal geography."
+      "[.sedI'mentri] adj. 沉积形成的"
     ]
   },
   {
     "name": "seismic",
     "trans": [
-      "Day 28 | adj. | English: connected with or caused by earthquakes | Example: The equipment from the Apollo Moon landings (1969-1972), such as solar wind sensors and seismic sensors, remains there to this day, but the data from these missions were mostly inaccessible until a recent data-transfer project made them available."
+      "['sarzIik] adj. 地震的"
     ]
   },
   {
     "name": "semantic",
     "trans": [
-      "Day 28 | adj. | English: connected with the meaning of words and sentences | Example: Semantic relations among the two nouns and the concept they signify can be tenuous."
+      "adj. 语义的"
     ]
   },
   {
     "name": "semblance",
     "trans": [
-      "Day 28 | n. | English: a situation in which sth seems to exist although this may not, in fact, be the case Some robots such as Surena (developed in 2008) and COMAN (developed in 2012) are designed to resemble humans so that people will find it easier to interact with them. To this end, certain features such as the ability to respond to voice commands can help to create the comforting semblance of humanity."
+      "['scmblans] n. 表象"
     ]
   },
   {
     "name": "semiconductor",
     "trans": [
-      "Day 28 | n. | English: asolid substance that conducts electricity in particular conditions, better than insulators but not as well as conductors | Example: The invention in 1958 of the integrated circuit (or microchip) radically altered the semiconductor industry."
+      "['scmikandxktar] n. 半导体"
     ]
   },
   {
     "name": "sensation",
     "trans": [
-      "Day 28 | n. | English: very great surprise, excitement, or interest among a lot of people; the person or the thing that causes this surprise | Example: By the laity of Milby and its neighbourhood [Mr. Ely] was regarded as a man of quite remarkable powers and learning, who must make a considerable sensation in London pulpits and drawing-rooms on his occasional visit to the metropolis."
+      "[sen'serln] n. 轰动"
     ]
   },
   {
     "name": "sentimental",
     "trans": [
-      "Day 28 | adj. | English: producing emotions such as pity, romantic love or sadness, which may be too strong or not appropriate; feeling these emotions too much | Example: In his afterword to Crowley's book Little, Big, Bloom argues that the novel adroitly blends what playwright Friedrich Schiller termed the naive and sentimental modes."
+      "[.scntr'mcntl] adj. 多愁善感的"
     ]
   },
   {
     "name": "serenity",
     "trans": [
-      "Day 28 | n. | English: peacefulness and calmness | Example: To contrast the demands of the speaker's everyday life with the serenity of being rocked to sleep by the ocean"
+      "[s3'renati] n. 平静"
     ]
   },
   {
     "name": "sermon",
     "trans": [
-      "Day 28 | n. | English: moral advice that a person tries to give you in a long talk | Example: The sermon is a sound of words spoken to the ear, and prepared only for present meditation and extends no farther than the strength of memory can convey it."
+      "['83:Iman] n. 冗长的说教"
     ]
   },
   {
     "name": "setting",
     "trans": [
-      "Day 28 | n. | English: a set of surroundings; the place at which sth happens | Example: It sketches a setting by presenting a series of images of nature."
+      "['setn] n. 环境"
     ]
   },
   {
     "name": "settlement",
     "trans": [
-      "Day 28 | n. | English: a place where people have come to live and make their homes, especially where few or no people lived before | Example: One challenge faced by researchers studying global urbanization is that countries may define urban settlements differently."
+      "['setlmant] n. 定居点"
     ]
   },
   {
     "name": "severity",
     "trans": [
-      "Day 28 | n. | English: seriousness | Example: It emphasizes the severity of a storm that is expected to arrive soon in Puerto Cabello."
+      "[SI'verati] n. 严重性"
     ]
   },
   {
     "name": "sharpen",
     "trans": [
-      "Day 28 | v. | English: to become or make sth better, more skilful, more effective, etc. than before | Example: Recent analyses of fossils like that of the individual known as KNM-KP 271, discovered in Kenya in 1963, have sharpened our picture of what a day in the life of KNM-KP 271 may have looked like."
+      "['Ja:rpan] v. （使"
     ]
   },
   {
     "name": "shed",
     "trans": [
-      "Day 28 | v. | English: to get rid of sth that is no longer wanted | Example: Instead, Luu et al. are likely correct that 6478 Gault is shedding mass due to rotational instability."
+      "[jed] v. 去除"
     ]
   },
   {
     "name": "sheen",
     "trans": [
-      "Day 28 | n. | English: a soft smooth shiny quality | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+      "[:\"] n. 光泽"
     ]
   },
   {
     "name": "sheer",
     "trans": [
-      "Day 28 | v. | English: v. to change direction suddenly, especially in order to avoid hitting sth; adj. (used to emphasize the size, degree or amount of sth) | Example: [1] And the shaggy Nannie goat is calling, calling, calling / From her little trampled corner of the long wide lea / That stretches to the waters of the hill-stream falling / Sheer upon the flat rocks joyously. 2] The minor planet 1095 Tulipa was named after the plant genus that includes tulips, but given the sheer number of minor planets that have been discovered (more than 500,000 so far), most are given only an identification number."
+      "v.；v.；adj. （用来强调事物的大小"
     ]
   },
   {
     "name": "shell",
     "trans": [
-      "Day 28 | n. | English: the hard outer part of eggs, nuts, some seeds and some animals | Example: With a shell that measured 1.7 meters, the extinct mollusk Parapuzosia seppenradensis is the largest ammonite in the fossil record."
+      "[fel] n. 壳"
     ]
   },
   {
     "name": "shipwreck",
     "trans": [
-      "Day 28 | n. | English: a ship that has been lost or destroyed at sea | Example: Rachel Mugge and colleagues were particularly curious about the effects of wooden shipwrecks on seafloor microbial communities."
+      "[Jiprek] n. 失事的船"
     ]
   },
   {
     "name": "shrewd",
     "trans": [
-      "Day 28 | adj. | English: clever at understanding and making judgements about a situation | Example: She is a shrewd judge of character."
+      "[fiu:d] adj. 精明的"
     ]
   },
   {
     "name": "shriek",
     "trans": [
-      "Day 28 | n. | English: a loud high shout, for example one that you make when you are excited, frightened or in pain | Example: Two shrieks pierced the air simultaneously, as the two trains passed each other."
+      "[fri:k] n. 尖叫"
     ]
   },
   {
     "name": "shrill",
     "trans": [
-      "Day 28 | v. | English: to make an unpleasant high loud sound | Example: Among the wild rice in the still lagoon. / In monotone the lizard shrills his tune. / The wild goose, homing, seeks a sheltering, / Where rushes grow, and oozing lichens cling."
+      "v. 发出刺耳的声音"
     ]
   },
   {
     "name": "shrink",
     "trans": [
-      "Day 28 | v. | English: to become or to make sth smaller in size or amount | Example: In southern and central Georgia, many buildings and other structures rest on soil that is expansive, meaning that it swells or shrinks as its moisture level changes."
+      "[figk] v. （使）缩小,收缩,减少"
     ]
   },
   {
     "name": "shroud",
     "trans": [
-      "Day 28 | n. | English: a thing that covers, surrounds or hides sth | Example: And having cleared the ramparts | had to confess the sky was clearing, prior to its winding in the other shroud, night."
+      "[fragd] n. 覆盖物"
     ]
   },
   {
     "name": "shuffle",
     "trans": [
-      "Day 29 | v. | English: to move paper or things into different positions or a different order | Example: When exposed to low levels of light, the plant's chloroplasts— the cellular organs that generate energy from light—reshuffled to form a tightly packed, glass-like surface ideal for collecting more light."
+      "['Jfl] v. 把（纸张等）娈换位置"
     ]
   },
   {
     "name": "sidewalk",
     "trans": [
-      "Day 29 | n. | English: A sidewalk is a path with a hard surface by the side of a road. | Example: Some cities track pedestrian activity to map their sidewalks, but this method often neglects sidewalks few pedestrians use, resulting in incomplete maps."
+      "['saIdwo:k] n. 人行道"
     ]
   },
   {
     "name": "sierra",
     "trans": [
-      "Day 29 | n. | English: a long range of steep mountains with sharp points, especially in Spain and America | Example: The sierra is clad in gala colors. Over its inaccessible peaks the opalescent fog settles like a snowy veil on the forehead of a bride."
+      "[si'era] n. 锯齿状山脉"
     ]
   },
   {
     "name": "sigh",
     "trans": [
-      "Day 29 | v. | English: to take and then let out a long deep breath that can be heard, to show that you are disappointed, sad, tired, etc. | Example: In his solitary retreat on the shore of the sea, whose mobile surface was visible through the open windows, extending outward until it mingled with the horizon, Padre Florentino was relieving the monotony by playing on his harmonium sad and melancholy tunes, to which the sonorous roar of the surf and the sighing of the treetops of the neighboring wood served as accompaniments."
+      "[sa] v. 叹气"
     ]
   },
   {
     "name": "signature",
     "trans": [
-      "Day 29 | n. | English: a particular quality that makes sth different from other similar things and makes it easy to recognize | Example: In addition, while wild foxes have a diet entirely made of meat, isotopic signatures of the skeleton's teeth indicated that the fox's diet, like that of the humans, was partly composed of plant material."
+      "['signatfar] n. 特征"
     ]
   },
   {
     "name": "silhouette",
     "trans": [
-      "Day 29 | n. | English: a picture that shows sb/sth as a black shape against a light background, especially one that shows the side view of a person's fac | Example: Over the course of three years, Reiniger and her collaborators painstakingly made more than 250,000 individual images of hand-cut paper silhouettes and repeatedly had to invent entirely new methods and tools to create the special effects Reiniger envisioned."
+      "[srlu'et] n. 剪影"
     ]
   },
   {
     "name": "simulate",
     "trans": [
-      "Day 29 | v. | English: to create particular conditions that exist in real life using computers, models, etc., usually for study or training purposes | Example: They found that during harmless simulated attacks on isolated caterpillars, 33% of the tested species produced sound, which ranged from clicks in Actias luna to chirps in Schausiella santarosensis."
+      "['smmjulert] v. 用计算机或模型等二"
     ]
   },
   {
     "name": "simulation",
     "trans": [
-      "Day 29 | n. | English: a situation in which a particular set of conditions is created artificially in order to study or experience sth that could exist in reality | Example: Stars form in cloudlike swirls of gas and dust that cannot be touched, but astrophysicist Nia Imara believes these formations need not remain completely intangible to researchers: she uses simulation data and sophisticated 3D printers to produce interactive models of these stellar nurseries."
+      "[sIju'lerln] n. 模拟"
     ]
   },
   {
     "name": "simultaneous",
     "trans": [
-      "Day 29 | adj. | English: happening or done at the same time as sth else | Example: Two shrieks pierced the air simultaneously, as the two trains passed each other."
+      "[.salml'temnias] adj. 同时发生的"
     ]
   },
   {
     "name": "skeptical",
     "trans": [
-      "Day 29 | adj. | English: having doubts that a claim or statement is true or that sth will happen | Example: Participants regarded the experiences of both the doctors and former trial volunteers as relevant to the subject of clinical trials but were skeptical of the doctors' status as credentialed experts."
+      "['skeptkl] adj. 持怀疑态度的"
     ]
   },
   {
     "name": "sketch",
     "trans": [
-      "Day 29 | v. | English: to give a general description of sth, giving only the basic facts | Example: It sketches a setting by presenting a series of images of nature."
+      "[sketl] v. 概述"
     ]
   },
   {
     "name": "slumber",
     "trans": [
-      "Day 29 | v. | English: v. to sleep; n. sleep | Example: [1] You have not known what you are, you have slumber'd upon yourself / all your life, / Your eyelids have been the same as closed most of the time. 2] Blessed are the slumbers of the innocent! They are kindlier than balm, and they refresh and gladden the spirit of childhood, like ministerings from a better world."
+      "['slmbar] v.；v.；n. 睡眠"
     ]
   },
   {
     "name": "slumberous",
     "trans": [
-      "Day 29 | adj. | English: sleepy; drowsy | Example: Just let me drift far out from toil and care, / Where lapping of the waves shall be the sound, / Which mingled with the winds that gently bear / Me on between a peaceful sea and sky, /To make my soothing slumberous lullaby."
+      "adj. 想睡的"
     ]
   },
   {
     "name": "smoulder",
     "trans": [
-      "Day 29 | v. | English: Ifa feeling such as anger or hatred smoulders inside you, you continue to feel it but do not show it. | Example: “The color is repellant, almost revolting; a smouldering unclean yellow, strangely faded by the slow-turning sunlight.”"
+      "v. （愤怒或仇恨等情感）"
     ]
   },
   {
     "name": "sob",
     "trans": [
-      "Day 29 | n. | English: n. an act or the sound of sobbing; v. to cry noisily, taking sudden, sharp breaths | Example: [1] “The [train] engines of this valley have a whistle, the echoes of which sound like iterated gasps and sobs. | always think of them as crude music.” 2] Then we sit and sob, and long for the gas-lit streets, and the sound of human voices, and the answering throb of human life."
+      "[sa:b] n.；n.；v. 抽噎"
     ]
   },
   {
     "name": "solicit",
     "trans": [
-      "Day 29 | v. | English: to ask sb for sth, such as support, money, or information; to try to get sth or persuade sb to do sth | Example: This was the case for both separation problems and dog rivalry but was especially pronounced for attachment and attention-seeking, which can be seen when a dog solicits affection or attention."
+      "[s3'IIsit] v. 索求"
     ]
   },
   {
     "name": "solidify",
     "trans": [
-      "Day 29 | v. | English: to become or to make sth become more definite and less likely to change | Example: Now, by producing acclaimed works, Gary Pak has solidified his place in that literary tradition."
+      "[s3'Iidrfar] v. 巩固"
     ]
   },
   {
     "name": "solitary",
     "trans": [
-      "Day 29 | adj. | English: done alone; without other people | Example: Caterpillars that were found to produce sounds in response to simulated attacks are typically solitary and were tested in isolation."
+      "['sa:lateri] adj. 单独的"
     ]
   },
   {
     "name": "solitude",
     "trans": [
-      "Day 29 | n. | English: the state of being alone, especially when you find this pleasant | Example: The following text is from Sara Teasdale’s 1922 poem “Two Songs for Solitude.”"
+      "['sa:latu:d] n. 独处"
     ]
   },
   {
     "name": "solstice",
     "trans": [
-      "Day 29 | n. | English: either of the two times of the year at which the sun reaches its highest or lowest point in the sky at midday, marked by the longest and shortest days | Example: By observing the sun's position in relation to various points on the mountains surrounding the Basin of Mexico, the Mexica were able to precisely identify the dates when significant events such as solstices occurred."
+      "n. （夏或冬）至"
     ]
   },
   {
     "name": "sonorous",
     "trans": [
-      "Day 29 | adj. | English: having a pleasant full deep sound The sonorous, joyful bells rang again. From within the church, the honeyed voices of a female chorus rose melancholy and grave."
+      "['sa:naras] adj. 雄浑的,浑厚的"
     ]
   },
   {
     "name": "soothe",
     "trans": [
-      "Day 29 | v. | English: to make sb who is anxious, upset, etc. feel calmer | Example: Some robots such as Surena (developed in 2008) and COMAN (developed in 2012) are designed to resemble humans so that people will find it easier to interact with them. To this end, certain features such as the ability to respond to voice commands can help to create the comforting semblance of humanity, but a robot that appears too similar to humans can make people feel more unsettled than soothed."
+      "[su:0] v. 安慰"
     ]
   },
   {
     "name": "sophist",
     "trans": [
-      "Day 29 | n. | English: a teacher of philosophy in ancient Greece, especially one with an attitude of doubting that statements are true | Example: Socrates, a sophist, explains why he studies astronomy while sitting in a basket hanging a few feet off the ground, saying, \"| should not have rightly discovered things celestial if | had not suspended the intellect, and mixed the thought in a subtle form with its kindred air.\""
+      "n. （尤指怀质疑态度的）哲人,智者"
     ]
   },
   {
     "name": "sophisticated",
     "trans": [
-      "Day 29 | adj. | English: clever and complicated in the way that it works or is presented | Example: By conceding that the genre of historical fiction contains many works that are less sophisticated than Sula is"
+      "[53'fistkertd] adj. 复杂精妙的"
     ]
   },
   {
     "name": "sophistication",
     "trans": [
-      "Day 29 | n. | English: the quality of being sophisticated | Example: It would take many decades to build up the level of education and sophistication required."
+      "[53,fistr'kerhn] n. 复杂巧妙"
     ]
   },
   {
     "name": "sovereignty",
     "trans": [
-      "Day 29 | n. | English: the state of being a country with freedom to govern itself | Example: He has been praised for his role in affirming the sovereignty of tribal nations, and he once made an attempt at reforming United States health care policy that is arguably a precursor to the Affordable Care Act, which became law during the Barack Obama administration."
+      "['sa:vranti] n. 独立自主"
     ]
   },
   {
     "name": "spark",
     "trans": [
-      "Day 29 | v. | English: to cause sth to start or develop, especially suddenly | Example: Extensive travels abroad later sparked an engagement with modernist and functionalist aesthetics."
+      "[spa:I] v. 引发"
     ]
   },
   {
     "name": "spatial",
     "trans": [
-      "Day 29 | adj. | English: relating to space and the position, size, shape, etc. of things in it | Example: Economist Jingting Fan argues that the effects of international trade may display spatial variation at sub-national levels."
+      "['sperl] adj. 空间的"
     ]
   },
   {
     "name": "spawn",
     "trans": [
-      "Day 29 | n. | English: to lay eggs | Example: The logjams create shady pools where the blueback salmon can rest and spawn, thus promoting blueback population recovery."
+      "[5p3:\"] n. 产卵"
     ]
   },
   {
     "name": "spear",
     "trans": [
-      "Day 29 | n. | English: a weapon with a long wooden handle and a sharp metal point used for fighting, hunting and fishing in the past | Example: Researchers have long hypothesized that woolly mammoths were hunted to extinction in North America by humans using spears with grooved tips known as Clovis points."
+      "[spr] n. 矛"
     ]
   },
   {
     "name": "spearhead",
     "trans": [
-      "Day 29 | v. | English: to begin an activity or lead an attack against sb/sth | Example: Led by experienced organizers such as Dorothy Cotton and Septima Clark, CEP attendees—more than 7,000 in all—participated in workshops on topics ranging from public speaking to legal doctrine before returning home and using their newly acquired knowledge to spearhead local civil rights initiatives."
+      "['sprrhed] v. 的先锋"
     ]
   },
   {
     "name": "specimen",
     "trans": [
-      "Day 29 | n. | English: a small amount of sth that shows what the rest of it is like | Example: Excavating a pterosaur fossil is a difficult process, since it can take weeks or even months of hard, physically tiring work to clear away the dirt and rock covering the specimen."
+      "['spesrman] n. 标本"
     ]
   },
   {
     "name": "speck",
     "trans": [
-      "Day 29 | n. | English: avery small spot; a small piece of dirt, etc | Example: He watches his father raise a kite within minutes into the wind, so high that Gogol must tip his head back in order to see, a rippling speck against the sky."
+      "[spek] n. 小点"
     ]
   },
   {
     "name": "spectacle",
     "trans": [
-      "Day 29 | n. | English: a performance or an event that is very impressive and exciting to look at | Example: The bald cypresses spread themselves along the water courses while the willows wept as they always did. Mr. Bradford was conscious of this gorgeous spectacle of nature."
+      "['spektakl] n. 壮观的场面"
     ]
   },
   {
     "name": "spectral",
     "trans": [
-      "Day 29 | adj. | English: like a ghost ; connected with a ghost | Example: At five-thirty the old Panhandle bridge, supported by massive sandstone pillars, stalwart, as when erected fifty years before to serve a generation now passed behind the portals of life, had become a spectral outline against the sky."
+      "['spektral] adj. 幽灵似的"
     ]
   },
   {
     "name": "speculate",
     "trans": [
-      "Day 29 | v. | English: to form an opinion about sth without knowing all the details or facts | Example: It examines how tribal citizens responded to exhibits at tribal cultural centers, then speculates how non-Indigenous audiences would respond to the same exhibits."
+      "['spekjulert] v. 猜测"
     ]
   },
   {
     "name": "spew",
     "trans": [
-      "Day 29 | v. | English: to flow out quickly, or to make sth flow out quickly, in large amounts | Example: | think Québec City needs more streets like Rue du Petit-Champlain, not more streets full of loud cars spewing exhaust fumes into the air."
+      "[spju:] v. （使）喷出,涌出"
     ]
   },
   {
     "name": "spillover",
     "trans": [
-      "Day 29 | n. | English: the results or the effects of sth that have spread to other situations or places | Example: The potential for knowledge spillovers, a dominant driver of collocation in this industry, was largely absent from the paint manufacturing industry."
+      "['splloovar] n. 影响"
     ]
   },
   {
     "name": "spiteful",
     "trans": [
-      "Day 29 | adj. | English: behaving in an unkind way in order to hurt or upset sb | Example: You are cultured and intelligent, [Vanya], and you surely understand that the world is not destroyed by villains and conflagrations, but by hate and malice and all this spiteful tattling."
+      "['spartfl] adj. 恶意的"
     ]
   },
   {
     "name": "splash",
     "trans": [
-      "Day 29 | v. | English: to make sb/sth wet by making water, mud, etc. fall on them/it | Example: People splash and spray each other for fun at the festival's community-wide water fights."
+      "[splal] v. （泥等）泼在"
     ]
   },
   {
     "name": "spoilt",
     "trans": [
-      "Day 29 | adj. | English: rude and badly behaved because they are given everything they ask for and not enough discipline | Example: The banker, spoilt and frivolous, with millions beyond his reckoning, was delighted at the bet."
+      "[spoilt] adj. 宠坏的"
     ]
   },
   {
     "name": "spontaneously",
     "trans": [
-      "Day 29 | n. | English: happen naturally without being made to happen | Example: When classical pianist Martha Argerich performs, it appears as if the music is coming to her spontaneously."
+      "[spa:n'tcmniasli] n. 自发地"
     ]
   },
   {
     "name": "sporadic",
     "trans": [
-      "Day 29 | adj. | English: happening only occasionally or at intervals that are not regular | Example: As Rachana Kamtekar observes, this argument is difficult to reconcile with our lay conception of character: we expect a person of helpful character to be frequently helpful, not sporadically helpful."
+      "[sp3'radik] adj. 偶尔发生的"
     ]
   },
   {
     "name": "spray",
     "trans": [
-      "Day 29 | v. | English: to cover sb/sth with very small drops of a liquid that are forced out of a container or sent through the air | Example: Sprinkler irrigation systems are a contemporary way of irrigating that requires machinery to spray water in all directions. springup Bi, iW 32 3CF% SL: If something springs up, it suddenly appears or begins to exist. A gleaming carpet was springing up everywhere."
+      "[sprer] v. 喷洒"
     ]
   },
   {
     "name": "spring up",
     "trans": [
-      "Day 29 | English: If something springs up, it suddenly appears or begins to exist. | Example: A gleaming carpet was springing up everywhere."
+      "冒出,涌现"
     ]
   },
   {
     "name": "sprout",
     "trans": [
-      "Day 29 | v. | English: (of plants or seeds) to produce new leaves or buds | Example: In fact, some species actually did better in Martian soil than in Earth soil: 30 percent of field mustard seeds sprouted when planted in simulated Martian soil, compared with 4 percent that did when planted in soil from their home planet."
+      "[spraot] v. 发芽"
     ]
   },
   {
     "name": "spur",
     "trans": [
-      "Day 29 | v. | English: to encourage a horse to go faster, especially by pushing the spurs on your boots into its side | Example: They spurred their horses to a gallop as if in that mad race they laid claims of possession to the earth."
+      "[503:1] v. 策（马）前进"
     ]
   },
   {
     "name": "spurious",
     "trans": [
-      "Day 29 | adj. | English: false, although seeming to be genuine | Example: Though most hoaxes perpetrated as jokes by mischievous users of Wikipedia, an online encyclopedia that almost anyone can freely edit, have quickly been detected and removed, a few entries that knowledgeable readers should have realized were spurious, such as those for the American new wave band Transforatix and the 19th-century German poet Emilia Dering, persisted on the site for many years before they were finally recognized as falsehoods and deleted."
+      "['spjurios] adj. 虚假的"
     ]
   },
   {
     "name": "stage",
     "trans": [
-      "Day 29 | v. | English: to organize and present a play or an event for people to see | Example: While they might be eager to produce an established classic like Annie, for example, most would be hesitant to stage a work from a relatively unknown playwright."
+      "[sterd3] v. 上演,举办"
     ]
   },
   {
     "name": "staging",
     "trans": [
-      "Day 29 | n. | English: the way in which a play is produced and presented on stage | Example: | aim to create a clear sense of the character and the world they inhabit. Sometimes this means adhering to the historical period's style, but frequently, as in stagings of A Midsummer Night's Dream, some flexibility is required to communicate an idea to the audience."
+      "n. 演出形式"
     ]
   },
   {
     "name": "stagnant",
     "trans": [
-      "Day 30 | adj. | English: not developing, growing or changing | Example: Early Earth is thought to have been characterized by a stagnant lid tectonic regime."
+      "['stagnant] adj. 无娈化的"
     ]
   },
   {
     "name": "stalwart",
     "trans": [
-      "Day 30 | adj. | English: loyal and able to be relied on, even in a difficult situation | Example: At five-thirty the old Panhandle bridge, supported by massive sandstone pillars, stalwart, as when erected fifty years before to serve a generation now passed behind the portals of life, had become a spectral outline against the sky."
+      "['st3:Iwart] adj. 忠实的"
     ]
   },
   {
     "name": "stance",
     "trans": [
-      "Day 30 | n. | English: the opinions that sb has about sth and expresses publicly | Example: Thus, Enke et al. suggest that although the behavior of high-income earners who advocate for higher taxes may seem counterintuitive, such people likely do so because they feel enabled by their economic security to take a stance they think is morally correct."
+      "[stans] n. （公开表明的）"
     ]
   },
   {
     "name": "staple",
     "trans": [
-      "Day 30 | English: a basic type of food that is used a lot | Example: Kwaxsistalla WathI'thla, a song keeper for the Kwakwaka'wakw people in Canada, collaborated with ethnobiologist Dana Lepofsky et al., sharing songs referencing terraced intertidal clam gardens the people implemented in the past to foster healthy development of a dietary staple."
+      "['sterpl] 主食"
     ]
   },
   {
     "name": "startle",
     "trans": [
-      "Day 30 | v. | English: to surprise sb suddenly in a way that slightly shocks or frightens them | Example: I didn't mean to startle you."
+      "['sta:rtl] v. 使大吃一惊"
     ]
   },
   {
     "name": "statue",
     "trans": [
-      "Day 30 | n. | English: a figure of a person or an animal in stone, metal, etc., usually the same size as in real life or larger We simply do not know enough about the people of the time to say with certainty what the statue meant to them."
+      "['statfu:] n. 雕塑"
     ]
   },
   {
     "name": "steady",
     "trans": [
-      "Day 30 | adj. | English: not changing and not interrupted | Example: Many believe that lullabies, characterized by their less steady beat, contain some acoustic features that are universally calming to infants."
+      "['stedi] adj. 稳定的"
     ]
   },
   {
     "name": "steep",
     "trans": [
-      "Day 30 | adj. | English: rising or falling quickly, not gradually | Example: Do | behold these steep and lofty cliffs, / Which on a wild secluded scene impress / Thoughts of more deep seclusion; and connect / The landscape with the quiet of the sky."
+      "[sti:p] adj. 陡峭的"
     ]
   },
   {
     "name": "steer",
     "trans": [
-      "Day 30 | v. | English: if you steer someone in a particular direction, you guide them there | Example: [The Rat] had patiently hunted through the wood for an hour or more, when at last to his joy he heard a little answering cry. Steering himself by the sound, he made his way through the gathering darkness to the foot of an old beech tree."
+      "[str] v. 引领"
     ]
   },
   {
     "name": "stellar",
     "trans": [
-      "Day 30 | adj. | English: connected with the stars | Example: Stars form in cloudlike swirls of gas and dust that cannot be touched, but astrophysicist Nia Imara believes these formations need not remain completely intangible to researchers: she uses simulation data and sophisticated 3D printers to produce interactive models of these stellar nurseries."
+      "['stelar] adj. 恒星的"
     ]
   },
   {
     "name": "still",
     "trans": [
-      "Day 30 | adj. | English: not moving; calm and quiet | Example: [The] Mole stood still a moment, held in thought."
+      "[strl] adj. 静止的"
     ]
   },
   {
     "name": "stimulus",
     "trans": [
-      "Day 30 | n. | English: something that helps sb/sth to develop better or more quickly | Example: Bainbridge and colleagues also measured pupil size, as pupils typically become larger when a stimulus captures a person's attention."
+      "['strmjalas] n. 刺激物"
     ]
   },
   {
     "name": "stirring",
     "trans": [
-      "Day 30 | adj. | English: causing strong feelings; exciting | Example: Those who have had the rare privilege of reading her stirring biography, will, | am sure, bear me out in this statement."
+      "adj. 激动人心的"
     ]
   },
   {
     "name": "straddle",
     "trans": [
-      "Day 30 | v. | English: to sit or stand with one of your legs on either side of sb/sth | Example: The late-period pieces of James Tate arguably fit this description, since they straddle the line between prose and poetry."
+      "['stradl] v. 跨坐"
     ]
   },
   {
     "name": "straighten",
     "trans": [
-      "Day 30 | v. | English: to make your body straight and vertical | Example: He stood up and straightened his shoulders."
+      "v. 挺直,端正"
     ]
   },
   {
     "name": "strand",
     "trans": [
-      "Day 30 | n. | English: a single thin piece of thread, wire, hair, etc. | Example: Is there an available barrier material that can block roots and liquids while allowing fungal strands through?"
+      "[strend] n. （毛发等的）股"
     ]
   },
   {
     "name": "strata",
     "trans": [
-      "Day 30 | n. | English: a layer or set of layers of rock, earth, etc. | Example: The sequence of strata shows where the animal roamed during life."
+      "['strerta] n. 复数"
     ]
   },
   {
     "name": "stratum",
     "trans": [
-      "Day 30 | n. | English: a layer or set of layers of rock, earth, etc. | Example: Mammoth tusks grew in sequential layers, incorporating ingested minerals and organics, and so each ivory stratum reflects the ratio of strontium isotopes (87Sr/86Sr) in the local environment."
+      "['strertam] n. 层"
     ]
   },
   {
     "name": "strenuous",
     "trans": [
-      "Day 30 | adj. | English: needing great effort and energy; showing great energy and determination | Example: In the novel, a group of soldiers travel through a canyon, where their collective mood becomes strongly affected by the strenuous conditions of their journey."
+      "['strenjuas] adj. 费力的"
     ]
   },
   {
     "name": "stretch",
     "trans": [
-      "Day 30 | v. | English: v. to put out an arm ora leg in order to reach sth; v. to continue over a period of time [1] \"I'm going to have one of these gorgeous oranges,\" said Mrs. Wilkins, staying where she was and stretching toward a black bowl piled with them. | Example: 2] Although the literary works of David Malo and Lee Cataluna have universal appeal, they are also inextricable from the Hawaiian literary tradition in which both authors work and that stretches back to the traditional stories of the Kanaka Maoli, the Native Hawaiian people."
+      "[stretj] v.；v.；v. 伸出,伸长"
     ]
   },
   {
     "name": "strictly",
     "trans": [
-      "Day 30 | adv. | English: with a lot of control and rules that must be obeyed | Example: People sometimes dismiss a claim if it comes from a source they regard as self-interested, but from a strictly logical perspective, the source of a claim is irrelevant."
+      "['strktli] adv. 严格地"
     ]
   },
   {
     "name": "stricture",
     "trans": [
-      "Day 30 | n. | English: a severe criticism, especially of sb's behaviou | Example: The Times [a British newspaper], replying to some foreign strictures on the dress, looks, and behavior of the English abroad, urges that the English ideal is that everyone should be free to do and to look just as he likes."
+      "['striktfar] n. 指责"
     ]
   },
   {
     "name": "strife",
     "trans": [
-      "Day 30 | n. | English: angry or violent disagreement between two people or groups of people | Example: He told me how calm his soul was laid / By the lack of anvil and strife."
+      "[strarf] n. 冲突"
     ]
   },
   {
     "name": "striking",
     "trans": [
-      "Day 30 | adj. | English: interesting and unusual enough to attract attention | Example: Cuttlefish changed their striking position to match the 3D images, suggesting that their vision is more like that of sheep and falcons than that of octopuses or squid."
+      "['strarkn] adj. 显著的"
     ]
   },
   {
     "name": "strip",
     "trans": [
-      "Day 30 | n. | English: along narrow area of land, sea, etc | Example: As with other river deltas, the Krishna River delta is dynamic: it is a constantly evolving network of channels and strips of land that change in size and shape as the river deposits new sedimentary particles where the river meets the waters of the Bay of Bengal."
+      "[strp] n. 狭长地带"
     ]
   },
   {
     "name": "strive",
     "trans": [
-      "Day 30 | v. | English: to try very hard to achieve sth | Example: Each is contemptuous of the other attendees but strives to impress them."
+      "[strarv] v. 努力"
     ]
   },
   {
     "name": "stroke",
     "trans": [
-      "Day 30 | n. | English: a single movement of the arm when hitting sb/sth One person after another rose, and, as with an ill-balanced axe, attempted to hew out his conception of art a little more clearly, and sat down with the feeling that, for some reason which he could not grasp, his strokes had gone awry."
+      "[strouk] n. （击等的）"
     ]
   },
   {
     "name": "sturdy",
     "trans": [
-      "Day 30 | adj. | English: physically strong and healthy | Example: It compares the sturdiness of two types of boats."
+      "['st3:rdi] adj. 结实的"
     ]
   },
   {
     "name": "stymie",
     "trans": [
-      "Day 30 | v. | English: to prevent sb from doing sth that they have planned or want to do; to prevent sth from happening | Example: Proposals to raise the age at which retirees begin receiving government transfers of funds are generally discussed in terms of the effects on transfer recipients, but Andria Smythe has argued that delaying such transfers could stymie wealth creation among working adults by lengthening the period in which they are providing financial support to their nonworking parents."
+      "['starmi] v. 阻碍"
     ]
   },
   {
     "name": "subdued",
     "trans": [
-      "Day 30 | adj. | English: not very bright | Example: Although oil shocks—such as the 16% rise in oil prices from April to September of 1973—can strongly affect individual consumers, Gbadebo Oladosu and colleagues have shown that at the level of national economies, their effects are often quite subdued."
+      "[sab'du:d] adj. 柔和的"
     ]
   },
   {
     "name": "subordinate",
     "trans": [
-      "Day 30 | adj. | English: less important than sth else | Example: Today, the mobile application Instagram is thought of exclusively as a photo- and video- sharing program, but image sharing was originally subordinate to the app's main purpose, which was to allow users to indicate their locations to other users in real time."
+      "[53'b3:rdmat] adj. 次要的"
     ]
   },
   {
     "name": "subscribe",
     "trans": [
-      "Day 30 | v. | English: to pay an amount of money regularly in order to receive or use sth | Example: A survey found that in April 2022, 7.6 percent of subscribers to fashion and apparel services canceled their subscriptions."
+      "[s3b'skrarb] v. 订购"
     ]
   },
   {
     "name": "subsequent",
     "trans": [
-      "Day 30 | adj. | English: happening or coming after sth else | Example: It recounts a moment in Johnson's personal life that enabled the success of his subsequent career, which is summarized in the following sentence."
+      "['sAbsrkwant] adj. 随后的"
     ]
   },
   {
     "name": "subside",
     "trans": [
-      "Day 30 | v. | English: to become calmer or quieter | Example: Reducing this kind of subscriber turnover is especially challenging for subscription sellers: customers’ initial enthusiasm for a subscription is often quick to subside, and sellers must thus devise other incentives to bolster retention."
+      "[s3b'sad] v. 减弱"
     ]
   },
   {
     "name": "substantial",
     "trans": [
-      "Day 30 | adj. | English: of considerable importance, size, or worth | Example: By suggesting that future research may provide substantial advancements in the field of automated genre classification"
+      "[sab'stenjl] adj. 大量的"
     ]
   },
   {
     "name": "substitute",
     "trans": [
-      "Day 30 | v. | English: v. to take the place of sb/sth else; to use sb/sth instead of sb/sth els; n. a person or thing that you use or have instead of the one you normally use or have | Example: [1] Rai's approach substitutes a natural plant-based substance for the hazardous Chemicals that manufacturers have traditionally used. 2] Using a mechanical spear-thrower, he launched spears with Clovis points into mounds of clay—substitutes for the animals’ large bodies."
+      "['SAbstrtu:t] v.；v.；n. （以）代替"
     ]
   },
   {
     "name": "subtlety",
     "trans": [
-      "Day 30 | n. | English: the small but important details or aspects of sth | Example: The tendency to group authors together into distinct literary movements often encourages literary scholars to discount subtleties in an author's style."
+      "n. 细小但重要的地方,微妙之处"
     ]
   },
   {
     "name": "subvert",
     "trans": [
-      "Day 30 | v. | English: to try to destroy the authority of a political, religious, etc. system by attacking it secretly or indirectly | Example: In general terms, the young tend to subvert traditions."
+      "[53b'v3:r] v. 颠覆"
     ]
   },
   {
     "name": "succession",
     "trans": [
-      "Day 30 | n. | English: the regular pattern of one thing following another thing All day long [the soldiers] rode through the canyon, up and down the steep, round hills, dirty and bald as a man’s head, hill after hill in endless succession."
+      "[sak'se[(3] n. 交替"
     ]
   },
   {
     "name": "successor",
     "trans": [
-      "Day 30 | n. | English: a person or thing that comes after sb/sth else and takes their/its place | Example: Barring major archaeological discoveries, we are unlikely to ever have an exhaustive account of ancient Egypt under the female pharaoh Hatshepsut, as much of the evidence of her reign was deliberately destroyed by her successors."
+      "[sak'sesar] n. 继任者"
     ]
   },
   {
     "name": "summation",
     "trans": [
-      "Day 30 | n. | English: a summary of what has been done or said | Example: What he said was a fair summation of the discussion."
+      "n. 总结,概括"
     ]
   },
   {
     "name": "summit",
     "trans": [
-      "Day 30 | n. | English: the highest point of sth, especially the top of a mountai | Example: When he reached the summit, he glanced down to see the sun steeping the valley in a lake of gold."
+      "['sAmt] n. 最高点"
     ]
   },
   {
     "name": "summon",
     "trans": [
-      "Day 30 | v. | English: to make a feeling, an idea, a memory, etc. come into your mind | Example: Miranda's ability to summon details of an experience she had before arriving on the island suggests that she may also be able to summon details of her arrival on the island."
+      "['sAman] v. 唤起,使想起"
     ]
   },
   {
     "name": "superfluous",
     "trans": [
-      "Day 30 | adj. | English: Something that is superfluous is unnecessary or is no longer needed. | Example: In short, knowledge of economics is not superfluous and must not be left to economists alone."
+      "[su:'p3:Ifluas] adj. 多余的"
     ]
   },
   {
     "name": "superior",
     "trans": [
-      "Day 30 | adj. | English: better in quality than sb/sth else; greater than sb/sth else | Example: The program's performance was superior to that of the road-map method: it more accurately identified sidewalks, and it even distinguished between concrete and brick."
+      "[su:'plriar] adj. （在品质上）"
     ]
   },
   {
     "name": "supersede",
     "trans": [
-      "Day 30 | v. | English: to take the place of sth/sb that is considered to be old-fashioned or no longer the best available | Example: The theory has been superseded by more recent research."
+      "[.su:par'si:d] v. 取代"
     ]
   },
   {
     "name": "supplant",
     "trans": [
-      "Day 30 | v. | English: to take the place of sb/sth | Example: Douglass believes that rather than supplanting books, technology is simply making new forms of expression possible."
+      "[sa'plent] v. 取代"
     ]
   },
   {
     "name": "supplement",
     "trans": [
-      "Day 30 | v. | English: to add sth to sth in order to improve it or make it more complete | Example: There are many art exhibitions in the Art Institute of Chicago, but browsing some other art works in the street can supplement the visitor’s experience."
+      "['sAplmont] v. 增补,补充"
     ]
   },
   {
     "name": "supplemental",
     "trans": [
-      "Day 30 | adj. | English: provided in addition to sth else in order to improve or complete it | Example: Providing supplemental vitamin D to chimpanzees in zoos in Sweden and other mid-latitude countries would likely not be beneficial."
+      "[.SApla'mentl] adj. 额外的"
     ]
   },
   {
     "name": "supposition",
     "trans": [
-      "Day 30 | n. | English: an idea that you think is true although you may not be able to prove it | Example: Ifone has a supposition that the word “own” has a high incidence in English, for example, an analysis of a corpus can support that hypothesis by showing that “own” is the eighth most commonly used adjective."
+      "[.54p3'2Ihh] n. 推测"
     ]
   },
   {
     "name": "suppress",
     "trans": [
-      "Day 31 | v. | English: vv. to prevent sth from being published or made known; v. to prevent yourself from having or expressing a feeling or an emotion | Example: [1] Although the government of the Soviet Union attempted to suppress Georgi Viadimov's novel Faithful Ruslan, copies of the book circulated in secret among readers in several parts of the country. 2] Demetrio suppressed a sigh. Memories crowded and buzzed through his brain like bees about a hive."
+      "[sa'pres] v.；v. 禁止（发表）"
     ]
   },
   {
     "name": "surf",
     "trans": [
-      "Day 31 | n. | English: large waves in the sea or ocean, and the white foam that they produce as they fall on the beach, on rocks, etc. | Example: In his solitary retreat on the shore of the sea, whose mobile surface was visible through the open windows, extending outward until it mingled with the horizon, Padre Florentino was relieving the monotony by playing on his harmonium sad and melancholy tunes, to which the sonorous roar of the surf and the sighing of the treetops of the neighboring wood served as accompaniments."
+      "n. 拍岸浪花"
     ]
   },
   {
     "name": "surpass",
     "trans": [
-      "Day 31 | v. | English: to do or be better than sb/sth | Example: But El Paso surpassed all other cities in the state."
+      "[sarPRs] v. 超过"
     ]
   },
   {
     "name": "surplus",
     "trans": [
-      "Day 31 | n. | English: the amount by which the amount of money received is greater than the amount of money spent | Example: Although the government regularly defaulted on debt, it ran an even larger overall surplus than did the government of eighteenth-century Britain, which historians consider a model of fiscal virtue."
+      "['83:Il4s] n. 盈余"
     ]
   },
   {
     "name": "surrender",
     "trans": [
-      "Day 31 | v. | English: to admit that you have been defeated and want to stop fighting; to allow yourself to be caught, taken prisoner, etc. | Example: The hijackers eventually surrendered themselves to the police."
+      "[sa'rcndar] v. 投降"
     ]
   },
   {
     "name": "survey",
     "trans": [
-      "Day 31 | v. | English: to look carefully at the whole of sth, especially in order to get a general impression of it | Example: He surveyed the fence, and all gladness left him and a deep melancholy settled down upon his spirit."
+      "['s3:ver] v. 查看"
     ]
   },
   {
     "name": "susceptibility",
     "trans": [
-      "Day 31 | n. | English: the state of being very likely to be influenced, harmed or affected by sth | Example: These animals are thought to be especially vulnerable to ocean acidification due to calcium carbonate's susceptibility to dissolution at lower pH values."
+      "[83.scpta'bilati] n. 易受影响（或伤害等）的特性"
     ]
   },
   {
     "name": "susceptible",
     "trans": [
-      "Day 31 | adj. | English: very likely to be influenced, harmed or affected by sb/sth | Example: The Kaua''amakihi is an example of a species unique to the Hawaiian archipelago that is highly specialized and therefore particularly susceptible to habitat disturbances."
+      "[53'septabl] adj. （或伤害等）的"
     ]
   },
   {
     "name": "suspect",
     "trans": [
-      "Day 31 | v. | English: to be suspicious about sth | Example: Although historians strongly suspect that a particular sculpture is Desiderio's portrait bust of Strozzi, they do not currently have a method for conclusively verifying the artist or subject."
+      "[53'spekt] v. 怀疑"
     ]
   },
   {
     "name": "sustain",
     "trans": [
-      "Day 31 | v. | English: to provide enough of what sb/sth needs in order to live or exist | Example: Matthew S. Savoca and colleagues resolve this apparent discrepancy by pointing out that baleen whales cycle iron in the ocean, helping support phytoplankton populations, which, in turn, sustain krill populations."
+      "[53'stemn] v. （生命"
     ]
   },
   {
     "name": "swale",
     "trans": [
-      "Day 31 | n. | English: a moist depression in a tract of land, usually with rank vegetation | Example: Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow's o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+      "n. 沼泽地"
     ]
   },
   {
     "name": "swap",
     "trans": [
-      "Day 31 | v. | English: to replace one person or thing with another | Example: Wireless headphones and other small electronic devices sometimes use batteries that can't be taken out and swapped for new ones."
+      "[swa:p] v. 替换"
     ]
   },
   {
     "name": "swathe",
     "trans": [
-      "Day 31 | v. | English: to wrap or cover sb/sth in sth | Example: Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow’s o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+      "[swerd] v. 包"
     ]
   },
   {
     "name": "sweep",
     "trans": [
-      "Day 31 | n. | English: the range of an idea, a piece of writing, etc. that considers many different things | Example: Asimov wanted to convey the vast sweep of human history over centuries, and one of his points is that at such a timescale, individuals don't matter."
+      "[swi:p] n. 广博的范围"
     ]
   },
   {
     "name": "swell",
     "trans": [
-      "Day 31 | v. | English: to increase or make sth increase in number or size | Example: Thy warm and land-locked waters swell with an easy motion, / And gently glides the light"
+      "[swel] v. 增大,扩大"
     ]
   },
   {
     "name": "sweltering",
     "trans": [
-      "Day 31 | adj. | English: If you describe the weather as sweltering, you mean that it is extremely hot and makes you feel uncomfortable | Example: Summer is typically thought of as a sweltering season."
+      "['sweltarn] adj. 酷热难耐的"
     ]
   },
   {
     "name": "swoon",
     "trans": [
-      "Day 31 | v. | English: If you swoon, you are strongly affected by your feelings for someone you love or admire very much. | Example: My spirit swoons, and all my senses cry / For Ocean's breast and covering of the sky."
+      "v. 痴迷"
     ]
   },
   {
     "name": "symbolize",
     "trans": [
-      "Day 31 | v. | English: to be a symbol of sth | Example: The figures reach out to each other in a pose that symbolizes a close, supportive relationship."
+      "['sImbalarz] v. 象征"
     ]
   },
   {
     "name": "symmetry",
     "trans": [
-      "Day 31 | n. | English: the exact match in size and shape between two halves, parts or sides of sth | Example: The way in which individual elements are balanced within a photographic image tends to affect how viewers perceive it: symmetry tends to give the elements equal importance, asymmetry emphasizes differences, and radial balance (organizing the elements around a central point) emphasizes the center over the periphery."
+      "['sImatri] n. 对称"
     ]
   },
   {
     "name": "synonymous",
     "trans": [
-      "Day 31 | adj. | English: so closely connected with sth that the two things appear to be the same To conclude that this approach accounts for the ethereal qualities now synonymous with the Highwaymen aesthetic is tempting but inaccurate."
+      "[SI'na:nras] adj. 等同于"
     ]
   },
   {
     "name": "synopsis",
     "trans": [
-      "Day 31 | n. | English: asummary of a piece of writing, a play, etc. | Example: It provides a synopsis of an interaction in an Austen novel that illustrates a literary concept discussed in the following sentence."
+      "[sI'na:psIs] n. （剧本等的）大纲"
     ]
   },
   {
     "name": "tablet",
     "trans": [
-      "Day 31 | n. | English: a flat piece of stone that has words written on it, especially one that has been fixed to a wall in memory of an important person or event | Example: The team found a tablet in Merneith's tomb with writing suggesting that she was in charge of the country's treasury and other central offices."
+      "['tablat] n. （固定于墙上作纪念的）牌"
     ]
   },
   {
     "name": "tactile",
     "trans": [
-      "Day 31 | adj. | English: connected with the sense of touch; using your sense of touch | Example: Woven from recycled yarn and hand tufted using a carpet weaving technique passed down by the artist's Turkish grandmother, the topological tapestries of Argentine textile artist Alexandra Kehayoglou are so lush and tactilely inviting that you are tempted to reach out and touch them."
+      "['tektl] adj. 触觉的"
     ]
   },
   {
     "name": "tally",
     "trans": [
-      "Day 31 | v. | English: to calculate the total number, cost, etc. of sth | Example: One way to evaluate the importance of a scholar's research is to tally other scholars’ references to that research."
+      "['tl] v. 计算"
     ]
   },
   {
     "name": "tattle",
     "trans": [
-      "Day 31 | v. | English: to tell sb, especially sb in authority, about sth bad that sb else has done | Example: You are cultured and intelligent, [Vanya], and you surely understand that the world is not destroyed by villains and conflagrations, but by hate and malice and all this spiteful tattling."
+      "v. 打小报告"
     ]
   },
   {
     "name": "tectonic plate",
     "trans": [
-      "Day 31 | English: one of the parts of the earth's surface that move in relation to each other | Example: This project has allowed researcher Renee Weber to make use of the information in investigating tectonic activity on the Moon."
+      "地壳板块"
     ]
   },
   {
     "name": "telling",
     "trans": [
-      "Day 31 | adj. | English: showing effectively what sb/sth is really like, but often without intending to | Example: In harmonious periods and telling phrases the different shades of political opinion, the divergences and disagreements, are adjusted."
+      "['teln] adj. 能说明问题的"
     ]
   },
   {
     "name": "telltale",
     "trans": [
-      "Day 31 | adj. | English: showing that sth exists or has happened | Example: This structure, which the team named Nadir, exhibits all the telltale signs of a high-velocity impact crater."
+      "['telterl] adj. 能说明问题的"
     ]
   },
   {
     "name": "temperate",
     "trans": [
-      "Day 31 | adj. | English: having a mild temperature without extremes of heat or cold | Example: Much of the research ornithologists have carried out has been near universities in the temperate northern hemisphere, where female birdsong is less common than it is in the tropics."
+      "['temparat] adj. 温带的"
     ]
   },
   {
     "name": "tempest",
     "trans": [
-      "Day 31 | n. | English: a violent storm | Example: And while outside the tempest is raving o’er the ocean, / And the ship is madly driving on some lone and desert shore."
+      "['tempIst] n. 暴风雨"
     ]
   },
   {
     "name": "temporal",
     "trans": [
-      "Day 31 | adj. | English: connected with or limited by time | Example: Rafael Nufiez and colleagues recorded Yupno speakers explaining several of these temporal-related words and phrases and coded each speaker's manual gestures."
+      "['temparal] adj. 时间的"
     ]
   },
   {
     "name": "temporary",
     "trans": [
-      "Day 31 | adj. | English: lasting or intended to last or be used only for a short time; not permanen | Example: In the story, Mrs. Sommers attends a play, which she experiences as a temporary escape from the circumstances of her daily life."
+      "['tempareri] adj. 暂时的"
     ]
   },
   {
     "name": "tempting",
     "trans": [
-      "Day 31 | adj. | English: something that is tempting is attractive, and makes people want to have it, do it, etc. | Example: It is tempting to treat the clustering of information technology firms in Northern California as representative of industrial agglomeration generally."
+      "['temptn] adj. 吸引人的"
     ]
   },
   {
     "name": "tend",
     "trans": [
-      "Day 31 | v. | English: to care for sb/sth | Example: Louis Pipestone tended the petition like a garden."
+      "[tend] v. 照料"
     ]
   },
   {
     "name": "tender",
     "trans": [
-      "Day 31 | adj. | English: kind, gentle and loving | Example: Trade and science and craft and art, / Have opened their doors to the call of woman; / And greater she grows in her greater part, / More tenderly wise, and more sweetly human."
+      "['tendar] adj. 温柔的"
     ]
   },
   {
     "name": "tentacle",
     "trans": [
-      "Day 31 | n. | English: along thin part of the body of some creatures, such as an octopus , used for feeling or holding things, for moving or for getting food | Example: The fog extended its tentacles over city and river gradually obliterating traces of familiar landscapes."
+      "['tentakl] n. 触手,触须"
     ]
   },
   {
     "name": "tenuous",
     "trans": [
-      "Day 31 | adj. | English: so weak or uncertain that it hardly exists | Example: Semantic relations among the two nouns and the concept they signify can be tenuous."
+      "['tenjuas] adj. 站不住脚的"
     ]
   },
   {
     "name": "tenure",
     "trans": [
-      "Day 31 | n. | English: the period of time when sb holds an important job, especially a political one; the act of holding an important job | Example: Legal scholars James Melton and Tom Ginsburg's analysis of de jure judicial independence and its growth over decades identifies six constitutional features that enhance such independence, including judicial tenure and selection procedure. Romania's constitution contains one of these features."
+      "n. （尤指重要政治职务的"
     ]
   },
   {
     "name": "term",
     "trans": [
-      "Day 31 | v. | English: to use a particular name or word to describe sb/sth | Example: In his afterword to Crowley's book Little, Big, Bloom argues that the novel adroitly blends what playwright Friedrich Schiller termed the naive and sentimental modes."
+      "[t3:1m] v. 称为"
     ]
   },
   {
     "name": "terrain",
     "trans": [
-      "Day 31 | n. | English: used to refer to an area of land when you are mentioning its natural features, for example, if it is rough, flat, etc. | Example: Conservationists have argued that an ecosystem-based approach that incorporates the many interactions between the climate, terrain, and various species of a given geographical area may lead to better outcomes for all the species in a given location."
+      "[ta'rcmn] n. 地形"
     ]
   },
   {
     "name": "terrestrial",
     "trans": [
-      "Day 31 | adj. | English: operating on earth rather than from a satellit | Example: The declination, or celestial latitude, of the Aurigid meteor shower's radiant—the point in the sky from which, to a terrestrial observer, the shower's meteors appear to emanate—is 39 degrees, meaning that its radiant is located 39 degrees north of the celestial equator, in close"
+      "[ta'restrial] adj. （与卫星相对而言"
     ]
   },
   {
     "name": "tertiary",
     "trans": [
-      "Day 31 | adj. | English: third in order, rank or importance | Example: He might dissect, anatomize, and give names; but, not to speak of a final cause, causes in their secondary and tertiary grades were utterly unknown to him."
+      "['t3:rieri,'ts:rari] adj. 第三的"
     ]
   },
   {
     "name": "testament",
     "trans": [
-      "Day 31 | n. | English: a thing that shows that sth else exists or is true | Example: That his work is enjoyable despite this is a testament to his prodigious imagination—even if people read his books only for the ideas, they will have plenty to consider."
+      "['testamant] n. 证据,证明"
     ]
   },
   {
     "name": "thematic",
     "trans": [
-      "Day 31 | adj. | English: connected with the theme or themes of sth | Example: Although Hawaiian literature is highly heterogeneous in many ways, it is also characterized by considerable thematic continuity."
+      "adj. 主题的"
     ]
   },
   {
     "name": "thereby",
     "trans": [
-      "Day 31 | adv. | English: used to introduce the result of the action or situation mentioned | Example: Knowing this can assuage potential investors' worries about bureaucratic minutiae and thereby allow them to instead focus on identifying sound business opportunities."
+      "[Jer'ba] adv. 因此"
     ]
   },
   {
     "name": "thermal",
     "trans": [
-      "Day 31 | adj. | English: connected with heat | Example: Shedding light on the thermal biology of fungi, research by Radamés Cordero et al. indicates that certain mushrooms (including Marasmius capillaris and species from the genus Russula) can achieve a hypothermic state through evaporative cooling."
+      "['03:1(3)1] adj. 热的"
     ]
   },
   {
     "name": "thick",
     "trans": [
-      "Day 31 | adj. | English: having a larger distance between opposite sides or surfaces than other similar objects or than normal | Example: She has a thick curtain of long, curly hair that practically engulfs her."
+      "[8] adj. 厚的"
     ]
   },
   {
     "name": "thorough",
     "trans": [
-      "Day 31 | adj. | English: done completely; with great attention to detail | Example: Colours might have been better chosen and lights more perfectly diffused; but perhaps in doing so the thorough clerical aspect of the whole might have been somewhat marred."
+      "['03:rO0] adj. 彻底的"
     ]
   },
   {
     "name": "thoughtful",
     "trans": [
-      "Day 31 | adj. | English: showing that you think about and care for other people | Example: It was very thoughtful of you to send the flowers."
+      "['03:4I] adj. 体贴的"
     ]
   },
   {
     "name": "thrill",
     "trans": [
-      "Day 31 | v. | English: to excite or please sb very much | Example: For example, her 1991 novel The Crown of Columbus is essentially adventure fiction, and the thrilling events in its plot are set largely on a Caribbean island."
+      "[Orl] v. 使非常兴奋"
     ]
   },
   {
     "name": "thrive",
     "trans": [
-      "Day 32 | v. | English: to become, and continue to be, successful, strong, healthy, etc. | Example: Elderberry bushes grow best when planted in shaded areas, while chia flowers do not require shade to thrive."
+      "[Oramv] v. 旺盛"
     ]
   },
   {
     "name": "throb",
     "trans": [
-      "Day 32 | v. | English: v. to beat or sound with a strong, regular rhythm; n. a strong regular beat | Example: | rest me deep within the wood, / Drawn by its silent call, / Far from the throbbing crowd of men, / On nature's breast | fall."
+      "[Ora:b] v.；v.；n. 强烈有节奏地"
     ]
   },
   {
     "name": "throne",
     "trans": [
-      "Day 32 | n. | English: the position of being a king or queen | Example: Whether the reign of a French monarch such as Louis VII or Henry V was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy and therefore cannot be understood without a corollary understanding of the characteristics without which the monarch would have been forced to abandon the throne."
+      "[Oroun] n.；V. 王权"
     ]
   },
   {
     "name": "throng",
     "trans": [
-      "Day 32 | n. | English: to go somewhere or be present somewhere in large numbers | Example: Buyers who hadn't previously wanted to purchase old action figures thronged the market, believing prices would continue to rise and the toys could be resold later at a profit."
+      "[0r3:] n. 涌向"
     ]
   },
   {
     "name": "thundering",
     "trans": [
-      "Day 32 | adj. | English: very great or excessive | Example: [Mercedes] was still very pale, and her hands yet trembled, when the thundering of the east- bound train was heard in the distance."
+      "adj. 十足的"
     ]
   },
   {
     "name": "till",
     "trans": [
-      "Day 32 | v. | English: to prepare and use land for growing crops | Example: As he hurried along, eagerly anticipating the moment when he would be at home again among the things he knew and liked, the Mole saw clearly that he was an animal of tilled field and hedge-row, linked to the ploughed furrow, the frequented pasture, the lane of evening lingerings, the cultivated garden-plot."
+      "v. 犁地"
     ]
   },
   {
     "name": "timeworn",
     "trans": [
-      "Day 32 | adj. | English: Something that is timeworn is old or has been used a lot over a long period of time. Even in the dim light the equipment looked old and timeworn."
+      "['taImw3:mn] adj. 陈旧的"
     ]
   },
   {
     "name": "tip",
     "trans": [
-      "Day 32 | v. | English: to move so that one end or side is higher than the other; to move sth into this position | Example: He watches his father raise a kite within minutes into the wind, so high that Gogol must tip his head back in order to see, a rippling speck against the sky."
+      "[m] v. （使）倾斜"
     ]
   },
   {
     "name": "toil",
     "trans": [
-      "Day 32 | n. | English: hard unpleasant work that makes you very tired | Example: Just let me drift far out from toil and care, / Where lapping of the waves shall be the sound."
+      "[torl] n. 劳累的工作"
     ]
   },
   {
     "name": "toll",
     "trans": [
-      "Day 32 | n. | English: 1. money that you pay to use a particular road or bridge adj. happening now; of the present time | Example: Any effort to raise the toll that drivers must pay to use the Ogdensburg-Prescott Bridge, which spans the Saint Lawrence River to connect New York State and Ontario, Canada, should explain why a higher toll is necessary."
+      "[tool] n.；adj. （桥梁的）通行费"
     ]
   },
   {
     "name": "tomb",
     "trans": [
-      "Day 32 | n. | English: a large grave, especially one built of stone above or below the ground | Example: The team found a tablet in Merneith's tomb with writing suggesting that she was in charge of the country's treasury and other central offices."
+      "[t:皿] n. 坟墓"
     ]
   },
   {
     "name": "torrent",
     "trans": [
-      "Day 32 | n. | English: a large amount of water moving very quickly | Example: Then Clarence was wildly apostrophized, and a torrent of tears relieved the overcharged, aching heart."
+      "['to:rant] n. 急流"
     ]
   },
   {
     "name": "toss",
     "trans": [
-      "Day 32 | v. | English: to throw sth lightly or carelessly | Example: I'm as hungry as the winter, I'm ill, I'm shaken... and where haven't | been—fate has tossed me everywhere!"
+      "[t3:5] v. （轻轻或漫不经心地）"
     ]
   },
   {
     "name": "tough",
     "trans": [
-      "Day 32 | adj. | English: strong enough to deal successfully with difficult conditions or situations | Example: I'm little of course, but terribly quick and wiry and tough."
+      "[tuf] adj. 坚强的"
     ]
   },
   {
     "name": "towering",
     "trans": [
-      "Day 32 | adj. | English: extremely tall or high and therefore impressive | Example: [1] The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead. 2] Pops’s pride and joy is his wall of towering bookshelves."
+      "['taoarm] adj. 高耸的,屹立的"
     ]
   },
   {
     "name": "track",
     "trans": [
-      "Day 32 | v. | English: to follow the movements of sb/sth, especially by using special electronic equipment | Example: The work of Tobias Gerstenberg et al. on tracking eye movements supports a theory that people engage in counterfactual thinking when making causal judgments."
+      "[trak] v. 追踪"
     ]
   },
   {
     "name": "trade-off",
     "trans": [
-      "Day 32 | n. | English: the act of balancing two things that you need or want but which are opposed to each other | Example: Optimal foraging theory (OFT) holds that animals foraging behaviors reflect cost-benefit trade-offs that vary by species and width dynamic ecological circumstances."
+      "n. （在需要而又相互对立的两者间的）权衡"
     ]
   },
   {
     "name": "trait",
     "trans": [
-      "Day 32 | n. | English: a particular quality in your personality | Example: That's because birdsong has long been considered a male trait; researchers have argued that singing enables males to attract mates and claim territory."
+      "[trert] n. 特征"
     ]
   },
   {
     "name": "trajectory",
     "trans": [
-      "Day 32 | n. | English: the curved path of sth that has been fired, hit or thrown into the air | Example: J. Mason Heberling and David J. Burke relied on historical DNA (nDNA)—genomic data incidentally preserved in specimens housed in natural history collections—to investigate the evolutionary trajectory of arbuscular mycorrhizal fungi."
+      "[tra'd3ektari] n. （射体在空中的）"
     ]
   },
   {
     "name": "tranquil",
     "trans": [
-      "Day 32 | adj. | English: quiet and peaceful | Example: This creates a more tranquil environment with calmer waters where animals can take shelter."
+      "['trankwil] adj. 平静的"
     ]
   },
   {
     "name": "tranquility",
     "trans": [
-      "Day 32 | n. | English: a peaceful, calm state, without noise, violence, worry, etc. | Example: It contrasts the tranquility of the waters near Puerto Cabello with the roughness of waters elsewhere."
+      "[tan'kwllati] n. 平静"
     ]
   },
   {
     "name": "transform",
     "trans": [
-      "Day 32 | v. | English: to change the form of sth | Example: In fact, some historians argue that it fundamentally transformed the industry by enabling it to take advantage of mass production methods for the first time."
+      "[trans'1:r] v. 使改娈形态"
     ]
   },
   {
     "name": "transient",
     "trans": [
-      "Day 32 | adj. | English: Transient is used to describe a situation that lasts only a short time or is constantly changing | Example: Occurring in the constellation Virgo, 60 million light-years from Earth, the transient yet powerful blast propelled particles and debris into space at extremely high speeds."
+      "['trenjnt] adj. 短暂的"
     ]
   },
   {
     "name": "translucent",
     "trans": [
-      "Day 32 | adj. | English: allowing light to pass through but not transparent Allowing only some light to pass through, hauyne is instead classified as translucent."
+      "[tranz'lu:snttrens'lu:snt] adj. 半透明的"
     ]
   },
   {
     "name": "transparency",
     "trans": [
-      "Day 32 | n. | English: the quality of sth, such as glass, that allows you to see through it | Example: While some commentators lauded this development, asserting that such blogs had a welcome transparency missing from traditional news, less sanguine observers countered that such blogs tended to ideological extremes that exacerbated political polarization to problematic levels."
+      "n. 透明"
     ]
   },
   {
     "name": "transpose",
     "trans": [
-      "Day 32 | v. | English: to move or change sth to a different place or environment or into a different form | Example: The director transposes Shakespeare's play from 16th century Venice to present-day England."
+      "v. 使转移"
     ]
   },
   {
     "name": "traverse",
     "trans": [
-      "Day 32 | v. | English: an act of moving sideways or walking across a steep slope, not climbing up or down it; a place where this is possible or necessary | Example: There is no Frigate like a Book / To take us Lands away / Nor any Coursers like a Page / Of prancing Poetry— / This Traverse may the poorest take / Without oppress of Toll— / How frugal is the Chariot / That bears the Human soul."
+      "['trav3:IS;tra'V3:rS] v. 横越"
     ]
   },
   {
     "name": "tread",
     "trans": [
-      "Day 32 | v. | English: to put your foot down while you are stepping or walking | Example: A gleaming carpet was springing up everywhere, that looked too delicate to be trodden upon by rough feet."
+      "[tred] v. （过去式"
     ]
   },
   {
     "name": "treasury",
     "trans": [
-      "Day 32 | n. | English: aplace ina castle, etc. where valuable things are stored | Example: The team found a tablet in Merneith's tomb with writing suggesting that she was in charge of the country's treasury and other central offices."
+      "n. （城堡等中的）金银财宝库"
     ]
   },
   {
     "name": "treat",
     "trans": [
-      "Day 32 | n. | English: something very pleasant and enjoyable, especially sth that you give sb or do for them | Example: Cuttlefish appear to be surprisingly competent at exercising self-control: in a 2021 study conducted by behavioral ecologist Alexandra Schnell, these cephalopods routinely demonstrated restraint by delaying gratification, waiting for a favorite treat instead of instantly devouring a readily available meal."
+      "[tri:t] n. 款待"
     ]
   },
   {
     "name": "trek",
     "trans": [
-      "Day 32 | v. | English: to make a long or difficult journey, especially on foot | Example: We trekked into a far country, / My friend and |."
+      "[trek] v. 尤指徒步"
     ]
   },
   {
     "name": "tremble",
     "trans": [
-      "Day 32 | v. | English: to shake in a way that you cannot control, especially because you are very nervous, excited, frightened, etc. | Example: [Mercedes] was still very pale, and her hands yet trembled, when the thundering of the east- bound train was heard in the distance."
+      "['trembl] v. （惊慌等）颤抖"
     ]
   },
   {
     "name": "trial",
     "trans": [
-      "Day 32 | n. | English: an experience or a person that causes difficulties for sb | Example: She went through the crucible of unprecedented adversities and trials of life and came out one of the rare shining lights that beautify the New England sky."
+      "['traral] n. 考验,磨练"
     ]
   },
   {
     "name": "tribe",
     "trans": [
-      "Day 32 | n. | English: (in developing countries) a group of people of the same race, and with the same customs, language, religion, etc., living in a particular area and often led by a chief | Example: In what is now Washington state, the Tulalip Tribes operate the Hibulb Cultural Center. Relying on traditional knowledge to guide the design of exhibits, this institution presents Tulalip history and culture to the tribes’ citizens."
+      "[trarb] n. 部落"
     ]
   },
   {
     "name": "tribute",
     "trans": [
-      "Day 32 | n. | English: an act, a statement or a gift that is intended to show your respect or admiration, especially for a dead person | Example: Novelist Leon Forrest admired William Faulkner's writing style. Forrest's novel Divine Days contains a long passage in tribute to Faulkner that is a perfect imitation of Faulkner's style: anyone familiar with Faulkner's writing would see the resemblance."
+      "['trrbju:t] n. （尤指对死者的）"
     ]
   },
   {
     "name": "trifling",
     "trans": [
-      "Day 32 | adj. | English: small and not important | Example: How careful ought we to be to speak nothing but the truth, even in regard to the most trifling circumstances; and not only so, but to be well assured that what we suppose to be true, is truth, before we receive it as such."
+      "['trarfln] adj. 微不足道的"
     ]
   },
   {
     "name": "trigger",
     "trans": [
-      "Day 32 | v. | English: to make sth happen suddenly | Example: The arrival of humans to the Americas is thought to have triggered a sudden decrease in biodiversity throughout the continents."
+      "['trgar] v. 引起"
     ]
   },
   {
     "name": "trivial",
     "trans": [
-      "Day 32 | adj. | English: not important or serious; not worth considering | Example: | know it sounds trivial , but I'm worried about it."
+      "['trrvial] adj. 微不足道的"
     ]
   },
   {
     "name": "trunk",
     "trans": [
-      "Day 32 | n. | English: the main part of the human body apart from the head, arms and legs | Example: The morphological novelty of echinoderms marine—invertebrates with radial symmetry, usually starlike, around a central point—impedes comparisons with most other animals, in which bilateral symmetry on an anterior-posterior (head to tail) axis through a trunk is typical."
+      "[trAgk] n. 躯干"
     ]
   },
   {
     "name": "tune",
     "trans": [
-      "Day 32 | n. | English: a series of musical notes that are sung or played in a particular order to form a piece of music Among the wild rice in the still lagoon. / In monotone the lizard shrills his tune. / The wild goose, homing, seeks a sheltering, / Where rushes grow, and oozing lichens cling."
+      "[乜:\"] n. 曲调"
     ]
   },
   {
     "name": "turbulence",
     "trans": [
-      "Day 32 | n. | English: a series of sudden and violent changes in the direction that air or water is moving in | Example: For large vortices, fish with intermediate heads would be better able than narrow-headed fish to distinguish between vortices and general turbulence in the water."
+      "['t3:rbjalans] n. （空气和水的）湍流,涡流"
     ]
   },
   {
     "name": "turf",
     "trans": [
-      "Day 32 | n. | English: short grass and the surface layer of soil that is held together by its roots; a piece of this that has been cut from the ground and is used especially for making lawns (= the area of grass in a garden/yard) | Example: [Jim] went on to the lawn, very slowly, and kicking wretchedly at the turf."
+      "n. 草皮"
     ]
   },
   {
     "name": "turnover",
     "trans": [
-      "Day 32 | n. | English: the rate at which goods are sold in a shop/store and replaced by others Reducing this kind of subscriber turnover is especially challenging for subscription sellers: customers’ initial enthusiasm for a subscription is often quick to subside, and sellers must thus devise other incentives to bolster retention. tusk on. (RARER oA) KF either of the long curved teeth that stick out of the mouth of elephants and some other animals | Example: Narwhals are shy whales that live in the remote Arctic Ocean. Some of them have a long tusk, like a unicorn horn, with sensitive nerves."
+      "['t3:Inoovar] n. （商店的）货物周转率"
     ]
   },
   {
     "name": "tusk",
     "trans": [
-      "Day 32 | n. | English: either of the long curved teeth that stick out of the mouth of elephants and some other animals | Example: Narwhals are shy whales that live in the remote Arctic Ocean. Some of them have a long tusk, like a unicorn horn, with sensitive nerves."
+      "n. 象和某些其他动物的"
     ]
   },
   {
     "name": "twilight",
     "trans": [
-      "Day 32 | n. | English: the faint light or the period of time at the end of the day after the sun has gone down | Example: Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow's o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+      "['twallart] n. 暮色"
     ]
   },
   {
     "name": "ubiquitous",
     "trans": [
-      "Day 32 | adj. | English: seeming to be everywhere or in several places at the same time; very common | Example: However, Nufiez and colleagues claim that this tendency is not in fact ubiquitous."
+      "[ju:'blkwrtas] adj. 无处不在的"
     ]
   },
   {
     "name": "ultrasonic",
     "trans": [
-      "Day 32 | adj. | English: higher than humans can hear | Example: The jade hawkmoth, a large-bodied moth, defends itself against the eastern red bat and other insect-eating bats, which use echolocation to hunt, by emitting ultrasonic clicks that can, for instance, disrupt the bats' echolocation signals."
+      "adj. 超声的"
     ]
   },
   {
     "name": "ultrasound",
     "trans": [
-      "Day 32 | n. | English: sound that is higher than humans can hear | Example: To investigate moths' defensive ultrasound—which researchers had thought was exclusive to tiger moths, hawkmoths, and one species of geometer moths—Akito Y, Kawahara et al."
+      "['Altrasaznd] n. 超声"
     ]
   },
   {
     "name": "unadorned",
     "trans": [
-      "Day 32 | adj. | English: without any decoration | Example: The project's unadorned geometric forms, typical of the modernist aesthetic, contrasted with the historically inspired architecture seen in his earlier projects in Guadalajara, such as the house for Emiliano Robles Leon."
+      "[4na'do:rnd] adj. 不加装饰的,简朴的"
     ]
   },
   {
     "name": "unaffiliated",
     "trans": [
-      "Day 32 | adj. | English: not belonging to or connected with a political party or a large organization | Example: Scholar's who reviewed the 1984 edition were unaffiliated with its production and were mostly either Joyce specialists who were largely unfamiliar with editorial theories and practices or specialists in such theories and practices who were insufficiently familiar with Joyce."
+      "adj. 独立的"
     ]
   },
   {
     "name": "unanimous",
     "trans": [
-      "Day 33 | adj. | English: if.a decision or an opinion is unanimous , it is agreed or shared by everyone in a group | Example: The text summarizes an argument made in a collection of essays and then suggests that the essays’ authors didn't unanimously agree with the argument."
+      "[ju'nanImas] adj. 一致同意的"
     ]
   },
   {
     "name": "unassuming",
     "trans": [
-      "Day 33 | adj. | English: not wanting to draw attention to yourself or to your abilities or status | Example: A casual description of Scherezade Garcia's 2019 mural Blame It on the Bean: The Power of Coffee can make the work seem unassuming."
+      "[.4n3'su:N] adj. 不爱出风头的,谦逊的"
     ]
   },
   {
     "name": "unattainable",
     "trans": [
-      "Day 33 | adj. | English: impossible to achieve or reach | Example: It presents evidence in support of the hypothesis that seed germination in lunar habitats is an unattainable goal."
+      "[.Ana'temabl] adj. 无法得到的"
     ]
   },
   {
     "name": "unblemished",
     "trans": [
-      "Day 33 | adj. | English: not spoiled, damaged or marked in any wa | Example: This style largely rejected the conventions of the romantic style evident in many paintings by Thomas Couture, which instead accentuated their subjects’ positive traits by, for example, placing them in staged settings with expensive looking decorations and presenting them with smooth, unblemished skin."
+      "[Anblemift] adj. 完好无损的"
     ]
   },
   {
     "name": "uncanny",
     "trans": [
-      "Day 33 | adj. | English: strange and difficult to explain | Example: While these features can help to engender feelings of comfort in people, a robot that looks too like human can fall into the “uncanny valley,” meaning that its appearance unintentionally unsettles those who encounter it."
+      "[An'kani] adj. 难以解释的"
     ]
   },
   {
     "name": "unclassifiable",
     "trans": [
-      "Day 33 | adj. | English: impossible to classify (= say which group or type something or someone belongs to) Writer Lydia Davis observed that while traditional literary forms, such as the novel, are recognizable as such even as they evolve, there are rarer “intergeneric” forms that might, for example, use elements of both fiction and essays to create something unclassifiable."
+      "adj. 不可归类的"
     ]
   },
   {
     "name": "uncouth",
     "trans": [
-      "Day 33 | adj. | English: rude or socially unacceptable | Example: The great men of culture are those who have had a passion for diffusing, for making prevail, for carrying from one end of society to the other, the best knowledge, the best ideas of their time; who have labored to divest knowledge of all that was harsh, uncouth, difficult, abstract, professional, exclusive; to humanise it, to make it efficient outside the clique of the cultivated and learned, yet still remaining the best knowledge and thought of the time, and a true source, therefore, of sweetness and light."
+      "[An'ku:0] adj. 粗鲁的"
     ]
   },
   {
     "name": "underestimate",
     "trans": [
-      "Day 33 | v. | English: to think or guess that the amount, cost or size of sth is smaller than it really is | Example: By claiming that the author of Text 1 has underestimated the richness and complexity of Sula"
+      "[.Andar'estImert] v. 低估"
     ]
   },
   {
     "name": "undergo",
     "trans": [
-      "Day 33 | v. | English: to experience sth, especially a change or sth unpleasant | Example: Believe me, Anya, believe me! I'm not thirty yet, I'm young, I'm still a student, but | have undergone a great deal!"
+      "[.Andor'gou] v. （不快的事等）"
     ]
   },
   {
     "name": "undermine",
     "trans": [
-      "Day 33 | v. | English: to make sth, especially sb's confidence or authority, gradually weaker or less effective | Example: It undermines an assertion made later in the text."
+      "[.Andarmamn] v. 逐渐削弱"
     ]
   },
   {
     "name": "underpin",
     "trans": [
-      "Day 33 | v. | English: to support or form the basis of an argument, a claim, etc. | Example: The French bulldog and the cairn terrier differ with respect to the genetic underpinnings for attachment and attention-seeking."
+      "[AndarPnn] v. 加强"
     ]
   },
   {
     "name": "underscore",
     "trans": [
-      "Day 33 | v. | English: underline | Example: The fact that publications by University of Minnesota economist Ellen R. McGrattan, who studies financial policy, are so frequently cited in other scholars' work underscores the usefulness of her research for her peers—other economists clearly find her studies valuable for their own scholarship."
+      "[Andar'sko:r] v. 强调"
     ]
   },
   {
     "name": "unearth",
     "trans": [
-      "Day 33 | v. | English: to find sth in the ground by digging | Example: _Hoards found before the 1960s, however, such as the discovery of the Auchnacree hoard around 1921 were not aided by such technologies and thus were much more likely to result from artifacts being unearthed accidentally."
+      "[4n'3:r0] v. 挖掘"
     ]
   },
   {
     "name": "unequivocal",
     "trans": [
-      "Day 33 | adj. | English: expressing your opinion or intention very clearly and firmly | Example: Unequivocal though it seemed to many mathematicians, Nagata’s conjecture, posed in 1972, eventually yielded to the combined efforts of Ualbai U. Umirbaev and Ivan P. Shestakov, who presented a proof of it in 2004."
+      "[.Anr'kwrvakl] adj. 毫不含糊的"
     ]
   },
   {
     "name": "uneventful",
     "trans": [
-      "Day 33 | adj. | English: in which nothing interesting, unusual or exciting happens | Example: Whether the reign of a French monarch such as Louis VII or Henry V was historically consequential or relatively uneventful, its trajectory was shaped by questions of legitimacy and therefore cannot be understood without a corollary understanding of the characteristics without which the monarch would have been forced to abandon the throne."
+      "[Anr'venttl] adj.；V. 平淡无奇的"
     ]
   },
   {
     "name": "unfailing",
     "trans": [
-      "Day 33 | adj. | English: that you can rely on to always be there and always be the same | Example: She fought the disease with unfailing good humour ."
+      "[4n'fel] adj. 可靠的"
     ]
   },
   {
     "name": "unflattering",
     "trans": [
-      "Day 33 | adj. | English: making sb/sth seem worse or less attractive than they really are | Example: Ancient Greek and Roman sculpture is sometimes characterized as idealizing human subjects, but in fact there are many Greco-Roman sculptures that depict people in decidedly unflattering ways."
+      "adj. 贬损的,有损形象的,不恭维的"
     ]
   },
   {
     "name": "unfold",
     "trans": [
-      "Day 33 | v. | English: to spread open or flat sth that has previously been folded; to become open and flat To describe how each step of the peer review process unfolds."
+      "[An'foold] v. 展开"
     ]
   },
   {
     "name": "unintended",
     "trans": [
-      "Day 33 | adj. | English: an unintended effect, result or meaning is one that you did not plan or intend to happen | Example: About half of all pregnancies globally are unintended"
+      "[.AnIn'tendid] adj. 非计划的"
     ]
   },
   {
     "name": "unprecedented",
     "trans": [
-      "Day 33 | adj. | English: that has never happened, been done or been known before | Example: She went through the crucible of unprecedented adversities and trials of life and came out one of the rare shining lights that beautify the New England sky."
+      "[4npresidentid] adj. 前所未有的"
     ]
   },
   {
     "name": "unravel",
     "trans": [
-      "Day 33 | v. | English: if you unravel threads that are twisted, woven or knitted, or if they unravel , they become separated | Example: and leave thou (inexpressibly to unravel) / thou life, with its immensity and fear, / so that, now bounded, now immeasurable, / it is alternately stone in thy and star."
+      "[4n'revl] v. 拆开"
     ]
   },
   {
     "name": "unrivaled",
     "trans": [
-      "Day 33 | adj. | English: having no rival | Example: The views afforded here are unrivaled."
+      "[4n'rarvld] adj. 无可匹敌的"
     ]
   },
   {
     "name": "unsettle",
     "trans": [
-      "Day 33 | v. | English: to make sb feel upset or worried, especially because a situation has changed | Example: While these features can help to engender feelings of comfort in people, a robot that looks too like human can fall into the “uncanny valley,” meaning that its appearance unintentionally unsettles those who encounter it."
+      "[4n'sct(a)] v. 使心神不宁"
     ]
   },
   {
     "name": "unsettled",
     "trans": [
-      "Day 33 | adj. | English: not calm or relaxed | Example: To this end, certain features such as the ability to respond to voice commands can help to create the comforting semblance of humanity, but a robot that appears too similar to humans can make people feel more unsettled than soothed."
+      "adj. 心绪不宁的,不安的"
     ]
   },
   {
     "name": "unsympathetic",
     "trans": [
-      "Day 33 | adj. | English: not in agreement with sth; not supporting an idea, aim, etc. | Example: Drivers who strongly believe that the toll they must pay to use the San Luis Pass-Vacek Toll Bridge, which spans the San Luis Pass in Texas, is currently too high are likely to be unsympathetic to arguments for increasing the toll."
+      "adj. （）不一致的"
     ]
   },
   {
     "name": "untaught",
     "trans": [
-      "Day 33 | adj. | English: without training or education | Example: The untaught peasant beheld the elements around him and was acquainted with their practical uses."
+      "adj. 未受教育的"
     ]
   },
   {
     "name": "untenable",
     "trans": [
-      "Day 33 | adj. | English: that cannot be defended against attack or criticism | Example: And as Jane X. Luu et al. point out, the singular nature of impact ejection makes it untenable as an account of multiple loss episodes of similar duration over several years."
+      "[4n'tenabl] adj. 站不住脚的"
     ]
   },
   {
     "name": "unveil",
     "trans": [
-      "Day 33 | v. | English: to show or introduce a new plan, product, etc. to the public for the first time | Example: The most learned philosopher knew little more. He had partially unveiled the face of Nature, but her immortal lineaments were still a wonder and a mystery."
+      "[.An'verl] v. 揭示"
     ]
   },
   {
     "name": "unwarranted",
     "trans": [
-      "Day 33 | adj. | English: not reasonable or necessary; not appropriate | Example: To present findings that suggest that a concern about the effects of ocean acidification on pteropod shells may be unwarranted."
+      "adj. 无正当理由的"
     ]
   },
   {
     "name": "unwavering",
     "trans": [
-      "Day 33 | adj. | English: not changing or becoming weaker in any way They reveal that Caravan is unwaveringly precise in his daily routine because of the unreasonable expectations of his employers."
+      "[4n'weIVaIs] adj. 不动摇的,坚定的,始终如一的"
     ]
   },
   {
     "name": "unyielding",
     "trans": [
-      "Day 33 | adj. | English: ifa person is unyielding , they are not easily influenced and they are unlikely to change their mind | Example: Political scientists have found that although voters claim to prefer candidates who have nuanced perspectives on issues and who show a willingness to compromise, when asked to compare speeches expressing such views with speeches expressing dogmatic views, voters tend to regard the unyielding rhetoric of the latter more favorably."
+      "adj. 坚定的"
     ]
   },
   {
     "name": "upstart",
     "trans": [
-      "Day 33 | n. | English: a person who has just started in a new position or job but who behaves as if they are more important than other people, in a way that is annoying | Example: She had the air of a queen and gazed disdainfully at the whole house, as if to say, \"I've come later than all of you, you crowd of upstarts and provincials, I've come later than you!\""
+      "n. 命不凡的新上任者,狂妄自大的新手"
     ]
   },
   {
     "name": "uptake",
     "trans": [
-      "Day 33 | n. | English: the process by which sth is taken into a body or system | Example: Among nautilids, there is no effect of sex on the uptake of oxygen-18 from water or its deposition in septa."
+      "['Apteik] n. 吸收"
     ]
   },
   {
     "name": "urbanization",
     "trans": [
-      "Day 33 | n. | English: Urbanization is the process of creating cities or towns in country areas. | Example: This new measure establishes global criteria used to define three types of settlements (cities, towns, and rural areas) and allows researchers to better understand global urbanization rates."
+      "[.3:+b313'zeIRh] n. 城市化"
     ]
   },
   {
     "name": "urge",
     "trans": [
-      "Day 33 | v. | English: to advise or try hard to persuade sb to do sth | Example: The Times [a British newspaper], replying to some foreign strictures on the dress, looks, and behavior of the English abroad, urges that the English ideal is that everyone should be free to do and to look just as he likes."
+      "[3:rd3] v. 力劝"
     ]
   },
   {
     "name": "usher",
     "trans": [
-      "Day 33 | v. | English: to take or show sb where they should go | Example: But there were vacant seats here and there, and into one of them she was ushered, between brilliantly dressed women who had gone there to kill time and eat candy and display their gaudy attire."
+      "['AJor] v. 引往"
     ]
   },
   {
     "name": "utensil",
     "trans": [
-      "Day 33 | n. | English: a tool that is used in the house | Example: Guojun He and colleagues studied a food-delivery phone app that is popular in China. The researchers found that having \"no cutlery\" automatically selected influences whether customers request disposable plastic utensils with their food orders."
+      "[ju:'tensl] n. 用具"
     ]
   },
   {
     "name": "utterly",
     "trans": [
-      "Day 33 | adj. | English: You use utterly to emphasize that something is very great in extent, degree, or amount. | Example: He might dissect, anatomise, and give names; but, not to speak of a final cause, causes in their secondary and tertiary grades were utterly unknown to him."
+      "['Atarli] adj. 完全地"
     ]
   },
   {
     "name": "vacant",
     "trans": [
-      "Day 33 | adj. | English: empty; not being used | Example: A lady accompanied by her husband entered at that moment and took her place in one of the two vacant boxes."
+      "['verkant] adj. 空的"
     ]
   },
   {
     "name": "vacate",
     "trans": [
-      "Day 33 | v. | English: to leave a building, seat, etc., especially so that sb else can use it Guests are requested to vacate their rooms by noon on the day of departure."
+      "['verkert] v. 搬出,腾出"
     ]
   },
   {
     "name": "vacillating",
     "trans": [
-      "Day 33 | adj. | English: inclined to waver; indecisive | Example: Vacillating people seldom succeed."
+      "adj. 动摇的,犹豫的"
     ]
   },
   {
     "name": "vague",
     "trans": [
-      "Day 33 | adj. | English: not having or giving enough information or details about sth | Example: Miranda's impression of a scene is vague because she is remembering a scenario she had daydreamed about as a child rather than a scenario that had occurred in reality."
+      "[verg] adj. 不具体的"
     ]
   },
   {
     "name": "vain",
     "trans": [
-      "Day 33 | adj. | English: that does not produce the result you want; too proud of your own appearance, abilities or achievements | Example: The little conductor stood on tiptoe in an effort to keep one hand on the signal rope, craning his neck in a vain and dissatisfied endeavor to pierce the miasma of the fog."
+      "[vem] adj. 徒劳的"
     ]
   },
   {
     "name": "validate",
     "trans": [
-      "Day 33 | v. | English: to prove that sth is true | Example: For example, a linguist who assumes that the word “own” appears quite often in written English could validate that assumption with data from a corpus: “own” is the eighth most commonly used adjective."
+      "['validert] v. 证实"
     ]
   },
   {
     "name": "vanish",
     "trans": [
-      "Day 33 | v. | English: to stop existing | Example: Holes, hollows, pools, pitfalls, and other menaces to the wayfarer were vanishing fast."
+      "['vaN] v. 消失"
     ]
   },
   {
     "name": "vaporize",
     "trans": [
-      "Day 33 | v. | English: to turn into gas; to make sth turn into gas | Example: Asteroid 6478 Gault has experienced intermittent mass loss since at least 2013, but in contrast to some other asteroids with repeated mass-loss episodes, 6478 Gault has not lost mass at its perihelion (the closest point of its orbit to the Sun), and thus the loss is not attributable to solar energy—driven ice vaporization."
+      "['verparanz] v. 蒸发"
     ]
   },
   {
     "name": "vapour",
     "trans": [
-      "Day 33 | n. | English: amass of very small drops of liquid in the air, for example steam | Example: Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow's o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+      "['velpar] n. 蒸气"
     ]
   },
   {
     "name": "variable",
     "trans": [
-      "Day 33 | n. | English: n.a situation, number or quantity that can vary or be varied; adj. often changing; likely to change | Example: [1] While there are several possible reasons for this, one is that practitioners may overlook confounding variables that account for the results they attribute to the interventions in question. what drives firms in certain industries to cluster may not be especially relevant among other industries."
+      "['veriabl,'veriabl] n.；n.；adj. 娈量"
     ]
   },
   {
     "name": "vehement",
     "trans": [
-      "Day 33 | vi. | English: showing very strong feelings, especially anger | Example: Mercedes, being not quite seventeen, her grief at parting from Clarence was wild, vehement and all-absorbing."
+      "['vi:amant] vi. 感情-"
     ]
   },
   {
     "name": "veil",
     "trans": [
-      "Day 33 | n. | English: a covering of very thin transparent material worn, especially by women | Example: Late cranes with heavy wing, and lazy flight. / Sail up the silence with the nearing night. / And like a spirit, swathed in some soft veil, / Steals twilight and its shadow's o'er the swale. / Hushed lie the sedges, and the vapours creep. / Thick, grey and humid, while the marshes sleep."
+      "[verl] n. （尤指女用的"
     ]
   },
   {
     "name": "veiled",
     "trans": [
-      "Day 34 | adj. | English: not expressed directly or clearly because you do not want your meaning to be obvious | Example: | sauntered along, forgetful of musty papers, of the offices, of my chief, my colleagues, my documents, and thinking of the good things that were sure to come to me, of all the veiled unknown contained in the future."
+      "adj. 掩盖的"
     ]
   },
   {
     "name": "venerate",
     "trans": [
-      "Day 34 | v. | English: (formal) to have and show a lot of respect for sb/sth, especially sb/sth that is considered to be holy or very important | Example: These children are venerated as holy beings."
+      "['venarert] v. 崇敬"
     ]
   },
   {
     "name": "verdant",
     "trans": [
-      "Day 34 | adj. | English: fresh and green | Example: The moss in the towering water oaks had become enlivened with a verdant sheen of silver and hung like festoons of carnival or like funeral decorations for the mourning of the dead."
+      "['v3:rdnt] adj. 嫩绿的"
     ]
   },
   {
     "name": "veritable",
     "trans": [
-      "Day 34 | adj. | English: aword used to emphasize that sb/sth can be compared to sb/sth else that is more exciting, more impressive, etc. | Example: The meal that followed was a veritable banquet."
+      "['veritabl] adj. 名副其实的"
     ]
   },
   {
     "name": "verse",
     "trans": [
-      "Day 34 | n. | English: writing that is arranged in lines, often with a regular rhythm or pattern of rhyme, | Example: Its unintelligibility may cause its formal function within a line of verse to go unnoticed by present-day readers."
+      "[V3:rs] n. 诗"
     ]
   },
   {
     "name": "vertical",
     "trans": [
-      "Day 34 | adj. | English: going straight up or down from a level surface or from top to bottom in a picture, etc. | Example: Vertical gene transfer involves the transmission of genetic material from a parent to offspring: horizontal gene transfer, on the other hand, involves the exchange of genetic material between organisms not in a parent-offspring relationship."
+      "['v3:rtkl] adj. 竖的,垂直的"
     ]
   },
   {
     "name": "viable",
     "trans": [
-      "Day 34 | adj. | English: that can be done | Example: While hDNA has potential for enhancing scientists’ understanding of the evolutionary past, the difficulty of deriving viable data from it at present has limited its use."
+      "['varabl] adj. 切实可行的"
     ]
   },
   {
     "name": "viaduct",
     "trans": [
-      "Day 34 | n. | English: along high bridge, usually with arches , that carries a road or railway/railroad across a river or valley | Example: And suddenly | perceived the great viaduct of Point du Jour which blocked the river."
+      "['varadakt] n. 高架桥"
     ]
   },
   {
     "name": "vibrant",
     "trans": [
-      "Day 34 | adj. | English: full of life and energy | Example: Evocative of African sculpture and American and Scandinavian folk art, these portraits feature flat, deliberately oversimplified figures in a vibrant but limited color palette."
+      "['valbrant] adj. 充满生机的"
     ]
   },
   {
     "name": "vibrate",
     "trans": [
-      "Day 34 | v. | English: to move or make sth move from side to side very quickly and with small movements Rusty-spotted cats, which are much smaller than jaguars, have a rigid hyoid that rumbles when the cat's larynx vibrates, resulting in a purr."
+      "['valbrert] v. 使一"
     ]
   },
   {
     "name": "vie",
     "trans": [
-      "Day 34 | v. | English: to compete strongly with sb in order to obtain or achieve sth | Example: These lions weren't just there to be admired by visitors, though. Rather, they lived free lives, prowling the game reserve in coalitions (bands of male lions) and vying for territory."
+      "[va] v. （现在分词形式是"
     ]
   },
   {
     "name": "vigilance",
     "trans": [
-      "Day 34 | n. | English: very careful to notice any signs of danger or trouble | Example: Constant vigilance is necessary in order to avoid accidents."
+      "['vidgllons] n. 警惕"
     ]
   },
   {
     "name": "vigorous",
     "trans": [
-      "Day 34 | adj. | English: very active, determined or full of energy | Example: Notes long, full, mournful as a prayer, yet still vigorous, escaped from the old instrument."
+      "['vIg3ras] adj. 充满活力的"
     ]
   },
   {
     "name": "villain",
     "trans": [
-      "Day 34 | n. | English: a person who is morally bad or responsible for causing trouble or harm | Example: You are cultured and intelligent, [Vanya], and you surely understand that the world is not destroyed by villains and conflagrations, but by hate and malice and all this spiteful tattling."
+      "['vlan] n. 恶棍,坏蛋"
     ]
   },
   {
     "name": "vindicate",
     "trans": [
-      "Day 34 | v. | English: to prove that sth is true or that you were right to do sth, especially when other people had a different opinion I have every confidence that this decision will be fully vindicated."
+      "['vndikert] v. 证实"
     ]
   },
   {
     "name": "virtually",
     "trans": [
-      "Day 34 | adv. | English: almost or very nearly, so that any slight difference is not important | Example: Superlubricity, the state of virtually no friction between materials, has desirable applications in many industries."
+      "['v3:rtjiali] adv. 几乎"
     ]
   },
   {
     "name": "virtue",
     "trans": [
-      "Day 34 | n. | English: an attractive or useful quality | Example: Perhaps it is a little depressing to inherit not lands but an example of intellectual virtue."
+      "['v3:rtlu:] n. 优点"
     ]
   },
   {
     "name": "virtuosity",
     "trans": [
-      "Day 34 | n. | English: a very high degree of skill in performing or playing | Example: Despite Argerich's experience and virtuosity, she never takes for granted that she knows a piece of music."
+      "[.v3:rtfil'a:sati] n. 高超技艺"
     ]
   },
   {
     "name": "virtuous",
     "trans": [
-      "Day 34 | adj. | English: behaving in a very good and moral way | Example: Although people seek to be viewed as virtuous, the most insignificant setbacks will often inhibit them from being so."
+      "['v3:Ttfuas] adj. 品行端正的"
     ]
   },
   {
     "name": "viscous",
     "trans": [
-      "Day 34 | adj. | English: thick and sticky; not flowing freely | Example: Chemists Mare A. Meyers and Andrew Grazela studied the mass and heat transfer processes that occur when foods are fried in batters containing hydrocolloids, polymers that become viscous or gel-like in water."
+      "['VIskas] adj. 粘稠的"
     ]
   },
   {
     "name": "vision",
     "trans": [
-      "Day 34 | n. | English: an idea or a picture in your imagination | Example: Each fails at presenting a wholly coherent vision of art but does not understand why."
+      "['vI3n] n. 想象"
     ]
   },
   {
     "name": "visualize",
     "trans": [
-      "Day 34 | v. | English: to form a picture of sb/sth in your mind | Example: I can't visualize what this room looked like before it was decorated."
+      "['vI3ualarz] v. 使形象化"
     ]
   },
   {
     "name": "vital",
     "trans": [
-      "Day 34 | adj. | English: necessary or essential in order for sth to succeed or exist | Example: Ina 2018 article celebrating films depicting the Black experience, critics for the New York Times commended William Greaves's 1968 film Symbiopsychotaxiplasm, Take One and Spike Lee's 1992 film Malcolm X, praising the former as \"a vital artifact of its time\" and the latter as \"electrifying.\""
+      "['vartl] adj. 必不可少的"
     ]
   },
   {
     "name": "voucher",
     "trans": [
-      "Day 34 | n. | English: one that gurantees | Example: A book printed is a record, remaining in every man’s possession, always ready to renew its acquaintance with his memory, and always ready to be produced as an authority or voucher to any reports he makes out of it, and conveys its contents for ages to come, to the eternity- of mortal time, when the author is forgotten in his grave."
+      "['vaotjar] n. 保证者"
     ]
   },
   {
     "name": "vowel",
     "trans": [
-      "Day 34 | n. | English: a speech sound in which the mouth is open and the tongue is not touching the top of the , e, O:/ | Example: For example, the way certain vowel sounds are pronounced in it can be traced to how they"
+      "['vaoal] n. 元音"
     ]
   },
   {
     "name": "wander",
     "trans": [
-      "Day 34 | v. | English: to walk slowly around or to a place, often without any particular sense of purpose or direction Night, guardian of dreams, / Now wanders through the land; / The moon, a lily white, / Blossoms within her hand."
+      "['wa:ndar] v. 漫游"
     ]
   },
   {
     "name": "warranted",
     "trans": [
-      "Day 34 | adj. | English: justified or well-founded | Example: There is thus no cause for uncertainty here, and no warranted basis for any speculation."
+      "adj. 合理的"
     ]
   },
   {
     "name": "wayfarer",
     "trans": [
-      "Day 34 | n. | English: a person who travels from one place to another, usually on foot | Example: Holes, hollows, pools, pitfalls, and other menaces to the wayfarer were vanishing fast."
+      "n. 徒步旅行者"
     ]
   },
   {
     "name": "wear on",
     "trans": [
-      "Day 34 | English: pass slowly (of time) | Example: [Katharine's] descent from [a celebrated poet] was no surprise to her, but matter for satisfaction, until, as the years wore on, certain drawbacks made themselves very manifest."
+      "随着时间的推移"
     ]
   },
   {
     "name": "weary",
     "trans": [
-      "Day 34 | adj. | English: very tired, especially after you have been working hard or doing sth for a long time | Example: Our world, so worn and weary, / Needs music, pure and strong. /To hush the jangle and discords / Of sorrow, pain, and wrong."
+      "['wri] adj. 疲劳的"
     ]
   },
   {
     "name": "weave",
     "trans": [
-      "Day 34 | v. | English: to make cloth, a carpet, a basket , etc. by crossing threads or strips across, over and under each other by hand or on a machine | Example: Mexican textile artist Victoria Villasana weaves stories of triumph, using her unique method of applying colorful yarn to photographs of people."
+      "[wi:v] v. 编织"
     ]
   },
   {
     "name": "weep",
     "trans": [
-      "Day 34 | v. | English: to cry, usually because you are sad | Example: The bald cypresses spread themselves along the water courses while the willows wept as they always did."
+      "[wi:p] v. （过去式和过去分词都是"
     ]
   },
   {
     "name": "weld",
     "trans": [
-      "Day 34 | v. | English: to join pieces of metal together by heating their edges and pressing them together | Example: Cut, bent, and welded from discarded metal materials, the sculptures of London-based Nigerian artist Sokari Douglas Camp are meant to challenge viewers to consider their own relationships to material wastes."
+      "[weld] v. 焊接"
     ]
   },
   {
     "name": "whip",
     "trans": [
-      "Day 34 | v. | English: to move, or make sth move, quickly and suddenly or violently in a particular direction | Example: The wind whips around their ears, turning their faces cold."
+      "[W] v. （使朝某一方向）"
     ]
   },
   {
     "name": "willful",
     "trans": [
-      "Day 34 | adj. | English: determined to do what you want; not caring about what other people want | Example: So as long as a listener's interpretation isn't willfully absurd or the result of inattention, it is difficult to justify the claim that the listener has misunderstood the piece."
+      "['wlfl] adj. 任性的"
     ]
   },
   {
     "name": "wind",
     "trans": [
-      "Day 34 | v. | English: to wrap or twist sth around itself or sth else | Example: And having cleared the ramparts | had to confess the sky was clearing, prior to its winding in the other shroud, night."
+      "[wnd] v. 缠绕"
     ]
   },
   {
     "name": "wiry",
     "trans": [
-      "Day 34 | adj. | English: thin but strong | Example: I'm little of course, but terribly quick and wiry and tough."
+      "['warari] adj. 瘦而结实的"
     ]
   },
   {
     "name": "withdrawal",
     "trans": [
-      "Day 34 | n. | English: the act of moving or taking sth away or back Roughly 70% of the world's water withdrawals, from sources such as rivers, lakes, and aquifers, is for irrigation water used to meet various agricultural demands."
+      "[WIO'dr3:3l] n. 撤走"
     ]
   },
   {
     "name": "withstand",
     "trans": [
-      "Day 34 | v. | English: to be strong enough not to be hurt or damaged by extreme conditions, the use of force, etc. | Example: By contrast, the black bear (makwa in Ojibwe) should be able to withstand the highest predicted warming without much harm and so likely won't require the conservation efforts that the northern wild rice will."
+      "[WIO'stand,WIO'stend] v. 承受"
     ]
   },
   {
     "name": "woeful",
     "trans": [
-      "Day 34 | adj. | English: very bad or serious; that you disapprove of | Example: Meanwhile, the work of Countee Cullen, who relied on conventional poetic forms associated with previous literary periods, attracts woefully little attention from scholars of modernism."
+      "['woutl] adj. 糟糕的"
     ]
   },
   {
     "name": "woods",
     "trans": [
-      "Day 34 | n. | English: A wood or woods is a fairly large area of trees growing near each other. | Example: The following text is from Kenneth Grahame’s 1908 novel The Wind in the Willows. The Rat is looking for the Mole, his friend, in the woods."
+      "[wodz] n. 树林"
     ]
   },
   {
     "name": "woolly",
     "trans": [
-      "Day 34 | adj. | English: covered with wool or with hair like wool | Example: Researchers have long hypothesized that woolly mammoths were hunted to extinction in North America by humans using spears with grooved tips known as Clovis points."
+      "['woli] adj. 有毛覆盖的"
     ]
   },
   {
     "name": "workmanlike",
     "trans": [
-      "Day 34 | adj. | English: done, made, etc. in a skilful and thorough way but not usually very original or exciting | Example: His prose is workmanlike: his characters are flat and discuss ideas rather than emotions."
+      "adj. 但无新意一"
     ]
   },
   {
     "name": "worrisome",
     "trans": [
-      "Day 34 | adj. | English: that makes you worry | Example: While bioaccumulation of manufactured nanoparticles may be inherently worrisome, it has been hypothesized that CuO-NP bioaccumulation in invertebrates like L. stagnalis could serve a valuable proxy role, obviating the need for manufacturers to conduct costly and intrusive sampling of vertebrate species—such as African clawed frogs (Xenopus laevis), commonly used in regulatory compliance testing—for nanoparticle bioaccumulation, as environmental protection laws currently require."
+      "['w3:risam] adj. 令人担心的"
     ]
   },
   {
     "name": "wrapper",
     "trans": [
-      "Day 34 | n. | English: a piece of paper, plastic, etc. that is wrapped around sth, especially food, when you buy it in order to protect it and keep it clean | Example: Studying wrappers from discontinued candies, menus from nineteenth-century restaurants, and flyers promoting long-forgotten sporting events may seem like a frivolous pursuit, but ephemeral objects like these are useful as markers of cultural change."
+      "['repar] n. （食品等的）"
     ]
   },
   {
     "name": "wreak",
     "trans": [
-      "Day 34 | v. | English: to do great damage or harm to sb/sth | Example: On March 23, 2021, a gust of wind wreaked havoc on global trade."
+      "[ri:k] v. （巨大的破坏或伤害）"
     ]
   },
   {
     "name": "wretched",
     "trans": [
-      "Day 34 | adj. | English: making you feel sympathy or pity | Example: “[Jim] went on to the lawn, very slowly, and kicking wretchedly at the turf. Presently his father came along with the whirring machine, while the sweet, new grass blades spun from the knives.”"
+      "['retfid] adj. 可怜的,悲惨的"
     ]
   },
   {
     "name": "wrought",
     "trans": [
-      "Day 34 | v. | English: caused sth to happen, especially a change | Example: Though few critics consider Vasily Grossman's novel Stalingrad—which focuses on the experience of the Soviet Union in the early years of World War —to be as well written as his later book Everything Flows, some compliment it despite the damage wrought by Soviet censors."
+      "[r:t] v. （尤指娈化）"
     ]
   },
   {
     "name": "yield",
     "trans": [
-      "Day 34 | v. | English: to produce or provide sth, for example a profit, result or crop | Example: The compositions of Delia Derbyshire can yield as many different interpretations as there are people to listen to them."
+      "[ji:ld] v. 产生"
     ]
   },
   {
     "name": "zenith",
     "trans": [
-      "Day 34 | n. | English: the highest point that the sun or moon reaches in the sky, directly above you; | Example: The sun, already down, was manifest in the livid tongues of fire darting towards the zenith, falling and darting again, ever more pale and languid, and doomed no sooner lit to be extinguished."
+      "['zi:ng] n. 太阳或月亮在天空中的最高点"
     ]
   }
 ]

--- a/src/resources/dictionary.ts
+++ b/src/resources/dictionary.ts
@@ -1376,6 +1376,17 @@ const internationalExam: DictionaryResource[] = [
     languageCategory: 'en',
   },
   {
+    id: 'sat-1700-2025-day-grouped',
+    name: 'SAT 1700 2025 Day Grouped',
+    description: '机考SAT真题1700词-2025版，按原书 Day 顺序整理；Day 信息保留在释义字段中。',
+    category: '英语学习',
+    tags: ['SAT', '机考SAT', '真题词汇'],
+    url: '/dicts/SAT_1700_2025_Day_Grouped.json',
+    length: 1700,
+    language: 'en',
+    languageCategory: 'en',
+  },
+  {
     id: 'toefl',
     name: 'TOEFL',
     description: '托福考试常见词',

--- a/src/resources/dictionary.ts
+++ b/src/resources/dictionary.ts
@@ -1377,8 +1377,8 @@ const internationalExam: DictionaryResource[] = [
   },
   {
     id: 'sat-1700-2025-day-grouped',
-    name: 'SAT 1700 2025 Day Grouped',
-    description: '机考SAT真题1700词-2025版，按原书 Day 顺序整理；Day 信息保留在释义字段中。',
+    name: 'SAT 1700 2025',
+    description: '机考SAT真题1700词-2025版，保留原书 Day 顺序；释义仅包含音标、词性和中文释义。',
     category: '英语学习',
     tags: ['SAT', '机考SAT', '真题词汇'],
     url: '/dicts/SAT_1700_2025_Day_Grouped.json',


### PR DESCRIPTION
## Summary

This PR adds a new SAT vocabulary dictionary: SAT 1700 2025 Day Grouped.

## Changes

- Added `/public/dicts/SAT_1700_2025_Day_Grouped.json`
- Registered the dictionary in `/src/resources/dictionary.ts`
- Preserved the original Day grouping information inside the translation field

## Dictionary Info

- Name: SAT 1700 2025 Day Grouped
- Category: 英语学习
- Language: en
- Length: 1700

## Testing

- Ran `yarn`
- Ran `node scripts/update-dict-size.js`
- Ran `yarn dev`
- Verified that the dictionary appears locally