### PR TITLE
[codex] Shuffle Duolingo vocabulary dictionaries

### DIFF
--- a/public/dicts/Duolingo_Vocabulary_B1.json
+++ b/public/dicts/Duolingo_Vocabulary_B1.json
@@ -1,219 +1,315 @@
 [
     {
-        "name": "academic",
+        "name": "eastern",
         "trans": [
-            "n. 大学生，大学教师；学者"
+            "n. 东方人；（美国）东部地区的人"
         ],
-        "usphone": "[ˌækəˈdemɪk]",
-        "ukphone": "[ˌækəˈdemɪk]"
+        "usphone": "[ˈiːstərn]",
+        "ukphone": "[ˈiːstən]"
     },
     {
-        "name": "access",
+        "name": "qualified",
         "trans": [
-            "n. 进入；使用权；通路"
+            "v. 限制（qualify的过去分词）；描述；授权予"
         ],
-        "usphone": "[ˈækses]",
-        "ukphone": "[ˈækses]"
+        "usphone": "[ˈkwɑːlɪfaɪd]",
+        "ukphone": "[ˈkwɒlɪfaɪd]"
     },
     {
-        "name": "accommodation",
+        "name": "summary",
         "trans": [
-            "n. 住处，膳宿；调节；和解；预订铺位"
+            "n. 概要，摘要，总结"
         ],
-        "usphone": "[əˌkɑːməˈdeɪʃn]",
-        "ukphone": "[əˌkɒməˈdeɪʃ(ə)n]"
+        "usphone": "[ˈsʌməri]",
+        "ukphone": "[ˈsʌməri]"
     },
     {
-        "name": "account",
+        "name": "historical",
         "trans": [
-            "n. 账户；解释；账目，账单；理由；描述"
+            "adj. 历史的；史学的；基于史实的"
         ],
-        "usphone": "[əˈkaʊnt]",
-        "ukphone": "[əˈkaʊnt]"
+        "usphone": "[hɪˈstɔːrɪkl]",
+        "ukphone": "[hɪˈstɒrɪk(ə)l]"
     },
     {
-        "name": "achievement",
+        "name": "employment",
         "trans": [
-            "n. 成就；完成；达到；成绩"
+            "n. 使用；职业；雇用"
         ],
-        "usphone": "[əˈtʃiːvmənt]",
-        "ukphone": "[əˈtʃiːvmənt]"
+        "usphone": "[ɪmˈplɔɪmənt]",
+        "ukphone": "[ɪmˈplɔɪmənt]"
     },
     {
-        "name": "act",
+        "name": "category",
         "trans": [
-            "n. 行为，行动；法令，法案；（戏剧，歌剧的）一幕，段；装腔作势"
+            "n. 种类，分类；[数] 范畴"
         ],
-        "usphone": "[ækt]",
-        "ukphone": "[ækt]"
+        "usphone": "[ˈkætəɡɔːri]",
+        "ukphone": "[ˈkætəɡəri]"
     },
     {
-        "name": "ad",
+        "name": "flow",
         "trans": [
-            "n. 公元；广告（ad）"
+            "n. 流动；流量；涨潮，泛滥"
         ],
-        "usphone": "[æd]",
-        "ukphone": "[æd]"
+        "usphone": "[floʊ]",
+        "ukphone": "[fləʊ]"
     },
     {
-        "name": "addition",
+        "name": "stadium",
         "trans": [
-            "n. 添加；[数] 加法；增加物"
+            "n. 体育场；露天大型运动场"
         ],
-        "usphone": "[əˈdɪʃn]",
-        "ukphone": "[əˈdɪʃn]"
+        "usphone": "[ˈsteɪdiəm]",
+        "ukphone": "[ˈsteɪdiəm]"
     },
     {
-        "name": "admire",
+        "name": "win",
         "trans": [
-            "vt. 钦佩；赞美"
+            "n. 赢；胜利"
         ],
-        "usphone": "[ədˈmaɪər]",
-        "ukphone": "[ədˈmaɪə(r)]"
+        "usphone": "[wɪn]",
+        "ukphone": "[wɪn]"
     },
     {
-        "name": "admit",
+        "name": "punish",
         "trans": [
-            "vi. 承认；容许"
+            "vt. 惩罚；严厉对待；贪婪地吃喝"
         ],
-        "usphone": "[ədˈmɪt]",
-        "ukphone": "[ədˈmɪt]"
+        "usphone": "[ˈpʌnɪʃ]",
+        "ukphone": "[ˈpʌnɪʃ]"
     },
     {
-        "name": "advanced",
+        "name": "worth",
         "trans": [
-            "adj. 先进的；高级的；晚期的；年老的"
+            "n. 价值；财产"
         ],
-        "usphone": "[ədˈvænst]",
-        "ukphone": "[ədˈvɑːnst]"
+        "usphone": "[wɜːrθ]",
+        "ukphone": "[wɜːθ]"
     },
     {
-        "name": "advise",
+        "name": "highlight",
         "trans": [
-            "vt. 建议；劝告，忠告；通知；警告"
+            "n. 最精彩的部分；最重要的事情；加亮区"
         ],
-        "usphone": "[ədˈvaɪz]",
-        "ukphone": "[ədˈvaɪz]"
+        "usphone": "[ˈhaɪlaɪt]",
+        "ukphone": "[ˈhaɪlaɪt]"
     },
     {
-        "name": "afford",
+        "name": "effective",
         "trans": [
-            "vt. 给予，提供；买得起"
+            "adj. 有效的，起作用的；实际的，实在的；给人深刻印象"
         ],
-        "usphone": "[əˈfɔːrd]",
-        "ukphone": "[əˈfɔːd]"
+        "usphone": "[ɪˈfektɪv]",
+        "ukphone": "[ɪˈfektɪv]"
     },
     {
-        "name": "age",
+        "name": "doubt",
         "trans": [
-            "n. 年龄；时代；寿命，使用年限；阶段"
+            "n. 怀疑；疑问；疑惑"
         ],
-        "usphone": "[eɪdʒ]",
-        "ukphone": "[eɪdʒ]"
+        "usphone": "[daʊt]",
+        "ukphone": "[daʊt]"
     },
     {
-        "name": "aged",
+        "name": "mess",
         "trans": [
-            "v. 老化（age的过去式）；成熟；变老"
+            "n. 混乱；食堂，伙食团；困境；脏乱的东西"
         ],
-        "usphone": "[eɪdʒd; ˈeɪdʒɪd]",
-        "ukphone": "[eɪdʒd]"
+        "usphone": "[mes]",
+        "ukphone": "[mes]"
     },
     {
-        "name": "agent",
+        "name": "personally",
         "trans": [
-            "n. 代理人，代理商；药剂；特工"
+            "adv. 亲自地；当面；个别地；就自己而言"
         ],
-        "usphone": "[ˈeɪdʒənt]",
-        "ukphone": "[ˈeɪdʒənt]"
+        "usphone": "[ˈpɜːrsənəli]",
+        "ukphone": "[ˈpɜːsənəli]"
     },
     {
-        "name": "agreement",
+        "name": "vote",
         "trans": [
-            "n. 协议；同意，一致"
+            "n. 投票，选举；选票；得票数"
         ],
-        "usphone": "[əˈɡriːmənt]",
-        "ukphone": "[əˈɡriːmənt]"
+        "usphone": "[voʊt]",
+        "ukphone": "[vəʊt]"
     },
     {
-        "name": "ahead",
+        "name": "election",
         "trans": [
-            "adj. 向前；在前的；领先"
+            "n. 选举；当选；选择权；上帝的选拔"
         ],
-        "usphone": "[əˈhed]",
-        "ukphone": "[əˈhed]"
+        "usphone": "[ɪˈlekʃn]",
+        "ukphone": "[ɪˈlekʃ(ə)n]"
     },
     {
-        "name": "aim",
+        "name": "similarly",
         "trans": [
-            "n. 目的；目标；对准"
+            "adv. 同样地；类似于"
         ],
-        "usphone": "[eɪm]",
-        "ukphone": "[eɪm]"
+        "usphone": "[ˈsɪmələrli]",
+        "ukphone": "[ˈsɪmələli]"
     },
     {
-        "name": "alarm",
+        "name": "iron",
         "trans": [
-            "n. 闹钟；警报，警告器；惊慌"
+            "n. 熨斗；烙铁；坚强"
         ],
-        "usphone": "[əˈlɑːrm]",
-        "ukphone": "[əˈlɑːm]"
+        "usphone": "[ˈaɪərn]",
+        "ukphone": "[ˈaɪən]"
     },
     {
-        "name": "album",
+        "name": "drunk",
         "trans": [
-            "n. 相簿；唱片集；集邮簿；签名纪念册"
+            "v. 喝酒（drink的过去分词）"
         ],
-        "usphone": "[ˈælbəm]",
-        "ukphone": "[ˈælbəm]"
+        "usphone": "[drʌŋk]",
+        "ukphone": "[drʌŋk]"
     },
     {
-        "name": "alcohol",
+        "name": "effort",
         "trans": [
-            "n. 酒精，乙醇"
+            "n. 努力；成就"
         ],
-        "usphone": "[ˈælkəhɔːl]",
-        "ukphone": "[ˈælkəhɒl]"
+        "usphone": "[ˈefərt]",
+        "ukphone": "[ˈefət]"
     },
     {
-        "name": "alcoholic",
+        "name": "fancy",
         "trans": [
-            "n. 酒鬼，酗酒者"
+            "n. 幻想；想象力；爱好"
         ],
-        "usphone": "[ˌælkəˈhɑːlɪk]",
-        "ukphone": "[ˌælkəˈhɒlɪk]"
+        "usphone": "[ˈfænsi]",
+        "ukphone": "[ˈfænsi]"
     },
     {
-        "name": "alternative",
+        "name": "simply",
         "trans": [
-            "n. 二中择一；供替代的选择"
+            "adv. 简单地；仅仅；简直；朴素地；坦白地"
         ],
-        "usphone": "[ɔːlˈtɜːrnətɪv]",
-        "ukphone": "[ɔːlˈtɜːnətɪv]"
+        "usphone": "[ˈsɪmpli]",
+        "ukphone": "[ˈsɪmpli]"
     },
     {
-        "name": "amazed",
+        "name": "cheap",
         "trans": [
-            "v. 使…吃惊；把…弄糊涂（amaze的过去分词）"
+            "adj. 便宜的；小气的；不值钱的"
         ],
-        "usphone": "[əˈmeɪzd]",
-        "ukphone": "[əˈmeɪzd]"
+        "usphone": "[tʃiːp]",
+        "ukphone": "[tʃiːp]"
     },
     {
-        "name": "ambition",
+        "name": "successfully",
         "trans": [
-            "n. 野心，雄心；抱负，志向"
+            "adv. 成功地；顺利地"
         ],
-        "usphone": "[æmˈbɪʃ(ə)n]",
-        "ukphone": "[æmˈbɪʃn]"
+        "usphone": "[səkˈsesfəli]",
+        "ukphone": "[səkˈsesfəli]"
     },
     {
-        "name": "ambitious",
+        "name": "nail",
         "trans": [
-            "adj. 野心勃勃的；有雄心的；热望的；炫耀的"
+            "vt. 钉；使固定；揭露"
         ],
-        "usphone": "[æmˈbɪʃəs]",
-        "ukphone": "[æmˈbɪʃəs]"
+        "usphone": "[neɪl]",
+        "ukphone": "[neɪl]"
+    },
+    {
+        "name": "weapon",
+        "trans": [
+            "n. 武器，兵器"
+        ],
+        "usphone": "[ˈwepən]",
+        "ukphone": "[ˈwepən]"
+    },
+    {
+        "name": "trick",
+        "trans": [
+            "n. 诡计；恶作剧；窍门；花招；骗局；欺诈"
+        ],
+        "usphone": "[trɪk]",
+        "ukphone": "[trɪk]"
+    },
+    {
+        "name": "throughout",
+        "trans": [
+            "prep. 贯穿，遍及"
+        ],
+        "usphone": "[θruːˈaʊt]",
+        "ukphone": "[θruːˈaʊt]"
+    },
+    {
+        "name": "store",
+        "trans": [
+            "n. 商店；储备，贮藏；仓库"
+        ],
+        "usphone": "[stɔːr]",
+        "ukphone": "[stɔː(r)]"
+    },
+    {
+        "name": "rugby",
+        "trans": [
+            "n. 英式橄榄球；拉格比（英格兰中部的城市）"
+        ],
+        "usphone": "[ˈrʌɡbi]",
+        "ukphone": "[ˈrʌɡbi]"
+    },
+    {
+        "name": "double",
+        "trans": [
+            "n. 两倍；双精度型"
+        ],
+        "usphone": "[ˈdʌbl]",
+        "ukphone": "[ˈdʌb(ə)l]"
+    },
+    {
+        "name": "effectively",
+        "trans": [
+            "adv. 有效地，生效地；有力地；实际上"
+        ],
+        "usphone": "[ɪˈfektɪvli]",
+        "ukphone": "[ɪˈfektɪvli]"
+    },
+    {
+        "name": "face",
+        "trans": [
+            "n. 脸；表面；面子；面容；外观；威信"
+        ],
+        "usphone": "[feɪs]",
+        "ukphone": "[feɪs]"
+    },
+    {
+        "name": "regularly",
+        "trans": [
+            "adv. 定期地；有规律地；整齐地；匀称地"
+        ],
+        "usphone": "[ˈreɡjələrli]",
+        "ukphone": "[ˈreɡjələli]"
+    },
+    {
+        "name": "retired",
+        "trans": [
+            "adj. 退休的；退役的；幽闭的"
+        ],
+        "usphone": "[rɪˈtaɪərd]",
+        "ukphone": "[rɪˈtaɪəd]"
+    },
+    {
+        "name": "shine",
+        "trans": [
+            "vt. 照射，擦亮；把…的光投向；（口）通过擦拭使…变得有光泽或光"
+        ],
+        "usphone": "[ʃaɪn]",
+        "ukphone": "[ʃaɪn]"
+    },
+    {
+        "name": "generation",
+        "trans": [
+            "n. 一代；产生；一代人；生殖"
+        ],
+        "usphone": "[ˌdʒenəˈreɪʃn]",
+        "ukphone": "[ˌdʒenəˈreɪʃn]"
     },
     {
         "name": "analyse",
@@ -224,268 +320,60 @@
         "ukphone": "[ˈænəlaɪz]"
     },
     {
-        "name": "analysis",
+        "name": "gentle",
         "trans": [
-            "n. 分析；分解；验定"
+            "n. 蛆，饵"
         ],
-        "usphone": "[əˈnæləsɪs]",
-        "ukphone": "[əˈnæləsɪs]"
+        "usphone": "[ˈdʒentl]",
+        "ukphone": "[ˈdʒent(ə)l]"
     },
     {
-        "name": "announce",
+        "name": "unpleasant",
         "trans": [
-            "vt. 宣布；述说；预示；播报"
+            "adj. 讨厌的；使人不愉快的"
         ],
-        "usphone": "[əˈnaʊns]",
-        "ukphone": "[əˈnaʊns]"
+        "usphone": "[ʌnˈpleznt]",
+        "ukphone": "[ʌnˈplez(ə)nt]"
     },
     {
-        "name": "announcement",
+        "name": "rise",
         "trans": [
-            "n. 公告；宣告；发表；通告"
+            "n. 上升；高地；增加；出现"
         ],
-        "usphone": "[əˈnaʊnsmənt]",
-        "ukphone": "[əˈnaʊnsmənt]"
+        "usphone": "[raɪz]",
+        "ukphone": "[raɪz]"
     },
     {
-        "name": "annoy",
+        "name": "locate",
         "trans": [
-            "n. 烦恼（等于annoyance）"
+            "vt. 位于；查找…的地点"
         ],
-        "usphone": "[əˈnɔɪ]",
-        "ukphone": "[əˈnɔɪ]"
+        "usphone": "[ˈloʊkeɪt]",
+        "ukphone": "[ləʊˈkeɪt]"
     },
     {
-        "name": "annoyed",
+        "name": "connection",
         "trans": [
-            "v. 使烦恼；打扰（annoy的过去分词）"
+            "n. 连接；关系；人脉；连接件"
         ],
-        "usphone": "[əˈnɔɪd]",
-        "ukphone": "[əˈnɔɪd]"
+        "usphone": "[kəˈnekʃn]",
+        "ukphone": "[kəˈnekʃn]"
     },
     {
-        "name": "annoying",
+        "name": "indoor",
         "trans": [
-            "v. 骚扰（annoy的ing形式）"
+            "adj. 室内的，户内的"
         ],
-        "usphone": "[əˈnɔɪɪŋ]",
-        "ukphone": "[əˈnɔɪɪŋ]"
+        "usphone": "[ˈɪndɔːr]",
+        "ukphone": "[ˈɪndɔː(r)]"
     },
     {
-        "name": "apart",
+        "name": "kick",
         "trans": [
-            "adj. 分离的；与众不同的"
+            "vt. 踢；反冲，朝后座"
         ],
-        "usphone": "[əˈpɑːrt]",
-        "ukphone": "[əˈpɑːt]"
-    },
-    {
-        "name": "apologize",
-        "trans": [
-            "vi. 道歉；辩解；赔不是"
-        ],
-        "usphone": "[əˈpɑːlədʒaɪz]",
-        "ukphone": "[əˈpɒlədʒaɪz]"
-    },
-    {
-        "name": "application",
-        "trans": [
-            "n. 应用；申请；应用程序；敷用"
-        ],
-        "usphone": "[ˌæplɪˈkeɪʃn]",
-        "ukphone": "[ˌæplɪˈkeɪʃ(ə)n]"
-    },
-    {
-        "name": "appointment",
-        "trans": [
-            "n. 任命；约定；任命的职位"
-        ],
-        "usphone": "[əˈpɔɪntmənt]",
-        "ukphone": "[əˈpɔɪntmənt]"
-    },
-    {
-        "name": "appreciate",
-        "trans": [
-            "vi. 增值；涨价"
-        ],
-        "usphone": "[əˈpriːʃieɪt]",
-        "ukphone": "[əˈpriːʃieɪt]"
-    },
-    {
-        "name": "approximately",
-        "trans": [
-            "adv. 大约，近似地；近于"
-        ],
-        "usphone": "[əˈprɑːksɪmətli]",
-        "ukphone": "[əˈprɒksɪmətli]"
-    },
-    {
-        "name": "arrest",
-        "trans": [
-            "n. 逮捕；监禁"
-        ],
-        "usphone": "[əˈrest]",
-        "ukphone": "[əˈrest]"
-    },
-    {
-        "name": "arrival",
-        "trans": [
-            "n. 到来；到达；到达者"
-        ],
-        "usphone": "[əˈraɪvl]",
-        "ukphone": "[əˈraɪvl]"
-    },
-    {
-        "name": "assignment",
-        "trans": [
-            "n. 分配；任务；作业；功课"
-        ],
-        "usphone": "[əˈsaɪnmənt]",
-        "ukphone": "[əˈsaɪnmənt]"
-    },
-    {
-        "name": "assist",
-        "trans": [
-            "n. 帮助；助攻"
-        ],
-        "usphone": "[əˈsɪst]",
-        "ukphone": "[əˈsɪst]"
-    },
-    {
-        "name": "atmosphere",
-        "trans": [
-            "n. 气氛；大气；空气"
-        ],
-        "usphone": "[ˈætməsfɪr]",
-        "ukphone": "[ˈætməsfɪə(r)]"
-    },
-    {
-        "name": "attach",
-        "trans": [
-            "vi. 附加；附属；伴随"
-        ],
-        "usphone": "[əˈtætʃ]",
-        "ukphone": "[əˈtætʃ]"
-    },
-    {
-        "name": "attitude",
-        "trans": [
-            "n. 态度；看法；意见；姿势"
-        ],
-        "usphone": "[ˈætɪtuːd]",
-        "ukphone": "[ˈætɪtjuːd]"
-    },
-    {
-        "name": "attract",
-        "trans": [
-            "vt. 吸引；引起"
-        ],
-        "usphone": "[əˈtrækt]",
-        "ukphone": "[əˈtrækt]"
-    },
-    {
-        "name": "attraction",
-        "trans": [
-            "n. 吸引，吸引力；引力；吸引人的事物"
-        ],
-        "usphone": "[əˈtrækʃn]",
-        "ukphone": "[əˈtrækʃ(ə)n]"
-    },
-    {
-        "name": "authority",
-        "trans": [
-            "n. 权威；权力；当局"
-        ],
-        "usphone": "[əˈθɔːrəti]",
-        "ukphone": "[ɔːˈθɒrəti]"
-    },
-    {
-        "name": "average",
-        "trans": [
-            "n. 平均；平均数；海损"
-        ],
-        "usphone": "[ˈævərɪdʒ]",
-        "ukphone": "[ˈævərɪdʒ]"
-    },
-    {
-        "name": "award",
-        "trans": [
-            "n. 奖品；判决"
-        ],
-        "usphone": "[əˈwɔːrd]",
-        "ukphone": "[əˈwɔːd]"
-    },
-    {
-        "name": "aware",
-        "trans": [
-            "adj. 意识到的；知道的；有…方面知识的；懂世故的"
-        ],
-        "usphone": "[əˈwer]",
-        "ukphone": "[əˈweə(r)]"
-    },
-    {
-        "name": "backwards",
-        "trans": [
-            "adv. 倒；向后；逆"
-        ],
-        "usphone": "[ˈbækwərdz]",
-        "ukphone": "[ˈbækwədz]"
-    },
-    {
-        "name": "bake",
-        "trans": [
-            "n. 烤；烘烤食品"
-        ],
-        "usphone": "[beɪk]",
-        "ukphone": "[beɪk]"
-    },
-    {
-        "name": "balance",
-        "trans": [
-            "n. 平衡；余额；匀称"
-        ],
-        "usphone": "[ˈbæləns]",
-        "ukphone": "[ˈbæləns]"
-    },
-    {
-        "name": "ban",
-        "trans": [
-            "n. 禁令，禁忌"
-        ],
-        "usphone": "[bæn]",
-        "ukphone": "[bæn]"
-    },
-    {
-        "name": "base",
-        "trans": [
-            "n. 基础；底部；垒"
-        ],
-        "usphone": "[beɪs]",
-        "ukphone": "[beɪs]"
-    },
-    {
-        "name": "basic",
-        "trans": [
-            "n. 基础；要素"
-        ],
-        "usphone": "[ˈbeɪsɪk]",
-        "ukphone": "[ˈbeɪsɪk]"
-    },
-    {
-        "name": "basis",
-        "trans": [
-            "n. 基础；底部；主要成分；基本原则或原理"
-        ],
-        "usphone": "[ˈbeɪsɪs]",
-        "ukphone": "[ˈbeɪsɪs]"
-    },
-    {
-        "name": "battery",
-        "trans": [
-            "n. [电] 电池，蓄电池"
-        ],
-        "usphone": "[ˈbætəri]",
-        "ukphone": "[ˈbætri; ˈbætəri]"
+        "usphone": "[kɪk]",
+        "ukphone": "[kɪk]"
     },
     {
         "name": "battle",
@@ -496,60 +384,164 @@
         "ukphone": "[ˈbæt(ə)l]"
     },
     {
-        "name": "beauty",
+        "name": "annoying",
         "trans": [
-            "n. 美；美丽；美人；美好的东西"
+            "v. 骚扰（annoy的ing形式）"
         ],
-        "usphone": "[ˈbjuːti]",
-        "ukphone": "[ˈbjuːti]"
+        "usphone": "[əˈnɔɪɪŋ]",
+        "ukphone": "[əˈnɔɪɪŋ]"
     },
     {
-        "name": "bee",
+        "name": "volunteer",
         "trans": [
-            "n. 蜜蜂，蜂；勤劳的人"
+            "n. 志愿者；志愿兵"
         ],
-        "usphone": "[biː]",
-        "ukphone": "[biː]"
+        "usphone": "[ˌvɑːlənˈtɪr]",
+        "ukphone": "[ˌvɒlənˈtɪə(r)]"
     },
     {
-        "name": "belief",
+        "name": "issue",
         "trans": [
-            "n. 相信，信赖；信仰；教义"
+            "n. 问题；流出；期号；发行物"
         ],
-        "usphone": "[bɪˈliːf]",
-        "ukphone": "[bɪˈliːf]"
+        "usphone": "[ˈɪʃuː]",
+        "ukphone": "[ˈɪʃuː]"
     },
     {
-        "name": "bell",
+        "name": "unfair",
         "trans": [
-            "n. 铃，钟；钟声，铃声；钟状物"
+            "adj. 不公平的，不公正的"
         ],
-        "usphone": "[bel]",
-        "ukphone": "[bel]"
+        "usphone": "[ˌʌnˈfer]",
+        "ukphone": "[ˌʌnˈfeə(r)]"
     },
     {
-        "name": "bend",
+        "name": "knock",
         "trans": [
-            "n. 弯曲"
+            "vi. 敲；打；敲击"
         ],
-        "usphone": "[bend]",
-        "ukphone": "[bend]"
+        "usphone": "[nɑːk]",
+        "ukphone": "[nɒk]"
     },
     {
-        "name": "benefit",
+        "name": "supporter",
         "trans": [
-            "n. 利益，好处；救济金"
+            "n. 支持者；拥护者"
         ],
-        "usphone": "[ˈbenɪfɪt]",
-        "ukphone": "[ˈbenɪfɪt]"
+        "usphone": "[səˈpɔːrtər]",
+        "ukphone": "[səˈpɔːtə(r)]"
     },
     {
-        "name": "better",
+        "name": "magic",
         "trans": [
-            "n. 长辈；较好者；打赌的人（等于bettor）"
+            "n. 巫术；魔法；戏法"
         ],
-        "usphone": "[ˈbetər]",
-        "ukphone": "[ˈbetə(r)]"
+        "usphone": "[ˈmædʒɪk]",
+        "ukphone": "[ˈmædʒɪk]"
+    },
+    {
+        "name": "attract",
+        "trans": [
+            "vt. 吸引；引起"
+        ],
+        "usphone": "[əˈtrækt]",
+        "ukphone": "[əˈtrækt]"
+    },
+    {
+        "name": "scan",
+        "trans": [
+            "n. 扫描；浏览；审视；细看"
+        ],
+        "usphone": "[skæn]",
+        "ukphone": "[skæn]"
+    },
+    {
+        "name": "generous",
+        "trans": [
+            "adj. 慷慨的，大方的；宽宏大量的；有雅量的"
+        ],
+        "usphone": "[ˈdʒenərəs]",
+        "ukphone": "[ˈdʒenərəs]"
+    },
+    {
+        "name": "will",
+        "trans": [
+            "n. 意志；决心；情感；遗嘱；意图；心愿"
+        ],
+        "usphone": "[wɪl]",
+        "ukphone": "[wɪl]"
+    },
+    {
+        "name": "frightening",
+        "trans": [
+            "adj. 令人恐惧的；引起突然惊恐的"
+        ],
+        "usphone": "[ˈfraɪtnɪŋ]",
+        "ukphone": "[ˈfraɪt(ə)nɪŋ]"
+    },
+    {
+        "name": "honest",
+        "trans": [
+            "adj. 诚实的，实在的；可靠的；坦率的"
+        ],
+        "usphone": "[ˈɑːnɪst]",
+        "ukphone": "[ˈɒnɪst]"
+    },
+    {
+        "name": "sort",
+        "trans": [
+            "n. 种类；方式；品质"
+        ],
+        "usphone": "[sɔːrt]",
+        "ukphone": "[sɔːt]"
+    },
+    {
+        "name": "mad",
+        "trans": [
+            "adj. 疯狂的；发疯的；愚蠢的；着迷的"
+        ],
+        "usphone": "[mæd]",
+        "ukphone": "[mæd]"
+    },
+    {
+        "name": "consequence",
+        "trans": [
+            "n. 结果；重要性；推论"
+        ],
+        "usphone": "[ˈkɑːnsɪkwens]",
+        "ukphone": "[ˈkɒnsɪkwəns]"
+    },
+    {
+        "name": "silent",
+        "trans": [
+            "n. 无声电影"
+        ],
+        "usphone": "[ˈsaɪlənt]",
+        "ukphone": "[ˈsaɪlənt]"
+    },
+    {
+        "name": "powder",
+        "trans": [
+            "n. 粉；粉末；[化工][军] 火药；尘土"
+        ],
+        "usphone": "[ˈpaʊdər]",
+        "ukphone": "[ˈpaʊdə(r)]"
+    },
+    {
+        "name": "annoy",
+        "trans": [
+            "n. 烦恼（等于annoyance）"
+        ],
+        "usphone": "[əˈnɔɪ]",
+        "ukphone": "[əˈnɔɪ]"
+    },
+    {
+        "name": "embarrassing",
+        "trans": [
+            "adj. 使人尴尬的；令人为难的"
+        ],
+        "usphone": "[ɪmˈbærəsɪŋ]",
+        "ukphone": "[ɪmˈbærəsɪŋ]"
     },
     {
         "name": "bite",
@@ -560,28 +552,1444 @@
         "ukphone": "[baɪt]"
     },
     {
-        "name": "block",
+        "name": "further",
         "trans": [
-            "n. 块；街区；大厦；障碍物"
+            "adj. 更远的；深一层的"
         ],
-        "usphone": "[blɑːk]",
-        "ukphone": "[blɒk]"
+        "usphone": "[ˈfɜːrðər]",
+        "ukphone": "[ˈfɜːðə(r)]"
     },
     {
-        "name": "board",
+        "name": "servant",
         "trans": [
-            "n. 董事会；木板；甲板；膳食"
+            "n. 仆人，佣人；公务员；雇工"
         ],
-        "usphone": "[bɔːrd]",
-        "ukphone": "[bɔːd]"
+        "usphone": "[ˈsɜːrvənt]",
+        "ukphone": "[ˈsɜːvənt]"
     },
     {
-        "name": "bomb",
+        "name": "guilty",
         "trans": [
-            "n. 炸弹"
+            "adj. 有罪的；内疚的"
         ],
-        "usphone": "[bɑːm]",
-        "ukphone": "[bɒm]"
+        "usphone": "[ˈɡɪlti]",
+        "ukphone": "[ˈɡɪlti]"
+    },
+    {
+        "name": "measure",
+        "trans": [
+            "n. 测量；措施；程度；尺寸"
+        ],
+        "usphone": "[ˈmeʒər]",
+        "ukphone": "[ˈmeʒə(r)]"
+    },
+    {
+        "name": "portrait",
+        "trans": [
+            "n. 肖像；描写；半身雕塑像"
+        ],
+        "usphone": "[ˈpɔːrtrət]",
+        "ukphone": "[ˈpɔːtreɪt]"
+    },
+    {
+        "name": "curtain",
+        "trans": [
+            "n. 幕；窗帘"
+        ],
+        "usphone": "[ˈkɜːrtn]",
+        "ukphone": "[ˈkɜːt(ə)n]"
+    },
+    {
+        "name": "revise",
+        "trans": [
+            "n. 修订；校订"
+        ],
+        "usphone": "[rɪˈvaɪz]",
+        "ukphone": "[rɪˈvaɪz]"
+    },
+    {
+        "name": "sculpture",
+        "trans": [
+            "n. 雕塑；雕刻；刻蚀"
+        ],
+        "usphone": "[ˈskʌlptʃər]",
+        "ukphone": "[ˈskʌlptʃə(r)]"
+    },
+    {
+        "name": "still",
+        "trans": [
+            "conj. 仍然；但是；尽管如此"
+        ],
+        "usphone": "[stɪl]",
+        "ukphone": "[stɪl]"
+    },
+    {
+        "name": "young",
+        "trans": [
+            "n. 年轻人；（动物的）崽，仔"
+        ],
+        "usphone": "[jʌŋ]",
+        "ukphone": "[jʌŋ]"
+    },
+    {
+        "name": "competitive",
+        "trans": [
+            "adj. 竞争的；比赛的；求胜心切的"
+        ],
+        "usphone": "[kəmˈpetətɪv]",
+        "ukphone": "[kəmˈpetətɪv]"
+    },
+    {
+        "name": "favour",
+        "trans": [
+            "n. 偏爱；赞同；善行"
+        ],
+        "usphone": "[ˈfeɪvər]",
+        "ukphone": "[ˈfeɪvə(r)]"
+    },
+    {
+        "name": "princess",
+        "trans": [
+            "n. 公主；王妃；女巨头"
+        ],
+        "usphone": "[ˈprɪnses]",
+        "ukphone": "[ˌprɪnˈses; ˈprɪnses]"
+    },
+    {
+        "name": "empty",
+        "trans": [
+            "n. 空车；空的东西"
+        ],
+        "usphone": "[ˈempti]",
+        "ukphone": "[ˈempti]"
+    },
+    {
+        "name": "quote",
+        "trans": [
+            "n. 引用"
+        ],
+        "usphone": "[kwoʊt]",
+        "ukphone": "[kwəʊt]"
+    },
+    {
+        "name": "alcoholic",
+        "trans": [
+            "n. 酒鬼，酗酒者"
+        ],
+        "usphone": "[ˌælkəˈhɑːlɪk]",
+        "ukphone": "[ˌælkəˈhɒlɪk]"
+    },
+    {
+        "name": "graduate",
+        "trans": [
+            "n. 研究生；毕业生"
+        ],
+        "usphone": "[ˈɡrædʒuət]",
+        "ukphone": "[ˈɡrædʒuət]"
+    },
+    {
+        "name": "throat",
+        "trans": [
+            "n. 喉咙；嗓子，嗓音；窄路"
+        ],
+        "usphone": "[θroʊt]",
+        "ukphone": "[θrəʊt]"
+    },
+    {
+        "name": "odd",
+        "trans": [
+            "adj. 奇数的；古怪的；剩余的；临时的；零散的"
+        ],
+        "usphone": "[ɑːd]",
+        "ukphone": "[ɒd]"
+    },
+    {
+        "name": "this",
+        "trans": [
+            "adj. 这；本；这个；今"
+        ],
+        "usphone": "[ðɪs]",
+        "ukphone": "[ðɪs]"
+    },
+    {
+        "name": "occasion",
+        "trans": [
+            "n. 时机，机会；场合；理由"
+        ],
+        "usphone": "[əˈkeɪʒn]",
+        "ukphone": "[əˈkeɪʒ(ə)n]"
+    },
+    {
+        "name": "pipe",
+        "trans": [
+            "n. 管；烟斗；笛"
+        ],
+        "usphone": "[paɪp]",
+        "ukphone": "[paɪp]"
+    },
+    {
+        "name": "primary",
+        "trans": [
+            "n. 原色；最主要者"
+        ],
+        "usphone": "[ˈpraɪmeri]",
+        "ukphone": "[ˈpraɪməri]"
+    },
+    {
+        "name": "practical",
+        "trans": [
+            "adj. 实际的；实用性的"
+        ],
+        "usphone": "[ˈpræktɪkl]",
+        "ukphone": "[ˈpræktɪkl]"
+    },
+    {
+        "name": "belief",
+        "trans": [
+            "n. 相信，信赖；信仰；教义"
+        ],
+        "usphone": "[bɪˈliːf]",
+        "ukphone": "[bɪˈliːf]"
+    },
+    {
+        "name": "determined",
+        "trans": [
+            "v. 决定；断定（determine的过去分词）"
+        ],
+        "usphone": "[dɪˈtɜːrmɪnd]",
+        "ukphone": "[dɪˈtɜːmɪnd]"
+    },
+    {
+        "name": "whole",
+        "trans": [
+            "n. 整体；全部"
+        ],
+        "usphone": "[hoʊl]",
+        "ukphone": "[həʊl]"
+    },
+    {
+        "name": "fitness",
+        "trans": [
+            "n. 健康；适当；适合性"
+        ],
+        "usphone": "[ˈfɪtnəs]",
+        "ukphone": "[ˈfɪtnəs]"
+    },
+    {
+        "name": "approximately",
+        "trans": [
+            "adv. 大约，近似地；近于"
+        ],
+        "usphone": "[əˈprɑːksɪmətli]",
+        "ukphone": "[əˈprɒksɪmətli]"
+    },
+    {
+        "name": "sudden",
+        "trans": [
+            "n. 突然发生的事"
+        ],
+        "usphone": "[ˈsʌdn]",
+        "ukphone": "[ˈsʌd(ə)n]"
+    },
+    {
+        "name": "currency",
+        "trans": [
+            "n. 货币；通货"
+        ],
+        "usphone": "[ˈkɜːrənsi]",
+        "ukphone": "[ˈkʌrənsi]"
+    },
+    {
+        "name": "politics",
+        "trans": [
+            "n. 政治，政治学；政治活动；政纲"
+        ],
+        "usphone": "[ˈpɑːlətɪks]",
+        "ukphone": "[ˈpɒlətɪks]"
+    },
+    {
+        "name": "bake",
+        "trans": [
+            "n. 烤；烘烤食品"
+        ],
+        "usphone": "[beɪk]",
+        "ukphone": "[beɪk]"
+    },
+    {
+        "name": "engaged",
+        "trans": [
+            "v. 保证；约定；同…订婚（engage的过去分词）"
+        ],
+        "usphone": "[ɪnˈɡeɪdʒd]",
+        "ukphone": "[ɪnˈɡeɪdʒd]"
+    },
+    {
+        "name": "journal",
+        "trans": [
+            "n. 日报，杂志；日记；分类账"
+        ],
+        "usphone": "[ˈdʒɜːrnl]",
+        "ukphone": "[ˈdʒɜːn(ə)l]"
+    },
+    {
+        "name": "though",
+        "trans": [
+            "conj. 虽然；尽管"
+        ],
+        "usphone": "[ðoʊ]",
+        "ukphone": "[ðəʊ]"
+    },
+    {
+        "name": "award",
+        "trans": [
+            "n. 奖品；判决"
+        ],
+        "usphone": "[əˈwɔːrd]",
+        "ukphone": "[əˈwɔːd]"
+    },
+    {
+        "name": "outdoors",
+        "trans": [
+            "adv. 在户外"
+        ],
+        "usphone": "[ˌaʊtˈdɔːrz]",
+        "ukphone": "[ˌaʊtˈdɔːz]"
+    },
+    {
+        "name": "retire",
+        "trans": [
+            "n. 退休；退隐；退兵信号"
+        ],
+        "usphone": "[rɪˈtaɪər]",
+        "ukphone": "[rɪˈtaɪə(r)]"
+    },
+    {
+        "name": "transport",
+        "trans": [
+            "n. 运输；运输机；狂喜；流放犯"
+        ],
+        "usphone": "[ˈtrænspɔːrt]",
+        "ukphone": "[ˈtrænspɔːt]"
+    },
+    {
+        "name": "headline",
+        "trans": [
+            "n. 大标题；内容提要；栏外标题；头版头条新闻"
+        ],
+        "usphone": "[ˈhedlaɪn]",
+        "ukphone": "[ˈhedlaɪn]"
+    },
+    {
+        "name": "security",
+        "trans": [
+            "n. 安全；保证；证券；抵押品"
+        ],
+        "usphone": "[sɪˈkjʊrəti]",
+        "ukphone": "[sɪˈkjʊərəti]"
+    },
+    {
+        "name": "responsibility",
+        "trans": [
+            "n. 责任，职责；义务"
+        ],
+        "usphone": "[rɪˌspɑːnsəˈbɪləti]",
+        "ukphone": "[rɪˌspɒnsəˈbɪləti]"
+    },
+    {
+        "name": "excitement",
+        "trans": [
+            "n. 兴奋；刺激；令人兴奋的事物"
+        ],
+        "usphone": "[ɪkˈsaɪtmənt]",
+        "ukphone": "[ɪkˈsaɪtmənt]"
+    },
+    {
+        "name": "suffer",
+        "trans": [
+            "vi. 遭受，忍受；受痛苦；经验；受损害"
+        ],
+        "usphone": "[ˈsʌfər]",
+        "ukphone": "[ˈsʌfə(r)]"
+    },
+    {
+        "name": "appointment",
+        "trans": [
+            "n. 任命；约定；任命的职位"
+        ],
+        "usphone": "[əˈpɔɪntmənt]",
+        "ukphone": "[əˈpɔɪntmənt]"
+    },
+    {
+        "name": "aware",
+        "trans": [
+            "adj. 意识到的；知道的；有…方面知识的；懂世故的"
+        ],
+        "usphone": "[əˈwer]",
+        "ukphone": "[əˈweə(r)]"
+    },
+    {
+        "name": "IT",
+        "trans": [
+            "abbr. 信息技术information technology"
+        ],
+        "usphone": "[ˌaɪ ˈtiː]",
+        "ukphone": "[ˌaɪ ˈtiː]"
+    },
+    {
+        "name": "promote",
+        "trans": [
+            "vi. 成为王后或其他大于卒的子"
+        ],
+        "usphone": "[prəˈmoʊt]",
+        "ukphone": "[prəˈməʊt]"
+    },
+    {
+        "name": "photography",
+        "trans": [
+            "n. 摄影；摄影术"
+        ],
+        "usphone": "[fəˈtɑːɡrəfi]",
+        "ukphone": "[fəˈtɒɡrəfi]"
+    },
+    {
+        "name": "leading",
+        "trans": [
+            "adj. 领导的；主要的"
+        ],
+        "usphone": "[ˈliːdɪŋ; ˈledɪŋ]",
+        "ukphone": "[ˈliːdɪŋ]"
+    },
+    {
+        "name": "therefore",
+        "trans": [
+            "adv. 因此；所以"
+        ],
+        "usphone": "[ˈðerfɔːr]",
+        "ukphone": "[ˈðeəfɔː(r)]"
+    },
+    {
+        "name": "episode",
+        "trans": [
+            "n. 插曲；一段情节；插话；有趣的事件"
+        ],
+        "usphone": "[ˈepɪsoʊd]",
+        "ukphone": "[ˈepɪsəʊd]"
+    },
+    {
+        "name": "fixed",
+        "trans": [
+            "adj. 确定的；固执的；<美口>处境...的；准备好的"
+        ],
+        "usphone": "[fɪkst]",
+        "ukphone": "[fɪkst]"
+    },
+    {
+        "name": "hire",
+        "trans": [
+            "n. 雇用，租用；租金，工钱"
+        ],
+        "usphone": "[ˈhaɪər]",
+        "ukphone": "[ˈhaɪə(r)]"
+    },
+    {
+        "name": "kiss",
+        "trans": [
+            "vt. 吻；（风等）轻拂"
+        ],
+        "usphone": "[kɪs]",
+        "ukphone": "[kɪs]"
+    },
+    {
+        "name": "involved",
+        "trans": [
+            "v. 涉及；使参与；包含（involve的过去式和过去分词）"
+        ],
+        "usphone": "[ɪnˈvɑːlvd]",
+        "ukphone": "[ɪnˈvɒlvd]"
+    },
+    {
+        "name": "sexual",
+        "trans": [
+            "adj. 性的；性别的；有性的"
+        ],
+        "usphone": "[ˈsekʃuəl]",
+        "ukphone": "[ˈsekʃuəl]"
+    },
+    {
+        "name": "surface",
+        "trans": [
+            "n. 表面；表层；外观"
+        ],
+        "usphone": "[ˈsɜːrfɪs]",
+        "ukphone": "[ˈsɜːfɪs]"
+    },
+    {
+        "name": "explosion",
+        "trans": [
+            "n. 爆炸；爆发；激增"
+        ],
+        "usphone": "[ɪkˈsploʊʒn]",
+        "ukphone": "[ɪkˈspləʊʒ(ə)n]"
+    },
+    {
+        "name": "worse",
+        "trans": [
+            "n. 更坏的事；更恶劣的事"
+        ],
+        "usphone": "[wɜːrs]",
+        "ukphone": "[wɜːs]"
+    },
+    {
+        "name": "decorate",
+        "trans": [
+            "vt. 装饰；布置；授勋给"
+        ],
+        "usphone": "[ˈdekəreɪt]",
+        "ukphone": "[ˈdekəreɪt]"
+    },
+    {
+        "name": "financial",
+        "trans": [
+            "adj. 金融的；财政的，财务的"
+        ],
+        "usphone": "[faɪˈnænʃl; fəˈnænʃl]",
+        "ukphone": "[faɪˈnænʃ(ə)l]"
+    },
+    {
+        "name": "annoyed",
+        "trans": [
+            "v. 使烦恼；打扰（annoy的过去分词）"
+        ],
+        "usphone": "[əˈnɔɪd]",
+        "ukphone": "[əˈnɔɪd]"
+    },
+    {
+        "name": "lonely",
+        "trans": [
+            "adj. 寂寞的；偏僻的"
+        ],
+        "usphone": "[ˈloʊnli]",
+        "ukphone": "[ˈləʊnli]"
+    },
+    {
+        "name": "particularly",
+        "trans": [
+            "adv. 特别地，独特地；详细地，具体地；明确地，细致地"
+        ],
+        "usphone": "[pərˈtɪkjələrli]",
+        "ukphone": "[pəˈtɪkjələli]"
+    },
+    {
+        "name": "claim",
+        "trans": [
+            "n. 要求；声称；索赔；断言；值得"
+        ],
+        "usphone": "[kleɪm]",
+        "ukphone": "[kleɪm]"
+    },
+    {
+        "name": "garage",
+        "trans": [
+            "n. 车库；汽车修理厂；飞机库"
+        ],
+        "usphone": "[ɡəˈrɑːʒ; ɡəˈrɑːdʒ]",
+        "ukphone": "[ˈɡærɑːʒ]"
+    },
+    {
+        "name": "entry",
+        "trans": [
+            "n. 进入；入口；条目；登记；报关手续；对土地的侵占"
+        ],
+        "usphone": "[ˈentri]",
+        "ukphone": "[ˈentri]"
+    },
+    {
+        "name": "prediction",
+        "trans": [
+            "n. 预报；预言"
+        ],
+        "usphone": "[prɪˈdɪkʃn]",
+        "ukphone": "[prɪˈdɪkʃn]"
+    },
+    {
+        "name": "improvement",
+        "trans": [
+            "n. 改进，改善；提高"
+        ],
+        "usphone": "[ɪmˈpruːvmənt]",
+        "ukphone": "[ɪmˈpruːvmənt]"
+    },
+    {
+        "name": "shift",
+        "trans": [
+            "n. 移动；变化；手段；轮班"
+        ],
+        "usphone": "[ʃɪft]",
+        "ukphone": "[ʃɪft]"
+    },
+    {
+        "name": "warn",
+        "trans": [
+            "vt. 警告，提醒；通知"
+        ],
+        "usphone": "[wɔːrn]",
+        "ukphone": "[wɔːn]"
+    },
+    {
+        "name": "indoors",
+        "trans": [
+            "adv. 在室内，在户内"
+        ],
+        "usphone": "[ˌɪnˈdɔːrz]",
+        "ukphone": "[ˌɪnˈdɔːz]"
+    },
+    {
+        "name": "smooth",
+        "trans": [
+            "n. 平滑部分；一块平地"
+        ],
+        "usphone": "[smuːð]",
+        "ukphone": "[smuːð]"
+    },
+    {
+        "name": "function",
+        "trans": [
+            "n. 功能；[数] 函数；职责；盛大的集会"
+        ],
+        "usphone": "[ˈfʌŋkʃn]",
+        "ukphone": "[ˈfʌŋkʃ(ə)n]"
+    },
+    {
+        "name": "relate",
+        "trans": [
+            "vt. 叙述；使…有联系"
+        ],
+        "usphone": "[rɪˈleɪt]",
+        "ukphone": "[rɪˈleɪt]"
+    },
+    {
+        "name": "hand",
+        "trans": [
+            "n. 手，手艺；帮助；指针；插手"
+        ],
+        "usphone": "[hænd]",
+        "ukphone": "[hænd]"
+    },
+    {
+        "name": "nor",
+        "trans": [
+            "conj. 也不；也不是"
+        ],
+        "usphone": "[nɔːr]",
+        "ukphone": "[nɔː(r)]"
+    },
+    {
+        "name": "wool",
+        "trans": [
+            "n. 羊毛；毛线；绒线；毛织品；毛料衣物"
+        ],
+        "usphone": "[wʊl]",
+        "ukphone": "[wʊl]"
+    },
+    {
+        "name": "consist",
+        "trans": [
+            "vi. 由…组成；在于；符合"
+        ],
+        "usphone": "[kənˈsɪst]",
+        "ukphone": "[kənˈsɪst]"
+    },
+    {
+        "name": "range",
+        "trans": [
+            "n. 范围；幅度；排；山脉"
+        ],
+        "usphone": "[reɪndʒ]",
+        "ukphone": "[reɪndʒ]"
+    },
+    {
+        "name": "mixture",
+        "trans": [
+            "n. 混合；混合物；混合剂"
+        ],
+        "usphone": "[ˈmɪkstʃər]",
+        "ukphone": "[ˈmɪkstʃə(r)]"
+    },
+    {
+        "name": "imaginary",
+        "trans": [
+            "adj. 虚构的，假想的；想像的；虚数的"
+        ],
+        "usphone": "[ɪˈmædʒɪneri]",
+        "ukphone": "[ɪˈmædʒɪnəri]"
+    },
+    {
+        "name": "symptom",
+        "trans": [
+            "n. [临床] 症状；征兆"
+        ],
+        "usphone": "[ˈsɪmptəm]",
+        "ukphone": "[ˈsɪmptəm]"
+    },
+    {
+        "name": "indirect",
+        "trans": [
+            "adj. 间接的；迂回的；非直截了当的"
+        ],
+        "usphone": "[ˌɪndəˈrektˌˌɪndaɪˈrekt]",
+        "ukphone": "[ˌɪndəˈrekt; ˌɪndaɪˈrekt]"
+    },
+    {
+        "name": "bend",
+        "trans": [
+            "n. 弯曲"
+        ],
+        "usphone": "[bend]",
+        "ukphone": "[bend]"
+    },
+    {
+        "name": "total",
+        "trans": [
+            "n. 总数，合计"
+        ],
+        "usphone": "[ˈtoʊtl]",
+        "ukphone": "[ˈtəʊt(ə)l]"
+    },
+    {
+        "name": "ahead",
+        "trans": [
+            "adj. 向前；在前的；领先"
+        ],
+        "usphone": "[əˈhed]",
+        "ukphone": "[əˈhed]"
+    },
+    {
+        "name": "production",
+        "trans": [
+            "n. 成果；产品；生产；作品"
+        ],
+        "usphone": "[prəˈdʌkʃn]",
+        "ukphone": "[prəˈdʌkʃn]"
+    },
+    {
+        "name": "net",
+        "trans": [
+            "n. 网；网络；净利；实价"
+        ],
+        "usphone": "[net]",
+        "ukphone": "[net]"
+    },
+    {
+        "name": "since",
+        "trans": [
+            "conj. 因为；由于；既然；自…以来；自…以后"
+        ],
+        "usphone": "[sɪns]",
+        "ukphone": "[sɪns]"
+    },
+    {
+        "name": "path",
+        "trans": [
+            "n. 道路；小路；轨道"
+        ],
+        "usphone": "[pæθ]",
+        "ukphone": "[pɑːθ]"
+    },
+    {
+        "name": "feature",
+        "trans": [
+            "n. 特色，特征；容貌；特写或专题节目"
+        ],
+        "usphone": "[ˈfiːtʃər]",
+        "ukphone": "[ˈfiːtʃə(r)]"
+    },
+    {
+        "name": "campaign",
+        "trans": [
+            "n. 运动；活动；战役"
+        ],
+        "usphone": "[kæmˈpeɪn]",
+        "ukphone": "[kæmˈpeɪn]"
+    },
+    {
+        "name": "content",
+        "trans": [
+            "n. 内容，目录；满足；容量"
+        ],
+        "usphone": "[ˈkɑːntent; kənˈtent]",
+        "ukphone": "[ˈkɒntent]"
+    },
+    {
+        "name": "flour",
+        "trans": [
+            "n. 面粉；粉状物质"
+        ],
+        "usphone": "[ˈflaʊər]",
+        "ukphone": "[ˈflaʊə(r)]"
+    },
+    {
+        "name": "emergency",
+        "trans": [
+            "n. 紧急情况；突发事件；非常时刻"
+        ],
+        "usphone": "[ɪˈmɜːrdʒənsi]",
+        "ukphone": "[ɪˈmɜːdʒənsi]"
+    },
+    {
+        "name": "move",
+        "trans": [
+            "n. 移动；步骤；迁居；策略"
+        ],
+        "usphone": "[muːv]",
+        "ukphone": "[muːv]"
+    },
+    {
+        "name": "departure",
+        "trans": [
+            "n. 离开；出发；违背"
+        ],
+        "usphone": "[dɪˈpɑːrtʃər]",
+        "ukphone": "[dɪˈpɑːtʃə(r)]"
+    },
+    {
+        "name": "court",
+        "trans": [
+            "n. 法院；球场；朝廷；奉承"
+        ],
+        "usphone": "[kɔːrt]",
+        "ukphone": "[kɔːt]"
+    },
+    {
+        "name": "sailor",
+        "trans": [
+            "n. 水手，海员；乘船者"
+        ],
+        "usphone": "[ˈseɪlər]",
+        "ukphone": "[ˈseɪlə(r)]"
+    },
+    {
+        "name": "hunt",
+        "trans": [
+            "n. 狩猎；搜寻"
+        ],
+        "usphone": "[hʌnt]",
+        "ukphone": "[hʌnt]"
+    },
+    {
+        "name": "advise",
+        "trans": [
+            "vt. 建议；劝告，忠告；通知；警告"
+        ],
+        "usphone": "[ədˈvaɪz]",
+        "ukphone": "[ədˈvaɪz]"
+    },
+    {
+        "name": "click",
+        "trans": [
+            "n. 单击；滴答声"
+        ],
+        "usphone": "[klɪk]",
+        "ukphone": "[klɪk]"
+    },
+    {
+        "name": "supply",
+        "trans": [
+            "n. 供给，补给；供应品"
+        ],
+        "usphone": "[səˈplaɪ]",
+        "ukphone": "[səˈplaɪ]"
+    },
+    {
+        "name": "string",
+        "trans": [
+            "n. 线，弦，细绳；一串，一行"
+        ],
+        "usphone": "[strɪŋ]",
+        "ukphone": "[strɪŋ]"
+    },
+    {
+        "name": "embarrassed",
+        "trans": [
+            "v. 使...困窘；使...局促不安（embarrass的过去分词形式）"
+        ],
+        "usphone": "[ɪmˈbærəst]",
+        "ukphone": "[ɪmˈbærəst]"
+    },
+    {
+        "name": "flood",
+        "trans": [
+            "n. 洪水；泛滥；一大批"
+        ],
+        "usphone": "[flʌd]",
+        "ukphone": "[flʌd]"
+    },
+    {
+        "name": "warning",
+        "trans": [
+            "n. 警告；预兆；预告"
+        ],
+        "usphone": "[ˈwɔːrnɪŋ]",
+        "ukphone": "[ˈwɔːnɪŋ]"
+    },
+    {
+        "name": "poem",
+        "trans": [
+            "n. 诗"
+        ],
+        "usphone": "[ˈpoʊəm]",
+        "ukphone": "[ˈpəʊɪm]"
+    },
+    {
+        "name": "indeed",
+        "trans": [
+            "adv. 的确；实在；真正地；甚至"
+        ],
+        "usphone": "[ɪnˈdiːd]",
+        "ukphone": "[ɪnˈdiːd]"
+    },
+    {
+        "name": "current",
+        "trans": [
+            "n. （水，气，电）流；趋势；涌流"
+        ],
+        "usphone": "[ˈkɜːrənt]",
+        "ukphone": "[ˈkʌrənt]"
+    },
+    {
+        "name": "stranger",
+        "trans": [
+            "n. 陌生人；外地人；局外人"
+        ],
+        "usphone": "[ˈstreɪndʒər]",
+        "ukphone": "[ˈstreɪndʒə(r)]"
+    },
+    {
+        "name": "daily",
+        "trans": [
+            "n. 日报；朝来夜去的女佣"
+        ],
+        "usphone": "[ˈdeɪli]",
+        "ukphone": "[ˈdeɪli]"
+    },
+    {
+        "name": "application",
+        "trans": [
+            "n. 应用；申请；应用程序；敷用"
+        ],
+        "usphone": "[ˌæplɪˈkeɪʃn]",
+        "ukphone": "[ˌæplɪˈkeɪʃ(ə)n]"
+    },
+    {
+        "name": "invest",
+        "trans": [
+            "vi. 投资，入股；花钱买"
+        ],
+        "usphone": "[ɪnˈvest]",
+        "ukphone": "[ɪnˈvest]"
+    },
+    {
+        "name": "count",
+        "trans": [
+            "n. 计数；计算；伯爵"
+        ],
+        "usphone": "[kaʊnt]",
+        "ukphone": "[kaʊnt]"
+    },
+    {
+        "name": "conclude",
+        "trans": [
+            "vi. 推断；断定；决定"
+        ],
+        "usphone": "[kənˈkluːd]",
+        "ukphone": "[kənˈkluːd]"
+    },
+    {
+        "name": "poisonous",
+        "trans": [
+            "adj. 有毒的；恶毒的；讨厌的"
+        ],
+        "usphone": "[ˈpɔɪzənəs]",
+        "ukphone": "[ˈpɔɪzənəs]"
+    },
+    {
+        "name": "percentage",
+        "trans": [
+            "n. 百分比；百分率，百分数"
+        ],
+        "usphone": "[pərˈsentɪdʒ]",
+        "ukphone": "[pəˈsentɪdʒ]"
+    },
+    {
+        "name": "various",
+        "trans": [
+            "adj. 各种各样的；多方面的"
+        ],
+        "usphone": "[ˈveriəs; ˈværiəs]",
+        "ukphone": "[ˈveəriəs]"
+    },
+    {
+        "name": "receipt",
+        "trans": [
+            "n. 收到；收据；收入"
+        ],
+        "usphone": "[rɪˈsiːt]",
+        "ukphone": "[rɪˈsiːt]"
+    },
+    {
+        "name": "mystery",
+        "trans": [
+            "n. 秘密，谜；神秘，神秘的事物；推理小说，推理剧；常作 mysteries 秘技，秘诀"
+        ],
+        "usphone": "[ˈmɪstəri]",
+        "ukphone": "[ˈmɪstri]"
+    },
+    {
+        "name": "unemployment",
+        "trans": [
+            "n. 失业；失业率；失业人数"
+        ],
+        "usphone": "[ˌʌnɪmˈplɔɪmənt]",
+        "ukphone": "[ˌʌnɪmˈplɔɪmənt]"
+    },
+    {
+        "name": "destination",
+        "trans": [
+            "n. 目的地，终点"
+        ],
+        "usphone": "[ˌdestɪˈneɪʃn]",
+        "ukphone": "[ˌdestɪˈneɪʃn]"
+    },
+    {
+        "name": "killing",
+        "trans": [
+            "adj. 杀害的；迷人的；使人筋疲力尽的"
+        ],
+        "usphone": "[ˈkɪlɪŋ]",
+        "ukphone": "[ˈkɪlɪŋ]"
+    },
+    {
+        "name": "impact",
+        "trans": [
+            "vi. 影响；撞击；冲突；压紧（on，upon，with）"
+        ],
+        "usphone": "[ˈɪmpækt]",
+        "ukphone": "[ˈɪmpækt]"
+    },
+    {
+        "name": "judge",
+        "trans": [
+            "vt. 判断；审判"
+        ],
+        "usphone": "[dʒʌdʒ]",
+        "ukphone": "[dʒʌdʒ]"
+    },
+    {
+        "name": "queue",
+        "trans": [
+            "n. 队列；长队；辫子"
+        ],
+        "usphone": "[kjuː]",
+        "ukphone": "[kjuː]"
+    },
+    {
+        "name": "fry",
+        "trans": [
+            "n. 鱼苗；油炸食物"
+        ],
+        "usphone": "[fraɪ]",
+        "ukphone": "[fraɪ]"
+    },
+    {
+        "name": "spending",
+        "trans": [
+            "n. 花费；开销"
+        ],
+        "usphone": "[ˈspendɪŋ]",
+        "ukphone": "[ˈspendɪŋ]"
+    },
+    {
+        "name": "average",
+        "trans": [
+            "n. 平均；平均数；海损"
+        ],
+        "usphone": "[ˈævərɪdʒ]",
+        "ukphone": "[ˈævərɪdʒ]"
+    },
+    {
+        "name": "drum",
+        "trans": [
+            "n. 鼓；鼓声"
+        ],
+        "usphone": "[drʌm]",
+        "ukphone": "[drʌm]"
+    },
+    {
+        "name": "agent",
+        "trans": [
+            "n. 代理人，代理商；药剂；特工"
+        ],
+        "usphone": "[ˈeɪdʒənt]",
+        "ukphone": "[ˈeɪdʒənt]"
+    },
+    {
+        "name": "lay",
+        "trans": [
+            "vt. 躺下；产卵；搁放；放置；铺放；涂，敷"
+        ],
+        "usphone": "[leɪ]",
+        "ukphone": "[leɪ]"
+    },
+    {
+        "name": "impressive",
+        "trans": [
+            "adj. 感人的；令人钦佩的；给人以深刻印象的"
+        ],
+        "usphone": "[ɪmˈpresɪv]",
+        "ukphone": "[ɪmˈpresɪv]"
+    },
+    {
+        "name": "friendship",
+        "trans": [
+            "n. 友谊；友爱；友善"
+        ],
+        "usphone": "[ˈfrendʃɪp]",
+        "ukphone": "[ˈfrendʃɪp]"
+    },
+    {
+        "name": "leather",
+        "trans": [
+            "n. 皮革；皮革制品"
+        ],
+        "usphone": "[ˈleðər]",
+        "ukphone": "[ˈleðə(r)]"
+    },
+    {
+        "name": "fascinating",
+        "trans": [
+            "adj. 迷人的；吸引人的；使人神魂颠倒的"
+        ],
+        "usphone": "[ˈfæsɪneɪtɪŋ]",
+        "ukphone": "[ˈfæsɪneɪtɪŋ]"
+    },
+    {
+        "name": "poison",
+        "trans": [
+            "n. 毒药，毒物；酒；有毒害的事物；[助剂] 抑制剂"
+        ],
+        "usphone": "[ˈpɔɪzn]",
+        "ukphone": "[ˈpɔɪz(ə)n]"
+    },
+    {
+        "name": "shiny",
+        "trans": [
+            "adj. 有光泽的，擦亮的；闪耀的；晴朗的；磨损的"
+        ],
+        "usphone": "[ˈʃaɪni]",
+        "ukphone": "[ˈʃaɪni]"
+    },
+    {
+        "name": "live",
+        "trans": [
+            "adj. 活的；生动的；实况转播的；精力充沛的"
+        ],
+        "usphone": "[lɪv; laɪv]",
+        "ukphone": "[lɪv]"
+    },
+    {
+        "name": "freeze",
+        "trans": [
+            "n. 冻结；凝固"
+        ],
+        "usphone": "[friːz]",
+        "ukphone": "[friːz]"
+    },
+    {
+        "name": "quit",
+        "trans": [
+            "n. 离开；[计] 退出"
+        ],
+        "usphone": "[kwɪt]",
+        "ukphone": "[kwɪt]"
+    },
+    {
+        "name": "release",
+        "trans": [
+            "n. 释放；发布；让与"
+        ],
+        "usphone": "[rɪˈliːs]",
+        "ukphone": "[rɪˈliːs]"
+    },
+    {
+        "name": "unless",
+        "trans": [
+            "conj. 除非，如果不"
+        ],
+        "usphone": "[ənˈles]",
+        "ukphone": "[ənˈles]"
+    },
+    {
+        "name": "yard",
+        "trans": [
+            "n. 院子；码（英制中丈量长度单位，1码=3英尺）；庭院；帆桁"
+        ],
+        "usphone": "[jɑːrd]",
+        "ukphone": "[jɑːd]"
+    },
+    {
+        "name": "profit",
+        "trans": [
+            "n. 利润；利益"
+        ],
+        "usphone": "[ˈprɑːfɪt]",
+        "ukphone": "[ˈprɒfɪt]"
+    },
+    {
+        "name": "basic",
+        "trans": [
+            "n. 基础；要素"
+        ],
+        "usphone": "[ˈbeɪsɪk]",
+        "ukphone": "[ˈbeɪsɪk]"
+    },
+    {
+        "name": "collection",
+        "trans": [
+            "n. 采集，聚集；[税收] 征收；收藏品；募捐"
+        ],
+        "usphone": "[kəˈlekʃn]",
+        "ukphone": "[kəˈlekʃn]"
+    },
+    {
+        "name": "specifically",
+        "trans": [
+            "adv. 特别地；明确地"
+        ],
+        "usphone": "[spəˈsɪfɪkli]",
+        "ukphone": "[spəˈsɪfɪkli]"
+    },
+    {
+        "name": "academic",
+        "trans": [
+            "n. 大学生，大学教师；学者"
+        ],
+        "usphone": "[ˌækəˈdemɪk]",
+        "ukphone": "[ˌækəˈdemɪk]"
+    },
+    {
+        "name": "request",
+        "trans": [
+            "n. 请求；需要"
+        ],
+        "usphone": "[rɪˈkwest]",
+        "ukphone": "[rɪˈkwest]"
+    },
+    {
+        "name": "tend",
+        "trans": [
+            "vt. 照料，照管"
+        ],
+        "usphone": "[tend]",
+        "ukphone": "[tend]"
+    },
+    {
+        "name": "union",
+        "trans": [
+            "n. 联盟，协会；工会；联合"
+        ],
+        "usphone": "[ˈjuːniən]",
+        "ukphone": "[ˈjuːniən]"
+    },
+    {
+        "name": "assist",
+        "trans": [
+            "n. 帮助；助攻"
+        ],
+        "usphone": "[əˈsɪst]",
+        "ukphone": "[əˈsɪst]"
+    },
+    {
+        "name": "punishment",
+        "trans": [
+            "n. 惩罚；严厉对待，虐待"
+        ],
+        "usphone": "[ˈpʌnɪʃmənt]",
+        "ukphone": "[ˈpʌnɪʃmənt]"
+    },
+    {
+        "name": "concentrate",
+        "trans": [
+            "n. 浓缩，精选；浓缩液"
+        ],
+        "usphone": "[ˈkɑːns(ə)ntreɪt]",
+        "ukphone": "[ˈkɒns(ə)ntreɪt]"
+    },
+    {
+        "name": "switch",
+        "trans": [
+            "n. 开关；转换；鞭子"
+        ],
+        "usphone": "[swɪtʃ]",
+        "ukphone": "[swɪtʃ]"
+    },
+    {
+        "name": "software",
+        "trans": [
+            "n. 软件"
+        ],
+        "usphone": "[ˈsɔːftwer]",
+        "ukphone": "[ˈsɒftweə(r)]"
+    },
+    {
+        "name": "communication",
+        "trans": [
+            "n. 通讯，[通信] 通信；交流；信函"
+        ],
+        "usphone": "[kəˌmjuːnɪˈkeɪʃn]",
+        "ukphone": "[kəˌmjuːnɪˈkeɪʃ(ə)n]"
+    },
+    {
+        "name": "seed",
+        "trans": [
+            "n. 种子；根据；精液；萌芽；子孙；原由"
+        ],
+        "usphone": "[siːd]",
+        "ukphone": "[siːd]"
+    },
+    {
+        "name": "explore",
+        "trans": [
+            "vi. 探索；探测；探险"
+        ],
+        "usphone": "[ɪkˈsplɔːr]",
+        "ukphone": "[ɪkˈsplɔː(r)]"
+    },
+    {
+        "name": "tail",
+        "trans": [
+            "n. 尾巴；踪迹；辫子；燕尾服"
+        ],
+        "usphone": "[teɪl]",
+        "ukphone": "[teɪl]"
+    },
+    {
+        "name": "account",
+        "trans": [
+            "n. 账户；解释；账目，账单；理由；描述"
+        ],
+        "usphone": "[əˈkaʊnt]",
+        "ukphone": "[əˈkaʊnt]"
+    },
+    {
+        "name": "hurry",
+        "trans": [
+            "n. 匆忙，急忙"
+        ],
+        "usphone": "[ˈhɜːri]",
+        "ukphone": "[ˈhʌri]"
+    },
+    {
+        "name": "possibly",
+        "trans": [
+            "adv. 可能地；也许；大概"
+        ],
+        "usphone": "[ˈpɑːsəbli]",
+        "ukphone": "[ˈpɒsəbli]"
+    },
+    {
+        "name": "competitor",
+        "trans": [
+            "n. 竞争者，对手"
+        ],
+        "usphone": "[kəmˈpetɪtər]",
+        "ukphone": "[kəmˈpetɪtə(r)]"
+    },
+    {
+        "name": "spicy",
+        "trans": [
+            "adj. 辛辣的；香的，多香料的；下流的"
+        ],
+        "usphone": "[ˈspaɪsi]",
+        "ukphone": "[ˈspaɪsi]"
+    },
+    {
+        "name": "needle",
+        "trans": [
+            "n. 针；指针；刺激；针状物"
+        ],
+        "usphone": "[ˈniːdl]",
+        "ukphone": "[ˈniːdl]"
+    },
+    {
+        "name": "custom",
+        "trans": [
+            "n. 习惯，惯例；风俗；海关，关税；经常光顾；[总称]（经常性的）顾客"
+        ],
+        "usphone": "[ˈkʌstəm]",
+        "ukphone": "[ˈkʌstəm]"
+    },
+    {
+        "name": "surely",
+        "trans": [
+            "adv. 当然；无疑；坚定地；稳当地"
+        ],
+        "usphone": "[ˈʃʊrli]",
+        "ukphone": "[ˈʃʊəli; ˈʃɔːli]"
+    },
+    {
+        "name": "ceremony",
+        "trans": [
+            "n. 典礼，仪式；礼节，礼仪；客套，虚礼"
+        ],
+        "usphone": "[ˈserəmoʊni]",
+        "ukphone": "[ˈserəməni]"
+    },
+    {
+        "name": "container",
+        "trans": [
+            "n. 集装箱；容器"
+        ],
+        "usphone": "[kənˈteɪnər]",
+        "ukphone": "[kənˈteɪnə(r)]"
+    },
+    {
+        "name": "criminal",
+        "trans": [
+            "n. 罪犯"
+        ],
+        "usphone": "[ˈkrɪmɪnl]",
+        "ukphone": "[ˈkrɪmɪn(ə)l]"
+    },
+    {
+        "name": "tax",
+        "trans": [
+            "n. 税金；重负"
+        ],
+        "usphone": "[tæks]",
+        "ukphone": "[tæks]"
+    },
+    {
+        "name": "represent",
+        "trans": [
+            "vt. 代表；表现；描绘；回忆；再赠送"
+        ],
+        "usphone": "[ˌreprɪˈzent]",
+        "ukphone": "[ˌreprɪˈzent]"
+    },
+    {
+        "name": "romantic",
+        "trans": [
+            "n. 浪漫的人"
+        ],
+        "usphone": "[roʊˈmæntɪk]",
+        "ukphone": "[rəʊˈmæntɪk]"
+    },
+    {
+        "name": "whatever",
+        "trans": [
+            "conj. 无论什么"
+        ],
+        "usphone": "[wətˈevər]",
+        "ukphone": "[wɒtˈevə(r)]"
     },
     {
         "name": "border",
@@ -600,1516 +2008,12 @@
         "ukphone": "[ˈbɒðə(r)]"
     },
     {
-        "name": "branch",
+        "name": "presentation",
         "trans": [
-            "n. 树枝，分枝；分部；支流"
+            "n. 展示；描述，陈述；介绍；赠送"
         ],
-        "usphone": "[bræntʃ]",
-        "ukphone": "[brɑːntʃ]"
-    },
-    {
-        "name": "brand",
-        "trans": [
-            "n. 商标，牌子；烙印"
-        ],
-        "usphone": "[brænd]",
-        "ukphone": "[brænd]"
-    },
-    {
-        "name": "brave",
-        "trans": [
-            "n. 勇士"
-        ],
-        "usphone": "[breɪv]",
-        "ukphone": "[breɪv]"
-    },
-    {
-        "name": "breath",
-        "trans": [
-            "n. 呼吸，气息；一口气，（呼吸的）一次；瞬间，瞬息；微风；迹象；无声音，气音"
-        ],
-        "usphone": "[breθ]",
-        "ukphone": "[breθ]"
-    },
-    {
-        "name": "breathe",
-        "trans": [
-            "vi. 呼吸；低语；松口气；（风）轻拂"
-        ],
-        "usphone": "[briːð]",
-        "ukphone": "[briːð]"
-    },
-    {
-        "name": "breathing",
-        "trans": [
-            "n. 呼吸；瞬间；微风"
-        ],
-        "usphone": "[ˈbriːðɪŋ]",
-        "ukphone": "[ˈbriːðɪŋ]"
-    },
-    {
-        "name": "bride",
-        "trans": [
-            "n. 新娘；姑娘，女朋友"
-        ],
-        "usphone": "[braɪd]",
-        "ukphone": "[braɪd]"
-    },
-    {
-        "name": "bubble",
-        "trans": [
-            "n. 气泡，泡沫，泡状物；透明圆形罩，圆形顶"
-        ],
-        "usphone": "[ˈbʌb(ə)l]",
-        "ukphone": "[ˈbʌb(ə)l]"
-    },
-    {
-        "name": "bury",
-        "trans": [
-            "vt. 埋葬；隐藏"
-        ],
-        "usphone": "[ˈberi]",
-        "ukphone": "[ˈberi]"
-    },
-    {
-        "name": "by",
-        "trans": [
-            "prep. 通过；被；依据；经由；在附近；在……之前"
-        ],
-        "usphone": "[baɪ]",
-        "ukphone": "[baɪ]"
-    },
-    {
-        "name": "calm",
-        "trans": [
-            "n. 风平浪静"
-        ],
-        "usphone": "[kɑːm]",
-        "ukphone": "[kɑːm]"
-    },
-    {
-        "name": "campaign",
-        "trans": [
-            "n. 运动；活动；战役"
-        ],
-        "usphone": "[kæmˈpeɪn]",
-        "ukphone": "[kæmˈpeɪn]"
-    },
-    {
-        "name": "campus",
-        "trans": [
-            "n. （大学）校园；大学，大学生活；校园内的草地"
-        ],
-        "usphone": "[ˈkæmpəs]",
-        "ukphone": "[ˈkæmpəs]"
-    },
-    {
-        "name": "candidate",
-        "trans": [
-            "n. 候选人，候补者；应试者"
-        ],
-        "usphone": "[ˈkændɪdət; ˈkændɪdeɪt]",
-        "ukphone": "[ˈkændɪdət]"
-    },
-    {
-        "name": "cap",
-        "trans": [
-            "n. 盖；帽子"
-        ],
-        "usphone": "[kæp]",
-        "ukphone": "[kæp]"
-    },
-    {
-        "name": "captain",
-        "trans": [
-            "n. 队长，首领；船长；上尉；海军上校"
-        ],
-        "usphone": "[ˈkæptɪn]",
-        "ukphone": "[ˈkæptɪn]"
-    },
-    {
-        "name": "careless",
-        "trans": [
-            "adj. 粗心的；无忧无虑的；淡漠的"
-        ],
-        "usphone": "[ˈkerləs]",
-        "ukphone": "[ˈkeələs]"
-    },
-    {
-        "name": "category",
-        "trans": [
-            "n. 种类，分类；[数] 范畴"
-        ],
-        "usphone": "[ˈkætəɡɔːri]",
-        "ukphone": "[ˈkætəɡəri]"
-    },
-    {
-        "name": "ceiling",
-        "trans": [
-            "n. 天花板；上限"
-        ],
-        "usphone": "[ˈsiːlɪŋ]",
-        "ukphone": "[ˈsiːlɪŋ]"
-    },
-    {
-        "name": "celebration",
-        "trans": [
-            "n. 庆典，庆祝会；庆祝；颂扬"
-        ],
-        "usphone": "[ˌselɪˈbreɪʃn]",
-        "ukphone": "[ˌselɪˈbreɪʃn]"
-    },
-    {
-        "name": "central",
-        "trans": [
-            "n. 电话总机"
-        ],
-        "usphone": "[ˈsentrəl]",
-        "ukphone": "[ˈsentrəl]"
-    },
-    {
-        "name": "centre",
-        "trans": [
-            "n. 中心"
-        ],
-        "usphone": "[ˈsentər]",
-        "ukphone": "[ˈsentə(r)]"
-    },
-    {
-        "name": "ceremony",
-        "trans": [
-            "n. 典礼，仪式；礼节，礼仪；客套，虚礼"
-        ],
-        "usphone": "[ˈserəmoʊni]",
-        "ukphone": "[ˈserəməni]"
-    },
-    {
-        "name": "chain",
-        "trans": [
-            "n. 链；束缚；枷锁"
-        ],
-        "usphone": "[tʃeɪn]",
-        "ukphone": "[tʃeɪn]"
-    },
-    {
-        "name": "challenge",
-        "trans": [
-            "n. 挑战；怀疑"
-        ],
-        "usphone": "[ˈtʃælɪndʒ]",
-        "ukphone": "[ˈtʃælɪndʒ]"
-    },
-    {
-        "name": "champion",
-        "trans": [
-            "n. 冠军；拥护者；战士"
-        ],
-        "usphone": "[ˈtʃæmpiən]",
-        "ukphone": "[ˈtʃæmpiən]"
-    },
-    {
-        "name": "channel",
-        "trans": [
-            "n. 通道；频道；海峡"
-        ],
-        "usphone": "[ˈtʃænl]",
-        "ukphone": "[ˈtʃæn(ə)l]"
-    },
-    {
-        "name": "chapter",
-        "trans": [
-            "n. 章，回；（俱乐部、协会等的）分会；人生或历史上的重要时期"
-        ],
-        "usphone": "[ˈtʃæptər]",
-        "ukphone": "[ˈtʃæptə(r)]"
-    },
-    {
-        "name": "charge",
-        "trans": [
-            "n. 费用；电荷；掌管；控告；命令；负载"
-        ],
-        "usphone": "[tʃɑːrdʒ]",
-        "ukphone": "[tʃɑːdʒ]"
-    },
-    {
-        "name": "cheap",
-        "trans": [
-            "adj. 便宜的；小气的；不值钱的"
-        ],
-        "usphone": "[tʃiːp]",
-        "ukphone": "[tʃiːp]"
-    },
-    {
-        "name": "cheat",
-        "trans": [
-            "n. 欺骗，作弊；骗子"
-        ],
-        "usphone": "[tʃiːt]",
-        "ukphone": "[tʃiːt]"
-    },
-    {
-        "name": "cheerful",
-        "trans": [
-            "adj. 快乐的；愉快的；高兴的"
-        ],
-        "usphone": "[ˈtʃɪrfl]",
-        "ukphone": "[ˈtʃɪəf(ə)l]"
-    },
-    {
-        "name": "chemical",
-        "trans": [
-            "n. 化学制品，化学药品"
-        ],
-        "usphone": "[ˈkemɪkl]",
-        "ukphone": "[ˈkemɪkl]"
-    },
-    {
-        "name": "chest",
-        "trans": [
-            "n. 胸，胸部；衣柜；箱子；金库"
-        ],
-        "usphone": "[tʃest]",
-        "ukphone": "[tʃest]"
-    },
-    {
-        "name": "childhood",
-        "trans": [
-            "n. 童年时期；幼年时代"
-        ],
-        "usphone": "[ˈtʃaɪldhʊd]",
-        "ukphone": "[ˈtʃaɪldhʊd]"
-    },
-    {
-        "name": "claim",
-        "trans": [
-            "n. 要求；声称；索赔；断言；值得"
-        ],
-        "usphone": "[kleɪm]",
-        "ukphone": "[kleɪm]"
-    },
-    {
-        "name": "clause",
-        "trans": [
-            "n. 条款；[计] 子句"
-        ],
-        "usphone": "[klɔːz]",
-        "ukphone": "[klɔːz]"
-    },
-    {
-        "name": "clear",
-        "trans": [
-            "n. 清除；空隙"
-        ],
-        "usphone": "[klɪr]",
-        "ukphone": "[klɪə(r)]"
-    },
-    {
-        "name": "click",
-        "trans": [
-            "n. 单击；滴答声"
-        ],
-        "usphone": "[klɪk]",
-        "ukphone": "[klɪk]"
-    },
-    {
-        "name": "client",
-        "trans": [
-            "n. [经] 客户；顾客；委托人"
-        ],
-        "usphone": "[ˈklaɪənt]",
-        "ukphone": "[ˈklaɪənt]"
-    },
-    {
-        "name": "climb",
-        "trans": [
-            "n. 爬；攀登"
-        ],
-        "usphone": "[klaɪm]",
-        "ukphone": "[klaɪm]"
-    },
-    {
-        "name": "close",
-        "trans": [
-            "n. 结束"
-        ],
-        "usphone": "[kloʊz; kloʊs]",
-        "ukphone": "[kləʊz]"
-    },
-    {
-        "name": "cloth",
-        "trans": [
-            "n. 布；织物；桌布"
-        ],
-        "usphone": "[klɔːθ]",
-        "ukphone": "[klɒθ]"
-    },
-    {
-        "name": "clue",
-        "trans": [
-            "n. 线索；（故事等的）情节"
-        ],
-        "usphone": "[kluː]",
-        "ukphone": "[kluː]"
-    },
-    {
-        "name": "coach",
-        "trans": [
-            "n. 教练；旅客车厢；长途公车；四轮大马车"
-        ],
-        "usphone": "[koʊtʃ]",
-        "ukphone": "[kəʊtʃ]"
-    },
-    {
-        "name": "coal",
-        "trans": [
-            "n. 煤；煤块；木炭"
-        ],
-        "usphone": "[koʊl]",
-        "ukphone": "[kəʊl]"
-    },
-    {
-        "name": "coin",
-        "trans": [
-            "n. 硬币，钱币"
-        ],
-        "usphone": "[kɔɪn]",
-        "ukphone": "[kɔɪn]"
-    },
-    {
-        "name": "collection",
-        "trans": [
-            "n. 采集，聚集；[税收] 征收；收藏品；募捐"
-        ],
-        "usphone": "[kəˈlekʃn]",
-        "ukphone": "[kəˈlekʃn]"
-    },
-    {
-        "name": "coloured",
-        "trans": [
-            "n. 混血人；有色人种的人"
-        ],
-        "usphone": "[ˈkʌlərd]",
-        "ukphone": "[ˈkʌləd]"
-    },
-    {
-        "name": "combine",
-        "trans": [
-            "n. 联合收割机；联合企业"
-        ],
-        "usphone": "[kəmˈbaɪn]",
-        "ukphone": "[kəmˈbaɪn]"
-    },
-    {
-        "name": "comment",
-        "trans": [
-            "n. 评论；意见；批评"
-        ],
-        "usphone": "[ˈkɑːment]",
-        "ukphone": "[ˈkɒment]"
-    },
-    {
-        "name": "commercial",
-        "trans": [
-            "n. 商业广告"
-        ],
-        "usphone": "[kəˈmɜːrʃl]",
-        "ukphone": "[kəˈmɜːʃ(ə)l]"
-    },
-    {
-        "name": "commit",
-        "trans": [
-            "vt. 犯罪，做错事；把...交托给；指派…作战；使…承担义务"
-        ],
-        "usphone": "[kəˈmɪt]",
-        "ukphone": "[kəˈmɪt]"
-    },
-    {
-        "name": "communication",
-        "trans": [
-            "n. 通讯，[通信] 通信；交流；信函"
-        ],
-        "usphone": "[kəˌmjuːnɪˈkeɪʃn]",
-        "ukphone": "[kəˌmjuːnɪˈkeɪʃ(ə)n]"
-    },
-    {
-        "name": "comparison",
-        "trans": [
-            "n. 比较；对照；比喻；比较关系"
-        ],
-        "usphone": "[kəmˈpærɪsn]",
-        "ukphone": "[kəmˈpærɪs(ə)n]"
-    },
-    {
-        "name": "competitive",
-        "trans": [
-            "adj. 竞争的；比赛的；求胜心切的"
-        ],
-        "usphone": "[kəmˈpetətɪv]",
-        "ukphone": "[kəmˈpetətɪv]"
-    },
-    {
-        "name": "competitor",
-        "trans": [
-            "n. 竞争者，对手"
-        ],
-        "usphone": "[kəmˈpetɪtər]",
-        "ukphone": "[kəmˈpetɪtə(r)]"
-    },
-    {
-        "name": "complaint",
-        "trans": [
-            "n. 抱怨；诉苦；疾病；委屈"
-        ],
-        "usphone": "[kəmˈpleɪnt]",
-        "ukphone": "[kəmˈpleɪnt]"
-    },
-    {
-        "name": "complex",
-        "trans": [
-            "n. 复合体；综合设施"
-        ],
-        "usphone": "[kəmˈpleks; ˈkɑːmpleks]",
-        "ukphone": "[ˈkɒmpleks]"
-    },
-    {
-        "name": "concentrate",
-        "trans": [
-            "n. 浓缩，精选；浓缩液"
-        ],
-        "usphone": "[ˈkɑːns(ə)ntreɪt]",
-        "ukphone": "[ˈkɒns(ə)ntreɪt]"
-    },
-    {
-        "name": "conclude",
-        "trans": [
-            "vi. 推断；断定；决定"
-        ],
-        "usphone": "[kənˈkluːd]",
-        "ukphone": "[kənˈkluːd]"
-    },
-    {
-        "name": "conclusion",
-        "trans": [
-            "n. 结论；结局；推论"
-        ],
-        "usphone": "[kənˈkluːʒn]",
-        "ukphone": "[kənˈkluːʒn]"
-    },
-    {
-        "name": "confident",
-        "trans": [
-            "adj. 自信的；确信的"
-        ],
-        "usphone": "[ˈkɑːnfɪdənt]",
-        "ukphone": "[ˈkɒnfɪdənt]"
-    },
-    {
-        "name": "confirm",
-        "trans": [
-            "vt. 确认；确定；证实；批准；使巩固"
-        ],
-        "usphone": "[kənˈfɜːrm]",
-        "ukphone": "[kənˈfɜːm]"
-    },
-    {
-        "name": "confuse",
-        "trans": [
-            "vt. 使混乱；使困惑"
-        ],
-        "usphone": "[kənˈfjuːz]",
-        "ukphone": "[kənˈfjuːz]"
-    },
-    {
-        "name": "confused",
-        "trans": [
-            "v. 困惑（confuse的过去式）"
-        ],
-        "usphone": "[kənˈfjuːzd]",
-        "ukphone": "[kənˈfjuːzd]"
-    },
-    {
-        "name": "connection",
-        "trans": [
-            "n. 连接；关系；人脉；连接件"
-        ],
-        "usphone": "[kəˈnekʃn]",
-        "ukphone": "[kəˈnekʃn]"
-    },
-    {
-        "name": "consequence",
-        "trans": [
-            "n. 结果；重要性；推论"
-        ],
-        "usphone": "[ˈkɑːnsɪkwens]",
-        "ukphone": "[ˈkɒnsɪkwəns]"
-    },
-    {
-        "name": "consist",
-        "trans": [
-            "vi. 由…组成；在于；符合"
-        ],
-        "usphone": "[kənˈsɪst]",
-        "ukphone": "[kənˈsɪst]"
-    },
-    {
-        "name": "consume",
-        "trans": [
-            "vt. 消耗，消费；使…着迷；挥霍"
-        ],
-        "usphone": "[kənˈsuːm]",
-        "ukphone": "[kənˈsjuːm]"
-    },
-    {
-        "name": "consumer",
-        "trans": [
-            "n. 消费者；用户，顾客"
-        ],
-        "usphone": "[kənˈsuːmər]",
-        "ukphone": "[kənˈsjuːmə(r)]"
-    },
-    {
-        "name": "contact",
-        "trans": [
-            "n. 接触，联系"
-        ],
-        "usphone": "[ˈkɑːntækt]",
-        "ukphone": "[ˈkɒntækt]"
-    },
-    {
-        "name": "container",
-        "trans": [
-            "n. 集装箱；容器"
-        ],
-        "usphone": "[kənˈteɪnər]",
-        "ukphone": "[kənˈteɪnə(r)]"
-    },
-    {
-        "name": "content",
-        "trans": [
-            "n. 内容，目录；满足；容量"
-        ],
-        "usphone": "[ˈkɑːntent; kənˈtent]",
-        "ukphone": "[ˈkɒntent]"
-    },
-    {
-        "name": "continuous",
-        "trans": [
-            "adj. 连续的，持续的；继续的；连绵不断的"
-        ],
-        "usphone": "[kənˈtɪnjuəs]",
-        "ukphone": "[kənˈtɪnjuəs]"
-    },
-    {
-        "name": "contrast",
-        "trans": [
-            "n. 对比；差别；对照物"
-        ],
-        "usphone": "[ˈkɑːntræst]",
-        "ukphone": "[ˈkɒntrɑːst]"
-    },
-    {
-        "name": "convenient",
-        "trans": [
-            "adj. 方便的；[废语]适当的；[口语]近便的；实用的"
-        ],
-        "usphone": "[kənˈviːniənt]",
-        "ukphone": "[kənˈviːniənt]"
-    },
-    {
-        "name": "convince",
-        "trans": [
-            "vt. 说服；使确信，使信服"
-        ],
-        "usphone": "[kənˈvɪns]",
-        "ukphone": "[kənˈvɪns]"
-    },
-    {
-        "name": "cool",
-        "trans": [
-            "n. 凉爽；凉爽的空气"
-        ],
-        "usphone": "[kuːl]",
-        "ukphone": "[kuːl]"
-    },
-    {
-        "name": "costume",
-        "trans": [
-            "n. 服装，装束；戏装，剧装"
-        ],
-        "usphone": "[ˈkɑːstuːm]",
-        "ukphone": "[ˈkɒstjuːm]"
-    },
-    {
-        "name": "cottage",
-        "trans": [
-            "n. 小屋；村舍；（农舍式的）小别墅"
-        ],
-        "usphone": "[ˈkɑːtɪdʒ]",
-        "ukphone": "[ˈkɒtɪdʒ]"
-    },
-    {
-        "name": "cotton",
-        "trans": [
-            "n. 棉花；棉布；棉线"
-        ],
-        "usphone": "[ˈkɑːtn]",
-        "ukphone": "[ˈkɒtn]"
-    },
-    {
-        "name": "count",
-        "trans": [
-            "n. 计数；计算；伯爵"
-        ],
-        "usphone": "[kaʊnt]",
-        "ukphone": "[kaʊnt]"
-    },
-    {
-        "name": "countryside",
-        "trans": [
-            "n. 农村，乡下；乡下的全体居民"
-        ],
-        "usphone": "[ˈkʌntrisaɪd]",
-        "ukphone": "[ˈkʌntrisaɪd]"
-    },
-    {
-        "name": "court",
-        "trans": [
-            "n. 法院；球场；朝廷；奉承"
-        ],
-        "usphone": "[kɔːrt]",
-        "ukphone": "[kɔːt]"
-    },
-    {
-        "name": "cover",
-        "trans": [
-            "n. 封面，封皮；盖子；掩蔽物;幌子，借口"
-        ],
-        "usphone": "[ˈkʌvər]",
-        "ukphone": "[ˈkʌvə(r)]"
-    },
-    {
-        "name": "covered",
-        "trans": [
-            "v. 覆盖；包括；掩护（cover的过去分词）"
-        ],
-        "usphone": "[ˈkʌvərd]",
-        "ukphone": "[ˈkʌvəd]"
-    },
-    {
-        "name": "cream",
-        "trans": [
-            "n. 奶油，乳脂；精华；面霜；乳酪"
-        ],
-        "usphone": "[kriːm]",
-        "ukphone": "[kriːm]"
-    },
-    {
-        "name": "criminal",
-        "trans": [
-            "n. 罪犯"
-        ],
-        "usphone": "[ˈkrɪmɪnl]",
-        "ukphone": "[ˈkrɪmɪn(ə)l]"
-    },
-    {
-        "name": "cruel",
-        "trans": [
-            "adj. 残酷的，残忍的；使人痛苦的，让人受难的；无情的，严酷的"
-        ],
-        "usphone": "[ˈkruːəl]",
-        "ukphone": "[ˈkruːəl]"
-    },
-    {
-        "name": "cultural",
-        "trans": [
-            "adj. 文化的；教养的"
-        ],
-        "usphone": "[ˈkʌltʃərəl]",
-        "ukphone": "[ˈkʌltʃərəl]"
-    },
-    {
-        "name": "currency",
-        "trans": [
-            "n. 货币；通货"
-        ],
-        "usphone": "[ˈkɜːrənsi]",
-        "ukphone": "[ˈkʌrənsi]"
-    },
-    {
-        "name": "current",
-        "trans": [
-            "n. （水，气，电）流；趋势；涌流"
-        ],
-        "usphone": "[ˈkɜːrənt]",
-        "ukphone": "[ˈkʌrənt]"
-    },
-    {
-        "name": "currently",
-        "trans": [
-            "adv. 当前；一般地"
-        ],
-        "usphone": "[ˈkɜːrəntli]",
-        "ukphone": "[ˈkʌrəntli]"
-    },
-    {
-        "name": "curtain",
-        "trans": [
-            "n. 幕；窗帘"
-        ],
-        "usphone": "[ˈkɜːrtn]",
-        "ukphone": "[ˈkɜːt(ə)n]"
-    },
-    {
-        "name": "custom",
-        "trans": [
-            "n. 习惯，惯例；风俗；海关，关税；经常光顾；[总称]（经常性的）顾客"
-        ],
-        "usphone": "[ˈkʌstəm]",
-        "ukphone": "[ˈkʌstəm]"
-    },
-    {
-        "name": "cut",
-        "trans": [
-            "n. 伤口；切口；削减；（服装等的）式样；削球；切入"
-        ],
-        "usphone": "[kʌt]",
-        "ukphone": "[kʌt]"
-    },
-    {
-        "name": "daily",
-        "trans": [
-            "n. 日报；朝来夜去的女佣"
-        ],
-        "usphone": "[ˈdeɪli]",
-        "ukphone": "[ˈdeɪli]"
-    },
-    {
-        "name": "damage",
-        "trans": [
-            "vi. 损害；损毁"
-        ],
-        "usphone": "[ˈdæmɪdʒ]",
-        "ukphone": "[ˈdæmɪdʒ]"
-    },
-    {
-        "name": "deal",
-        "trans": [
-            "n. 交易；（美）政策；待遇；份量"
-        ],
-        "usphone": "[diːl]",
-        "ukphone": "[diːl]"
-    },
-    {
-        "name": "decade",
-        "trans": [
-            "n. 十年，十年期；十"
-        ],
-        "usphone": "[ˈdekeɪdˌdɪˈkeɪd]",
-        "ukphone": "[ˈdekeɪd]"
-    },
-    {
-        "name": "decorate",
-        "trans": [
-            "vt. 装饰；布置；授勋给"
-        ],
-        "usphone": "[ˈdekəreɪt]",
-        "ukphone": "[ˈdekəreɪt]"
-    },
-    {
-        "name": "deep",
-        "trans": [
-            "n. 深处；深渊"
-        ],
-        "usphone": "[diːp]",
-        "ukphone": "[diːp]"
-    },
-    {
-        "name": "define",
-        "trans": [
-            "vt. 定义；使明确；规定"
-        ],
-        "usphone": "[dɪˈfaɪn]",
-        "ukphone": "[dɪˈfaɪn]"
-    },
-    {
-        "name": "definite",
-        "trans": [
-            "adj. 一定的；确切的"
-        ],
-        "usphone": "[ˈdefɪnət]",
-        "ukphone": "[ˈdefɪnət]"
-    },
-    {
-        "name": "definition",
-        "trans": [
-            "n. 定义；[物] 清晰度；解说"
-        ],
-        "usphone": "[ˌdefɪˈnɪʃn]",
-        "ukphone": "[ˌdefɪˈnɪʃn]"
-    },
-    {
-        "name": "deliver",
-        "trans": [
-            "n. 投球"
-        ],
-        "usphone": "[dɪˈlɪvər]",
-        "ukphone": "[dɪˈlɪvə(r)]"
-    },
-    {
-        "name": "departure",
-        "trans": [
-            "n. 离开；出发；违背"
-        ],
-        "usphone": "[dɪˈpɑːrtʃər]",
-        "ukphone": "[dɪˈpɑːtʃə(r)]"
-    },
-    {
-        "name": "despite",
-        "trans": [
-            "prep. 尽管，不管"
-        ],
-        "usphone": "[dɪˈspaɪt]",
-        "ukphone": "[dɪˈspaɪt]"
-    },
-    {
-        "name": "destination",
-        "trans": [
-            "n. 目的地，终点"
-        ],
-        "usphone": "[ˌdestɪˈneɪʃn]",
-        "ukphone": "[ˌdestɪˈneɪʃn]"
-    },
-    {
-        "name": "determine",
-        "trans": [
-            "v. （使）下决心，（使）做出决定"
-        ],
-        "usphone": "[dɪˈtɜːrmɪn]",
-        "ukphone": "[dɪˈtɜːmɪn]"
-    },
-    {
-        "name": "determined",
-        "trans": [
-            "v. 决定；断定（determine的过去分词）"
-        ],
-        "usphone": "[dɪˈtɜːrmɪnd]",
-        "ukphone": "[dɪˈtɜːmɪnd]"
-    },
-    {
-        "name": "development",
-        "trans": [
-            "n. 发展；开发；发育；住宅小区（专指由同一开发商开发的）；[摄] 显影"
-        ],
-        "usphone": "[dɪˈveləpmənt]",
-        "ukphone": "[dɪˈveləpmənt]"
-    },
-    {
-        "name": "diagram",
-        "trans": [
-            "n. 图表；图解"
-        ],
-        "usphone": "[ˈdaɪəɡræm]",
-        "ukphone": "[ˈdaɪəɡræm]"
-    },
-    {
-        "name": "diamond",
-        "trans": [
-            "n. 钻石，金刚石；菱形；方块牌"
-        ],
-        "usphone": "[ˈdaɪmənd]",
-        "ukphone": "[ˈdaɪmənd]"
-    },
-    {
-        "name": "difficulty",
-        "trans": [
-            "n. 困难，困境"
-        ],
-        "usphone": "[ˈdɪfɪkəlti]",
-        "ukphone": "[ˈdɪfɪkəlti]"
-    },
-    {
-        "name": "direct",
-        "trans": [
-            "adj. 直接的；直系的；亲身的；恰好的"
-        ],
-        "usphone": "[dəˈrekt; daɪˈrekt]",
-        "ukphone": "[dəˈrekt]"
-    },
-    {
-        "name": "directly",
-        "trans": [
-            "conj. 一…就"
-        ],
-        "usphone": "[dəˈrektli; daɪˈrektli]",
-        "ukphone": "[dəˈrektli]"
-    },
-    {
-        "name": "dirt",
-        "trans": [
-            "n. 污垢，泥土；灰尘，尘土；下流话"
-        ],
-        "usphone": "[dɜːrt]",
-        "ukphone": "[dɜːt]"
-    },
-    {
-        "name": "disadvantage",
-        "trans": [
-            "n. 缺点；不利条件；损失"
-        ],
-        "usphone": "[ˌdɪsədˈvæntɪdʒ]",
-        "ukphone": "[ˌdɪsədˈvɑːntɪdʒ]"
-    },
-    {
-        "name": "disappointed",
-        "trans": [
-            "adj. 失望的，沮丧的；受挫折的"
-        ],
-        "usphone": "[ˌdɪsəˈpɔɪntɪd]",
-        "ukphone": "[ˌdɪsəˈpɔɪntɪd]"
-    },
-    {
-        "name": "disappointing",
-        "trans": [
-            "adj. 令人失望的；令人扫兴的"
-        ],
-        "usphone": "[ˌdɪsəˈpɔɪntɪŋ]",
-        "ukphone": "[ˌdɪsəˈpɔɪntɪŋ]"
-    },
-    {
-        "name": "discount",
-        "trans": [
-            "n. 折扣；贴现率"
-        ],
-        "usphone": "[ˈdɪskaʊnt]",
-        "ukphone": "[ˈdɪskaʊnt]"
-    },
-    {
-        "name": "dislike",
-        "trans": [
-            "n. 嫌恶，反感，不喜爱"
-        ],
-        "usphone": "[dɪsˈlaɪk]",
-        "ukphone": "[dɪsˈlaɪk]"
-    },
-    {
-        "name": "divide",
-        "trans": [
-            "n. [地理] 分水岭，分水线"
-        ],
-        "usphone": "[dɪˈvaɪd]",
-        "ukphone": "[dɪˈvaɪd]"
-    },
-    {
-        "name": "documentary",
-        "trans": [
-            "n. 纪录片"
-        ],
-        "usphone": "[ˌdɑːkjuˈmentri]",
-        "ukphone": "[ˌdɒkjuˈment(ə)ri]"
-    },
-    {
-        "name": "donate",
-        "trans": [
-            "n. 捐赠；捐献"
-        ],
-        "usphone": "[ˈdoʊneɪt]",
-        "ukphone": "[dəʊˈneɪt]"
-    },
-    {
-        "name": "double",
-        "trans": [
-            "n. 两倍；双精度型"
-        ],
-        "usphone": "[ˈdʌbl]",
-        "ukphone": "[ˈdʌb(ə)l]"
-    },
-    {
-        "name": "doubt",
-        "trans": [
-            "n. 怀疑；疑问；疑惑"
-        ],
-        "usphone": "[daʊt]",
-        "ukphone": "[daʊt]"
-    },
-    {
-        "name": "dressed",
-        "trans": [
-            "v. 装饰；给…穿衣；布置（dress的过去分词）"
-        ],
-        "usphone": "[drest]",
-        "ukphone": "[drest]"
-    },
-    {
-        "name": "drop",
-        "trans": [
-            "n. 滴；落下；空投；微量；滴剂"
-        ],
-        "usphone": "[drɑːp]",
-        "ukphone": "[drɒp]"
-    },
-    {
-        "name": "drum",
-        "trans": [
-            "n. 鼓；鼓声"
-        ],
-        "usphone": "[drʌm]",
-        "ukphone": "[drʌm]"
-    },
-    {
-        "name": "drunk",
-        "trans": [
-            "v. 喝酒（drink的过去分词）"
-        ],
-        "usphone": "[drʌŋk]",
-        "ukphone": "[drʌŋk]"
-    },
-    {
-        "name": "due",
-        "trans": [
-            "n. 应付款；应得之物"
-        ],
-        "usphone": "[duː]",
-        "ukphone": "[djuː]"
-    },
-    {
-        "name": "dust",
-        "trans": [
-            "n. 灰尘；尘埃；尘土"
-        ],
-        "usphone": "[dʌst]",
-        "ukphone": "[dʌst]"
-    },
-    {
-        "name": "duty",
-        "trans": [
-            "n. 责任；[税收] 关税；职务"
-        ],
-        "usphone": "[ˈduːti]",
-        "ukphone": "[ˈdjuːti]"
-    },
-    {
-        "name": "earthquake",
-        "trans": [
-            "n. 地震；大动荡"
-        ],
-        "usphone": "[ˈɜːrθkweɪk]",
-        "ukphone": "[ˈɜːθkweɪk]"
-    },
-    {
-        "name": "eastern",
-        "trans": [
-            "n. 东方人；（美国）东部地区的人"
-        ],
-        "usphone": "[ˈiːstərn]",
-        "ukphone": "[ˈiːstən]"
-    },
-    {
-        "name": "economic",
-        "trans": [
-            "adj. 经济的，经济上的；经济学的"
-        ],
-        "usphone": "[ˌiːkəˈnɑːmɪk; ˌekəˈnɑːmɪk]",
-        "ukphone": "[ˌiːkəˈnɒmɪk]"
-    },
-    {
-        "name": "economy",
-        "trans": [
-            "n. 经济；节约；理财"
-        ],
-        "usphone": "[ɪˈkɑːnəmi]",
-        "ukphone": "[ɪˈkɒnəmi]"
-    },
-    {
-        "name": "edge",
-        "trans": [
-            "n. 边缘；优势；刀刃；锋利"
-        ],
-        "usphone": "[edʒ]",
-        "ukphone": "[edʒ]"
-    },
-    {
-        "name": "editor",
-        "trans": [
-            "n. 编者，编辑；社论撰写人；编辑装置"
-        ],
-        "usphone": "[ˈedɪtər]",
-        "ukphone": "[ˈedɪtə(r)]"
-    },
-    {
-        "name": "educate",
-        "trans": [
-            "vt. 教育；培养；训练"
-        ],
-        "usphone": "[ˈedʒukeɪt]",
-        "ukphone": "[ˈedʒukeɪt]"
-    },
-    {
-        "name": "educated",
-        "trans": [
-            "v. 训练；教导；培育（educate的过去分词形式）"
-        ],
-        "usphone": "[ˈedʒukeɪtɪd]",
-        "ukphone": "[ˈedʒukeɪtɪd]"
-    },
-    {
-        "name": "educational",
-        "trans": [
-            "adj. 教育的；有教育意义的"
-        ],
-        "usphone": "[ˌedʒuˈkeɪʃənl]",
-        "ukphone": "[ˌedʒuˈkeɪʃən(ə)l]"
-    },
-    {
-        "name": "effective",
-        "trans": [
-            "adj. 有效的，起作用的；实际的，实在的；给人深刻印象"
-        ],
-        "usphone": "[ɪˈfektɪv]",
-        "ukphone": "[ɪˈfektɪv]"
-    },
-    {
-        "name": "effectively",
-        "trans": [
-            "adv. 有效地，生效地；有力地；实际上"
-        ],
-        "usphone": "[ɪˈfektɪvli]",
-        "ukphone": "[ɪˈfektɪvli]"
-    },
-    {
-        "name": "effort",
-        "trans": [
-            "n. 努力；成就"
-        ],
-        "usphone": "[ˈefərt]",
-        "ukphone": "[ˈefət]"
-    },
-    {
-        "name": "election",
-        "trans": [
-            "n. 选举；当选；选择权；上帝的选拔"
-        ],
-        "usphone": "[ɪˈlekʃn]",
-        "ukphone": "[ɪˈlekʃ(ə)n]"
-    },
-    {
-        "name": "element",
-        "trans": [
-            "n. 元素；要素；原理；成分；自然环境"
-        ],
-        "usphone": "[ˈelɪmənt]",
-        "ukphone": "[ˈelɪmənt]"
-    },
-    {
-        "name": "embarrassed",
-        "trans": [
-            "v. 使...困窘；使...局促不安（embarrass的过去分词形式）"
-        ],
-        "usphone": "[ɪmˈbærəst]",
-        "ukphone": "[ɪmˈbærəst]"
-    },
-    {
-        "name": "embarrassing",
-        "trans": [
-            "adj. 使人尴尬的；令人为难的"
-        ],
-        "usphone": "[ɪmˈbærəsɪŋ]",
-        "ukphone": "[ɪmˈbærəsɪŋ]"
-    },
-    {
-        "name": "emergency",
-        "trans": [
-            "n. 紧急情况；突发事件；非常时刻"
-        ],
-        "usphone": "[ɪˈmɜːrdʒənsi]",
-        "ukphone": "[ɪˈmɜːdʒənsi]"
-    },
-    {
-        "name": "emotion",
-        "trans": [
-            "n. 情感；情绪"
-        ],
-        "usphone": "[ɪˈmoʊʃn]",
-        "ukphone": "[ɪˈməʊʃn]"
-    },
-    {
-        "name": "employment",
-        "trans": [
-            "n. 使用；职业；雇用"
-        ],
-        "usphone": "[ɪmˈplɔɪmənt]",
-        "ukphone": "[ɪmˈplɔɪmənt]"
-    },
-    {
-        "name": "empty",
-        "trans": [
-            "n. 空车；空的东西"
-        ],
-        "usphone": "[ˈempti]",
-        "ukphone": "[ˈempti]"
-    },
-    {
-        "name": "encourage",
-        "trans": [
-            "vt. 鼓励，怂恿；激励；支持"
-        ],
-        "usphone": "[ɪnˈkɜːrɪdʒ]",
-        "ukphone": "[ɪnˈkʌrɪdʒ]"
-    },
-    {
-        "name": "enemy",
-        "trans": [
-            "n. 敌人，仇敌；敌军"
-        ],
-        "usphone": "[ˈenəmi]",
-        "ukphone": "[ˈenəmi]"
-    },
-    {
-        "name": "engaged",
-        "trans": [
-            "v. 保证；约定；同…订婚（engage的过去分词）"
-        ],
-        "usphone": "[ɪnˈɡeɪdʒd]",
-        "ukphone": "[ɪnˈɡeɪdʒd]"
-    },
-    {
-        "name": "engineering",
-        "trans": [
-            "n. 工程，工程学"
-        ],
-        "usphone": "[ˌendʒɪˈnɪrɪŋ]",
-        "ukphone": "[ˌendʒɪˈnɪərɪŋ]"
-    },
-    {
-        "name": "entertain",
-        "trans": [
-            "vt. 娱乐；招待；怀抱；容纳"
-        ],
-        "usphone": "[ˌentərˈteɪn]",
-        "ukphone": "[ˌentəˈteɪn]"
-    },
-    {
-        "name": "entertainment",
-        "trans": [
-            "n. 娱乐；消遣；款待"
-        ],
-        "usphone": "[ˌentərˈteɪnmənt]",
-        "ukphone": "[ˌentəˈteɪnmənt]"
-    },
-    {
-        "name": "entrance",
-        "trans": [
-            "n. 入口；进入"
-        ],
-        "usphone": "[ˈentrəns; ɪnˈtræns]",
-        "ukphone": "[ˈentrəns]"
-    },
-    {
-        "name": "entry",
-        "trans": [
-            "n. 进入；入口；条目；登记；报关手续；对土地的侵占"
-        ],
-        "usphone": "[ˈentri]",
-        "ukphone": "[ˈentri]"
-    },
-    {
-        "name": "environmental",
-        "trans": [
-            "adj. 环境的，周围的；有关环境的"
-        ],
-        "usphone": "[ɪnˌvaɪrənˈmentl]",
-        "ukphone": "[ɪnˌvaɪrənˈment(ə)l]"
-    },
-    {
-        "name": "episode",
-        "trans": [
-            "n. 插曲；一段情节；插话；有趣的事件"
-        ],
-        "usphone": "[ˈepɪsoʊd]",
-        "ukphone": "[ˈepɪsəʊd]"
-    },
-    {
-        "name": "equal",
-        "trans": [
-            "n. 对手；匹敌；同辈；相等的事物"
-        ],
-        "usphone": "[ˈiːkwəl]",
-        "ukphone": "[ˈiːkwəl]"
-    },
-    {
-        "name": "equally",
-        "trans": [
-            "adv. 同样地；相等地，平等地；公平地"
-        ],
-        "usphone": "[ˈiːkwəli]",
-        "ukphone": "[ˈiːkwəli]"
-    },
-    {
-        "name": "escape",
-        "trans": [
-            "n. 逃跑；逃亡；逃走；逃跑工具或方法；野生种；泄漏"
-        ],
-        "usphone": "[ɪˈskeɪp]",
-        "ukphone": "[ɪˈskeɪp]"
-    },
-    {
-        "name": "essential",
-        "trans": [
-            "n. 本质；要素；要点；必需品"
-        ],
-        "usphone": "[ɪˈsenʃl]",
-        "ukphone": "[ɪˈsenʃl]"
-    },
-    {
-        "name": "eventually",
-        "trans": [
-            "adv. 最后，终于"
-        ],
-        "usphone": "[ɪˈventʃuəli]",
-        "ukphone": "[ɪˈventʃuəli]"
-    },
-    {
-        "name": "examine",
-        "trans": [
-            "vt. 检查；调查； 检测；考试"
-        ],
-        "usphone": "[ɪɡˈzæmɪn]",
-        "ukphone": "[ɪɡˈzæmɪn]"
-    },
-    {
-        "name": "except",
-        "trans": [
-            "conj. 除了；要不是"
-        ],
-        "usphone": "[ɪkˈsept]",
-        "ukphone": "[ɪkˈsept]"
-    },
-    {
-        "name": "exchange",
-        "trans": [
-            "n. 交换；交流；交易所；兑换"
-        ],
-        "usphone": "[ɪksˈtʃeɪndʒ]",
-        "ukphone": "[ɪksˈtʃeɪndʒ]"
-    },
-    {
-        "name": "excitement",
-        "trans": [
-            "n. 兴奋；刺激；令人兴奋的事物"
-        ],
-        "usphone": "[ɪkˈsaɪtmənt]",
-        "ukphone": "[ɪkˈsaɪtmənt]"
-    },
-    {
-        "name": "exhibition",
-        "trans": [
-            "n. 展览，显示；展览会；展览品"
-        ],
-        "usphone": "[ˌeksɪˈbɪʃn]",
-        "ukphone": "[ˌeksɪˈbɪʃ(ə)n]"
-    },
-    {
-        "name": "expand",
-        "trans": [
-            "vt. 扩张；使膨胀；详述"
-        ],
-        "usphone": "[ɪkˈspænd]",
-        "ukphone": "[ɪkˈspænd]"
-    },
-    {
-        "name": "expected",
-        "trans": [
-            "v. 预期；盼望（expect的过去分词）"
-        ],
-        "usphone": "[ɪkˈspektɪd]",
-        "ukphone": "[ɪkˈspektɪd]"
-    },
-    {
-        "name": "expedition",
-        "trans": [
-            "n. 远征；探险队；迅速"
-        ],
-        "usphone": "[ˌekspəˈdɪʃn]",
-        "ukphone": "[ˌekspəˈdɪʃ(ə)n]"
-    },
-    {
-        "name": "experience",
-        "trans": [
-            "n. 经验；经历；体验"
-        ],
-        "usphone": "[ɪkˈspɪriəns]",
-        "ukphone": "[ɪkˈspɪəriəns]"
-    },
-    {
-        "name": "experienced",
-        "trans": [
-            "adj. 老练的，熟练的；富有经验的"
-        ],
-        "usphone": "[ɪkˈspɪriənst]",
-        "ukphone": "[ɪkˈspɪəriənst]"
-    },
-    {
-        "name": "experiment",
-        "trans": [
-            "n. 实验，试验；尝试"
-        ],
-        "usphone": "[ɪkˈsperɪmənt]",
-        "ukphone": "[ɪkˈsperɪmənt]"
-    },
-    {
-        "name": "explode",
-        "trans": [
-            "vi. 爆炸，爆发；激增"
-        ],
-        "usphone": "[ɪkˈsploʊd]",
-        "ukphone": "[ɪkˈspləʊd]"
-    },
-    {
-        "name": "explore",
-        "trans": [
-            "vi. 探索；探测；探险"
-        ],
-        "usphone": "[ɪkˈsplɔːr]",
-        "ukphone": "[ɪkˈsplɔː(r)]"
-    },
-    {
-        "name": "explosion",
-        "trans": [
-            "n. 爆炸；爆发；激增"
-        ],
-        "usphone": "[ɪkˈsploʊʒn]",
-        "ukphone": "[ɪkˈspləʊʒ(ə)n]"
-    },
-    {
-        "name": "export",
-        "trans": [
-            "n. 输出，出口；出口商品"
-        ],
-        "usphone": "[ɪkˈspɔːrt; ˈekspɔːrt]",
-        "ukphone": "[ɪkˈspɔːt; ˈekspɔːt]"
-    },
-    {
-        "name": "extra",
-        "trans": [
-            "n. 临时演员；号外；额外的事物；上等产品"
-        ],
-        "usphone": "[ˈekstrə]",
-        "ukphone": "[ˈekstrə]"
-    },
-    {
-        "name": "face",
-        "trans": [
-            "n. 脸；表面；面子；面容；外观；威信"
-        ],
-        "usphone": "[feɪs]",
-        "ukphone": "[feɪs]"
-    },
-    {
-        "name": "fairly",
-        "trans": [
-            "adv. 相当地；公平地；简直"
-        ],
-        "usphone": "[ˈferli]",
-        "ukphone": "[ˈfeəli]"
+        "usphone": "[ˌpriːzenˈteɪʃn]",
+        "ukphone": "[ˌpreznˈteɪʃn]"
     },
     {
         "name": "familiar",
@@ -2120,124 +2024,12 @@
         "ukphone": "[fəˈmɪliə(r)]"
     },
     {
-        "name": "fancy",
+        "name": "frame",
         "trans": [
-            "n. 幻想；想象力；爱好"
+            "n. 框架；结构；[电影] 画面"
         ],
-        "usphone": "[ˈfænsi]",
-        "ukphone": "[ˈfænsi]"
-    },
-    {
-        "name": "far",
-        "trans": [
-            "n. 远方"
-        ],
-        "usphone": "[fɑːr]",
-        "ukphone": "[fɑː(r)]"
-    },
-    {
-        "name": "fascinating",
-        "trans": [
-            "adj. 迷人的；吸引人的；使人神魂颠倒的"
-        ],
-        "usphone": "[ˈfæsɪneɪtɪŋ]",
-        "ukphone": "[ˈfæsɪneɪtɪŋ]"
-    },
-    {
-        "name": "fashionable",
-        "trans": [
-            "adj. 流行的；时髦的；上流社会的"
-        ],
-        "usphone": "[ˈfæʃnəbl]",
-        "ukphone": "[ˈfæʃnəbl]"
-    },
-    {
-        "name": "fasten",
-        "trans": [
-            "vt. 使固定；集中于；扎牢；强加于"
-        ],
-        "usphone": "[ˈfæsn]",
-        "ukphone": "[ˈfɑːs(ə)n]"
-    },
-    {
-        "name": "favour",
-        "trans": [
-            "n. 偏爱；赞同；善行"
-        ],
-        "usphone": "[ˈfeɪvər]",
-        "ukphone": "[ˈfeɪvə(r)]"
-    },
-    {
-        "name": "fear",
-        "trans": [
-            "n. 害怕；恐惧；敬畏；担心"
-        ],
-        "usphone": "[fɪr]",
-        "ukphone": "[fɪə(r)]"
-    },
-    {
-        "name": "feature",
-        "trans": [
-            "n. 特色，特征；容貌；特写或专题节目"
-        ],
-        "usphone": "[ˈfiːtʃər]",
-        "ukphone": "[ˈfiːtʃə(r)]"
-    },
-    {
-        "name": "fence",
-        "trans": [
-            "n. 栅栏；围墙；剑术"
-        ],
-        "usphone": "[fens]",
-        "ukphone": "[fens]"
-    },
-    {
-        "name": "fighting",
-        "trans": [
-            "n. 战斗，搏斗"
-        ],
-        "usphone": "[ˈfaɪtɪŋ]",
-        "ukphone": "[ˈfaɪtɪŋ]"
-    },
-    {
-        "name": "file",
-        "trans": [
-            "n. 文件；档案；文件夹；锉刀"
-        ],
-        "usphone": "[faɪl]",
-        "ukphone": "[faɪl]"
-    },
-    {
-        "name": "financial",
-        "trans": [
-            "adj. 金融的；财政的，财务的"
-        ],
-        "usphone": "[faɪˈnænʃl; fəˈnænʃl]",
-        "ukphone": "[faɪˈnænʃ(ə)l]"
-    },
-    {
-        "name": "fire",
-        "trans": [
-            "n. 火；火灾；炮火；炉火；热情；激情；磨难"
-        ],
-        "usphone": "[ˈfaɪər]",
-        "ukphone": "[ˈfaɪə(r)]"
-    },
-    {
-        "name": "fitness",
-        "trans": [
-            "n. 健康；适当；适合性"
-        ],
-        "usphone": "[ˈfɪtnəs]",
-        "ukphone": "[ˈfɪtnəs]"
-    },
-    {
-        "name": "fixed",
-        "trans": [
-            "adj. 确定的；固执的；<美口>处境...的；准备好的"
-        ],
-        "usphone": "[fɪkst]",
-        "ukphone": "[fɪkst]"
+        "usphone": "[freɪm]",
+        "ukphone": "[freɪm]"
     },
     {
         "name": "flag",
@@ -2248,2668 +2040,20 @@
         "ukphone": "[flæɡ]"
     },
     {
-        "name": "flood",
+        "name": "substance",
         "trans": [
-            "n. 洪水；泛滥；一大批"
+            "n. 物质；实质；资产；主旨"
         ],
-        "usphone": "[flʌd]",
-        "ukphone": "[flʌd]"
+        "usphone": "[ˈsʌbstəns]",
+        "ukphone": "[ˈsʌbstəns]"
     },
     {
-        "name": "flour",
+        "name": "countryside",
         "trans": [
-            "n. 面粉；粉状物质"
+            "n. 农村，乡下；乡下的全体居民"
         ],
-        "usphone": "[ˈflaʊər]",
-        "ukphone": "[ˈflaʊə(r)]"
-    },
-    {
-        "name": "flow",
-        "trans": [
-            "n. 流动；流量；涨潮，泛滥"
-        ],
-        "usphone": "[floʊ]",
-        "ukphone": "[fləʊ]"
-    },
-    {
-        "name": "fold",
-        "trans": [
-            "n. 折痕；信徒；羊栏"
-        ],
-        "usphone": "[foʊld]",
-        "ukphone": "[fəʊld]"
-    },
-    {
-        "name": "folk",
-        "trans": [
-            "n. 民族；人们；亲属（复数）"
-        ],
-        "usphone": "[foʊk]",
-        "ukphone": "[fəʊk]"
-    },
-    {
-        "name": "following",
-        "trans": [
-            "n. 下列事物；一批追随者"
-        ],
-        "usphone": "[ˈfɑːloʊɪŋ]",
-        "ukphone": "[ˈfɒləʊɪŋ]"
-    },
-    {
-        "name": "force",
-        "trans": [
-            "n. 力量；武力；军队；魄力"
-        ],
-        "usphone": "[fɔːrs]",
-        "ukphone": "[fɔːs]"
-    },
-    {
-        "name": "forever",
-        "trans": [
-            "adv. 永远；不断地；常常"
-        ],
-        "usphone": "[fərˈevər]",
-        "ukphone": "[fərˈevə(r)]"
-    },
-    {
-        "name": "frame",
-        "trans": [
-            "n. 框架；结构；[电影] 画面"
-        ],
-        "usphone": "[freɪm]",
-        "ukphone": "[freɪm]"
-    },
-    {
-        "name": "freeze",
-        "trans": [
-            "n. 冻结；凝固"
-        ],
-        "usphone": "[friːz]",
-        "ukphone": "[friːz]"
-    },
-    {
-        "name": "frequently",
-        "trans": [
-            "adv. 频繁地，经常地；时常，屡次"
-        ],
-        "usphone": "[ˈfriːkwəntli]",
-        "ukphone": "[ˈfriːkwəntli]"
-    },
-    {
-        "name": "friendship",
-        "trans": [
-            "n. 友谊；友爱；友善"
-        ],
-        "usphone": "[ˈfrendʃɪp]",
-        "ukphone": "[ˈfrendʃɪp]"
-    },
-    {
-        "name": "frighten",
-        "trans": [
-            "vt. 使惊吓；吓唬…"
-        ],
-        "usphone": "[ˈfraɪtn]",
-        "ukphone": "[ˈfraɪtn]"
-    },
-    {
-        "name": "frightened",
-        "trans": [
-            "v. 害怕；使吃惊；吓走（frighten的过去分词）"
-        ],
-        "usphone": "[ˈfraɪtnd]",
-        "ukphone": "[ˈfraɪtnd]"
-    },
-    {
-        "name": "frightening",
-        "trans": [
-            "adj. 令人恐惧的；引起突然惊恐的"
-        ],
-        "usphone": "[ˈfraɪtnɪŋ]",
-        "ukphone": "[ˈfraɪt(ə)nɪŋ]"
-    },
-    {
-        "name": "frozen",
-        "trans": [
-            "v. 结冰（freeze的过去分词）；凝固；变得刻板"
-        ],
-        "usphone": "[ˈfroʊzn]",
-        "ukphone": "[ˈfrəʊz(ə)n]"
-    },
-    {
-        "name": "fry",
-        "trans": [
-            "n. 鱼苗；油炸食物"
-        ],
-        "usphone": "[fraɪ]",
-        "ukphone": "[fraɪ]"
-    },
-    {
-        "name": "fuel",
-        "trans": [
-            "n. 燃料；刺激因素"
-        ],
-        "usphone": "[ˈfjuːəl]",
-        "ukphone": "[ˈfjuːəl]"
-    },
-    {
-        "name": "function",
-        "trans": [
-            "n. 功能；[数] 函数；职责；盛大的集会"
-        ],
-        "usphone": "[ˈfʌŋkʃn]",
-        "ukphone": "[ˈfʌŋkʃ(ə)n]"
-    },
-    {
-        "name": "fur",
-        "trans": [
-            "n. 皮，皮子；毛皮；软毛"
-        ],
-        "usphone": "[fɜːr]",
-        "ukphone": "[fɜː(r)]"
-    },
-    {
-        "name": "further",
-        "trans": [
-            "adj. 更远的；深一层的"
-        ],
-        "usphone": "[ˈfɜːrðər]",
-        "ukphone": "[ˈfɜːðə(r)]"
-    },
-    {
-        "name": "garage",
-        "trans": [
-            "n. 车库；汽车修理厂；飞机库"
-        ],
-        "usphone": "[ɡəˈrɑːʒ; ɡəˈrɑːdʒ]",
-        "ukphone": "[ˈɡærɑːʒ]"
-    },
-    {
-        "name": "gather",
-        "trans": [
-            "n. 聚集；衣褶；收获量"
-        ],
-        "usphone": "[ˈɡæðər]",
-        "ukphone": "[ˈɡæðə(r)]"
-    },
-    {
-        "name": "generally",
-        "trans": [
-            "adv. 通常；普遍地，一般地"
-        ],
-        "usphone": "[ˈdʒenrəli]",
-        "ukphone": "[ˈdʒenrəli]"
-    },
-    {
-        "name": "generation",
-        "trans": [
-            "n. 一代；产生；一代人；生殖"
-        ],
-        "usphone": "[ˌdʒenəˈreɪʃn]",
-        "ukphone": "[ˌdʒenəˈreɪʃn]"
-    },
-    {
-        "name": "generous",
-        "trans": [
-            "adj. 慷慨的，大方的；宽宏大量的；有雅量的"
-        ],
-        "usphone": "[ˈdʒenərəs]",
-        "ukphone": "[ˈdʒenərəs]"
-    },
-    {
-        "name": "gentle",
-        "trans": [
-            "n. 蛆，饵"
-        ],
-        "usphone": "[ˈdʒentl]",
-        "ukphone": "[ˈdʒent(ə)l]"
-    },
-    {
-        "name": "gentleman",
-        "trans": [
-            "n. 先生；绅士；有身份的人"
-        ],
-        "usphone": "[ˈdʒent(ə)lmən]",
-        "ukphone": "[ˈdʒentlmən]"
-    },
-    {
-        "name": "ghost",
-        "trans": [
-            "n. 鬼，幽灵"
-        ],
-        "usphone": "[ɡoʊst]",
-        "ukphone": "[ɡəʊst]"
-    },
-    {
-        "name": "giant",
-        "trans": [
-            "n. 巨人；伟人；[动] 巨大的动物"
-        ],
-        "usphone": "[ˈdʒaɪənt]",
-        "ukphone": "[ˈdʒaɪənt]"
-    },
-    {
-        "name": "glad",
-        "trans": [
-            "adj. 高兴的；乐意的；令人高兴的；灿烂美丽的"
-        ],
-        "usphone": "[ɡlæd]",
-        "ukphone": "[ɡlæd]"
-    },
-    {
-        "name": "global",
-        "trans": [
-            "adj. 全球的；总体的；球形的"
-        ],
-        "usphone": "[ˈɡloʊbl]",
-        "ukphone": "[ˈɡləʊb(ə)l]"
-    },
-    {
-        "name": "glove",
-        "trans": [
-            "n. 手套"
-        ],
-        "usphone": "[ɡlʌv]",
-        "ukphone": "[ɡlʌv]"
-    },
-    {
-        "name": "go",
-        "trans": [
-            "n. 去；进行；尝试"
-        ],
-        "usphone": "[ɡoʊ]",
-        "ukphone": "[ɡəʊ]"
-    },
-    {
-        "name": "goods",
-        "trans": [
-            "n. 商品；动产；合意的人；真本领"
-        ],
-        "usphone": "[ɡʊdz]",
-        "ukphone": "[ɡʊdz]"
-    },
-    {
-        "name": "grade",
-        "trans": [
-            "n. 年级；等级；成绩；级别；阶段"
-        ],
-        "usphone": "[ɡreɪd]",
-        "ukphone": "[ɡreɪd]"
-    },
-    {
-        "name": "graduate",
-        "trans": [
-            "n. 研究生；毕业生"
-        ],
-        "usphone": "[ˈɡrædʒuət]",
-        "ukphone": "[ˈɡrædʒuət]"
-    },
-    {
-        "name": "grain",
-        "trans": [
-            "n. 粮食；颗粒；[作物] 谷物；纹理"
-        ],
-        "usphone": "[ɡreɪn]",
-        "ukphone": "[ɡreɪn]"
-    },
-    {
-        "name": "grateful",
-        "trans": [
-            "adj. 感谢的；令人愉快的，宜人的"
-        ],
-        "usphone": "[ˈɡreɪtfl]",
-        "ukphone": "[ˈɡreɪtf(ə)l]"
-    },
-    {
-        "name": "growth",
-        "trans": [
-            "n. 增长；发展；生长；种植"
-        ],
-        "usphone": "[ɡroʊθ]",
-        "ukphone": "[ɡrəʊθ]"
-    },
-    {
-        "name": "guard",
-        "trans": [
-            "n. 守卫；警戒；护卫队；防护装置"
-        ],
-        "usphone": "[ɡɑːrd]",
-        "ukphone": "[ɡɑːd]"
-    },
-    {
-        "name": "guilty",
-        "trans": [
-            "adj. 有罪的；内疚的"
-        ],
-        "usphone": "[ˈɡɪlti]",
-        "ukphone": "[ˈɡɪlti]"
-    },
-    {
-        "name": "hand",
-        "trans": [
-            "n. 手，手艺；帮助；指针；插手"
-        ],
-        "usphone": "[hænd]",
-        "ukphone": "[hænd]"
-    },
-    {
-        "name": "hang",
-        "trans": [
-            "n. 悬挂；暂停，中止"
-        ],
-        "usphone": "[hæŋ]",
-        "ukphone": "[hæŋ]"
-    },
-    {
-        "name": "happiness",
-        "trans": [
-            "n. 幸福"
-        ],
-        "usphone": "[ˈhæpinəs]",
-        "ukphone": "[ˈhæpinəs]"
-    },
-    {
-        "name": "hardly",
-        "trans": [
-            "adv. 几乎不，简直不；刚刚"
-        ],
-        "usphone": "[ˈhɑːrdli]",
-        "ukphone": "[ˈhɑːdli]"
-    },
-    {
-        "name": "hate",
-        "trans": [
-            "n. 憎恨；反感"
-        ],
-        "usphone": "[heɪt]",
-        "ukphone": "[heɪt]"
-    },
-    {
-        "name": "head",
-        "trans": [
-            "n. 头；头痛；上端；最前的部分；理解力"
-        ],
-        "usphone": "[hed]",
-        "ukphone": "[hed]"
-    },
-    {
-        "name": "headline",
-        "trans": [
-            "n. 大标题；内容提要；栏外标题；头版头条新闻"
-        ],
-        "usphone": "[ˈhedlaɪn]",
-        "ukphone": "[ˈhedlaɪn]"
-    },
-    {
-        "name": "heating",
-        "trans": [
-            "n. [热] 加热；[建] 供暖；暖气设备"
-        ],
-        "usphone": "[ˈhiːtɪŋ]",
-        "ukphone": "[ˈhiːtɪŋ]"
-    },
-    {
-        "name": "heavily",
-        "trans": [
-            "adv. 沉重地；猛烈地；沉闷地"
-        ],
-        "usphone": "[ˈhevɪli]",
-        "ukphone": "[ˈhevɪli]"
-    },
-    {
-        "name": "helicopter",
-        "trans": [
-            "n. [航] 直升飞机"
-        ],
-        "usphone": "[ˈhelɪkɑːptər]",
-        "ukphone": "[ˈhelɪkɒptə(r)]"
-    },
-    {
-        "name": "highlight",
-        "trans": [
-            "n. 最精彩的部分；最重要的事情；加亮区"
-        ],
-        "usphone": "[ˈhaɪlaɪt]",
-        "ukphone": "[ˈhaɪlaɪt]"
-    },
-    {
-        "name": "highly",
-        "trans": [
-            "adv. 高度地；非常；非常赞许地"
-        ],
-        "usphone": "[ˈhaɪli]",
-        "ukphone": "[ˈhaɪli]"
-    },
-    {
-        "name": "hire",
-        "trans": [
-            "n. 雇用，租用；租金，工钱"
-        ],
-        "usphone": "[ˈhaɪər]",
-        "ukphone": "[ˈhaɪə(r)]"
-    },
-    {
-        "name": "historic",
-        "trans": [
-            "adj. 有历史意义的；历史上著名的"
-        ],
-        "usphone": "[hɪˈstɔːrɪk]",
-        "ukphone": "[hɪˈstɒrɪk]"
-    },
-    {
-        "name": "historical",
-        "trans": [
-            "adj. 历史的；史学的；基于史实的"
-        ],
-        "usphone": "[hɪˈstɔːrɪkl]",
-        "ukphone": "[hɪˈstɒrɪk(ə)l]"
-    },
-    {
-        "name": "honest",
-        "trans": [
-            "adj. 诚实的，实在的；可靠的；坦率的"
-        ],
-        "usphone": "[ˈɑːnɪst]",
-        "ukphone": "[ˈɒnɪst]"
-    },
-    {
-        "name": "horrible",
-        "trans": [
-            "adj. 可怕的；极讨厌的"
-        ],
-        "usphone": "[ˈhɔːrəbl]",
-        "ukphone": "[ˈhɒrəb(ə)l]"
-    },
-    {
-        "name": "horror",
-        "trans": [
-            "n. 惊骇；惨状；极端厌恶；令人恐怖的事物"
-        ],
-        "usphone": "[ˈhɔːrər]",
-        "ukphone": "[ˈhɒrə(r)]"
-    },
-    {
-        "name": "host",
-        "trans": [
-            "n. [计] 主机；主人；主持人；许多"
-        ],
-        "usphone": "[hoʊst]",
-        "ukphone": "[həʊst]"
-    },
-    {
-        "name": "hunt",
-        "trans": [
-            "n. 狩猎；搜寻"
-        ],
-        "usphone": "[hʌnt]",
-        "ukphone": "[hʌnt]"
-    },
-    {
-        "name": "hurricane",
-        "trans": [
-            "n. 飓风，暴风"
-        ],
-        "usphone": "[ˈhɜːrəkeɪn]",
-        "ukphone": "[ˈhʌrɪkən]"
-    },
-    {
-        "name": "hurry",
-        "trans": [
-            "n. 匆忙，急忙"
-        ],
-        "usphone": "[ˈhɜːri]",
-        "ukphone": "[ˈhʌri]"
-    },
-    {
-        "name": "identity",
-        "trans": [
-            "n. 身份；同一性，一致；特性；恒等式"
-        ],
-        "usphone": "[aɪˈdentəti]",
-        "ukphone": "[aɪˈdentəti]"
-    },
-    {
-        "name": "ignore",
-        "trans": [
-            "vt. 驳回诉讼；忽视；不理睬"
-        ],
-        "usphone": "[ɪɡˈnɔːr]",
-        "ukphone": "[ɪɡˈnɔː(r)]"
-    },
-    {
-        "name": "illegal",
-        "trans": [
-            "n. 非法移民，非法劳工"
-        ],
-        "usphone": "[ɪˈliːɡl]",
-        "ukphone": "[ɪˈliːɡ(ə)l]"
-    },
-    {
-        "name": "imaginary",
-        "trans": [
-            "adj. 虚构的，假想的；想像的；虚数的"
-        ],
-        "usphone": "[ɪˈmædʒɪneri]",
-        "ukphone": "[ɪˈmædʒɪnəri]"
-    },
-    {
-        "name": "immediate",
-        "trans": [
-            "adj. 立即的；直接的；最接近的"
-        ],
-        "usphone": "[ɪˈmiːdiət]",
-        "ukphone": "[ɪˈmiːdiət]"
-    },
-    {
-        "name": "immigrant",
-        "trans": [
-            "n. 移民，侨民"
-        ],
-        "usphone": "[ˈɪmɪɡrənt]",
-        "ukphone": "[ˈɪmɪɡrənt]"
-    },
-    {
-        "name": "impact",
-        "trans": [
-            "vi. 影响；撞击；冲突；压紧（on，upon，with）"
-        ],
-        "usphone": "[ˈɪmpækt]",
-        "ukphone": "[ˈɪmpækt]"
-    },
-    {
-        "name": "import",
-        "trans": [
-            "n. 进口，进口货；输入；意思，含义；重要性"
-        ],
-        "usphone": "[ˈɪmpɔːrt]",
-        "ukphone": "[ˈɪmpɔːt]"
-    },
-    {
-        "name": "importance",
-        "trans": [
-            "n. 价值；重要；重大；傲慢"
-        ],
-        "usphone": "[ɪmˈpɔːrtns]",
-        "ukphone": "[ɪmˈpɔːt(ə)ns]"
-    },
-    {
-        "name": "impression",
-        "trans": [
-            "n. 印象；效果，影响；压痕，印记；感想；曝光（衡量广告被显示的次数。打开一个带有该广告的网页，则该广告的impression 次数增加一次）"
-        ],
-        "usphone": "[ɪmˈpreʃn]",
-        "ukphone": "[ɪmˈpreʃ(ə)n]"
-    },
-    {
-        "name": "impressive",
-        "trans": [
-            "adj. 感人的；令人钦佩的；给人以深刻印象的"
-        ],
-        "usphone": "[ɪmˈpresɪv]",
-        "ukphone": "[ɪmˈpresɪv]"
-    },
-    {
-        "name": "improvement",
-        "trans": [
-            "n. 改进，改善；提高"
-        ],
-        "usphone": "[ɪmˈpruːvmənt]",
-        "ukphone": "[ɪmˈpruːvmənt]"
-    },
-    {
-        "name": "incredibly",
-        "trans": [
-            "adv. 难以置信地；非常地"
-        ],
-        "usphone": "[ɪnˈkredəbli]",
-        "ukphone": "[ɪnˈkredəbli]"
-    },
-    {
-        "name": "indeed",
-        "trans": [
-            "adv. 的确；实在；真正地；甚至"
-        ],
-        "usphone": "[ɪnˈdiːd]",
-        "ukphone": "[ɪnˈdiːd]"
-    },
-    {
-        "name": "indicate",
-        "trans": [
-            "vt. 表明；指出；预示；象征"
-        ],
-        "usphone": "[ˈɪndɪkeɪt]",
-        "ukphone": "[ˈɪndɪkeɪt]"
-    },
-    {
-        "name": "indirect",
-        "trans": [
-            "adj. 间接的；迂回的；非直截了当的"
-        ],
-        "usphone": "[ˌɪndəˈrektˌˌɪndaɪˈrekt]",
-        "ukphone": "[ˌɪndəˈrekt; ˌɪndaɪˈrekt]"
-    },
-    {
-        "name": "indoor",
-        "trans": [
-            "adj. 室内的，户内的"
-        ],
-        "usphone": "[ˈɪndɔːr]",
-        "ukphone": "[ˈɪndɔː(r)]"
-    },
-    {
-        "name": "indoors",
-        "trans": [
-            "adv. 在室内，在户内"
-        ],
-        "usphone": "[ˌɪnˈdɔːrz]",
-        "ukphone": "[ˌɪnˈdɔːz]"
-    },
-    {
-        "name": "influence",
-        "trans": [
-            "n. 影响；势力；感化；有影响的人或事"
-        ],
-        "usphone": "[ˈɪnfluəns]",
-        "ukphone": "[ˈɪnfluəns]"
-    },
-    {
-        "name": "ingredient",
-        "trans": [
-            "n. 原料；要素；组成部分"
-        ],
-        "usphone": "[ɪnˈɡriːdiənt]",
-        "ukphone": "[ɪnˈɡriːdiənt]"
-    },
-    {
-        "name": "injure",
-        "trans": [
-            "vt. 伤害，损害"
-        ],
-        "usphone": "[ˈɪndʒər]",
-        "ukphone": "[ˈɪndʒə(r)]"
-    },
-    {
-        "name": "injured",
-        "trans": [
-            "adj. 受伤的；受损害的"
-        ],
-        "usphone": "[ˈɪndʒərd]",
-        "ukphone": "[ˈɪndʒəd]"
-    },
-    {
-        "name": "innocent",
-        "trans": [
-            "n. 天真的人；笨蛋"
-        ],
-        "usphone": "[ˈɪnəsnt]",
-        "ukphone": "[ˈɪnəs(ə)nt]"
-    },
-    {
-        "name": "intelligence",
-        "trans": [
-            "n. 智力；情报工作；情报机关；理解力；才智，智慧；天分"
-        ],
-        "usphone": "[ɪnˈtelɪdʒəns]",
-        "ukphone": "[ɪnˈtelɪdʒəns]"
-    },
-    {
-        "name": "intend",
-        "trans": [
-            "vi. 有打算"
-        ],
-        "usphone": "[ɪnˈtend]",
-        "ukphone": "[ɪnˈtend]"
-    },
-    {
-        "name": "intention",
-        "trans": [
-            "n. 意图；目的；意向；愈合"
-        ],
-        "usphone": "[ɪnˈtenʃn]",
-        "ukphone": "[ɪnˈtenʃ(ə)n]"
-    },
-    {
-        "name": "invest",
-        "trans": [
-            "vi. 投资，入股；花钱买"
-        ],
-        "usphone": "[ɪnˈvest]",
-        "ukphone": "[ɪnˈvest]"
-    },
-    {
-        "name": "investigate",
-        "trans": [
-            "v. 调查；研究"
-        ],
-        "usphone": "[ɪnˈvestɪɡeɪt]",
-        "ukphone": "[ɪnˈvestɪɡeɪt]"
-    },
-    {
-        "name": "involved",
-        "trans": [
-            "v. 涉及；使参与；包含（involve的过去式和过去分词）"
-        ],
-        "usphone": "[ɪnˈvɑːlvd]",
-        "ukphone": "[ɪnˈvɒlvd]"
-    },
-    {
-        "name": "iron",
-        "trans": [
-            "n. 熨斗；烙铁；坚强"
-        ],
-        "usphone": "[ˈaɪərn]",
-        "ukphone": "[ˈaɪən]"
-    },
-    {
-        "name": "issue",
-        "trans": [
-            "n. 问题；流出；期号；发行物"
-        ],
-        "usphone": "[ˈɪʃuː]",
-        "ukphone": "[ˈɪʃuː]"
-    },
-    {
-        "name": "IT",
-        "trans": [
-            "abbr. 信息技术information technology"
-        ],
-        "usphone": "[ˌaɪ ˈtiː]",
-        "ukphone": "[ˌaɪ ˈtiː]"
-    },
-    {
-        "name": "journal",
-        "trans": [
-            "n. 日报，杂志；日记；分类账"
-        ],
-        "usphone": "[ˈdʒɜːrnl]",
-        "ukphone": "[ˈdʒɜːn(ə)l]"
-    },
-    {
-        "name": "judge",
-        "trans": [
-            "vt. 判断；审判"
-        ],
-        "usphone": "[dʒʌdʒ]",
-        "ukphone": "[dʒʌdʒ]"
-    },
-    {
-        "name": "keen",
-        "trans": [
-            "adj. 敏锐的，敏捷的；渴望的；强烈的；热心的；锐利的"
-        ],
-        "usphone": "[kiːn]",
-        "ukphone": "[kiːn]"
-    },
-    {
-        "name": "key",
-        "trans": [
-            "n. （打字机等的）键；关键；钥匙"
-        ],
-        "usphone": "[kiː]",
-        "ukphone": "[kiː]"
-    },
-    {
-        "name": "keyboard",
-        "trans": [
-            "n. 键盘"
-        ],
-        "usphone": "[ˈkiːbɔːrd]",
-        "ukphone": "[ˈkiːbɔːd]"
-    },
-    {
-        "name": "kick",
-        "trans": [
-            "vt. 踢；反冲，朝后座"
-        ],
-        "usphone": "[kɪk]",
-        "ukphone": "[kɪk]"
-    },
-    {
-        "name": "killing",
-        "trans": [
-            "adj. 杀害的；迷人的；使人筋疲力尽的"
-        ],
-        "usphone": "[ˈkɪlɪŋ]",
-        "ukphone": "[ˈkɪlɪŋ]"
-    },
-    {
-        "name": "kind",
-        "trans": [
-            "n. 种类；性质"
-        ],
-        "usphone": "[kaɪnd]",
-        "ukphone": "[kaɪnd]"
-    },
-    {
-        "name": "kiss",
-        "trans": [
-            "vt. 吻；（风等）轻拂"
-        ],
-        "usphone": "[kɪs]",
-        "ukphone": "[kɪs]"
-    },
-    {
-        "name": "knock",
-        "trans": [
-            "vi. 敲；打；敲击"
-        ],
-        "usphone": "[nɑːk]",
-        "ukphone": "[nɒk]"
-    },
-    {
-        "name": "label",
-        "trans": [
-            "vt. 标注；贴标签于"
-        ],
-        "usphone": "[ˈleɪbl]",
-        "ukphone": "[ˈleɪb(ə)l]"
-    },
-    {
-        "name": "laboratory",
-        "trans": [
-            "n. 实验室，研究室"
-        ],
-        "usphone": "[ˈlæbrətɔːri]",
-        "ukphone": "[ləˈbɒrətri]"
-    },
-    {
-        "name": "lack",
-        "trans": [
-            "vt. 缺乏；不足；没有；需要"
-        ],
-        "usphone": "[læk]",
-        "ukphone": "[læk]"
-    },
-    {
-        "name": "latest",
-        "trans": [
-            "adv. 最迟地；最后地"
-        ],
-        "usphone": "[ˈleɪtɪst]",
-        "ukphone": "[ˈleɪtɪst]"
-    },
-    {
-        "name": "lay",
-        "trans": [
-            "vt. 躺下；产卵；搁放；放置；铺放；涂，敷"
-        ],
-        "usphone": "[leɪ]",
-        "ukphone": "[leɪ]"
-    },
-    {
-        "name": "layer",
-        "trans": [
-            "n. 层，层次；膜；[植]压条；放置者，计划者"
-        ],
-        "usphone": "[ˈleɪər]",
-        "ukphone": "[ˈleɪə(r)]"
-    },
-    {
-        "name": "lead",
-        "trans": [
-            "n. 领导；铅；导线；榜样"
-        ],
-        "usphone": "[liːd; led]",
-        "ukphone": "[liːd]"
-    },
-    {
-        "name": "leading",
-        "trans": [
-            "adj. 领导的；主要的"
-        ],
-        "usphone": "[ˈliːdɪŋ; ˈledɪŋ]",
-        "ukphone": "[ˈliːdɪŋ]"
-    },
-    {
-        "name": "leaf",
-        "trans": [
-            "n. 叶子；（书籍等的）一张；扇页"
-        ],
-        "usphone": "[liːf]",
-        "ukphone": "[liːf]"
-    },
-    {
-        "name": "leather",
-        "trans": [
-            "n. 皮革；皮革制品"
-        ],
-        "usphone": "[ˈleðər]",
-        "ukphone": "[ˈleðə(r)]"
-    },
-    {
-        "name": "legal",
-        "trans": [
-            "adj. 法律的；合法的；法定的；依照法律的"
-        ],
-        "usphone": "[ˈliːɡl]",
-        "ukphone": "[ˈliːɡ(ə)l]"
-    },
-    {
-        "name": "leisure",
-        "trans": [
-            "n. 闲暇；空闲；安逸"
-        ],
-        "usphone": "[ˈliːʒər]",
-        "ukphone": "[ˈleʒə(r)]"
-    },
-    {
-        "name": "length",
-        "trans": [
-            "n. 长度，长；时间的长短；（语）音长"
-        ],
-        "usphone": "[leŋkθ]",
-        "ukphone": "[leŋkθ]"
-    },
-    {
-        "name": "level",
-        "trans": [
-            "n. 水平；标准；水平面"
-        ],
-        "usphone": "[ˈlevl]",
-        "ukphone": "[ˈlev(ə)l]"
-    },
-    {
-        "name": "lie",
-        "trans": [
-            "vi. 躺；说谎；位于；展现"
-        ],
-        "usphone": "[laɪ]",
-        "ukphone": "[laɪ]"
-    },
-    {
-        "name": "like",
-        "trans": [
-            "vt. 喜欢；想；愿意"
-        ],
-        "usphone": "[laɪk]",
-        "ukphone": "[laɪk]"
-    },
-    {
-        "name": "limit",
-        "trans": [
-            "n. 限制；限度；界线"
-        ],
-        "usphone": "[ˈlɪmɪt]",
-        "ukphone": "[ˈlɪmɪt]"
-    },
-    {
-        "name": "lip",
-        "trans": [
-            "n. 嘴唇；边缘"
-        ],
-        "usphone": "[lɪp]",
-        "ukphone": "[lɪp]"
-    },
-    {
-        "name": "liquid",
-        "trans": [
-            "adj. 液体的；清澈的；明亮的；易变的"
-        ],
-        "usphone": "[ˈlɪkwɪd]",
-        "ukphone": "[ˈlɪkwɪd]"
-    },
-    {
-        "name": "literature",
-        "trans": [
-            "n. 文学；文献；文艺；著作"
-        ],
-        "usphone": "[ˈlɪtrətʃər; ˈlɪtrətʃʊr; ˈlɪtərətʃʊr]",
-        "ukphone": "[ˈlɪtrətʃə(r)]"
-    },
-    {
-        "name": "live",
-        "trans": [
-            "adj. 活的；生动的；实况转播的；精力充沛的"
-        ],
-        "usphone": "[lɪv; laɪv]",
-        "ukphone": "[lɪv]"
-    },
-    {
-        "name": "living",
-        "trans": [
-            "adj. 活的；现存的；活跃的；逼真的"
-        ],
-        "usphone": "[ˈlɪvɪŋ]",
-        "ukphone": "[ˈlɪvɪŋ]"
-    },
-    {
-        "name": "local",
-        "trans": [
-            "n. [计] 局部；当地居民；本地新闻"
-        ],
-        "usphone": "[ˈloʊkl]",
-        "ukphone": "[ˈləʊk(ə)l]"
-    },
-    {
-        "name": "locate",
-        "trans": [
-            "vt. 位于；查找…的地点"
-        ],
-        "usphone": "[ˈloʊkeɪt]",
-        "ukphone": "[ləʊˈkeɪt]"
-    },
-    {
-        "name": "located",
-        "trans": [
-            "adj. 处于，位于；坐落的"
-        ],
-        "usphone": "[ˈloʊkeɪtɪd]",
-        "ukphone": "[ləʊˈkeɪtɪd]"
-    },
-    {
-        "name": "location",
-        "trans": [
-            "n. 位置（形容词locational）；地点；外景拍摄场地"
-        ],
-        "usphone": "[loʊˈkeɪʃn]",
-        "ukphone": "[ləʊˈkeɪʃn]"
-    },
-    {
-        "name": "lonely",
-        "trans": [
-            "adj. 寂寞的；偏僻的"
-        ],
-        "usphone": "[ˈloʊnli]",
-        "ukphone": "[ˈləʊnli]"
-    },
-    {
-        "name": "loss",
-        "trans": [
-            "n. 减少；亏损；失败；遗失"
-        ],
-        "usphone": "[lɔːs]",
-        "ukphone": "[lɒs]"
-    },
-    {
-        "name": "luxury",
-        "trans": [
-            "n. 奢侈，奢华；奢侈品；享受"
-        ],
-        "usphone": "[ˈlʌkʃəri]",
-        "ukphone": "[ˈlʌkʃəri]"
-    },
-    {
-        "name": "mad",
-        "trans": [
-            "adj. 疯狂的；发疯的；愚蠢的；着迷的"
-        ],
-        "usphone": "[mæd]",
-        "ukphone": "[mæd]"
-    },
-    {
-        "name": "magic",
-        "trans": [
-            "n. 巫术；魔法；戏法"
-        ],
-        "usphone": "[ˈmædʒɪk]",
-        "ukphone": "[ˈmædʒɪk]"
-    },
-    {
-        "name": "mainly",
-        "trans": [
-            "adv. 主要地，大体上"
-        ],
-        "usphone": "[ˈmeɪnli]",
-        "ukphone": "[ˈmeɪnli]"
-    },
-    {
-        "name": "mall",
-        "trans": [
-            "n. 购物商场；林荫路；铁圈球场"
-        ],
-        "usphone": "[mɔːl]",
-        "ukphone": "[mɔːl; mæl]"
-    },
-    {
-        "name": "management",
-        "trans": [
-            "n. 管理；管理人员；管理部门；操纵；经营手段"
-        ],
-        "usphone": "[ˈmænɪdʒmənt]",
-        "ukphone": "[ˈmænɪdʒmənt]"
-    },
-    {
-        "name": "market",
-        "trans": [
-            "n. 市场；行情；股票市场；市面；集市；销路；商店"
-        ],
-        "usphone": "[ˈmɑːrkɪt]",
-        "ukphone": "[ˈmɑːkɪt]"
-    },
-    {
-        "name": "marketing",
-        "trans": [
-            "n. 行销，销售"
-        ],
-        "usphone": "[ˈmɑːrkɪtɪŋ]",
-        "ukphone": "[ˈmɑːkɪtɪŋ]"
-    },
-    {
-        "name": "marriage",
-        "trans": [
-            "n. 结婚；婚姻生活；密切结合，合并"
-        ],
-        "usphone": "[ˈmærɪdʒ]",
-        "ukphone": "[ˈmærɪdʒ]"
-    },
-    {
-        "name": "meanwhile",
-        "trans": [
-            "adv. 同时，其间"
-        ],
-        "usphone": "[ˈmiːnwaɪl]",
-        "ukphone": "[ˈmiːnwaɪl]"
-    },
-    {
-        "name": "measure",
-        "trans": [
-            "n. 测量；措施；程度；尺寸"
-        ],
-        "usphone": "[ˈmeʒər]",
-        "ukphone": "[ˈmeʒə(r)]"
-    },
-    {
-        "name": "medium",
-        "trans": [
-            "adj. 中间的，中等的；半生熟的"
-        ],
-        "usphone": "[ˈmiːdiəm]",
-        "ukphone": "[ˈmiːdiəm]"
-    },
-    {
-        "name": "mental",
-        "trans": [
-            "adj. 精神的；脑力的；疯的"
-        ],
-        "usphone": "[ˈmentl]",
-        "ukphone": "[ˈmentl]"
-    },
-    {
-        "name": "mention",
-        "trans": [
-            "vt. 提到，谈到；提及，论及；说起"
-        ],
-        "usphone": "[ˈmenʃn]",
-        "ukphone": "[ˈmenʃn]"
-    },
-    {
-        "name": "mess",
-        "trans": [
-            "n. 混乱；食堂，伙食团；困境；脏乱的东西"
-        ],
-        "usphone": "[mes]",
-        "ukphone": "[mes]"
-    },
-    {
-        "name": "mild",
-        "trans": [
-            "adj. 温和的；轻微的；淡味的；文雅的；不含有害物质的的"
-        ],
-        "usphone": "[maɪld]",
-        "ukphone": "[maɪld]"
-    },
-    {
-        "name": "mine",
-        "trans": [
-            "n. 矿，矿藏；矿山，矿井；地雷，水雷"
-        ],
-        "usphone": "[maɪn]",
-        "ukphone": "[maɪn]"
-    },
-    {
-        "name": "mix",
-        "trans": [
-            "vt. 配制；混淆；使混和；使结交"
-        ],
-        "usphone": "[mɪks]",
-        "ukphone": "[mɪks]"
-    },
-    {
-        "name": "mixture",
-        "trans": [
-            "n. 混合；混合物；混合剂"
-        ],
-        "usphone": "[ˈmɪkstʃər]",
-        "ukphone": "[ˈmɪkstʃə(r)]"
-    },
-    {
-        "name": "mood",
-        "trans": [
-            "n. 情绪，语气；心境；气氛"
-        ],
-        "usphone": "[muːd]",
-        "ukphone": "[muːd]"
-    },
-    {
-        "name": "move",
-        "trans": [
-            "n. 移动；步骤；迁居；策略"
-        ],
-        "usphone": "[muːv]",
-        "ukphone": "[muːv]"
-    },
-    {
-        "name": "mud",
-        "trans": [
-            "vt. 弄脏；用泥涂"
-        ],
-        "usphone": "[mʌd]",
-        "ukphone": "[mʌd]"
-    },
-    {
-        "name": "murder",
-        "trans": [
-            "vt. 谋杀，凶杀"
-        ],
-        "usphone": "[ˈmɜːrdər]",
-        "ukphone": "[ˈmɜːdə(r)]"
-    },
-    {
-        "name": "muscle",
-        "trans": [
-            "n. 肌肉；力量"
-        ],
-        "usphone": "[ˈmʌsl]",
-        "ukphone": "[ˈmʌsl]"
-    },
-    {
-        "name": "musical",
-        "trans": [
-            "adj. 音乐的；悦耳的"
-        ],
-        "usphone": "[ˈmjuːzɪkl]",
-        "ukphone": "[ˈmjuːzɪk(ə)l]"
-    },
-    {
-        "name": "mystery",
-        "trans": [
-            "n. 秘密，谜；神秘，神秘的事物；推理小说，推理剧；常作 mysteries 秘技，秘诀"
-        ],
-        "usphone": "[ˈmɪstəri]",
-        "ukphone": "[ˈmɪstri]"
-    },
-    {
-        "name": "nail",
-        "trans": [
-            "vt. 钉；使固定；揭露"
-        ],
-        "usphone": "[neɪl]",
-        "ukphone": "[neɪl]"
-    },
-    {
-        "name": "narrative",
-        "trans": [
-            "n. 叙述；故事；讲述"
-        ],
-        "usphone": "[ˈnærətɪv]",
-        "ukphone": "[ˈnærətɪv]"
-    },
-    {
-        "name": "nation",
-        "trans": [
-            "n. 国家；民族；国民"
-        ],
-        "usphone": "[ˈneɪʃn]",
-        "ukphone": "[ˈneɪʃ(ə)n]"
-    },
-    {
-        "name": "native",
-        "trans": [
-            "adj. 本国的；土著的；天然的；与生俱来的；天赋的"
-        ],
-        "usphone": "[ˈneɪtɪv]",
-        "ukphone": "[ˈneɪtɪv]"
-    },
-    {
-        "name": "naturally",
-        "trans": [
-            "adv. 自然地"
-        ],
-        "usphone": "[ˈnætʃrəli]",
-        "ukphone": "[ˈnætʃ(ə)rəli]"
-    },
-    {
-        "name": "necessarily",
-        "trans": [
-            "adv. 必要地；必定地，必然地"
-        ],
-        "usphone": "[ˌnesəˈserəli]",
-        "ukphone": "[ˌnesəˈserəli; ˈnesəsərəli]"
-    },
-    {
-        "name": "need",
-        "trans": [
-            "n. 需要，要求；缺乏；必要之物"
-        ],
-        "usphone": "[niːd]",
-        "ukphone": "[niːd]"
-    },
-    {
-        "name": "needle",
-        "trans": [
-            "n. 针；指针；刺激；针状物"
-        ],
-        "usphone": "[ˈniːdl]",
-        "ukphone": "[ˈniːdl]"
-    },
-    {
-        "name": "neighbourhood",
-        "trans": [
-            "n. 邻近；周围；邻居关系；附近一带"
-        ],
-        "usphone": "[ˈneɪbərhʊd]",
-        "ukphone": "[ˈneɪbəhʊd]"
-    },
-    {
-        "name": "neither",
-        "trans": [
-            "conj. 也不；既不"
-        ],
-        "usphone": "[ˈniːðər; ˈnaɪðər]",
-        "ukphone": "[ˈnaɪðə(r)]"
-    },
-    {
-        "name": "net",
-        "trans": [
-            "n. 网；网络；净利；实价"
-        ],
-        "usphone": "[net]",
-        "ukphone": "[net]"
-    },
-    {
-        "name": "next",
-        "trans": [
-            "adv. 然后；下次；其次"
-        ],
-        "usphone": "[nekst]",
-        "ukphone": "[nekst]"
-    },
-    {
-        "name": "nor",
-        "trans": [
-            "conj. 也不；也不是"
-        ],
-        "usphone": "[nɔːr]",
-        "ukphone": "[nɔː(r)]"
-    },
-    {
-        "name": "normal",
-        "trans": [
-            "adj. 正常的；正规的，标准的"
-        ],
-        "usphone": "[ˈnɔːrm(ə)l]",
-        "ukphone": "[ˈnɔːm(ə)l]"
-    },
-    {
-        "name": "northern",
-        "trans": [
-            "adj. 北部的；北方的"
-        ],
-        "usphone": "[ˈnɔːrðərn]",
-        "ukphone": "[ˈnɔːðən]"
-    },
-    {
-        "name": "note",
-        "trans": [
-            "n. 笔记；音符；票据；注解；纸币；便笺；照会；调子"
-        ],
-        "usphone": "[noʊt]",
-        "ukphone": "[nəʊt]"
-    },
-    {
-        "name": "now",
-        "trans": [
-            "adv. 现在；如今；立刻"
-        ],
-        "usphone": "[naʊ]",
-        "ukphone": "[naʊ]"
-    },
-    {
-        "name": "nuclear",
-        "trans": [
-            "adj. 原子能的；[细胞] 细胞核的；中心的；原子核的"
-        ],
-        "usphone": "[ˈnuːkliər]",
-        "ukphone": "[ˈnjuːkliə(r)]"
-    },
-    {
-        "name": "obvious",
-        "trans": [
-            "adj. 明显的；显著的；平淡无奇的"
-        ],
-        "usphone": "[ˈɑːbviəs]",
-        "ukphone": "[ˈɒbviəs]"
-    },
-    {
-        "name": "obviously",
-        "trans": [
-            "adv. 明显地"
-        ],
-        "usphone": "[ˈɑːbviəsli]",
-        "ukphone": "[ˈɒbviəsli]"
-    },
-    {
-        "name": "occasion",
-        "trans": [
-            "n. 时机，机会；场合；理由"
-        ],
-        "usphone": "[əˈkeɪʒn]",
-        "ukphone": "[əˈkeɪʒ(ə)n]"
-    },
-    {
-        "name": "occur",
-        "trans": [
-            "vi. 发生；出现；存在"
-        ],
-        "usphone": "[əˈkɜːr]",
-        "ukphone": "[əˈkɜː(r)]"
-    },
-    {
-        "name": "odd",
-        "trans": [
-            "adj. 奇数的；古怪的；剩余的；临时的；零散的"
-        ],
-        "usphone": "[ɑːd]",
-        "ukphone": "[ɒd]"
-    },
-    {
-        "name": "official",
-        "trans": [
-            "adj. 官方的；正式的；公务的"
-        ],
-        "usphone": "[əˈfɪʃl]",
-        "ukphone": "[əˈfɪʃ(ə)l]"
-    },
-    {
-        "name": "old-fashioned",
-        "trans": [
-            "adj. 老式的；过时的；守旧的"
-        ],
-        "usphone": "[ˌoʊld ˈfæʃnd]",
-        "ukphone": "[ˌəʊld ˈfæʃnd]"
-    },
-    {
-        "name": "once",
-        "trans": [
-            "adv. 一次；曾经"
-        ],
-        "usphone": "[wʌns]",
-        "ukphone": "[wʌns]"
-    },
-    {
-        "name": "operation",
-        "trans": [
-            "n. 操作；经营；[外科] 手术；[数][计] 运算"
-        ],
-        "usphone": "[ˌɑːpəˈreɪʃ(ə)n]",
-        "ukphone": "[ˌɒpəˈreɪʃ(ə)n]"
-    },
-    {
-        "name": "organized",
-        "trans": [
-            "adj. 有组织的；安排有秩序的；做事有条理的"
-        ],
-        "usphone": "[ˈɔːrɡənaɪzd]",
-        "ukphone": "[ˈɔːɡənaɪzd]"
-    },
-    {
-        "name": "organizer",
-        "trans": [
-            "n. 组织者；承办单位；[生物] 组织导体"
-        ],
-        "usphone": "[ˈɔːrɡənaɪzər]",
-        "ukphone": "[ˈɔːɡənaɪzə(r)]"
-    },
-    {
-        "name": "original",
-        "trans": [
-            "n. 原件；原作；原物；原型"
-        ],
-        "usphone": "[əˈrɪdʒənl]",
-        "ukphone": "[əˈrɪdʒən(ə)l]"
-    },
-    {
-        "name": "originally",
-        "trans": [
-            "adv. 最初，起初；本来"
-        ],
-        "usphone": "[əˈrɪdʒənəli]",
-        "ukphone": "[əˈrɪdʒənəli]"
-    },
-    {
-        "name": "ought",
-        "trans": [
-            "aux. 应该，应当；大概"
-        ],
-        "usphone": "[ɔːt]",
-        "ukphone": "[ɔːt]"
-    },
-    {
-        "name": "ours",
-        "trans": [
-            "pron. 我们的"
-        ],
-        "usphone": "[ˈaʊərz]",
-        "ukphone": "[ˈaʊəz]"
-    },
-    {
-        "name": "outdoor",
-        "trans": [
-            "adj. 户外的；露天的；野外的（等于out-of-door）"
-        ],
-        "usphone": "[ˈaʊtdɔːr]",
-        "ukphone": "[ˈaʊtdɔː(r)]"
-    },
-    {
-        "name": "outdoors",
-        "trans": [
-            "adv. 在户外"
-        ],
-        "usphone": "[ˌaʊtˈdɔːrz]",
-        "ukphone": "[ˌaʊtˈdɔːz]"
-    },
-    {
-        "name": "pack",
-        "trans": [
-            "n. 包装；一群；背包；包裹；一副"
-        ],
-        "usphone": "[pæk]",
-        "ukphone": "[pæk]"
-    },
-    {
-        "name": "package",
-        "trans": [
-            "n. 包，包裹；套装软件，[计] 程序包"
-        ],
-        "usphone": "[ˈpækɪdʒ]",
-        "ukphone": "[ˈpækɪdʒ]"
-    },
-    {
-        "name": "painful",
-        "trans": [
-            "adj. 痛苦的；疼痛的；令人不快的"
-        ],
-        "usphone": "[ˈpeɪnfl]",
-        "ukphone": "[ˈpeɪnf(ə)l]"
-    },
-    {
-        "name": "pale",
-        "trans": [
-            "n. 前哨；栅栏；范围"
-        ],
-        "usphone": "[peɪl]",
-        "ukphone": "[peɪl]"
-    },
-    {
-        "name": "pan",
-        "trans": [
-            "n. 平底锅；盘状的器皿；淘盘子，金盘，秤盘"
-        ],
-        "usphone": "[pæn]",
-        "ukphone": "[pæn]"
-    },
-    {
-        "name": "participate",
-        "trans": [
-            "vi. 参与，参加；分享"
-        ],
-        "usphone": "[pɑːrˈtɪsɪpeɪt]",
-        "ukphone": "[pɑːˈtɪsɪpeɪt]"
-    },
-    {
-        "name": "particularly",
-        "trans": [
-            "adv. 特别地，独特地；详细地，具体地；明确地，细致地"
-        ],
-        "usphone": "[pərˈtɪkjələrli]",
-        "ukphone": "[pəˈtɪkjələli]"
-    },
-    {
-        "name": "pass",
-        "trans": [
-            "n. 及格；经过；护照；途径；传球"
-        ],
-        "usphone": "[pæs]",
-        "ukphone": "[pɑːs]"
-    },
-    {
-        "name": "passion",
-        "trans": [
-            "n. 激情；热情；酷爱；盛怒"
-        ],
-        "usphone": "[ˈpæʃ(ə)n]",
-        "ukphone": "[ˈpæʃ(ə)n]"
-    },
-    {
-        "name": "path",
-        "trans": [
-            "n. 道路；小路；轨道"
-        ],
-        "usphone": "[pæθ]",
-        "ukphone": "[pɑːθ]"
-    },
-    {
-        "name": "payment",
-        "trans": [
-            "n. 付款，支付；报酬，报答；偿还；惩罚，报应"
-        ],
-        "usphone": "[ˈpeɪmənt]",
-        "ukphone": "[ˈpeɪmənt]"
-    },
-    {
-        "name": "peaceful",
-        "trans": [
-            "adj. 和平的，爱好和平的；平静的"
-        ],
-        "usphone": "[ˈpiːsfl]",
-        "ukphone": "[ˈpiːsfl]"
-    },
-    {
-        "name": "percentage",
-        "trans": [
-            "n. 百分比；百分率，百分数"
-        ],
-        "usphone": "[pərˈsentɪdʒ]",
-        "ukphone": "[pəˈsentɪdʒ]"
-    },
-    {
-        "name": "perfectly",
-        "trans": [
-            "adv. 完美地；完全地；无瑕疵地"
-        ],
-        "usphone": "[ˈpɜːrfɪktli]",
-        "ukphone": "[ˈpɜːfɪktli]"
-    },
-    {
-        "name": "performance",
-        "trans": [
-            "n. 性能；绩效；表演；执行；表现"
-        ],
-        "usphone": "[pərˈfɔːrməns]",
-        "ukphone": "[pəˈfɔːməns]"
-    },
-    {
-        "name": "personally",
-        "trans": [
-            "adv. 亲自地；当面；个别地；就自己而言"
-        ],
-        "usphone": "[ˈpɜːrsənəli]",
-        "ukphone": "[ˈpɜːsənəli]"
-    },
-    {
-        "name": "persuade",
-        "trans": [
-            "vt. 说服，劝说；使某人相信；劝某人做（不做）某事"
-        ],
-        "usphone": "[pərˈsweɪd]",
-        "ukphone": "[pəˈsweɪd]"
-    },
-    {
-        "name": "photographer",
-        "trans": [
-            "n. 摄影师；照相师"
-        ],
-        "usphone": "[fəˈtɑːɡrəfər]",
-        "ukphone": "[fəˈtɒɡrəfə(r)]"
-    },
-    {
-        "name": "photography",
-        "trans": [
-            "n. 摄影；摄影术"
-        ],
-        "usphone": "[fəˈtɑːɡrəfi]",
-        "ukphone": "[fəˈtɒɡrəfi]"
-    },
-    {
-        "name": "pin",
-        "trans": [
-            "n. 大头针，别针，针；栓；琐碎物"
-        ],
-        "usphone": "[pɪn]",
-        "ukphone": "[pɪn]"
-    },
-    {
-        "name": "pipe",
-        "trans": [
-            "n. 管；烟斗；笛"
-        ],
-        "usphone": "[paɪp]",
-        "ukphone": "[paɪp]"
-    },
-    {
-        "name": "place",
-        "trans": [
-            "n. 地方；住所；座位"
-        ],
-        "usphone": "[pleɪs]",
-        "ukphone": "[pleɪs]"
-    },
-    {
-        "name": "planning",
-        "trans": [
-            "n. 规划；计划编制"
-        ],
-        "usphone": "[ˈplænɪŋ]",
-        "ukphone": "[ˈplænɪŋ]"
-    },
-    {
-        "name": "pleasant",
-        "trans": [
-            "adj. 令人愉快的，舒适的；讨人喜欢的，和蔼可亲的"
-        ],
-        "usphone": "[ˈpleznt]",
-        "ukphone": "[ˈplez(ə)nt]"
-    },
-    {
-        "name": "pleasure",
-        "trans": [
-            "n. 快乐；希望；娱乐；令人高兴的事"
-        ],
-        "usphone": "[ˈpleʒər]",
-        "ukphone": "[ˈpleʒə(r)]"
-    },
-    {
-        "name": "plenty",
-        "trans": [
-            "n. 丰富，大量；充足"
-        ],
-        "usphone": "[ˈplenti]",
-        "ukphone": "[ˈplenti]"
-    },
-    {
-        "name": "plot",
-        "trans": [
-            "n. 情节；图；阴谋"
-        ],
-        "usphone": "[plɑːt]",
-        "ukphone": "[plɒt]"
-    },
-    {
-        "name": "plus",
-        "trans": [
-            "prep. 加，加上"
-        ],
-        "usphone": "[plʌs]",
-        "ukphone": "[plʌs]"
-    },
-    {
-        "name": "poem",
-        "trans": [
-            "n. 诗"
-        ],
-        "usphone": "[ˈpoʊəm]",
-        "ukphone": "[ˈpəʊɪm]"
-    },
-    {
-        "name": "poet",
-        "trans": [
-            "n. 诗人"
-        ],
-        "usphone": "[ˈpoʊət]",
-        "ukphone": "[ˈpəʊɪt]"
-    },
-    {
-        "name": "poetry",
-        "trans": [
-            "n. 诗；诗意，诗情；诗歌艺术"
-        ],
-        "usphone": "[ˈpoʊətri]",
-        "ukphone": "[ˈpəʊətri]"
-    },
-    {
-        "name": "point",
-        "trans": [
-            "n. 要点；得分；标点；[机] 尖端"
-        ],
-        "usphone": "[pɔɪnt]",
-        "ukphone": "[pɔɪnt]"
-    },
-    {
-        "name": "poison",
-        "trans": [
-            "n. 毒药，毒物；酒；有毒害的事物；[助剂] 抑制剂"
-        ],
-        "usphone": "[ˈpɔɪzn]",
-        "ukphone": "[ˈpɔɪz(ə)n]"
-    },
-    {
-        "name": "poisonous",
-        "trans": [
-            "adj. 有毒的；恶毒的；讨厌的"
-        ],
-        "usphone": "[ˈpɔɪzənəs]",
-        "ukphone": "[ˈpɔɪzənəs]"
-    },
-    {
-        "name": "policy",
-        "trans": [
-            "n. 政策，方针；保险单"
-        ],
-        "usphone": "[ˈpɑːləsi]",
-        "ukphone": "[ˈpɒləsi]"
-    },
-    {
-        "name": "political",
-        "trans": [
-            "adj. 政治的；党派的"
-        ],
-        "usphone": "[pəˈlɪtɪkl]",
-        "ukphone": "[pəˈlɪtɪk(ə)l]"
-    },
-    {
-        "name": "politician",
-        "trans": [
-            "n. 政治家，政客"
-        ],
-        "usphone": "[ˌpɑːləˈtɪʃn]",
-        "ukphone": "[ˌpɒləˈtɪʃn]"
-    },
-    {
-        "name": "politics",
-        "trans": [
-            "n. 政治，政治学；政治活动；政纲"
-        ],
-        "usphone": "[ˈpɑːlətɪks]",
-        "ukphone": "[ˈpɒlətɪks]"
-    },
-    {
-        "name": "port",
-        "trans": [
-            "n. 港口，口岸；（计算机的）端口；左舷；舱门"
-        ],
-        "usphone": "[pɔːrt]",
-        "ukphone": "[pɔːt]"
-    },
-    {
-        "name": "portrait",
-        "trans": [
-            "n. 肖像；描写；半身雕塑像"
-        ],
-        "usphone": "[ˈpɔːrtrət]",
-        "ukphone": "[ˈpɔːtreɪt]"
-    },
-    {
-        "name": "possibly",
-        "trans": [
-            "adv. 可能地；也许；大概"
-        ],
-        "usphone": "[ˈpɑːsəbli]",
-        "ukphone": "[ˈpɒsəbli]"
-    },
-    {
-        "name": "pot",
-        "trans": [
-            "n. 壶；盆；罐"
-        ],
-        "usphone": "[pɑːt]",
-        "ukphone": "[pɒt]"
-    },
-    {
-        "name": "pour",
-        "trans": [
-            "n. 倾泻；流出；骤雨"
-        ],
-        "usphone": "[pɔːr]",
-        "ukphone": "[pɔː(r)]"
-    },
-    {
-        "name": "poverty",
-        "trans": [
-            "n. 贫困；困难；缺少；低劣"
-        ],
-        "usphone": "[ˈpɑːvərti]",
-        "ukphone": "[ˈpɒvəti]"
-    },
-    {
-        "name": "powder",
-        "trans": [
-            "n. 粉；粉末；[化工][军] 火药；尘土"
-        ],
-        "usphone": "[ˈpaʊdər]",
-        "ukphone": "[ˈpaʊdə(r)]"
-    },
-    {
-        "name": "powerful",
-        "trans": [
-            "adj. 强大的；强有力的"
-        ],
-        "usphone": "[ˈpaʊərfl]",
-        "ukphone": "[ˈpaʊəf(ə)l]"
-    },
-    {
-        "name": "practical",
-        "trans": [
-            "adj. 实际的；实用性的"
-        ],
-        "usphone": "[ˈpræktɪkl]",
-        "ukphone": "[ˈpræktɪkl]"
-    },
-    {
-        "name": "pray",
-        "trans": [
-            "vi. 祈祷；请；恳求"
-        ],
-        "usphone": "[preɪ]",
-        "ukphone": "[preɪ]"
-    },
-    {
-        "name": "prayer",
-        "trans": [
-            "n. 祈祷，祷告；恳求；祈祷文"
-        ],
-        "usphone": "[prer]",
-        "ukphone": "[preə(r)]"
-    },
-    {
-        "name": "prediction",
-        "trans": [
-            "n. 预报；预言"
-        ],
-        "usphone": "[prɪˈdɪkʃn]",
-        "ukphone": "[prɪˈdɪkʃn]"
-    },
-    {
-        "name": "prepared",
-        "trans": [
-            "v. 准备（prepare的过去分词）"
-        ],
-        "usphone": "[prɪˈperd]",
-        "ukphone": "[prɪˈpeəd]"
-    },
-    {
-        "name": "presentation",
-        "trans": [
-            "n. 展示；描述，陈述；介绍；赠送"
-        ],
-        "usphone": "[ˌpriːzenˈteɪʃn]",
-        "ukphone": "[ˌpreznˈteɪʃn]"
-    },
-    {
-        "name": "press",
-        "trans": [
-            "n. 压；按；新闻；出版社；[印刷] 印刷机"
-        ],
-        "usphone": "[pres]",
-        "ukphone": "[pres]"
-    },
-    {
-        "name": "pressure",
-        "trans": [
-            "n. 压力；压迫，[物] 压强"
-        ],
-        "usphone": "[ˈpreʃər]",
-        "ukphone": "[ˈpreʃə(r)]"
-    },
-    {
-        "name": "pretend",
-        "trans": [
-            "vt. 假装，伪装，模拟"
-        ],
-        "usphone": "[prɪˈtend]",
-        "ukphone": "[prɪˈtend]"
-    },
-    {
-        "name": "previous",
-        "trans": [
-            "adj. 以前的；早先的；过早的"
-        ],
-        "usphone": "[ˈpriːviəs]",
-        "ukphone": "[ˈpriːviəs]"
-    },
-    {
-        "name": "previously",
-        "trans": [
-            "adv. 以前；预先；仓促地"
-        ],
-        "usphone": "[ˈpriːviəsli]",
-        "ukphone": "[ˈpriːviəsli]"
-    },
-    {
-        "name": "priest",
-        "trans": [
-            "n. 牧师；神父；教士"
-        ],
-        "usphone": "[priːst]",
-        "ukphone": "[priːst]"
-    },
-    {
-        "name": "primary",
-        "trans": [
-            "n. 原色；最主要者"
-        ],
-        "usphone": "[ˈpraɪmeri]",
-        "ukphone": "[ˈpraɪməri]"
-    },
-    {
-        "name": "prince",
-        "trans": [
-            "n. 王子，国君；亲王；贵族"
-        ],
-        "usphone": "[prɪns]",
-        "ukphone": "[prɪns]"
-    },
-    {
-        "name": "princess",
-        "trans": [
-            "n. 公主；王妃；女巨头"
-        ],
-        "usphone": "[ˈprɪnses]",
-        "ukphone": "[ˌprɪnˈses; ˈprɪnses]"
-    },
-    {
-        "name": "printing",
-        "trans": [
-            "n. 印刷；印刷术"
-        ],
-        "usphone": "[ˈprɪntɪŋ]",
-        "ukphone": "[ˈprɪntɪŋ]"
-    },
-    {
-        "name": "prisoner",
-        "trans": [
-            "n. 囚犯，犯人；俘虏；刑事被告"
-        ],
-        "usphone": "[ˈprɪznər]",
-        "ukphone": "[ˈprɪznə(r)]"
-    },
-    {
-        "name": "private",
-        "trans": [
-            "n. 列兵；二等兵"
-        ],
-        "usphone": "[ˈpraɪvət]",
-        "ukphone": "[ˈpraɪvət]"
-    },
-    {
-        "name": "producer",
-        "trans": [
-            "n. 制作人，制片人；生产者；发生器"
-        ],
-        "usphone": "[prəˈduːsər]",
-        "ukphone": "[prəˈdjuːsə(r)]"
-    },
-    {
-        "name": "production",
-        "trans": [
-            "n. 成果；产品；生产；作品"
-        ],
-        "usphone": "[prəˈdʌkʃn]",
-        "ukphone": "[prəˈdʌkʃn]"
-    },
-    {
-        "name": "profession",
-        "trans": [
-            "n. 职业，专业；声明，宣布，表白"
-        ],
-        "usphone": "[prəˈfeʃn]",
-        "ukphone": "[prəˈfeʃn]"
-    },
-    {
-        "name": "profit",
-        "trans": [
-            "n. 利润；利益"
-        ],
-        "usphone": "[ˈprɑːfɪt]",
-        "ukphone": "[ˈprɒfɪt]"
-    },
-    {
-        "name": "program",
-        "trans": [
-            "n. 程序；计划；大纲"
-        ],
-        "usphone": "[ˈproʊɡræm]",
-        "ukphone": "[ˈprəʊɡræm]"
-    },
-    {
-        "name": "promote",
-        "trans": [
-            "vi. 成为王后或其他大于卒的子"
-        ],
-        "usphone": "[prəˈmoʊt]",
-        "ukphone": "[prəˈməʊt]"
-    },
-    {
-        "name": "proper",
-        "trans": [
-            "adj. 适当的；本身的；特有的；正派的"
-        ],
-        "usphone": "[ˈprɑːpər]",
-        "ukphone": "[ˈprɒpə(r)]"
-    },
-    {
-        "name": "properly",
-        "trans": [
-            "adv. 适当地；正确地；恰当地"
-        ],
-        "usphone": "[ˈprɑːpərli]",
-        "ukphone": "[ˈprɒpəli]"
-    },
-    {
-        "name": "property",
-        "trans": [
-            "n. 性质，性能；财产；所有权"
-        ],
-        "usphone": "[ˈprɑːpərti]",
-        "ukphone": "[ˈprɒpəti]"
-    },
-    {
-        "name": "protest",
-        "trans": [
-            "n. 抗议"
-        ],
-        "usphone": "[ˈproʊtest; prəˈtest]",
-        "ukphone": "[ˈprəʊtest]"
-    },
-    {
-        "name": "proud",
-        "trans": [
-            "adj. 自豪的；得意的；自负的"
-        ],
-        "usphone": "[praʊd]",
-        "ukphone": "[praʊd]"
-    },
-    {
-        "name": "prove",
-        "trans": [
-            "vi. 证明是"
-        ],
-        "usphone": "[pruːv]",
-        "ukphone": "[pruːv]"
-    },
-    {
-        "name": "pull",
-        "trans": [
-            "n. 拉，拉绳；拉力，牵引力；拖"
-        ],
-        "usphone": "[pʊl]",
-        "ukphone": "[pʊl]"
-    },
-    {
-        "name": "punish",
-        "trans": [
-            "vt. 惩罚；严厉对待；贪婪地吃喝"
-        ],
-        "usphone": "[ˈpʌnɪʃ]",
-        "ukphone": "[ˈpʌnɪʃ]"
-    },
-    {
-        "name": "punishment",
-        "trans": [
-            "n. 惩罚；严厉对待，虐待"
-        ],
-        "usphone": "[ˈpʌnɪʃmənt]",
-        "ukphone": "[ˈpʌnɪʃmənt]"
-    },
-    {
-        "name": "push",
-        "trans": [
-            "n. 推，决心；大规模攻势；矢志的追求"
-        ],
-        "usphone": "[pʊʃ]",
-        "ukphone": "[pʊʃ]"
-    },
-    {
-        "name": "qualification",
-        "trans": [
-            "n. 资格；条件；限制；赋予资格"
-        ],
-        "usphone": "[ˌkwɑːlɪfɪˈkeɪʃn]",
-        "ukphone": "[ˌkwɒlɪfɪˈkeɪʃn]"
-    },
-    {
-        "name": "qualified",
-        "trans": [
-            "v. 限制（qualify的过去分词）；描述；授权予"
-        ],
-        "usphone": "[ˈkwɑːlɪfaɪd]",
-        "ukphone": "[ˈkwɒlɪfaɪd]"
-    },
-    {
-        "name": "qualify",
-        "trans": [
-            "vi. 取得资格，有资格"
-        ],
-        "usphone": "[ˈkwɑːlɪfaɪ]",
-        "ukphone": "[ˈkwɒlɪfaɪ]"
-    },
-    {
-        "name": "queue",
-        "trans": [
-            "n. 队列；长队；辫子"
-        ],
-        "usphone": "[kjuː]",
-        "ukphone": "[kjuː]"
-    },
-    {
-        "name": "quit",
-        "trans": [
-            "n. 离开；[计] 退出"
-        ],
-        "usphone": "[kwɪt]",
-        "ukphone": "[kwɪt]"
-    },
-    {
-        "name": "quotation",
-        "trans": [
-            "n. [贸易] 报价单；引用语；引证"
-        ],
-        "usphone": "[kwoʊˈteɪʃn]",
-        "ukphone": "[kwəʊˈteɪʃn]"
-    },
-    {
-        "name": "quote",
-        "trans": [
-            "n. 引用"
-        ],
-        "usphone": "[kwoʊt]",
-        "ukphone": "[kwəʊt]"
-    },
-    {
-        "name": "racing",
-        "trans": [
-            "n. 赛马；竞赛"
-        ],
-        "usphone": "[ˈreɪsɪŋ]",
-        "ukphone": "[ˈreɪsɪŋ]"
-    },
-    {
-        "name": "range",
-        "trans": [
-            "n. 范围；幅度；排；山脉"
-        ],
-        "usphone": "[reɪndʒ]",
-        "ukphone": "[reɪndʒ]"
-    },
-    {
-        "name": "rare",
-        "trans": [
-            "adj. 稀有的；稀薄的；半熟的"
-        ],
-        "usphone": "[rer]",
-        "ukphone": "[reə(r)]"
-    },
-    {
-        "name": "rarely",
-        "trans": [
-            "adv. 很少地；难得；罕有地"
-        ],
-        "usphone": "[ˈrerli]",
-        "ukphone": "[ˈreəli]"
-    },
-    {
-        "name": "reaction",
-        "trans": [
-            "n. 反应，感应；反动，复古；反作用"
-        ],
-        "usphone": "[riˈækʃn]",
-        "ukphone": "[riˈækʃn]"
-    },
-    {
-        "name": "reality",
-        "trans": [
-            "n. 现实；实际；真实"
-        ],
-        "usphone": "[riˈæləti]",
-        "ukphone": "[riˈæləti]"
-    },
-    {
-        "name": "receipt",
-        "trans": [
-            "n. 收到；收据；收入"
-        ],
-        "usphone": "[rɪˈsiːt]",
-        "ukphone": "[rɪˈsiːt]"
-    },
-    {
-        "name": "recommendation",
-        "trans": [
-            "n. 推荐；建议；推荐信"
-        ],
-        "usphone": "[ˌrekəmenˈdeɪʃn]",
-        "ukphone": "[ˌrekəmenˈdeɪʃn]"
-    },
-    {
-        "name": "reference",
-        "trans": [
-            "n. 参考，参照；涉及，提及；参考书目；介绍信；证明书"
-        ],
-        "usphone": "[ˈrefrəns]",
-        "ukphone": "[ˈrefrəns]"
-    },
-    {
-        "name": "reflect",
-        "trans": [
-            "vt. 反映；反射，照出；表达；显示;反省"
-        ],
-        "usphone": "[rɪˈflekt]",
-        "ukphone": "[rɪˈflekt]"
-    },
-    {
-        "name": "regularly",
-        "trans": [
-            "adv. 定期地；有规律地；整齐地；匀称地"
-        ],
-        "usphone": "[ˈreɡjələrli]",
-        "ukphone": "[ˈreɡjələli]"
-    },
-    {
-        "name": "reject",
-        "trans": [
-            "n. 被弃之物或人；次品"
-        ],
-        "usphone": "[rɪˈdʒekt]",
-        "ukphone": "[rɪˈdʒekt]"
-    },
-    {
-        "name": "relate",
-        "trans": [
-            "vt. 叙述；使…有联系"
-        ],
-        "usphone": "[rɪˈleɪt]",
-        "ukphone": "[rɪˈleɪt]"
-    },
-    {
-        "name": "related",
-        "trans": [
-            "v. 叙述（relate过去式）"
-        ],
-        "usphone": "[rɪˈleɪtɪd]",
-        "ukphone": "[rɪˈleɪtɪd]"
-    },
-    {
-        "name": "relation",
-        "trans": [
-            "n. 关系；叙述；故事；亲属关系"
-        ],
-        "usphone": "[rɪˈleɪʃn]",
-        "ukphone": "[rɪˈleɪʃn]"
-    },
-    {
-        "name": "relative",
-        "trans": [
-            "n. 亲戚；相关物；[语] 关系词；亲缘植物"
-        ],
-        "usphone": "[ˈrelətɪv]",
-        "ukphone": "[ˈrelətɪv]"
-    },
-    {
-        "name": "relaxed",
-        "trans": [
-            "v. relax的过去式和过去分词"
-        ],
-        "usphone": "[rɪˈlækst]",
-        "ukphone": "[rɪˈlækst]"
-    },
-    {
-        "name": "relaxing",
-        "trans": [
-            "v. 放松；休息（relax的ing形式）；缓和；松懈"
-        ],
-        "usphone": "[rɪˈlæksɪŋ]",
-        "ukphone": "[rɪˈlæksɪŋ]"
-    },
-    {
-        "name": "release",
-        "trans": [
-            "n. 释放；发布；让与"
-        ],
-        "usphone": "[rɪˈliːs]",
-        "ukphone": "[rɪˈliːs]"
-    },
-    {
-        "name": "reliable",
-        "trans": [
-            "n. 可靠的人"
-        ],
-        "usphone": "[rɪˈlaɪəbl]",
-        "ukphone": "[rɪˈlaɪəb(ə)l]"
-    },
-    {
-        "name": "religion",
-        "trans": [
-            "n. 宗教；宗教信仰"
-        ],
-        "usphone": "[rɪˈlɪdʒən]",
-        "ukphone": "[rɪˈlɪdʒən]"
-    },
-    {
-        "name": "religious",
-        "trans": [
-            "n. 修道士；尼姑"
-        ],
-        "usphone": "[rɪˈlɪdʒəs]",
-        "ukphone": "[rɪˈlɪdʒəs]"
-    },
-    {
-        "name": "remain",
-        "trans": [
-            "n. 遗迹；剩余物，残骸"
-        ],
-        "usphone": "[rɪˈmeɪn]",
-        "ukphone": "[rɪˈmeɪn]"
-    },
-    {
-        "name": "remind",
-        "trans": [
-            "vt. 提醒；使想起"
-        ],
-        "usphone": "[rɪˈmaɪnd]",
-        "ukphone": "[rɪˈmaɪnd]"
-    },
-    {
-        "name": "remote",
-        "trans": [
-            "n. 远程"
-        ],
-        "usphone": "[rɪˈmoʊt]",
-        "ukphone": "[rɪˈməʊt]"
-    },
-    {
-        "name": "rent",
-        "trans": [
-            "n. 租金"
-        ],
-        "usphone": "[rent]",
-        "ukphone": "[rent]"
-    },
-    {
-        "name": "repair",
-        "trans": [
-            "n. 修理，修补；修补部位"
-        ],
-        "usphone": "[rɪˈper]",
-        "ukphone": "[rɪˈpeə(r)]"
-    },
-    {
-        "name": "repeat",
-        "trans": [
-            "n. 重复；副本"
-        ],
-        "usphone": "[rɪˈpiːt]",
-        "ukphone": "[rɪˈpiːt]"
-    },
-    {
-        "name": "repeated",
-        "trans": [
-            "adj. 再三的，反复的"
-        ],
-        "usphone": "[rɪˈpiːtɪd]",
-        "ukphone": "[rɪˈpiːtɪd]"
-    },
-    {
-        "name": "represent",
-        "trans": [
-            "vt. 代表；表现；描绘；回忆；再赠送"
-        ],
-        "usphone": "[ˌreprɪˈzent]",
-        "ukphone": "[ˌreprɪˈzent]"
-    },
-    {
-        "name": "request",
-        "trans": [
-            "n. 请求；需要"
-        ],
-        "usphone": "[rɪˈkwest]",
-        "ukphone": "[rɪˈkwest]"
-    },
-    {
-        "name": "require",
-        "trans": [
-            "vt. 需要；要求；命令"
-        ],
-        "usphone": "[rɪˈkwaɪər]",
-        "ukphone": "[rɪˈkwaɪə(r)]"
-    },
-    {
-        "name": "reservation",
-        "trans": [
-            "n. 预约，预订；保留"
-        ],
-        "usphone": "[ˌrezərˈveɪʃn]",
-        "ukphone": "[ˌrezəˈveɪʃn]"
-    },
-    {
-        "name": "resource",
-        "trans": [
-            "n. 资源，财力；办法；智谋"
-        ],
-        "usphone": "[ˈriːsɔːrs; rɪˈsɔːrs]",
-        "ukphone": "[rɪˈsɔːs]"
-    },
-    {
-        "name": "respect",
-        "trans": [
-            "n. 尊敬，尊重；方面；敬意"
-        ],
-        "usphone": "[rɪˈspekt]",
-        "ukphone": "[rɪˈspekt]"
-    },
-    {
-        "name": "responsibility",
-        "trans": [
-            "n. 责任，职责；义务"
-        ],
-        "usphone": "[rɪˌspɑːnsəˈbɪləti]",
-        "ukphone": "[rɪˌspɒnsəˈbɪləti]"
-    },
-    {
-        "name": "responsible",
-        "trans": [
-            "adj. 负责的，可靠的；有责任的"
-        ],
-        "usphone": "[rɪˈspɑːnsəbl]",
-        "ukphone": "[rɪˈspɒnsəb(ə)l]"
-    },
-    {
-        "name": "result",
-        "trans": [
-            "n. 结果；成绩；答案；比赛结果"
-        ],
-        "usphone": "[rɪˈzʌlt]",
-        "ukphone": "[rɪˈzʌlt]"
-    },
-    {
-        "name": "retire",
-        "trans": [
-            "n. 退休；退隐；退兵信号"
-        ],
-        "usphone": "[rɪˈtaɪər]",
-        "ukphone": "[rɪˈtaɪə(r)]"
-    },
-    {
-        "name": "retired",
-        "trans": [
-            "adj. 退休的；退役的；幽闭的"
-        ],
-        "usphone": "[rɪˈtaɪərd]",
-        "ukphone": "[rɪˈtaɪəd]"
-    },
-    {
-        "name": "revise",
-        "trans": [
-            "n. 修订；校订"
-        ],
-        "usphone": "[rɪˈvaɪz]",
-        "ukphone": "[rɪˈvaɪz]"
-    },
-    {
-        "name": "rise",
-        "trans": [
-            "n. 上升；高地；增加；出现"
-        ],
-        "usphone": "[raɪz]",
-        "ukphone": "[raɪz]"
-    },
-    {
-        "name": "risk",
-        "trans": [
-            "n. 风险；危险；冒险"
-        ],
-        "usphone": "[rɪsk]",
-        "ukphone": "[rɪsk]"
-    },
-    {
-        "name": "robot",
-        "trans": [
-            "n. 机器人；遥控设备，自动机械；机械般工作的人"
-        ],
-        "usphone": "[ˈroʊbɑːt]",
-        "ukphone": "[ˈrəʊbɒt]"
-    },
-    {
-        "name": "roll",
-        "trans": [
-            "n. 卷，卷形物；名单；摇晃"
-        ],
-        "usphone": "[roʊl]",
-        "ukphone": "[rəʊl]"
-    },
-    {
-        "name": "romantic",
-        "trans": [
-            "n. 浪漫的人"
-        ],
-        "usphone": "[roʊˈmæntɪk]",
-        "ukphone": "[rəʊˈmæntɪk]"
-    },
-    {
-        "name": "rope",
-        "trans": [
-            "n. 绳，绳索"
-        ],
-        "usphone": "[roʊp]",
-        "ukphone": "[rəʊp]"
-    },
-    {
-        "name": "rough",
-        "trans": [
-            "n. 艰苦；高低不平的地面；未经加工的材料；粗糙的部分"
-        ],
-        "usphone": "[rʌf]",
-        "ukphone": "[rʌf]"
-    },
-    {
-        "name": "row",
-        "trans": [
-            "n. 行，排；划船；街道；吵闹"
-        ],
-        "usphone": "[roʊ; raʊ]",
-        "ukphone": "[rəʊ; raʊ]"
-    },
-    {
-        "name": "royal",
-        "trans": [
-            "n. 王室；王室成员"
-        ],
-        "usphone": "[ˈrɔɪəl]",
-        "ukphone": "[ˈrɔɪəl]"
-    },
-    {
-        "name": "rugby",
-        "trans": [
-            "n. 英式橄榄球；拉格比（英格兰中部的城市）"
-        ],
-        "usphone": "[ˈrʌɡbi]",
-        "ukphone": "[ˈrʌɡbi]"
+        "usphone": "[ˈkʌntrisaɪd]",
+        "ukphone": "[ˈkʌntrisaɪd]"
     },
     {
         "name": "rule",
@@ -4920,1036 +2064,12 @@
         "ukphone": "[ruːl]"
     },
     {
-        "name": "safety",
+        "name": "heavily",
         "trans": [
-            "n. 安全；保险；安全设备；保险装置；安打"
+            "adv. 沉重地；猛烈地；沉闷地"
         ],
-        "usphone": "[ˈseɪfti]",
-        "ukphone": "[ˈseɪfti]"
-    },
-    {
-        "name": "sail",
-        "trans": [
-            "n. 帆，篷；航行"
-        ],
-        "usphone": "[seɪl]",
-        "ukphone": "[seɪl]"
-    },
-    {
-        "name": "sailor",
-        "trans": [
-            "n. 水手，海员；乘船者"
-        ],
-        "usphone": "[ˈseɪlər]",
-        "ukphone": "[ˈseɪlə(r)]"
-    },
-    {
-        "name": "sample",
-        "trans": [
-            "n. 样品；样本；例子"
-        ],
-        "usphone": "[ˈsæmpl]",
-        "ukphone": "[ˈsɑːmp(ə)l]"
-    },
-    {
-        "name": "sand",
-        "trans": [
-            "n. 沙；沙地；沙洲；沙滩；沙子"
-        ],
-        "usphone": "[sænd]",
-        "ukphone": "[sænd]"
-    },
-    {
-        "name": "scan",
-        "trans": [
-            "n. 扫描；浏览；审视；细看"
-        ],
-        "usphone": "[skæn]",
-        "ukphone": "[skæn]"
-    },
-    {
-        "name": "scientific",
-        "trans": [
-            "adj. 科学的，系统的"
-        ],
-        "usphone": "[ˌsaɪənˈtɪfɪk]",
-        "ukphone": "[ˌsaɪənˈtɪfɪk]"
-    },
-    {
-        "name": "script",
-        "trans": [
-            "n. 脚本；手迹；书写用的字母"
-        ],
-        "usphone": "[skrɪpt]",
-        "ukphone": "[skrɪpt]"
-    },
-    {
-        "name": "sculpture",
-        "trans": [
-            "n. 雕塑；雕刻；刻蚀"
-        ],
-        "usphone": "[ˈskʌlptʃər]",
-        "ukphone": "[ˈskʌlptʃə(r)]"
-    },
-    {
-        "name": "secondary",
-        "trans": [
-            "n. 副手；代理人"
-        ],
-        "usphone": "[ˈsekənderi]",
-        "ukphone": "[ˈsekənd(ə)ri]"
-    },
-    {
-        "name": "security",
-        "trans": [
-            "n. 安全；保证；证券；抵押品"
-        ],
-        "usphone": "[sɪˈkjʊrəti]",
-        "ukphone": "[sɪˈkjʊərəti]"
-    },
-    {
-        "name": "seed",
-        "trans": [
-            "n. 种子；根据；精液；萌芽；子孙；原由"
-        ],
-        "usphone": "[siːd]",
-        "ukphone": "[siːd]"
-    },
-    {
-        "name": "sensible",
-        "trans": [
-            "n. 可感觉到的东西; 敏感的人;"
-        ],
-        "usphone": "[ˈsensəb(ə)l]",
-        "ukphone": "[ˈsensəb(ə)l]"
-    },
-    {
-        "name": "separate",
-        "trans": [
-            "n. .分开；抽印本"
-        ],
-        "usphone": "[ˈseprət]",
-        "ukphone": "[ˈseprət]"
-    },
-    {
-        "name": "seriously",
-        "trans": [
-            "adv. 认真地；严重地，严肃地"
-        ],
-        "usphone": "[ˈsɪriəsli]",
-        "ukphone": "[ˈsɪəriəsli]"
-    },
-    {
-        "name": "servant",
-        "trans": [
-            "n. 仆人，佣人；公务员；雇工"
-        ],
-        "usphone": "[ˈsɜːrvənt]",
-        "ukphone": "[ˈsɜːvənt]"
-    },
-    {
-        "name": "set",
-        "trans": [
-            "n. [数] 集合；一套；布景；[机] 装置"
-        ],
-        "usphone": "[set]",
-        "ukphone": "[set]"
-    },
-    {
-        "name": "setting",
-        "trans": [
-            "n. 环境；安装；布置；[天] 沉落"
-        ],
-        "usphone": "[ˈsetɪŋ]",
-        "ukphone": "[ˈsetɪŋ]"
-    },
-    {
-        "name": "sex",
-        "trans": [
-            "n. 性；性别；性行为；色情"
-        ],
-        "usphone": "[seks]",
-        "ukphone": "[seks]"
-    },
-    {
-        "name": "sexual",
-        "trans": [
-            "adj. 性的；性别的；有性的"
-        ],
-        "usphone": "[ˈsekʃuəl]",
-        "ukphone": "[ˈsekʃuəl]"
-    },
-    {
-        "name": "shake",
-        "trans": [
-            "n. 摇动；哆嗦"
-        ],
-        "usphone": "[ʃeɪk]",
-        "ukphone": "[ʃeɪk]"
-    },
-    {
-        "name": "share",
-        "trans": [
-            "n. 份额；股份"
-        ],
-        "usphone": "[ʃer]",
-        "ukphone": "[ʃeə(r)]"
-    },
-    {
-        "name": "sharp",
-        "trans": [
-            "n. 尖头；骗子；内行"
-        ],
-        "usphone": "[ʃɑːrp]",
-        "ukphone": "[ʃɑːp]"
-    },
-    {
-        "name": "shelf",
-        "trans": [
-            "n. 架子；搁板；搁板状物；暗礁"
-        ],
-        "usphone": "[ʃelf]",
-        "ukphone": "[ʃelf]"
-    },
-    {
-        "name": "shell",
-        "trans": [
-            "n. 壳，贝壳；炮弹；外形"
-        ],
-        "usphone": "[ʃel]",
-        "ukphone": "[ʃel]"
-    },
-    {
-        "name": "shift",
-        "trans": [
-            "n. 移动；变化；手段；轮班"
-        ],
-        "usphone": "[ʃɪft]",
-        "ukphone": "[ʃɪft]"
-    },
-    {
-        "name": "shine",
-        "trans": [
-            "vt. 照射，擦亮；把…的光投向；（口）通过擦拭使…变得有光泽或光"
-        ],
-        "usphone": "[ʃaɪn]",
-        "ukphone": "[ʃaɪn]"
-    },
-    {
-        "name": "shiny",
-        "trans": [
-            "adj. 有光泽的，擦亮的；闪耀的；晴朗的；磨损的"
-        ],
-        "usphone": "[ˈʃaɪni]",
-        "ukphone": "[ˈʃaɪni]"
-    },
-    {
-        "name": "shoot",
-        "trans": [
-            "n. 射击；摄影；狩猎；急流"
-        ],
-        "usphone": "[ʃuːt]",
-        "ukphone": "[ʃuːt]"
-    },
-    {
-        "name": "shy",
-        "trans": [
-            "n. 投掷；惊跳"
-        ],
-        "usphone": "[ʃaɪ]",
-        "ukphone": "[ʃaɪ]"
-    },
-    {
-        "name": "sight",
-        "trans": [
-            "n. 视力；景象；眼界；见解"
-        ],
-        "usphone": "[saɪt]",
-        "ukphone": "[saɪt]"
-    },
-    {
-        "name": "signal",
-        "trans": [
-            "n. 信号；暗号；导火线"
-        ],
-        "usphone": "[ˈsɪɡnəl]",
-        "ukphone": "[ˈsɪɡnəl]"
-    },
-    {
-        "name": "silent",
-        "trans": [
-            "n. 无声电影"
-        ],
-        "usphone": "[ˈsaɪlənt]",
-        "ukphone": "[ˈsaɪlənt]"
-    },
-    {
-        "name": "silly",
-        "trans": [
-            "n. 傻瓜"
-        ],
-        "usphone": "[ˈsɪli]",
-        "ukphone": "[ˈsɪli]"
-    },
-    {
-        "name": "similarity",
-        "trans": [
-            "n. 类似；相似点"
-        ],
-        "usphone": "[ˌsɪməˈlærəti]",
-        "ukphone": "[ˌsɪməˈlærəti]"
-    },
-    {
-        "name": "similarly",
-        "trans": [
-            "adv. 同样地；类似于"
-        ],
-        "usphone": "[ˈsɪmələrli]",
-        "ukphone": "[ˈsɪmələli]"
-    },
-    {
-        "name": "simply",
-        "trans": [
-            "adv. 简单地；仅仅；简直；朴素地；坦白地"
-        ],
-        "usphone": "[ˈsɪmpli]",
-        "ukphone": "[ˈsɪmpli]"
-    },
-    {
-        "name": "since",
-        "trans": [
-            "conj. 因为；由于；既然；自…以来；自…以后"
-        ],
-        "usphone": "[sɪns]",
-        "ukphone": "[sɪns]"
-    },
-    {
-        "name": "sink",
-        "trans": [
-            "n. 水槽；洗涤槽；污水坑"
-        ],
-        "usphone": "[sɪŋk]",
-        "ukphone": "[sɪŋk]"
-    },
-    {
-        "name": "slice",
-        "trans": [
-            "n. 薄片；部分；菜刀，火铲"
-        ],
-        "usphone": "[slaɪs]",
-        "ukphone": "[slaɪs]"
-    },
-    {
-        "name": "slightly",
-        "trans": [
-            "adv. 些微地，轻微地；纤细地"
-        ],
-        "usphone": "[ˈslaɪtli]",
-        "ukphone": "[ˈslaɪtli]"
-    },
-    {
-        "name": "slow",
-        "trans": [
-            "adj. 慢的；减速的；迟钝的"
-        ],
-        "usphone": "[sloʊ]",
-        "ukphone": "[sləʊ]"
-    },
-    {
-        "name": "smart",
-        "trans": [
-            "adj. 聪明的；巧妙的；敏捷的；厉害的；潇洒的；剧烈的；时髦的"
-        ],
-        "usphone": "[smɑːrt]",
-        "ukphone": "[smɑːt]"
-    },
-    {
-        "name": "smooth",
-        "trans": [
-            "n. 平滑部分；一块平地"
-        ],
-        "usphone": "[smuːð]",
-        "ukphone": "[smuːð]"
-    },
-    {
-        "name": "software",
-        "trans": [
-            "n. 软件"
-        ],
-        "usphone": "[ˈsɔːftwer]",
-        "ukphone": "[ˈsɒftweə(r)]"
-    },
-    {
-        "name": "soil",
-        "trans": [
-            "n. 土地；土壤；国家；粪便；务农；温床"
-        ],
-        "usphone": "[sɔɪl]",
-        "ukphone": "[sɔɪl]"
-    },
-    {
-        "name": "solid",
-        "trans": [
-            "n. 固体；立方体"
-        ],
-        "usphone": "[ˈsɑːlɪd]",
-        "ukphone": "[ˈsɒlɪd]"
-    },
-    {
-        "name": "sort",
-        "trans": [
-            "n. 种类；方式；品质"
-        ],
-        "usphone": "[sɔːrt]",
-        "ukphone": "[sɔːt]"
-    },
-    {
-        "name": "southern",
-        "trans": [
-            "n. 南方人"
-        ],
-        "usphone": "[ˈsʌðərn]",
-        "ukphone": "[ˈsʌðən]"
-    },
-    {
-        "name": "specifically",
-        "trans": [
-            "adv. 特别地；明确地"
-        ],
-        "usphone": "[spəˈsɪfɪkli]",
-        "ukphone": "[spəˈsɪfɪkli]"
-    },
-    {
-        "name": "spending",
-        "trans": [
-            "n. 花费；开销"
-        ],
-        "usphone": "[ˈspendɪŋ]",
-        "ukphone": "[ˈspendɪŋ]"
-    },
-    {
-        "name": "spicy",
-        "trans": [
-            "adj. 辛辣的；香的，多香料的；下流的"
-        ],
-        "usphone": "[ˈspaɪsi]",
-        "ukphone": "[ˈspaɪsi]"
-    },
-    {
-        "name": "spirit",
-        "trans": [
-            "n. 精神；心灵；情绪；志气；烈酒"
-        ],
-        "usphone": "[ˈspɪrɪt]",
-        "ukphone": "[ˈspɪrɪt]"
-    },
-    {
-        "name": "spoken",
-        "trans": [
-            "v. 说（speak的过去分词）"
-        ],
-        "usphone": "[ˈspoʊkən]",
-        "ukphone": "[ˈspəʊkən]"
-    },
-    {
-        "name": "spot",
-        "trans": [
-            "n. 地点；斑点"
-        ],
-        "usphone": "[spɑːt]",
-        "ukphone": "[spɒt]"
-    },
-    {
-        "name": "spread",
-        "trans": [
-            "n. 传播；伸展"
-        ],
-        "usphone": "[spred]",
-        "ukphone": "[spred]"
-    },
-    {
-        "name": "stadium",
-        "trans": [
-            "n. 体育场；露天大型运动场"
-        ],
-        "usphone": "[ˈsteɪdiəm]",
-        "ukphone": "[ˈsteɪdiəm]"
-    },
-    {
-        "name": "staff",
-        "trans": [
-            "n. 职员；参谋；棒；支撑"
-        ],
-        "usphone": "[stæf]",
-        "ukphone": "[stɑːf]"
-    },
-    {
-        "name": "standard",
-        "trans": [
-            "n. 标准；水准；旗；度量衡标准"
-        ],
-        "usphone": "[ˈstændərd]",
-        "ukphone": "[ˈstændəd]"
-    },
-    {
-        "name": "state",
-        "trans": [
-            "n. 国家；州；情形"
-        ],
-        "usphone": "[steɪt]",
-        "ukphone": "[steɪt]"
-    },
-    {
-        "name": "statistic",
-        "trans": [
-            "n. 统计数值"
-        ],
-        "usphone": "[stəˈtɪstɪk]",
-        "ukphone": "[stəˈtɪstɪk]"
-    },
-    {
-        "name": "statue",
-        "trans": [
-            "n. 雕像，塑像"
-        ],
-        "usphone": "[ˈstætʃuː]",
-        "ukphone": "[ˈstætʃuː]"
-    },
-    {
-        "name": "stick",
-        "trans": [
-            "n. 棍；手杖；呆头呆脑的人"
-        ],
-        "usphone": "[stɪk]",
-        "ukphone": "[stɪk]"
-    },
-    {
-        "name": "still",
-        "trans": [
-            "conj. 仍然；但是；尽管如此"
-        ],
-        "usphone": "[stɪl]",
-        "ukphone": "[stɪl]"
-    },
-    {
-        "name": "store",
-        "trans": [
-            "n. 商店；储备，贮藏；仓库"
-        ],
-        "usphone": "[stɔːr]",
-        "ukphone": "[stɔː(r)]"
-    },
-    {
-        "name": "stranger",
-        "trans": [
-            "n. 陌生人；外地人；局外人"
-        ],
-        "usphone": "[ˈstreɪndʒər]",
-        "ukphone": "[ˈstreɪndʒə(r)]"
-    },
-    {
-        "name": "strength",
-        "trans": [
-            "n. 力量；力气；兵力；长处"
-        ],
-        "usphone": "[streŋθ]",
-        "ukphone": "[streŋθ]"
-    },
-    {
-        "name": "string",
-        "trans": [
-            "n. 线，弦，细绳；一串，一行"
-        ],
-        "usphone": "[strɪŋ]",
-        "ukphone": "[strɪŋ]"
-    },
-    {
-        "name": "strongly",
-        "trans": [
-            "adv. 强有力地；坚强地；激烈地；气味浓地"
-        ],
-        "usphone": "[ˈstrɔːŋli]",
-        "ukphone": "[ˈstrɒŋli]"
-    },
-    {
-        "name": "studio",
-        "trans": [
-            "n. 工作室；[广播][电视] 演播室；画室；电影制片厂"
-        ],
-        "usphone": "[ˈstuːdioʊ]",
-        "ukphone": "[ˈstjuːdiəʊ]"
-    },
-    {
-        "name": "stuff",
-        "trans": [
-            "n. 东西；材料；填充物；素材资料"
-        ],
-        "usphone": "[stʌf]",
-        "ukphone": "[stʌf]"
-    },
-    {
-        "name": "substance",
-        "trans": [
-            "n. 物质；实质；资产；主旨"
-        ],
-        "usphone": "[ˈsʌbstəns]",
-        "ukphone": "[ˈsʌbstəns]"
-    },
-    {
-        "name": "successfully",
-        "trans": [
-            "adv. 成功地；顺利地"
-        ],
-        "usphone": "[səkˈsesfəli]",
-        "ukphone": "[səkˈsesfəli]"
-    },
-    {
-        "name": "sudden",
-        "trans": [
-            "n. 突然发生的事"
-        ],
-        "usphone": "[ˈsʌdn]",
-        "ukphone": "[ˈsʌd(ə)n]"
-    },
-    {
-        "name": "suffer",
-        "trans": [
-            "vi. 遭受，忍受；受痛苦；经验；受损害"
-        ],
-        "usphone": "[ˈsʌfər]",
-        "ukphone": "[ˈsʌfə(r)]"
-    },
-    {
-        "name": "suit",
-        "trans": [
-            "n. 诉讼；恳求；套装，西装；一套外衣"
-        ],
-        "usphone": "[suːt]",
-        "ukphone": "[suːt]"
-    },
-    {
-        "name": "suitable",
-        "trans": [
-            "adj. 适当的；相配的"
-        ],
-        "usphone": "[ˈsuːtəbl]",
-        "ukphone": "[ˈsuːtəb(ə)l]"
-    },
-    {
-        "name": "summarize",
-        "trans": [
-            "vt. 总结；概述"
-        ],
-        "usphone": "[ˈsʌməraɪz]",
-        "ukphone": "[ˈsʌməraɪz]"
-    },
-    {
-        "name": "summary",
-        "trans": [
-            "n. 概要，摘要，总结"
-        ],
-        "usphone": "[ˈsʌməri]",
-        "ukphone": "[ˈsʌməri]"
-    },
-    {
-        "name": "supply",
-        "trans": [
-            "n. 供给，补给；供应品"
-        ],
-        "usphone": "[səˈplaɪ]",
-        "ukphone": "[səˈplaɪ]"
-    },
-    {
-        "name": "supporter",
-        "trans": [
-            "n. 支持者；拥护者"
-        ],
-        "usphone": "[səˈpɔːrtər]",
-        "ukphone": "[səˈpɔːtə(r)]"
-    },
-    {
-        "name": "surely",
-        "trans": [
-            "adv. 当然；无疑；坚定地；稳当地"
-        ],
-        "usphone": "[ˈʃʊrli]",
-        "ukphone": "[ˈʃʊəli; ˈʃɔːli]"
-    },
-    {
-        "name": "surface",
-        "trans": [
-            "n. 表面；表层；外观"
-        ],
-        "usphone": "[ˈsɜːrfɪs]",
-        "ukphone": "[ˈsɜːfɪs]"
-    },
-    {
-        "name": "survive",
-        "trans": [
-            "vi. 幸存；活下来"
-        ],
-        "usphone": "[sərˈvaɪv]",
-        "ukphone": "[səˈvaɪv]"
-    },
-    {
-        "name": "swim",
-        "trans": [
-            "n. 游泳；漂浮；眩晕"
-        ],
-        "usphone": "[swɪm]",
-        "ukphone": "[swɪm]"
-    },
-    {
-        "name": "switch",
-        "trans": [
-            "n. 开关；转换；鞭子"
-        ],
-        "usphone": "[swɪtʃ]",
-        "ukphone": "[swɪtʃ]"
-    },
-    {
-        "name": "symptom",
-        "trans": [
-            "n. [临床] 症状；征兆"
-        ],
-        "usphone": "[ˈsɪmptəm]",
-        "ukphone": "[ˈsɪmptəm]"
-    },
-    {
-        "name": "tail",
-        "trans": [
-            "n. 尾巴；踪迹；辫子；燕尾服"
-        ],
-        "usphone": "[teɪl]",
-        "ukphone": "[teɪl]"
-    },
-    {
-        "name": "talent",
-        "trans": [
-            "n. 才能；天才；天资"
-        ],
-        "usphone": "[ˈtælənt]",
-        "ukphone": "[ˈtælənt]"
-    },
-    {
-        "name": "talented",
-        "trans": [
-            "adj. 有才能的；多才的"
-        ],
-        "usphone": "[ˈtæləntɪd]",
-        "ukphone": "[ˈtæləntɪd]"
-    },
-    {
-        "name": "tape",
-        "trans": [
-            "n. 胶带；磁带；带子；卷尺"
-        ],
-        "usphone": "[teɪp]",
-        "ukphone": "[teɪp]"
-    },
-    {
-        "name": "tax",
-        "trans": [
-            "n. 税金；重负"
-        ],
-        "usphone": "[tæks]",
-        "ukphone": "[tæks]"
-    },
-    {
-        "name": "technical",
-        "trans": [
-            "adj. 工艺的，科技的；技术上的；专门的"
-        ],
-        "usphone": "[ˈteknɪkl]",
-        "ukphone": "[ˈteknɪk(ə)l]"
-    },
-    {
-        "name": "technique",
-        "trans": [
-            "n. 技巧，技术；手法"
-        ],
-        "usphone": "[tekˈniːk]",
-        "ukphone": "[tekˈniːk]"
-    },
-    {
-        "name": "tend",
-        "trans": [
-            "vt. 照料，照管"
-        ],
-        "usphone": "[tend]",
-        "ukphone": "[tend]"
-    },
-    {
-        "name": "tent",
-        "trans": [
-            "n. 帐篷；住处；帷幕"
-        ],
-        "usphone": "[tent]",
-        "ukphone": "[tent]"
-    },
-    {
-        "name": "that",
-        "trans": [
-            "conj. 因为；以至于"
-        ],
-        "usphone": "[ðæt]",
-        "ukphone": "[ðæt]"
-    },
-    {
-        "name": "theirs",
-        "trans": [
-            "pron. 他们的；她们的；它们的"
-        ],
-        "usphone": "[ðerz]",
-        "ukphone": "[ðeəz]"
-    },
-    {
-        "name": "theme",
-        "trans": [
-            "n. 主题；主旋律；题目"
-        ],
-        "usphone": "[θiːm]",
-        "ukphone": "[θiːm]"
-    },
-    {
-        "name": "theory",
-        "trans": [
-            "n. 理论；原理；学说；推测"
-        ],
-        "usphone": "[ˈθiːəri]",
-        "ukphone": "[ˈθɪəri]"
-    },
-    {
-        "name": "therefore",
-        "trans": [
-            "adv. 因此；所以"
-        ],
-        "usphone": "[ˈðerfɔːr]",
-        "ukphone": "[ˈðeəfɔː(r)]"
-    },
-    {
-        "name": "this",
-        "trans": [
-            "adj. 这；本；这个；今"
-        ],
-        "usphone": "[ðɪs]",
-        "ukphone": "[ðɪs]"
-    },
-    {
-        "name": "though",
-        "trans": [
-            "conj. 虽然；尽管"
-        ],
-        "usphone": "[ðoʊ]",
-        "ukphone": "[ðəʊ]"
-    },
-    {
-        "name": "throat",
-        "trans": [
-            "n. 喉咙；嗓子，嗓音；窄路"
-        ],
-        "usphone": "[θroʊt]",
-        "ukphone": "[θrəʊt]"
-    },
-    {
-        "name": "throughout",
-        "trans": [
-            "prep. 贯穿，遍及"
-        ],
-        "usphone": "[θruːˈaʊt]",
-        "ukphone": "[θruːˈaʊt]"
-    },
-    {
-        "name": "tight",
-        "trans": [
-            "adj. 紧的；密封的；绷紧的；麻烦的；严厉的；没空的；吝啬的"
-        ],
-        "usphone": "[taɪt]",
-        "ukphone": "[taɪt]"
-    },
-    {
-        "name": "till",
-        "trans": [
-            "prep. 直到"
-        ],
-        "usphone": "[tɪl]",
-        "ukphone": "[tɪl]"
-    },
-    {
-        "name": "tin",
-        "trans": [
-            "n. 锡；罐头，罐；马口铁"
-        ],
-        "usphone": "[tɪn]",
-        "ukphone": "[tɪn]"
-    },
-    {
-        "name": "tiny",
-        "trans": [
-            "adj. 微小的；很少的"
-        ],
-        "usphone": "[ˈtaɪni]",
-        "ukphone": "[ˈtaɪni]"
-    },
-    {
-        "name": "tip",
-        "trans": [
-            "n. 小费；尖端；小建议，小窍门；轻拍"
-        ],
-        "usphone": "[tɪp]",
-        "ukphone": "[tɪp]"
-    },
-    {
-        "name": "toe",
-        "trans": [
-            "n. 脚趾；足尖"
-        ],
-        "usphone": "[toʊ]",
-        "ukphone": "[təʊ]"
-    },
-    {
-        "name": "tongue",
-        "trans": [
-            "n. 舌头；语言"
-        ],
-        "usphone": "[tʌŋ]",
-        "ukphone": "[tʌŋ]"
-    },
-    {
-        "name": "total",
-        "trans": [
-            "n. 总数，合计"
-        ],
-        "usphone": "[ˈtoʊtl]",
-        "ukphone": "[ˈtəʊt(ə)l]"
-    },
-    {
-        "name": "totally",
-        "trans": [
-            "adv. 完全地"
-        ],
-        "usphone": "[ˈtoʊtəli]",
-        "ukphone": "[ˈtəʊtəli]"
-    },
-    {
-        "name": "touch",
-        "trans": [
-            "n. 接触；触觉；格调；少许"
-        ],
-        "usphone": "[tʌtʃ]",
-        "ukphone": "[tʌtʃ]"
-    },
-    {
-        "name": "tour",
-        "trans": [
-            "n. 旅游，旅行；巡回演出"
-        ],
-        "usphone": "[tʊr]",
-        "ukphone": "[tʊə(r)]"
-    },
-    {
-        "name": "trade",
-        "trans": [
-            "n. 贸易，交易；行业；职业"
-        ],
-        "usphone": "[treɪd]",
-        "ukphone": "[treɪd]"
-    },
-    {
-        "name": "translate",
-        "trans": [
-            "vt. 翻译；转化；解释；转变为；调动"
-        ],
-        "usphone": "[trænzˈleɪt; trænsˈleɪt]",
-        "ukphone": "[trænzˈleɪt]"
-    },
-    {
-        "name": "translation",
-        "trans": [
-            "n. 翻译；译文；转化；调任"
-        ],
-        "usphone": "[trænzˈleɪʃn; trænsˈleɪʃn]",
-        "ukphone": "[trænzˈleɪʃn; trænsˈleɪʃn]"
-    },
-    {
-        "name": "transport",
-        "trans": [
-            "n. 运输；运输机；狂喜；流放犯"
-        ],
-        "usphone": "[ˈtrænspɔːrt]",
-        "ukphone": "[ˈtrænspɔːt]"
-    },
-    {
-        "name": "treat",
-        "trans": [
-            "n. 请客；款待"
-        ],
-        "usphone": "[triːt]",
-        "ukphone": "[triːt]"
-    },
-    {
-        "name": "treatment",
-        "trans": [
-            "n. 治疗，疗法；处理；对待"
-        ],
-        "usphone": "[ˈtriːtmənt]",
-        "ukphone": "[ˈtriːtmənt]"
-    },
-    {
-        "name": "trend",
-        "trans": [
-            "n. 趋势，倾向；走向"
-        ],
-        "usphone": "[trend]",
-        "ukphone": "[trend]"
-    },
-    {
-        "name": "trick",
-        "trans": [
-            "n. 诡计；恶作剧；窍门；花招；骗局；欺诈"
-        ],
-        "usphone": "[trɪk]",
-        "ukphone": "[trɪk]"
-    },
-    {
-        "name": "truth",
-        "trans": [
-            "n. 真理；事实；诚实；实质"
-        ],
-        "usphone": "[truːθ]",
-        "ukphone": "[truːθ]"
-    },
-    {
-        "name": "tube",
-        "trans": [
-            "n. 管；电子管；隧道；电视机"
-        ],
-        "usphone": "[tuːb]",
-        "ukphone": "[tjuːb]"
-    },
-    {
-        "name": "type",
-        "trans": [
-            "n. 类型，品种；模范；样式"
-        ],
-        "usphone": "[taɪp]",
-        "ukphone": "[taɪp]"
-    },
-    {
-        "name": "typically",
-        "trans": [
-            "adv. 代表性地；作为特色地"
-        ],
-        "usphone": "[ˈtɪpɪkli]",
-        "ukphone": "[ˈtɪpɪkli]"
-    },
-    {
-        "name": "tyre",
-        "trans": [
-            "n. [橡胶] 轮胎；轮箍"
-        ],
-        "usphone": "[ˈtaɪər]",
-        "ukphone": "[ˈtaɪə(r)]"
+        "usphone": "[ˈhevɪli]",
+        "ukphone": "[ˈhevɪli]"
     },
     {
         "name": "ugly",
@@ -5960,108 +2080,276 @@
         "ukphone": "[ˈʌɡli]"
     },
     {
-        "name": "unable",
+        "name": "disappointing",
         "trans": [
-            "adj. 不会的，不能的；[劳经] 无能力的；不能胜任的"
+            "adj. 令人失望的；令人扫兴的"
         ],
-        "usphone": "[ʌnˈeɪbl]",
-        "ukphone": "[ʌnˈeɪb(ə)l]"
+        "usphone": "[ˌdɪsəˈpɔɪntɪŋ]",
+        "ukphone": "[ˌdɪsəˈpɔɪntɪŋ]"
     },
     {
-        "name": "uncomfortable",
+        "name": "disadvantage",
         "trans": [
-            "adj. 不舒服的；不安的"
+            "n. 缺点；不利条件；损失"
         ],
-        "usphone": "[ʌnˈkʌmftəbl; ʌnˈkʌmfərtəbl]",
-        "ukphone": "[ʌnˈkʌmftəb(ə)l]"
+        "usphone": "[ˌdɪsədˈvæntɪdʒ]",
+        "ukphone": "[ˌdɪsədˈvɑːntɪdʒ]"
     },
     {
-        "name": "underwear",
+        "name": "original",
         "trans": [
-            "n. 内衣物"
+            "n. 原件；原作；原物；原型"
         ],
-        "usphone": "[ˈʌndərwer]",
-        "ukphone": "[ˈʌndəweə(r)]"
+        "usphone": "[əˈrɪdʒənl]",
+        "ukphone": "[əˈrɪdʒən(ə)l]"
     },
     {
-        "name": "unemployed",
+        "name": "tongue",
         "trans": [
-            "adj. 失业的；未被利用的"
+            "n. 舌头；语言"
         ],
-        "usphone": "[ˌʌnɪmˈplɔɪd]",
-        "ukphone": "[ˌʌnɪmˈplɔɪd]"
+        "usphone": "[tʌŋ]",
+        "ukphone": "[tʌŋ]"
     },
     {
-        "name": "unemployment",
+        "name": "management",
         "trans": [
-            "n. 失业；失业率；失业人数"
+            "n. 管理；管理人员；管理部门；操纵；经营手段"
         ],
-        "usphone": "[ˌʌnɪmˈplɔɪmənt]",
-        "ukphone": "[ˌʌnɪmˈplɔɪmənt]"
+        "usphone": "[ˈmænɪdʒmənt]",
+        "ukphone": "[ˈmænɪdʒmənt]"
     },
     {
-        "name": "unfair",
+        "name": "royal",
         "trans": [
-            "adj. 不公平的，不公正的"
+            "n. 王室；王室成员"
         ],
-        "usphone": "[ˌʌnˈfer]",
-        "ukphone": "[ˌʌnˈfeə(r)]"
+        "usphone": "[ˈrɔɪəl]",
+        "ukphone": "[ˈrɔɪəl]"
     },
     {
-        "name": "union",
+        "name": "cream",
         "trans": [
-            "n. 联盟，协会；工会；联合"
+            "n. 奶油，乳脂；精华；面霜；乳酪"
         ],
-        "usphone": "[ˈjuːniən]",
-        "ukphone": "[ˈjuːniən]"
+        "usphone": "[kriːm]",
+        "ukphone": "[kriːm]"
     },
     {
-        "name": "unless",
+        "name": "rough",
         "trans": [
-            "conj. 除非，如果不"
+            "n. 艰苦；高低不平的地面；未经加工的材料；粗糙的部分"
         ],
-        "usphone": "[ənˈles]",
-        "ukphone": "[ənˈles]"
+        "usphone": "[rʌf]",
+        "ukphone": "[rʌf]"
     },
     {
-        "name": "unlike",
+        "name": "educational",
         "trans": [
-            "prep. 和…不同，不像"
+            "adj. 教育的；有教育意义的"
         ],
-        "usphone": "[ˌʌnˈlaɪk]",
-        "ukphone": "[ˌʌnˈlaɪk]"
+        "usphone": "[ˌedʒuˈkeɪʃənl]",
+        "ukphone": "[ˌedʒuˈkeɪʃən(ə)l]"
     },
     {
-        "name": "unlikely",
+        "name": "far",
         "trans": [
-            "adj. 不太可能的；没希望的"
+            "n. 远方"
         ],
-        "usphone": "[ʌnˈlaɪkli]",
-        "ukphone": "[ʌnˈlaɪkli]"
+        "usphone": "[fɑːr]",
+        "ukphone": "[fɑː(r)]"
     },
     {
-        "name": "unnecessary",
+        "name": "pass",
         "trans": [
-            "adj. 不必要的；多余的，无用的"
+            "n. 及格；经过；护照；途径；传球"
         ],
-        "usphone": "[ʌnˈnesəseri]",
-        "ukphone": "[ʌnˈnesəsəri]"
+        "usphone": "[pæs]",
+        "ukphone": "[pɑːs]"
     },
     {
-        "name": "unpleasant",
+        "name": "advanced",
         "trans": [
-            "adj. 讨厌的；使人不愉快的"
+            "adj. 先进的；高级的；晚期的；年老的"
         ],
-        "usphone": "[ʌnˈpleznt]",
-        "ukphone": "[ʌnˈplez(ə)nt]"
+        "usphone": "[ədˈvænst]",
+        "ukphone": "[ədˈvɑːnst]"
     },
     {
-        "name": "update",
+        "name": "authority",
         "trans": [
-            "n. 更新；现代化"
+            "n. 权威；权力；当局"
         ],
-        "usphone": "[ˌʌpˈdeɪt]",
-        "ukphone": "[ˌʌpˈdeɪt]"
+        "usphone": "[əˈθɔːrəti]",
+        "ukphone": "[ɔːˈθɒrəti]"
+    },
+    {
+        "name": "payment",
+        "trans": [
+            "n. 付款，支付；报酬，报答；偿还；惩罚，报应"
+        ],
+        "usphone": "[ˈpeɪmənt]",
+        "ukphone": "[ˈpeɪmənt]"
+    },
+    {
+        "name": "statistic",
+        "trans": [
+            "n. 统计数值"
+        ],
+        "usphone": "[stəˈtɪstɪk]",
+        "ukphone": "[stəˈtɪstɪk]"
+    },
+    {
+        "name": "narrative",
+        "trans": [
+            "n. 叙述；故事；讲述"
+        ],
+        "usphone": "[ˈnærətɪv]",
+        "ukphone": "[ˈnærətɪv]"
+    },
+    {
+        "name": "property",
+        "trans": [
+            "n. 性质，性能；财产；所有权"
+        ],
+        "usphone": "[ˈprɑːpərti]",
+        "ukphone": "[ˈprɒpəti]"
+    },
+    {
+        "name": "meanwhile",
+        "trans": [
+            "adv. 同时，其间"
+        ],
+        "usphone": "[ˈmiːnwaɪl]",
+        "ukphone": "[ˈmiːnwaɪl]"
+    },
+    {
+        "name": "branch",
+        "trans": [
+            "n. 树枝，分枝；分部；支流"
+        ],
+        "usphone": "[bræntʃ]",
+        "ukphone": "[brɑːntʃ]"
+    },
+    {
+        "name": "helicopter",
+        "trans": [
+            "n. [航] 直升飞机"
+        ],
+        "usphone": "[ˈhelɪkɑːptər]",
+        "ukphone": "[ˈhelɪkɒptə(r)]"
+    },
+    {
+        "name": "gather",
+        "trans": [
+            "n. 聚集；衣褶；收获量"
+        ],
+        "usphone": "[ˈɡæðər]",
+        "ukphone": "[ˈɡæðə(r)]"
+    },
+    {
+        "name": "mental",
+        "trans": [
+            "adj. 精神的；脑力的；疯的"
+        ],
+        "usphone": "[ˈmentl]",
+        "ukphone": "[ˈmentl]"
+    },
+    {
+        "name": "producer",
+        "trans": [
+            "n. 制作人，制片人；生产者；发生器"
+        ],
+        "usphone": "[prəˈduːsər]",
+        "ukphone": "[prəˈdjuːsə(r)]"
+    },
+    {
+        "name": "religious",
+        "trans": [
+            "n. 修道士；尼姑"
+        ],
+        "usphone": "[rɪˈlɪdʒəs]",
+        "ukphone": "[rɪˈlɪdʒəs]"
+    },
+    {
+        "name": "priest",
+        "trans": [
+            "n. 牧师；神父；教士"
+        ],
+        "usphone": "[priːst]",
+        "ukphone": "[priːst]"
+    },
+    {
+        "name": "campus",
+        "trans": [
+            "n. （大学）校园；大学，大学生活；校园内的草地"
+        ],
+        "usphone": "[ˈkæmpəs]",
+        "ukphone": "[ˈkæmpəs]"
+    },
+    {
+        "name": "enemy",
+        "trans": [
+            "n. 敌人，仇敌；敌军"
+        ],
+        "usphone": "[ˈenəmi]",
+        "ukphone": "[ˈenəmi]"
+    },
+    {
+        "name": "expected",
+        "trans": [
+            "v. 预期；盼望（expect的过去分词）"
+        ],
+        "usphone": "[ɪkˈspektɪd]",
+        "ukphone": "[ɪkˈspektɪd]"
+    },
+    {
+        "name": "convenient",
+        "trans": [
+            "adj. 方便的；[废语]适当的；[口语]近便的；实用的"
+        ],
+        "usphone": "[kənˈviːniənt]",
+        "ukphone": "[kənˈviːniənt]"
+    },
+    {
+        "name": "comment",
+        "trans": [
+            "n. 评论；意见；批评"
+        ],
+        "usphone": "[ˈkɑːment]",
+        "ukphone": "[ˈkɒment]"
+    },
+    {
+        "name": "safety",
+        "trans": [
+            "n. 安全；保险；安全设备；保险装置；安打"
+        ],
+        "usphone": "[ˈseɪfti]",
+        "ukphone": "[ˈseɪfti]"
+    },
+    {
+        "name": "theme",
+        "trans": [
+            "n. 主题；主旋律；题目"
+        ],
+        "usphone": "[θiːm]",
+        "ukphone": "[θiːm]"
+    },
+    {
+        "name": "experiment",
+        "trans": [
+            "n. 实验，试验；尝试"
+        ],
+        "usphone": "[ɪkˈsperɪmənt]",
+        "ukphone": "[ɪkˈsperɪmənt]"
+    },
+    {
+        "name": "engineering",
+        "trans": [
+            "n. 工程，工程学"
+        ],
+        "usphone": "[ˌendʒɪˈnɪrɪŋ]",
+        "ukphone": "[ˌendʒɪˈnɪərɪŋ]"
     },
     {
         "name": "upon",
@@ -6072,68 +2360,556 @@
         "ukphone": "[əˈpɒn]"
     },
     {
-        "name": "upset",
+        "name": "muscle",
         "trans": [
-            "n. 混乱；翻倒；颠覆"
+            "n. 肌肉；力量"
         ],
-        "usphone": "[ˌʌpˈset]",
-        "ukphone": "[ˌʌpˈset]"
+        "usphone": "[ˈmʌsl]",
+        "ukphone": "[ˈmʌsl]"
     },
     {
-        "name": "used",
+        "name": "champion",
         "trans": [
-            "v. 用（use的过去式）；（used to）过去常做"
+            "n. 冠军；拥护者；战士"
         ],
-        "usphone": "[juːst; juːzd]",
-        "ukphone": "[juːst]"
+        "usphone": "[ˈtʃæmpiən]",
+        "ukphone": "[ˈtʃæmpiən]"
     },
     {
-        "name": "valuable",
+        "name": "relaxed",
         "trans": [
-            "n. 贵重物品"
+            "v. relax的过去式和过去分词"
         ],
-        "usphone": "[ˈvæljuəbl]",
-        "ukphone": "[ˈvæljuəbl]"
+        "usphone": "[rɪˈlækst]",
+        "ukphone": "[rɪˈlækst]"
     },
     {
-        "name": "value",
+        "name": "shell",
         "trans": [
-            "n. 值；价值；价格；重要性；确切涵义"
+            "n. 壳，贝壳；炮弹；外形"
         ],
-        "usphone": "[ˈvæljuː]",
-        "ukphone": "[ˈvæljuː]"
+        "usphone": "[ʃel]",
+        "ukphone": "[ʃel]"
     },
     {
-        "name": "various",
+        "name": "technique",
         "trans": [
-            "adj. 各种各样的；多方面的"
+            "n. 技巧，技术；手法"
         ],
-        "usphone": "[ˈveriəs; ˈværiəs]",
-        "ukphone": "[ˈveəriəs]"
+        "usphone": "[tekˈniːk]",
+        "ukphone": "[tekˈniːk]"
     },
     {
-        "name": "version",
+        "name": "treat",
         "trans": [
-            "n. 版本；译文；倒转术"
+            "n. 请客；款待"
         ],
-        "usphone": "[ˈvɜːrʒn]",
-        "ukphone": "[ˈvɜːʃ(ə)n]"
+        "usphone": "[triːt]",
+        "ukphone": "[triːt]"
     },
     {
-        "name": "victim",
+        "name": "tube",
         "trans": [
-            "n. 受害人；牺牲品；牺牲者"
+            "n. 管；电子管；隧道；电视机"
         ],
-        "usphone": "[ˈvɪktɪm]",
-        "ukphone": "[ˈvɪktɪm]"
+        "usphone": "[tuːb]",
+        "ukphone": "[tjuːb]"
     },
     {
-        "name": "view",
+        "name": "discount",
         "trans": [
-            "n. 观察；视野；意见；风景"
+            "n. 折扣；贴现率"
         ],
-        "usphone": "[vjuː]",
-        "ukphone": "[vjuː]"
+        "usphone": "[ˈdɪskaʊnt]",
+        "ukphone": "[ˈdɪskaʊnt]"
+    },
+    {
+        "name": "keyboard",
+        "trans": [
+            "n. 键盘"
+        ],
+        "usphone": "[ˈkiːbɔːrd]",
+        "ukphone": "[ˈkiːbɔːd]"
+    },
+    {
+        "name": "lie",
+        "trans": [
+            "vi. 躺；说谎；位于；展现"
+        ],
+        "usphone": "[laɪ]",
+        "ukphone": "[laɪ]"
+    },
+    {
+        "name": "unnecessary",
+        "trans": [
+            "adj. 不必要的；多余的，无用的"
+        ],
+        "usphone": "[ʌnˈnesəseri]",
+        "ukphone": "[ʌnˈnesəsəri]"
+    },
+    {
+        "name": "remind",
+        "trans": [
+            "vt. 提醒；使想起"
+        ],
+        "usphone": "[rɪˈmaɪnd]",
+        "ukphone": "[rɪˈmaɪnd]"
+    },
+    {
+        "name": "unable",
+        "trans": [
+            "adj. 不会的，不能的；[劳经] 无能力的；不能胜任的"
+        ],
+        "usphone": "[ʌnˈeɪbl]",
+        "ukphone": "[ʌnˈeɪb(ə)l]"
+    },
+    {
+        "name": "ghost",
+        "trans": [
+            "n. 鬼，幽灵"
+        ],
+        "usphone": "[ɡoʊst]",
+        "ukphone": "[ɡəʊst]"
+    },
+    {
+        "name": "force",
+        "trans": [
+            "n. 力量；武力；军队；魄力"
+        ],
+        "usphone": "[fɔːrs]",
+        "ukphone": "[fɔːs]"
+    },
+    {
+        "name": "folk",
+        "trans": [
+            "n. 民族；人们；亲属（复数）"
+        ],
+        "usphone": "[foʊk]",
+        "ukphone": "[fəʊk]"
+    },
+    {
+        "name": "sand",
+        "trans": [
+            "n. 沙；沙地；沙洲；沙滩；沙子"
+        ],
+        "usphone": "[sænd]",
+        "ukphone": "[sænd]"
+    },
+    {
+        "name": "stuff",
+        "trans": [
+            "n. 东西；材料；填充物；素材资料"
+        ],
+        "usphone": "[stʌf]",
+        "ukphone": "[stʌf]"
+    },
+    {
+        "name": "determine",
+        "trans": [
+            "v. （使）下决心，（使）做出决定"
+        ],
+        "usphone": "[dɪˈtɜːrmɪn]",
+        "ukphone": "[dɪˈtɜːmɪn]"
+    },
+    {
+        "name": "frequently",
+        "trans": [
+            "adv. 频繁地，经常地；时常，屡次"
+        ],
+        "usphone": "[ˈfriːkwəntli]",
+        "ukphone": "[ˈfriːkwəntli]"
+    },
+    {
+        "name": "mall",
+        "trans": [
+            "n. 购物商场；林荫路；铁圈球场"
+        ],
+        "usphone": "[mɔːl]",
+        "ukphone": "[mɔːl; mæl]"
+    },
+    {
+        "name": "theory",
+        "trans": [
+            "n. 理论；原理；学说；推测"
+        ],
+        "usphone": "[ˈθiːəri]",
+        "ukphone": "[ˈθɪəri]"
+    },
+    {
+        "name": "normal",
+        "trans": [
+            "adj. 正常的；正规的，标准的"
+        ],
+        "usphone": "[ˈnɔːrm(ə)l]",
+        "ukphone": "[ˈnɔːm(ə)l]"
+    },
+    {
+        "name": "smart",
+        "trans": [
+            "adj. 聪明的；巧妙的；敏捷的；厉害的；潇洒的；剧烈的；时髦的"
+        ],
+        "usphone": "[smɑːrt]",
+        "ukphone": "[smɑːt]"
+    },
+    {
+        "name": "grateful",
+        "trans": [
+            "adj. 感谢的；令人愉快的，宜人的"
+        ],
+        "usphone": "[ˈɡreɪtfl]",
+        "ukphone": "[ˈɡreɪtf(ə)l]"
+    },
+    {
+        "name": "apart",
+        "trans": [
+            "adj. 分离的；与众不同的"
+        ],
+        "usphone": "[əˈpɑːrt]",
+        "ukphone": "[əˈpɑːt]"
+    },
+    {
+        "name": "hate",
+        "trans": [
+            "n. 憎恨；反感"
+        ],
+        "usphone": "[heɪt]",
+        "ukphone": "[heɪt]"
+    },
+    {
+        "name": "expand",
+        "trans": [
+            "vt. 扩张；使膨胀；详述"
+        ],
+        "usphone": "[ɪkˈspænd]",
+        "ukphone": "[ɪkˈspænd]"
+    },
+    {
+        "name": "kind",
+        "trans": [
+            "n. 种类；性质"
+        ],
+        "usphone": "[kaɪnd]",
+        "ukphone": "[kaɪnd]"
+    },
+    {
+        "name": "summarize",
+        "trans": [
+            "vt. 总结；概述"
+        ],
+        "usphone": "[ˈsʌməraɪz]",
+        "ukphone": "[ˈsʌməraɪz]"
+    },
+    {
+        "name": "charge",
+        "trans": [
+            "n. 费用；电荷；掌管；控告；命令；负载"
+        ],
+        "usphone": "[tʃɑːrdʒ]",
+        "ukphone": "[tʃɑːdʒ]"
+    },
+    {
+        "name": "living",
+        "trans": [
+            "adj. 活的；现存的；活跃的；逼真的"
+        ],
+        "usphone": "[ˈlɪvɪŋ]",
+        "ukphone": "[ˈlɪvɪŋ]"
+    },
+    {
+        "name": "point",
+        "trans": [
+            "n. 要点；得分；标点；[机] 尖端"
+        ],
+        "usphone": "[pɔɪnt]",
+        "ukphone": "[pɔɪnt]"
+    },
+    {
+        "name": "mainly",
+        "trans": [
+            "adv. 主要地，大体上"
+        ],
+        "usphone": "[ˈmeɪnli]",
+        "ukphone": "[ˈmeɪnli]"
+    },
+    {
+        "name": "careless",
+        "trans": [
+            "adj. 粗心的；无忧无虑的；淡漠的"
+        ],
+        "usphone": "[ˈkerləs]",
+        "ukphone": "[ˈkeələs]"
+    },
+    {
+        "name": "lack",
+        "trans": [
+            "vt. 缺乏；不足；没有；需要"
+        ],
+        "usphone": "[læk]",
+        "ukphone": "[læk]"
+    },
+    {
+        "name": "pin",
+        "trans": [
+            "n. 大头针，别针，针；栓；琐碎物"
+        ],
+        "usphone": "[pɪn]",
+        "ukphone": "[pɪn]"
+    },
+    {
+        "name": "poverty",
+        "trans": [
+            "n. 贫困；困难；缺少；低劣"
+        ],
+        "usphone": "[ˈpɑːvərti]",
+        "ukphone": "[ˈpɒvəti]"
+    },
+    {
+        "name": "limit",
+        "trans": [
+            "n. 限制；限度；界线"
+        ],
+        "usphone": "[ˈlɪmɪt]",
+        "ukphone": "[ˈlɪmɪt]"
+    },
+    {
+        "name": "highly",
+        "trans": [
+            "adv. 高度地；非常；非常赞许地"
+        ],
+        "usphone": "[ˈhaɪli]",
+        "ukphone": "[ˈhaɪli]"
+    },
+    {
+        "name": "captain",
+        "trans": [
+            "n. 队长，首领；船长；上尉；海军上校"
+        ],
+        "usphone": "[ˈkæptɪn]",
+        "ukphone": "[ˈkæptɪn]"
+    },
+    {
+        "name": "wing",
+        "trans": [
+            "n. 翼；翅膀；飞翔；派别；侧厅，耳房，厢房"
+        ],
+        "usphone": "[wɪŋ]",
+        "ukphone": "[wɪŋ]"
+    },
+    {
+        "name": "studio",
+        "trans": [
+            "n. 工作室；[广播][电视] 演播室；画室；电影制片厂"
+        ],
+        "usphone": "[ˈstuːdioʊ]",
+        "ukphone": "[ˈstjuːdiəʊ]"
+    },
+    {
+        "name": "place",
+        "trans": [
+            "n. 地方；住所；座位"
+        ],
+        "usphone": "[pleɪs]",
+        "ukphone": "[pleɪs]"
+    },
+    {
+        "name": "age",
+        "trans": [
+            "n. 年龄；时代；寿命，使用年限；阶段"
+        ],
+        "usphone": "[eɪdʒ]",
+        "ukphone": "[eɪdʒ]"
+    },
+    {
+        "name": "commercial",
+        "trans": [
+            "n. 商业广告"
+        ],
+        "usphone": "[kəˈmɜːrʃl]",
+        "ukphone": "[kəˈmɜːʃ(ə)l]"
+    },
+    {
+        "name": "confuse",
+        "trans": [
+            "vt. 使混乱；使困惑"
+        ],
+        "usphone": "[kənˈfjuːz]",
+        "ukphone": "[kənˈfjuːz]"
+    },
+    {
+        "name": "lip",
+        "trans": [
+            "n. 嘴唇；边缘"
+        ],
+        "usphone": "[lɪp]",
+        "ukphone": "[lɪp]"
+    },
+    {
+        "name": "level",
+        "trans": [
+            "n. 水平；标准；水平面"
+        ],
+        "usphone": "[ˈlevl]",
+        "ukphone": "[ˈlev(ə)l]"
+    },
+    {
+        "name": "cover",
+        "trans": [
+            "n. 封面，封皮；盖子；掩蔽物;幌子，借口"
+        ],
+        "usphone": "[ˈkʌvər]",
+        "ukphone": "[ˈkʌvə(r)]"
+    },
+    {
+        "name": "shake",
+        "trans": [
+            "n. 摇动；哆嗦"
+        ],
+        "usphone": "[ʃeɪk]",
+        "ukphone": "[ʃeɪk]"
+    },
+    {
+        "name": "port",
+        "trans": [
+            "n. 港口，口岸；（计算机的）端口；左舷；舱门"
+        ],
+        "usphone": "[pɔːrt]",
+        "ukphone": "[pɔːt]"
+    },
+    {
+        "name": "investigate",
+        "trans": [
+            "v. 调查；研究"
+        ],
+        "usphone": "[ɪnˈvestɪɡeɪt]",
+        "ukphone": "[ɪnˈvestɪɡeɪt]"
+    },
+    {
+        "name": "frightened",
+        "trans": [
+            "v. 害怕；使吃惊；吓走（frighten的过去分词）"
+        ],
+        "usphone": "[ˈfraɪtnd]",
+        "ukphone": "[ˈfraɪtnd]"
+    },
+    {
+        "name": "edge",
+        "trans": [
+            "n. 边缘；优势；刀刃；锋利"
+        ],
+        "usphone": "[edʒ]",
+        "ukphone": "[edʒ]"
+    },
+    {
+        "name": "intelligence",
+        "trans": [
+            "n. 智力；情报工作；情报机关；理解力；才智，智慧；天分"
+        ],
+        "usphone": "[ɪnˈtelɪdʒəns]",
+        "ukphone": "[ɪnˈtelɪdʒəns]"
+    },
+    {
+        "name": "apologize",
+        "trans": [
+            "vi. 道歉；辩解；赔不是"
+        ],
+        "usphone": "[əˈpɑːlədʒaɪz]",
+        "ukphone": "[əˈpɒlədʒaɪz]"
+    },
+    {
+        "name": "toe",
+        "trans": [
+            "n. 脚趾；足尖"
+        ],
+        "usphone": "[toʊ]",
+        "ukphone": "[təʊ]"
+    },
+    {
+        "name": "essential",
+        "trans": [
+            "n. 本质；要素；要点；必需品"
+        ],
+        "usphone": "[ɪˈsenʃl]",
+        "ukphone": "[ɪˈsenʃl]"
+    },
+    {
+        "name": "goods",
+        "trans": [
+            "n. 商品；动产；合意的人；真本领"
+        ],
+        "usphone": "[ɡʊdz]",
+        "ukphone": "[ɡʊdz]"
+    },
+    {
+        "name": "tent",
+        "trans": [
+            "n. 帐篷；住处；帷幕"
+        ],
+        "usphone": "[tent]",
+        "ukphone": "[tent]"
+    },
+    {
+        "name": "market",
+        "trans": [
+            "n. 市场；行情；股票市场；市面；集市；销路；商店"
+        ],
+        "usphone": "[ˈmɑːrkɪt]",
+        "ukphone": "[ˈmɑːkɪt]"
+    },
+    {
+        "name": "grain",
+        "trans": [
+            "n. 粮食；颗粒；[作物] 谷物；纹理"
+        ],
+        "usphone": "[ɡreɪn]",
+        "ukphone": "[ɡreɪn]"
+    },
+    {
+        "name": "cultural",
+        "trans": [
+            "adj. 文化的；教养的"
+        ],
+        "usphone": "[ˈkʌltʃərəl]",
+        "ukphone": "[ˈkʌltʃərəl]"
+    },
+    {
+        "name": "set",
+        "trans": [
+            "n. [数] 集合；一套；布景；[机] 装置"
+        ],
+        "usphone": "[set]",
+        "ukphone": "[set]"
+    },
+    {
+        "name": "album",
+        "trans": [
+            "n. 相簿；唱片集；集邮簿；签名纪念册"
+        ],
+        "usphone": "[ˈælbəm]",
+        "ukphone": "[ˈælbəm]"
+    },
+    {
+        "name": "mild",
+        "trans": [
+            "adj. 温和的；轻微的；淡味的；文雅的；不含有害物质的的"
+        ],
+        "usphone": "[maɪld]",
+        "ukphone": "[maɪld]"
+    },
+    {
+        "name": "prayer",
+        "trans": [
+            "n. 祈祷，祷告；恳求；祈祷文"
+        ],
+        "usphone": "[prer]",
+        "ukphone": "[preə(r)]"
+    },
+    {
+        "name": "growth",
+        "trans": [
+            "n. 增长；发展；生长；种植"
+        ],
+        "usphone": "[ɡroʊθ]",
+        "ukphone": "[ɡrəʊθ]"
     },
     {
         "name": "viewer",
@@ -6144,52 +2920,572 @@
         "ukphone": "[ˈvjuːə(r)]"
     },
     {
-        "name": "violent",
+        "name": "escape",
         "trans": [
-            "adj. 暴力的；猛烈的"
+            "n. 逃跑；逃亡；逃走；逃跑工具或方法；野生种；泄漏"
         ],
-        "usphone": "[ˈvaɪələnt]",
-        "ukphone": "[ˈvaɪələnt]"
+        "usphone": "[ɪˈskeɪp]",
+        "ukphone": "[ɪˈskeɪp]"
     },
     {
-        "name": "volunteer",
+        "name": "attitude",
         "trans": [
-            "n. 志愿者；志愿兵"
+            "n. 态度；看法；意见；姿势"
         ],
-        "usphone": "[ˌvɑːlənˈtɪr]",
-        "ukphone": "[ˌvɒlənˈtɪə(r)]"
+        "usphone": "[ˈætɪtuːd]",
+        "ukphone": "[ˈætɪtjuːd]"
     },
     {
-        "name": "vote",
+        "name": "require",
         "trans": [
-            "n. 投票，选举；选票；得票数"
+            "vt. 需要；要求；命令"
         ],
-        "usphone": "[voʊt]",
-        "ukphone": "[vəʊt]"
+        "usphone": "[rɪˈkwaɪər]",
+        "ukphone": "[rɪˈkwaɪə(r)]"
     },
     {
-        "name": "warm",
+        "name": "robot",
         "trans": [
-            "n. 取暖；加热"
+            "n. 机器人；遥控设备，自动机械；机械般工作的人"
         ],
-        "usphone": "[wɔːrm]",
-        "ukphone": "[wɔːm]"
+        "usphone": "[ˈroʊbɑːt]",
+        "ukphone": "[ˈrəʊbɒt]"
     },
     {
-        "name": "warn",
+        "name": "coal",
         "trans": [
-            "vt. 警告，提醒；通知"
+            "n. 煤；煤块；木炭"
         ],
-        "usphone": "[wɔːrn]",
-        "ukphone": "[wɔːn]"
+        "usphone": "[koʊl]",
+        "ukphone": "[kəʊl]"
     },
     {
-        "name": "warning",
+        "name": "fuel",
         "trans": [
-            "n. 警告；预兆；预告"
+            "n. 燃料；刺激因素"
         ],
-        "usphone": "[ˈwɔːrnɪŋ]",
-        "ukphone": "[ˈwɔːnɪŋ]"
+        "usphone": "[ˈfjuːəl]",
+        "ukphone": "[ˈfjuːəl]"
+    },
+    {
+        "name": "official",
+        "trans": [
+            "adj. 官方的；正式的；公务的"
+        ],
+        "usphone": "[əˈfɪʃl]",
+        "ukphone": "[əˈfɪʃ(ə)l]"
+    },
+    {
+        "name": "peaceful",
+        "trans": [
+            "adj. 和平的，爱好和平的；平静的"
+        ],
+        "usphone": "[ˈpiːsfl]",
+        "ukphone": "[ˈpiːsfl]"
+    },
+    {
+        "name": "conclusion",
+        "trans": [
+            "n. 结论；结局；推论"
+        ],
+        "usphone": "[kənˈkluːʒn]",
+        "ukphone": "[kənˈkluːʒn]"
+    },
+    {
+        "name": "respect",
+        "trans": [
+            "n. 尊敬，尊重；方面；敬意"
+        ],
+        "usphone": "[rɪˈspekt]",
+        "ukphone": "[rɪˈspekt]"
+    },
+    {
+        "name": "decade",
+        "trans": [
+            "n. 十年，十年期；十"
+        ],
+        "usphone": "[ˈdekeɪdˌdɪˈkeɪd]",
+        "ukphone": "[ˈdekeɪd]"
+    },
+    {
+        "name": "western",
+        "trans": [
+            "n. 西方人；西部片，西部小说"
+        ],
+        "usphone": "[ˈwestərn]",
+        "ukphone": "[ˈwestən]"
+    },
+    {
+        "name": "next",
+        "trans": [
+            "adv. 然后；下次；其次"
+        ],
+        "usphone": "[nekst]",
+        "ukphone": "[nekst]"
+    },
+    {
+        "name": "confused",
+        "trans": [
+            "v. 困惑（confuse的过去式）"
+        ],
+        "usphone": "[kənˈfjuːzd]",
+        "ukphone": "[kənˈfjuːzd]"
+    },
+    {
+        "name": "climb",
+        "trans": [
+            "n. 爬；攀登"
+        ],
+        "usphone": "[klaɪm]",
+        "ukphone": "[klaɪm]"
+    },
+    {
+        "name": "extra",
+        "trans": [
+            "n. 临时演员；号外；额外的事物；上等产品"
+        ],
+        "usphone": "[ˈekstrə]",
+        "ukphone": "[ˈekstrə]"
+    },
+    {
+        "name": "religion",
+        "trans": [
+            "n. 宗教；宗教信仰"
+        ],
+        "usphone": "[rɪˈlɪdʒən]",
+        "ukphone": "[rɪˈlɪdʒən]"
+    },
+    {
+        "name": "editor",
+        "trans": [
+            "n. 编者，编辑；社论撰写人；编辑装置"
+        ],
+        "usphone": "[ˈedɪtər]",
+        "ukphone": "[ˈedɪtə(r)]"
+    },
+    {
+        "name": "suitable",
+        "trans": [
+            "adj. 适当的；相配的"
+        ],
+        "usphone": "[ˈsuːtəbl]",
+        "ukphone": "[ˈsuːtəb(ə)l]"
+    },
+    {
+        "name": "relative",
+        "trans": [
+            "n. 亲戚；相关物；[语] 关系词；亲缘植物"
+        ],
+        "usphone": "[ˈrelətɪv]",
+        "ukphone": "[ˈrelətɪv]"
+    },
+    {
+        "name": "alcohol",
+        "trans": [
+            "n. 酒精，乙醇"
+        ],
+        "usphone": "[ˈælkəhɔːl]",
+        "ukphone": "[ˈælkəhɒl]"
+    },
+    {
+        "name": "drop",
+        "trans": [
+            "n. 滴；落下；空投；微量；滴剂"
+        ],
+        "usphone": "[drɑːp]",
+        "ukphone": "[drɒp]"
+    },
+    {
+        "name": "dirt",
+        "trans": [
+            "n. 污垢，泥土；灰尘，尘土；下流话"
+        ],
+        "usphone": "[dɜːrt]",
+        "ukphone": "[dɜːt]"
+    },
+    {
+        "name": "liquid",
+        "trans": [
+            "adj. 液体的；清澈的；明亮的；易变的"
+        ],
+        "usphone": "[ˈlɪkwɪd]",
+        "ukphone": "[ˈlɪkwɪd]"
+    },
+    {
+        "name": "recommendation",
+        "trans": [
+            "n. 推荐；建议；推荐信"
+        ],
+        "usphone": "[ˌrekəmenˈdeɪʃn]",
+        "ukphone": "[ˌrekəmenˈdeɪʃn]"
+    },
+    {
+        "name": "slice",
+        "trans": [
+            "n. 薄片；部分；菜刀，火铲"
+        ],
+        "usphone": "[slaɪs]",
+        "ukphone": "[slaɪs]"
+    },
+    {
+        "name": "push",
+        "trans": [
+            "n. 推，决心；大规模攻势；矢志的追求"
+        ],
+        "usphone": "[pʊʃ]",
+        "ukphone": "[pʊʃ]"
+    },
+    {
+        "name": "press",
+        "trans": [
+            "n. 压；按；新闻；出版社；[印刷] 印刷机"
+        ],
+        "usphone": "[pres]",
+        "ukphone": "[pres]"
+    },
+    {
+        "name": "contact",
+        "trans": [
+            "n. 接触，联系"
+        ],
+        "usphone": "[ˈkɑːntækt]",
+        "ukphone": "[ˈkɒntækt]"
+    },
+    {
+        "name": "deal",
+        "trans": [
+            "n. 交易；（美）政策；待遇；份量"
+        ],
+        "usphone": "[diːl]",
+        "ukphone": "[diːl]"
+    },
+    {
+        "name": "view",
+        "trans": [
+            "n. 观察；视野；意见；风景"
+        ],
+        "usphone": "[vjuː]",
+        "ukphone": "[vjuː]"
+    },
+    {
+        "name": "consume",
+        "trans": [
+            "vt. 消耗，消费；使…着迷；挥霍"
+        ],
+        "usphone": "[kənˈsuːm]",
+        "ukphone": "[kənˈsjuːm]"
+    },
+    {
+        "name": "rare",
+        "trans": [
+            "adj. 稀有的；稀薄的；半熟的"
+        ],
+        "usphone": "[rer]",
+        "ukphone": "[reə(r)]"
+    },
+    {
+        "name": "reflect",
+        "trans": [
+            "vt. 反映；反射，照出；表达；显示;反省"
+        ],
+        "usphone": "[rɪˈflekt]",
+        "ukphone": "[rɪˈflekt]"
+    },
+    {
+        "name": "import",
+        "trans": [
+            "n. 进口，进口货；输入；意思，含义；重要性"
+        ],
+        "usphone": "[ˈɪmpɔːrt]",
+        "ukphone": "[ˈɪmpɔːt]"
+    },
+    {
+        "name": "environmental",
+        "trans": [
+            "adj. 环境的，周围的；有关环境的"
+        ],
+        "usphone": "[ɪnˌvaɪrənˈmentl]",
+        "ukphone": "[ɪnˌvaɪrənˈment(ə)l]"
+    },
+    {
+        "name": "relaxing",
+        "trans": [
+            "v. 放松；休息（relax的ing形式）；缓和；松懈"
+        ],
+        "usphone": "[rɪˈlæksɪŋ]",
+        "ukphone": "[rɪˈlæksɪŋ]"
+    },
+    {
+        "name": "convince",
+        "trans": [
+            "vt. 说服；使确信，使信服"
+        ],
+        "usphone": "[kənˈvɪns]",
+        "ukphone": "[kənˈvɪns]"
+    },
+    {
+        "name": "slightly",
+        "trans": [
+            "adv. 些微地，轻微地；纤细地"
+        ],
+        "usphone": "[ˈslaɪtli]",
+        "ukphone": "[ˈslaɪtli]"
+    },
+    {
+        "name": "perfectly",
+        "trans": [
+            "adv. 完美地；完全地；无瑕疵地"
+        ],
+        "usphone": "[ˈpɜːrfɪktli]",
+        "ukphone": "[ˈpɜːfɪktli]"
+    },
+    {
+        "name": "emotion",
+        "trans": [
+            "n. 情感；情绪"
+        ],
+        "usphone": "[ɪˈmoʊʃn]",
+        "ukphone": "[ɪˈməʊʃn]"
+    },
+    {
+        "name": "earthquake",
+        "trans": [
+            "n. 地震；大动荡"
+        ],
+        "usphone": "[ˈɜːrθkweɪk]",
+        "ukphone": "[ˈɜːθkweɪk]"
+    },
+    {
+        "name": "organized",
+        "trans": [
+            "adj. 有组织的；安排有秩序的；做事有条理的"
+        ],
+        "usphone": "[ˈɔːrɡənaɪzd]",
+        "ukphone": "[ˈɔːɡənaɪzd]"
+    },
+    {
+        "name": "musical",
+        "trans": [
+            "adj. 音乐的；悦耳的"
+        ],
+        "usphone": "[ˈmjuːzɪkl]",
+        "ukphone": "[ˈmjuːzɪk(ə)l]"
+    },
+    {
+        "name": "attach",
+        "trans": [
+            "vi. 附加；附属；伴随"
+        ],
+        "usphone": "[əˈtætʃ]",
+        "ukphone": "[əˈtætʃ]"
+    },
+    {
+        "name": "examine",
+        "trans": [
+            "vt. 检查；调查； 检测；考试"
+        ],
+        "usphone": "[ɪɡˈzæmɪn]",
+        "ukphone": "[ɪɡˈzæmɪn]"
+    },
+    {
+        "name": "central",
+        "trans": [
+            "n. 电话总机"
+        ],
+        "usphone": "[ˈsentrəl]",
+        "ukphone": "[ˈsentrəl]"
+    },
+    {
+        "name": "legal",
+        "trans": [
+            "adj. 法律的；合法的；法定的；依照法律的"
+        ],
+        "usphone": "[ˈliːɡl]",
+        "ukphone": "[ˈliːɡ(ə)l]"
+    },
+    {
+        "name": "diamond",
+        "trans": [
+            "n. 钻石，金刚石；菱形；方块牌"
+        ],
+        "usphone": "[ˈdaɪmənd]",
+        "ukphone": "[ˈdaɪmənd]"
+    },
+    {
+        "name": "luxury",
+        "trans": [
+            "n. 奢侈，奢华；奢侈品；享受"
+        ],
+        "usphone": "[ˈlʌkʃəri]",
+        "ukphone": "[ˈlʌkʃəri]"
+    },
+    {
+        "name": "poet",
+        "trans": [
+            "n. 诗人"
+        ],
+        "usphone": "[ˈpoʊət]",
+        "ukphone": "[ˈpəʊɪt]"
+    },
+    {
+        "name": "eventually",
+        "trans": [
+            "adv. 最后，终于"
+        ],
+        "usphone": "[ɪˈventʃuəli]",
+        "ukphone": "[ɪˈventʃuəli]"
+    },
+    {
+        "name": "ceiling",
+        "trans": [
+            "n. 天花板；上限"
+        ],
+        "usphone": "[ˈsiːlɪŋ]",
+        "ukphone": "[ˈsiːlɪŋ]"
+    },
+    {
+        "name": "neither",
+        "trans": [
+            "conj. 也不；既不"
+        ],
+        "usphone": "[ˈniːðər; ˈnaɪðər]",
+        "ukphone": "[ˈnaɪðə(r)]"
+    },
+    {
+        "name": "profession",
+        "trans": [
+            "n. 职业，专业；声明，宣布，表白"
+        ],
+        "usphone": "[prəˈfeʃn]",
+        "ukphone": "[prəˈfeʃn]"
+    },
+    {
+        "name": "pale",
+        "trans": [
+            "n. 前哨；栅栏；范围"
+        ],
+        "usphone": "[peɪl]",
+        "ukphone": "[peɪl]"
+    },
+    {
+        "name": "heating",
+        "trans": [
+            "n. [热] 加热；[建] 供暖；暖气设备"
+        ],
+        "usphone": "[ˈhiːtɪŋ]",
+        "ukphone": "[ˈhiːtɪŋ]"
+    },
+    {
+        "name": "confident",
+        "trans": [
+            "adj. 自信的；确信的"
+        ],
+        "usphone": "[ˈkɑːnfɪdənt]",
+        "ukphone": "[ˈkɒnfɪdənt]"
+    },
+    {
+        "name": "glad",
+        "trans": [
+            "adj. 高兴的；乐意的；令人高兴的；灿烂美丽的"
+        ],
+        "usphone": "[ɡlæd]",
+        "ukphone": "[ɡlæd]"
+    },
+    {
+        "name": "horrible",
+        "trans": [
+            "adj. 可怕的；极讨厌的"
+        ],
+        "usphone": "[ˈhɔːrəbl]",
+        "ukphone": "[ˈhɒrəb(ə)l]"
+    },
+    {
+        "name": "frighten",
+        "trans": [
+            "vt. 使惊吓；吓唬…"
+        ],
+        "usphone": "[ˈfraɪtn]",
+        "ukphone": "[ˈfraɪtn]"
+    },
+    {
+        "name": "state",
+        "trans": [
+            "n. 国家；州；情形"
+        ],
+        "usphone": "[steɪt]",
+        "ukphone": "[steɪt]"
+    },
+    {
+        "name": "file",
+        "trans": [
+            "n. 文件；档案；文件夹；锉刀"
+        ],
+        "usphone": "[faɪl]",
+        "ukphone": "[faɪl]"
+    },
+    {
+        "name": "reliable",
+        "trans": [
+            "n. 可靠的人"
+        ],
+        "usphone": "[rɪˈlaɪəbl]",
+        "ukphone": "[rɪˈlaɪəb(ə)l]"
+    },
+    {
+        "name": "tape",
+        "trans": [
+            "n. 胶带；磁带；带子；卷尺"
+        ],
+        "usphone": "[teɪp]",
+        "ukphone": "[teɪp]"
+    },
+    {
+        "name": "value",
+        "trans": [
+            "n. 值；价值；价格；重要性；确切涵义"
+        ],
+        "usphone": "[ˈvæljuː]",
+        "ukphone": "[ˈvæljuː]"
+    },
+    {
+        "name": "rope",
+        "trans": [
+            "n. 绳，绳索"
+        ],
+        "usphone": "[roʊp]",
+        "ukphone": "[rəʊp]"
+    },
+    {
+        "name": "suit",
+        "trans": [
+            "n. 诉讼；恳求；套装，西装；一套外衣"
+        ],
+        "usphone": "[suːt]",
+        "ukphone": "[suːt]"
+    },
+    {
+        "name": "channel",
+        "trans": [
+            "n. 通道；频道；海峡"
+        ],
+        "usphone": "[ˈtʃænl]",
+        "ukphone": "[ˈtʃæn(ə)l]"
+    },
+    {
+        "name": "complex",
+        "trans": [
+            "n. 复合体；综合设施"
+        ],
+        "usphone": "[kəmˈpleks; ˈkɑːmpleks]",
+        "ukphone": "[ˈkɒmpleks]"
+    },
+    {
+        "name": "marriage",
+        "trans": [
+            "n. 结婚；婚姻生活；密切结合，合并"
+        ],
+        "usphone": "[ˈmærɪdʒ]",
+        "ukphone": "[ˈmærɪdʒ]"
     },
     {
         "name": "waste",
@@ -6208,6 +3504,502 @@
         "ukphone": "[ˈwɔːtə(r)]"
     },
     {
+        "name": "latest",
+        "trans": [
+            "adv. 最迟地；最后地"
+        ],
+        "usphone": "[ˈleɪtɪst]",
+        "ukphone": "[ˈleɪtɪst]"
+    },
+    {
+        "name": "stick",
+        "trans": [
+            "n. 棍；手杖；呆头呆脑的人"
+        ],
+        "usphone": "[stɪk]",
+        "ukphone": "[stɪk]"
+    },
+    {
+        "name": "aim",
+        "trans": [
+            "n. 目的；目标；对准"
+        ],
+        "usphone": "[eɪm]",
+        "ukphone": "[eɪm]"
+    },
+    {
+        "name": "ours",
+        "trans": [
+            "pron. 我们的"
+        ],
+        "usphone": "[ˈaʊərz]",
+        "ukphone": "[ˈaʊəz]"
+    },
+    {
+        "name": "spot",
+        "trans": [
+            "n. 地点；斑点"
+        ],
+        "usphone": "[spɑːt]",
+        "ukphone": "[spɒt]"
+    },
+    {
+        "name": "occur",
+        "trans": [
+            "vi. 发生；出现；存在"
+        ],
+        "usphone": "[əˈkɜːr]",
+        "ukphone": "[əˈkɜː(r)]"
+    },
+    {
+        "name": "similarity",
+        "trans": [
+            "n. 类似；相似点"
+        ],
+        "usphone": "[ˌsɪməˈlærəti]",
+        "ukphone": "[ˌsɪməˈlærəti]"
+    },
+    {
+        "name": "totally",
+        "trans": [
+            "adv. 完全地"
+        ],
+        "usphone": "[ˈtoʊtəli]",
+        "ukphone": "[ˈtəʊtəli]"
+    },
+    {
+        "name": "block",
+        "trans": [
+            "n. 块；街区；大厦；障碍物"
+        ],
+        "usphone": "[blɑːk]",
+        "ukphone": "[blɒk]"
+    },
+    {
+        "name": "repeat",
+        "trans": [
+            "n. 重复；副本"
+        ],
+        "usphone": "[rɪˈpiːt]",
+        "ukphone": "[rɪˈpiːt]"
+    },
+    {
+        "name": "secondary",
+        "trans": [
+            "n. 副手；代理人"
+        ],
+        "usphone": "[ˈsekənderi]",
+        "ukphone": "[ˈsekənd(ə)ri]"
+    },
+    {
+        "name": "neighbourhood",
+        "trans": [
+            "n. 邻近；周围；邻居关系；附近一带"
+        ],
+        "usphone": "[ˈneɪbərhʊd]",
+        "ukphone": "[ˈneɪbəhʊd]"
+    },
+    {
+        "name": "frozen",
+        "trans": [
+            "v. 结冰（freeze的过去分词）；凝固；变得刻板"
+        ],
+        "usphone": "[ˈfroʊzn]",
+        "ukphone": "[ˈfrəʊz(ə)n]"
+    },
+    {
+        "name": "importance",
+        "trans": [
+            "n. 价值；重要；重大；傲慢"
+        ],
+        "usphone": "[ɪmˈpɔːrtns]",
+        "ukphone": "[ɪmˈpɔːt(ə)ns]"
+    },
+    {
+        "name": "share",
+        "trans": [
+            "n. 份额；股份"
+        ],
+        "usphone": "[ʃer]",
+        "ukphone": "[ʃeə(r)]"
+    },
+    {
+        "name": "despite",
+        "trans": [
+            "prep. 尽管，不管"
+        ],
+        "usphone": "[dɪˈspaɪt]",
+        "ukphone": "[dɪˈspaɪt]"
+    },
+    {
+        "name": "entrance",
+        "trans": [
+            "n. 入口；进入"
+        ],
+        "usphone": "[ˈentrəns; ɪnˈtræns]",
+        "ukphone": "[ˈentrəns]"
+    },
+    {
+        "name": "experienced",
+        "trans": [
+            "adj. 老练的，熟练的；富有经验的"
+        ],
+        "usphone": "[ɪkˈspɪriənst]",
+        "ukphone": "[ɪkˈspɪəriənst]"
+    },
+    {
+        "name": "ambition",
+        "trans": [
+            "n. 野心，雄心；抱负，志向"
+        ],
+        "usphone": "[æmˈbɪʃ(ə)n]",
+        "ukphone": "[æmˈbɪʃn]"
+    },
+    {
+        "name": "directly",
+        "trans": [
+            "conj. 一…就"
+        ],
+        "usphone": "[dəˈrektli; daɪˈrektli]",
+        "ukphone": "[dəˈrektli]"
+    },
+    {
+        "name": "staff",
+        "trans": [
+            "n. 职员；参谋；棒；支撑"
+        ],
+        "usphone": "[stæf]",
+        "ukphone": "[stɑːf]"
+    },
+    {
+        "name": "experience",
+        "trans": [
+            "n. 经验；经历；体验"
+        ],
+        "usphone": "[ɪkˈspɪriəns]",
+        "ukphone": "[ɪkˈspɪəriəns]"
+    },
+    {
+        "name": "confirm",
+        "trans": [
+            "vt. 确认；确定；证实；批准；使巩固"
+        ],
+        "usphone": "[kənˈfɜːrm]",
+        "ukphone": "[kənˈfɜːm]"
+    },
+    {
+        "name": "pleasure",
+        "trans": [
+            "n. 快乐；希望；娱乐；令人高兴的事"
+        ],
+        "usphone": "[ˈpleʒər]",
+        "ukphone": "[ˈpleʒə(r)]"
+    },
+    {
+        "name": "obvious",
+        "trans": [
+            "adj. 明显的；显著的；平淡无奇的"
+        ],
+        "usphone": "[ˈɑːbviəs]",
+        "ukphone": "[ˈɒbviəs]"
+    },
+    {
+        "name": "hurricane",
+        "trans": [
+            "n. 飓风，暴风"
+        ],
+        "usphone": "[ˈhɜːrəkeɪn]",
+        "ukphone": "[ˈhʌrɪkən]"
+    },
+    {
+        "name": "persuade",
+        "trans": [
+            "vt. 说服，劝说；使某人相信；劝某人做（不做）某事"
+        ],
+        "usphone": "[pərˈsweɪd]",
+        "ukphone": "[pəˈsweɪd]"
+    },
+    {
+        "name": "act",
+        "trans": [
+            "n. 行为，行动；法令，法案；（戏剧，歌剧的）一幕，段；装腔作势"
+        ],
+        "usphone": "[ækt]",
+        "ukphone": "[ækt]"
+    },
+    {
+        "name": "northern",
+        "trans": [
+            "adj. 北部的；北方的"
+        ],
+        "usphone": "[ˈnɔːrðərn]",
+        "ukphone": "[ˈnɔːðən]"
+    },
+    {
+        "name": "cut",
+        "trans": [
+            "n. 伤口；切口；削减；（服装等的）式样；削球；切入"
+        ],
+        "usphone": "[kʌt]",
+        "ukphone": "[kʌt]"
+    },
+    {
+        "name": "key",
+        "trans": [
+            "n. （打字机等的）键；关键；钥匙"
+        ],
+        "usphone": "[kiː]",
+        "ukphone": "[kiː]"
+    },
+    {
+        "name": "related",
+        "trans": [
+            "v. 叙述（relate过去式）"
+        ],
+        "usphone": "[rɪˈleɪtɪd]",
+        "ukphone": "[rɪˈleɪtɪd]"
+    },
+    {
+        "name": "breathe",
+        "trans": [
+            "vi. 呼吸；低语；松口气；（风）轻拂"
+        ],
+        "usphone": "[briːð]",
+        "ukphone": "[briːð]"
+    },
+    {
+        "name": "injure",
+        "trans": [
+            "vt. 伤害，损害"
+        ],
+        "usphone": "[ˈɪndʒər]",
+        "ukphone": "[ˈɪndʒə(r)]"
+    },
+    {
+        "name": "entertain",
+        "trans": [
+            "vt. 娱乐；招待；怀抱；容纳"
+        ],
+        "usphone": "[ˌentərˈteɪn]",
+        "ukphone": "[ˌentəˈteɪn]"
+    },
+    {
+        "name": "statue",
+        "trans": [
+            "n. 雕像，塑像"
+        ],
+        "usphone": "[ˈstætʃuː]",
+        "ukphone": "[ˈstætʃuː]"
+    },
+    {
+        "name": "standard",
+        "trans": [
+            "n. 标准；水准；旗；度量衡标准"
+        ],
+        "usphone": "[ˈstændərd]",
+        "ukphone": "[ˈstændəd]"
+    },
+    {
+        "name": "brand",
+        "trans": [
+            "n. 商标，牌子；烙印"
+        ],
+        "usphone": "[brænd]",
+        "ukphone": "[brænd]"
+    },
+    {
+        "name": "board",
+        "trans": [
+            "n. 董事会；木板；甲板；膳食"
+        ],
+        "usphone": "[bɔːrd]",
+        "ukphone": "[bɔːd]"
+    },
+    {
+        "name": "bury",
+        "trans": [
+            "vt. 埋葬；隐藏"
+        ],
+        "usphone": "[ˈberi]",
+        "ukphone": "[ˈberi]"
+    },
+    {
+        "name": "fasten",
+        "trans": [
+            "vt. 使固定；集中于；扎牢；强加于"
+        ],
+        "usphone": "[ˈfæsn]",
+        "ukphone": "[ˈfɑːs(ə)n]"
+    },
+    {
+        "name": "rent",
+        "trans": [
+            "n. 租金"
+        ],
+        "usphone": "[rent]",
+        "ukphone": "[rent]"
+    },
+    {
+        "name": "arrival",
+        "trans": [
+            "n. 到来；到达；到达者"
+        ],
+        "usphone": "[əˈraɪvl]",
+        "ukphone": "[əˈraɪvl]"
+    },
+    {
+        "name": "commit",
+        "trans": [
+            "vt. 犯罪，做错事；把...交托给；指派…作战；使…承担义务"
+        ],
+        "usphone": "[kəˈmɪt]",
+        "ukphone": "[kəˈmɪt]"
+    },
+    {
+        "name": "qualify",
+        "trans": [
+            "vi. 取得资格，有资格"
+        ],
+        "usphone": "[ˈkwɑːlɪfaɪ]",
+        "ukphone": "[ˈkwɒlɪfaɪ]"
+    },
+    {
+        "name": "bubble",
+        "trans": [
+            "n. 气泡，泡沫，泡状物；透明圆形罩，圆形顶"
+        ],
+        "usphone": "[ˈbʌb(ə)l]",
+        "ukphone": "[ˈbʌb(ə)l]"
+    },
+    {
+        "name": "explode",
+        "trans": [
+            "vi. 爆炸，爆发；激增"
+        ],
+        "usphone": "[ɪkˈsploʊd]",
+        "ukphone": "[ɪkˈspləʊd]"
+    },
+    {
+        "name": "strength",
+        "trans": [
+            "n. 力量；力气；兵力；长处"
+        ],
+        "usphone": "[streŋθ]",
+        "ukphone": "[streŋθ]"
+    },
+    {
+        "name": "pretend",
+        "trans": [
+            "vt. 假装，伪装，模拟"
+        ],
+        "usphone": "[prɪˈtend]",
+        "ukphone": "[prɪˈtend]"
+    },
+    {
+        "name": "marketing",
+        "trans": [
+            "n. 行销，销售"
+        ],
+        "usphone": "[ˈmɑːrkɪtɪŋ]",
+        "ukphone": "[ˈmɑːkɪtɪŋ]"
+    },
+    {
+        "name": "separate",
+        "trans": [
+            "n. .分开；抽印本"
+        ],
+        "usphone": "[ˈseprət]",
+        "ukphone": "[ˈseprət]"
+    },
+    {
+        "name": "documentary",
+        "trans": [
+            "n. 纪录片"
+        ],
+        "usphone": "[ˌdɑːkjuˈmentri]",
+        "ukphone": "[ˌdɒkjuˈment(ə)ri]"
+    },
+    {
+        "name": "spread",
+        "trans": [
+            "n. 传播；伸展"
+        ],
+        "usphone": "[spred]",
+        "ukphone": "[spred]"
+    },
+    {
+        "name": "candidate",
+        "trans": [
+            "n. 候选人，候补者；应试者"
+        ],
+        "usphone": "[ˈkændɪdət; ˈkændɪdeɪt]",
+        "ukphone": "[ˈkændɪdət]"
+    },
+    {
+        "name": "pot",
+        "trans": [
+            "n. 壶；盆；罐"
+        ],
+        "usphone": "[pɑːt]",
+        "ukphone": "[pɒt]"
+    },
+    {
+        "name": "soil",
+        "trans": [
+            "n. 土地；土壤；国家；粪便；务农；温床"
+        ],
+        "usphone": "[sɔɪl]",
+        "ukphone": "[sɔɪl]"
+    },
+    {
+        "name": "loss",
+        "trans": [
+            "n. 减少；亏损；失败；遗失"
+        ],
+        "usphone": "[lɔːs]",
+        "ukphone": "[lɒs]"
+    },
+    {
+        "name": "remain",
+        "trans": [
+            "n. 遗迹；剩余物，残骸"
+        ],
+        "usphone": "[rɪˈmeɪn]",
+        "ukphone": "[rɪˈmeɪn]"
+    },
+    {
+        "name": "attraction",
+        "trans": [
+            "n. 吸引，吸引力；引力；吸引人的事物"
+        ],
+        "usphone": "[əˈtrækʃn]",
+        "ukphone": "[əˈtrækʃ(ə)n]"
+    },
+    {
+        "name": "quotation",
+        "trans": [
+            "n. [贸易] 报价单；引用语；引证"
+        ],
+        "usphone": "[kwoʊˈteɪʃn]",
+        "ukphone": "[kwəʊˈteɪʃn]"
+    },
+    {
+        "name": "trend",
+        "trans": [
+            "n. 趋势，倾向；走向"
+        ],
+        "usphone": "[trend]",
+        "ukphone": "[trend]"
+    },
+    {
+        "name": "damage",
+        "trans": [
+            "vi. 损害；损毁"
+        ],
+        "usphone": "[ˈdæmɪdʒ]",
+        "ukphone": "[ˈdæmɪdʒ]"
+    },
+    {
         "name": "wave",
         "trans": [
             "n. 波动；波浪；高潮；挥手示意；卷曲"
@@ -6216,116 +4008,52 @@
         "ukphone": "[weɪv]"
     },
     {
-        "name": "weapon",
+        "name": "impression",
         "trans": [
-            "n. 武器，兵器"
+            "n. 印象；效果，影响；压痕，印记；感想；曝光（衡量广告被显示的次数。打开一个带有该广告的网页，则该广告的impression 次数增加一次）"
         ],
-        "usphone": "[ˈwepən]",
-        "ukphone": "[ˈwepən]"
+        "usphone": "[ɪmˈpreʃn]",
+        "ukphone": "[ɪmˈpreʃ(ə)n]"
     },
     {
-        "name": "weigh",
+        "name": "scientific",
         "trans": [
-            "n. 权衡；称重量"
+            "adj. 科学的，系统的"
         ],
-        "usphone": "[weɪ]",
-        "ukphone": "[weɪ]"
+        "usphone": "[ˌsaɪənˈtɪfɪk]",
+        "ukphone": "[ˌsaɪənˈtɪfɪk]"
     },
     {
-        "name": "western",
+        "name": "happiness",
         "trans": [
-            "n. 西方人；西部片，西部小说"
+            "n. 幸福"
         ],
-        "usphone": "[ˈwestərn]",
-        "ukphone": "[ˈwestən]"
+        "usphone": "[ˈhæpinəs]",
+        "ukphone": "[ˈhæpinəs]"
     },
     {
-        "name": "whatever",
+        "name": "breath",
         "trans": [
-            "conj. 无论什么"
+            "n. 呼吸，气息；一口气，（呼吸的）一次；瞬间，瞬息；微风；迹象；无声音，气音"
         ],
-        "usphone": "[wətˈevər]",
-        "ukphone": "[wɒtˈevə(r)]"
+        "usphone": "[breθ]",
+        "ukphone": "[breθ]"
     },
     {
-        "name": "whenever",
+        "name": "mention",
         "trans": [
-            "conj. 每当；无论何时"
+            "vt. 提到，谈到；提及，论及；说起"
         ],
-        "usphone": "[wenˈevər]",
-        "ukphone": "[wenˈevə(r)]"
+        "usphone": "[ˈmenʃn]",
+        "ukphone": "[ˈmenʃn]"
     },
     {
-        "name": "whether",
+        "name": "client",
         "trans": [
-            "conj. 是否；不论"
+            "n. [经] 客户；顾客；委托人"
         ],
-        "usphone": "[ˈweðər]",
-        "ukphone": "[ˈweðə(r)]"
-    },
-    {
-        "name": "while",
-        "trans": [
-            "conj. 虽然；然而；当……的时候"
-        ],
-        "usphone": "[waɪl]",
-        "ukphone": "[waɪl]"
-    },
-    {
-        "name": "whole",
-        "trans": [
-            "n. 整体；全部"
-        ],
-        "usphone": "[hoʊl]",
-        "ukphone": "[həʊl]"
-    },
-    {
-        "name": "will",
-        "trans": [
-            "n. 意志；决心；情感；遗嘱；意图；心愿"
-        ],
-        "usphone": "[wɪl]",
-        "ukphone": "[wɪl]"
-    },
-    {
-        "name": "win",
-        "trans": [
-            "n. 赢；胜利"
-        ],
-        "usphone": "[wɪn]",
-        "ukphone": "[wɪn]"
-    },
-    {
-        "name": "wing",
-        "trans": [
-            "n. 翼；翅膀；飞翔；派别；侧厅，耳房，厢房"
-        ],
-        "usphone": "[wɪŋ]",
-        "ukphone": "[wɪŋ]"
-    },
-    {
-        "name": "within",
-        "trans": [
-            "prep. 在…之内"
-        ],
-        "usphone": "[wɪˈðɪn]",
-        "ukphone": "[wɪˈðɪn]"
-    },
-    {
-        "name": "wonder",
-        "trans": [
-            "n. 惊奇；奇迹；惊愕"
-        ],
-        "usphone": "[ˈwʌndər]",
-        "ukphone": "[ˈwʌndə(r)]"
-    },
-    {
-        "name": "wool",
-        "trans": [
-            "n. 羊毛；毛线；绒线；毛织品；毛料衣物"
-        ],
-        "usphone": "[wʊl]",
-        "ukphone": "[wʊl]"
+        "usphone": "[ˈklaɪənt]",
+        "ukphone": "[ˈklaɪənt]"
     },
     {
         "name": "worldwide",
@@ -6336,44 +4064,1220 @@
         "ukphone": "[ˌwɜːldˈwaɪd]"
     },
     {
-        "name": "worry",
+        "name": "sensible",
         "trans": [
-            "n. 担心；烦恼；撕咬"
+            "n. 可感觉到的东西; 敏感的人;"
         ],
-        "usphone": "[ˈwɜːri]",
-        "ukphone": "[ˈwʌri]"
+        "usphone": "[ˈsensəb(ə)l]",
+        "ukphone": "[ˈsensəb(ə)l]"
     },
     {
-        "name": "worse",
+        "name": "fur",
         "trans": [
-            "n. 更坏的事；更恶劣的事"
+            "n. 皮，皮子；毛皮；软毛"
         ],
-        "usphone": "[wɜːrs]",
-        "ukphone": "[wɜːs]"
+        "usphone": "[fɜːr]",
+        "ukphone": "[fɜː(r)]"
     },
     {
-        "name": "worst",
+        "name": "plot",
         "trans": [
-            "n. 最坏；最坏的时候"
+            "n. 情节；图；阴谋"
         ],
-        "usphone": "[wɜːrst]",
-        "ukphone": "[wɜːst]"
+        "usphone": "[plɑːt]",
+        "ukphone": "[plɒt]"
     },
     {
-        "name": "worth",
+        "name": "violent",
         "trans": [
-            "n. 价值；财产"
+            "adj. 暴力的；猛烈的"
         ],
-        "usphone": "[wɜːrθ]",
-        "ukphone": "[wɜːθ]"
+        "usphone": "[ˈvaɪələnt]",
+        "ukphone": "[ˈvaɪələnt]"
     },
     {
-        "name": "written",
+        "name": "mud",
         "trans": [
-            "adj. 书面的，成文的；文字的"
+            "vt. 弄脏；用泥涂"
         ],
-        "usphone": "[ˈrɪtn]",
-        "ukphone": "[ˈrɪt(ə)n]"
+        "usphone": "[mʌd]",
+        "ukphone": "[mʌd]"
+    },
+    {
+        "name": "announce",
+        "trans": [
+            "vt. 宣布；述说；预示；播报"
+        ],
+        "usphone": "[əˈnaʊns]",
+        "ukphone": "[əˈnaʊns]"
+    },
+    {
+        "name": "local",
+        "trans": [
+            "n. [计] 局部；当地居民；本地新闻"
+        ],
+        "usphone": "[ˈloʊkl]",
+        "ukphone": "[ˈləʊk(ə)l]"
+    },
+    {
+        "name": "roll",
+        "trans": [
+            "n. 卷，卷形物；名单；摇晃"
+        ],
+        "usphone": "[roʊl]",
+        "ukphone": "[rəʊl]"
+    },
+    {
+        "name": "ought",
+        "trans": [
+            "aux. 应该，应当；大概"
+        ],
+        "usphone": "[ɔːt]",
+        "ukphone": "[ɔːt]"
+    },
+    {
+        "name": "backwards",
+        "trans": [
+            "adv. 倒；向后；逆"
+        ],
+        "usphone": "[ˈbækwərdz]",
+        "ukphone": "[ˈbækwədz]"
+    },
+    {
+        "name": "unlike",
+        "trans": [
+            "prep. 和…不同，不像"
+        ],
+        "usphone": "[ˌʌnˈlaɪk]",
+        "ukphone": "[ˌʌnˈlaɪk]"
+    },
+    {
+        "name": "horror",
+        "trans": [
+            "n. 惊骇；惨状；极端厌恶；令人恐怖的事物"
+        ],
+        "usphone": "[ˈhɔːrər]",
+        "ukphone": "[ˈhɒrə(r)]"
+    },
+    {
+        "name": "survive",
+        "trans": [
+            "vi. 幸存；活下来"
+        ],
+        "usphone": "[sərˈvaɪv]",
+        "ukphone": "[səˈvaɪv]"
+    },
+    {
+        "name": "coin",
+        "trans": [
+            "n. 硬币，钱币"
+        ],
+        "usphone": "[kɔɪn]",
+        "ukphone": "[kɔɪn]"
+    },
+    {
+        "name": "pull",
+        "trans": [
+            "n. 拉，拉绳；拉力，牵引力；拖"
+        ],
+        "usphone": "[pʊl]",
+        "ukphone": "[pʊl]"
+    },
+    {
+        "name": "southern",
+        "trans": [
+            "n. 南方人"
+        ],
+        "usphone": "[ˈsʌðərn]",
+        "ukphone": "[ˈsʌðən]"
+    },
+    {
+        "name": "solid",
+        "trans": [
+            "n. 固体；立方体"
+        ],
+        "usphone": "[ˈsɑːlɪd]",
+        "ukphone": "[ˈsɒlɪd]"
+    },
+    {
+        "name": "pray",
+        "trans": [
+            "vi. 祈祷；请；恳求"
+        ],
+        "usphone": "[preɪ]",
+        "ukphone": "[preɪ]"
+    },
+    {
+        "name": "tyre",
+        "trans": [
+            "n. [橡胶] 轮胎；轮箍"
+        ],
+        "usphone": "[ˈtaɪər]",
+        "ukphone": "[ˈtaɪə(r)]"
+    },
+    {
+        "name": "ad",
+        "trans": [
+            "n. 公元；广告（ad）"
+        ],
+        "usphone": "[æd]",
+        "ukphone": "[æd]"
+    },
+    {
+        "name": "intend",
+        "trans": [
+            "vi. 有打算"
+        ],
+        "usphone": "[ɪnˈtend]",
+        "ukphone": "[ɪnˈtend]"
+    },
+    {
+        "name": "tin",
+        "trans": [
+            "n. 锡；罐头，罐；马口铁"
+        ],
+        "usphone": "[tɪn]",
+        "ukphone": "[tɪn]"
+    },
+    {
+        "name": "alarm",
+        "trans": [
+            "n. 闹钟；警报，警告器；惊慌"
+        ],
+        "usphone": "[əˈlɑːrm]",
+        "ukphone": "[əˈlɑːm]"
+    },
+    {
+        "name": "contrast",
+        "trans": [
+            "n. 对比；差别；对照物"
+        ],
+        "usphone": "[ˈkɑːntræst]",
+        "ukphone": "[ˈkɒntrɑːst]"
+    },
+    {
+        "name": "shelf",
+        "trans": [
+            "n. 架子；搁板；搁板状物；暗礁"
+        ],
+        "usphone": "[ʃelf]",
+        "ukphone": "[ʃelf]"
+    },
+    {
+        "name": "coach",
+        "trans": [
+            "n. 教练；旅客车厢；长途公车；四轮大马车"
+        ],
+        "usphone": "[koʊtʃ]",
+        "ukphone": "[kəʊtʃ]"
+    },
+    {
+        "name": "fashionable",
+        "trans": [
+            "adj. 流行的；时髦的；上流社会的"
+        ],
+        "usphone": "[ˈfæʃnəbl]",
+        "ukphone": "[ˈfæʃnəbl]"
+    },
+    {
+        "name": "type",
+        "trans": [
+            "n. 类型，品种；模范；样式"
+        ],
+        "usphone": "[taɪp]",
+        "ukphone": "[taɪp]"
+    },
+    {
+        "name": "nation",
+        "trans": [
+            "n. 国家；民族；国民"
+        ],
+        "usphone": "[ˈneɪʃn]",
+        "ukphone": "[ˈneɪʃ(ə)n]"
+    },
+    {
+        "name": "costume",
+        "trans": [
+            "n. 服装，装束；戏装，剧装"
+        ],
+        "usphone": "[ˈkɑːstuːm]",
+        "ukphone": "[ˈkɒstjuːm]"
+    },
+    {
+        "name": "version",
+        "trans": [
+            "n. 版本；译文；倒转术"
+        ],
+        "usphone": "[ˈvɜːrʒn]",
+        "ukphone": "[ˈvɜːʃ(ə)n]"
+    },
+    {
+        "name": "intention",
+        "trans": [
+            "n. 意图；目的；意向；愈合"
+        ],
+        "usphone": "[ɪnˈtenʃn]",
+        "ukphone": "[ɪnˈtenʃ(ə)n]"
+    },
+    {
+        "name": "reference",
+        "trans": [
+            "n. 参考，参照；涉及，提及；参考书目；介绍信；证明书"
+        ],
+        "usphone": "[ˈrefrəns]",
+        "ukphone": "[ˈrefrəns]"
+    },
+    {
+        "name": "go",
+        "trans": [
+            "n. 去；进行；尝试"
+        ],
+        "usphone": "[ɡoʊ]",
+        "ukphone": "[ɡəʊ]"
+    },
+    {
+        "name": "pour",
+        "trans": [
+            "n. 倾泻；流出；骤雨"
+        ],
+        "usphone": "[pɔːr]",
+        "ukphone": "[pɔː(r)]"
+    },
+    {
+        "name": "identity",
+        "trans": [
+            "n. 身份；同一性，一致；特性；恒等式"
+        ],
+        "usphone": "[aɪˈdentəti]",
+        "ukphone": "[aɪˈdentəti]"
+    },
+    {
+        "name": "ambitious",
+        "trans": [
+            "adj. 野心勃勃的；有雄心的；热望的；炫耀的"
+        ],
+        "usphone": "[æmˈbɪʃəs]",
+        "ukphone": "[æmˈbɪʃəs]"
+    },
+    {
+        "name": "while",
+        "trans": [
+            "conj. 虽然；然而；当……的时候"
+        ],
+        "usphone": "[waɪl]",
+        "ukphone": "[waɪl]"
+    },
+    {
+        "name": "reject",
+        "trans": [
+            "n. 被弃之物或人；次品"
+        ],
+        "usphone": "[rɪˈdʒekt]",
+        "ukphone": "[rɪˈdʒekt]"
+    },
+    {
+        "name": "agreement",
+        "trans": [
+            "n. 协议；同意，一致"
+        ],
+        "usphone": "[əˈɡriːmənt]",
+        "ukphone": "[əˈɡriːmənt]"
+    },
+    {
+        "name": "mine",
+        "trans": [
+            "n. 矿，矿藏；矿山，矿井；地雷，水雷"
+        ],
+        "usphone": "[maɪn]",
+        "ukphone": "[maɪn]"
+    },
+    {
+        "name": "performance",
+        "trans": [
+            "n. 性能；绩效；表演；执行；表现"
+        ],
+        "usphone": "[pərˈfɔːrməns]",
+        "ukphone": "[pəˈfɔːməns]"
+    },
+    {
+        "name": "laboratory",
+        "trans": [
+            "n. 实验室，研究室"
+        ],
+        "usphone": "[ˈlæbrətɔːri]",
+        "ukphone": "[ləˈbɒrətri]"
+    },
+    {
+        "name": "pack",
+        "trans": [
+            "n. 包装；一群；背包；包裹；一副"
+        ],
+        "usphone": "[pæk]",
+        "ukphone": "[pæk]"
+    },
+    {
+        "name": "incredibly",
+        "trans": [
+            "adv. 难以置信地；非常地"
+        ],
+        "usphone": "[ɪnˈkredəbli]",
+        "ukphone": "[ɪnˈkredəbli]"
+    },
+    {
+        "name": "photographer",
+        "trans": [
+            "n. 摄影师；照相师"
+        ],
+        "usphone": "[fəˈtɑːɡrəfər]",
+        "ukphone": "[fəˈtɒɡrəfə(r)]"
+    },
+    {
+        "name": "warm",
+        "trans": [
+            "n. 取暖；加热"
+        ],
+        "usphone": "[wɔːrm]",
+        "ukphone": "[wɔːm]"
+    },
+    {
+        "name": "cruel",
+        "trans": [
+            "adj. 残酷的，残忍的；使人痛苦的，让人受难的；无情的，严酷的"
+        ],
+        "usphone": "[ˈkruːəl]",
+        "ukphone": "[ˈkruːəl]"
+    },
+    {
+        "name": "fold",
+        "trans": [
+            "n. 折痕；信徒；羊栏"
+        ],
+        "usphone": "[foʊld]",
+        "ukphone": "[fəʊld]"
+    },
+    {
+        "name": "upset",
+        "trans": [
+            "n. 混乱；翻倒；颠覆"
+        ],
+        "usphone": "[ˌʌpˈset]",
+        "ukphone": "[ˌʌpˈset]"
+    },
+    {
+        "name": "unlikely",
+        "trans": [
+            "adj. 不太可能的；没希望的"
+        ],
+        "usphone": "[ʌnˈlaɪkli]",
+        "ukphone": "[ʌnˈlaɪkli]"
+    },
+    {
+        "name": "influence",
+        "trans": [
+            "n. 影响；势力；感化；有影响的人或事"
+        ],
+        "usphone": "[ˈɪnfluəns]",
+        "ukphone": "[ˈɪnfluəns]"
+    },
+    {
+        "name": "fighting",
+        "trans": [
+            "n. 战斗，搏斗"
+        ],
+        "usphone": "[ˈfaɪtɪŋ]",
+        "ukphone": "[ˈfaɪtɪŋ]"
+    },
+    {
+        "name": "balance",
+        "trans": [
+            "n. 平衡；余额；匀称"
+        ],
+        "usphone": "[ˈbæləns]",
+        "ukphone": "[ˈbæləns]"
+    },
+    {
+        "name": "remote",
+        "trans": [
+            "n. 远程"
+        ],
+        "usphone": "[rɪˈmoʊt]",
+        "ukphone": "[rɪˈməʊt]"
+    },
+    {
+        "name": "assignment",
+        "trans": [
+            "n. 分配；任务；作业；功课"
+        ],
+        "usphone": "[əˈsaɪnmənt]",
+        "ukphone": "[əˈsaɪnmənt]"
+    },
+    {
+        "name": "keen",
+        "trans": [
+            "adj. 敏锐的，敏捷的；渴望的；强烈的；热心的；锐利的"
+        ],
+        "usphone": "[kiːn]",
+        "ukphone": "[kiːn]"
+    },
+    {
+        "name": "hang",
+        "trans": [
+            "n. 悬挂；暂停，中止"
+        ],
+        "usphone": "[hæŋ]",
+        "ukphone": "[hæŋ]"
+    },
+    {
+        "name": "chest",
+        "trans": [
+            "n. 胸，胸部；衣柜；箱子；金库"
+        ],
+        "usphone": "[tʃest]",
+        "ukphone": "[tʃest]"
+    },
+    {
+        "name": "theirs",
+        "trans": [
+            "pron. 他们的；她们的；它们的"
+        ],
+        "usphone": "[ðerz]",
+        "ukphone": "[ðeəz]"
+    },
+    {
+        "name": "seriously",
+        "trans": [
+            "adv. 认真地；严重地，严肃地"
+        ],
+        "usphone": "[ˈsɪriəsli]",
+        "ukphone": "[ˈsɪəriəsli]"
+    },
+    {
+        "name": "sharp",
+        "trans": [
+            "n. 尖头；骗子；内行"
+        ],
+        "usphone": "[ʃɑːrp]",
+        "ukphone": "[ʃɑːp]"
+    },
+    {
+        "name": "donate",
+        "trans": [
+            "n. 捐赠；捐献"
+        ],
+        "usphone": "[ˈdoʊneɪt]",
+        "ukphone": "[dəʊˈneɪt]"
+    },
+    {
+        "name": "truth",
+        "trans": [
+            "n. 真理；事实；诚实；实质"
+        ],
+        "usphone": "[truːθ]",
+        "ukphone": "[truːθ]"
+    },
+    {
+        "name": "amazed",
+        "trans": [
+            "v. 使…吃惊；把…弄糊涂（amaze的过去分词）"
+        ],
+        "usphone": "[əˈmeɪzd]",
+        "ukphone": "[əˈmeɪzd]"
+    },
+    {
+        "name": "grade",
+        "trans": [
+            "n. 年级；等级；成绩；级别；阶段"
+        ],
+        "usphone": "[ɡreɪd]",
+        "ukphone": "[ɡreɪd]"
+    },
+    {
+        "name": "plus",
+        "trans": [
+            "prep. 加，加上"
+        ],
+        "usphone": "[plʌs]",
+        "ukphone": "[plʌs]"
+    },
+    {
+        "name": "afford",
+        "trans": [
+            "vt. 给予，提供；买得起"
+        ],
+        "usphone": "[əˈfɔːrd]",
+        "ukphone": "[əˈfɔːd]"
+    },
+    {
+        "name": "diagram",
+        "trans": [
+            "n. 图表；图解"
+        ],
+        "usphone": "[ˈdaɪəɡræm]",
+        "ukphone": "[ˈdaɪəɡræm]"
+    },
+    {
+        "name": "prince",
+        "trans": [
+            "n. 王子，国君；亲王；贵族"
+        ],
+        "usphone": "[prɪns]",
+        "ukphone": "[prɪns]"
+    },
+    {
+        "name": "tour",
+        "trans": [
+            "n. 旅游，旅行；巡回演出"
+        ],
+        "usphone": "[tʊr]",
+        "ukphone": "[tʊə(r)]"
+    },
+    {
+        "name": "necessarily",
+        "trans": [
+            "adv. 必要地；必定地，必然地"
+        ],
+        "usphone": "[ˌnesəˈserəli]",
+        "ukphone": "[ˌnesəˈserəli; ˈnesəsərəli]"
+    },
+    {
+        "name": "protest",
+        "trans": [
+            "n. 抗议"
+        ],
+        "usphone": "[ˈproʊtest; prəˈtest]",
+        "ukphone": "[ˈprəʊtest]"
+    },
+    {
+        "name": "appreciate",
+        "trans": [
+            "vi. 增值；涨价"
+        ],
+        "usphone": "[əˈpriːʃieɪt]",
+        "ukphone": "[əˈpriːʃieɪt]"
+    },
+    {
+        "name": "childhood",
+        "trans": [
+            "n. 童年时期；幼年时代"
+        ],
+        "usphone": "[ˈtʃaɪldhʊd]",
+        "ukphone": "[ˈtʃaɪldhʊd]"
+    },
+    {
+        "name": "chapter",
+        "trans": [
+            "n. 章，回；（俱乐部、协会等的）分会；人生或历史上的重要时期"
+        ],
+        "usphone": "[ˈtʃæptər]",
+        "ukphone": "[ˈtʃæptə(r)]"
+    },
+    {
+        "name": "injured",
+        "trans": [
+            "adj. 受伤的；受损害的"
+        ],
+        "usphone": "[ˈɪndʒərd]",
+        "ukphone": "[ˈɪndʒəd]"
+    },
+    {
+        "name": "resource",
+        "trans": [
+            "n. 资源，财力；办法；智谋"
+        ],
+        "usphone": "[ˈriːsɔːrs; rɪˈsɔːrs]",
+        "ukphone": "[rɪˈsɔːs]"
+    },
+    {
+        "name": "global",
+        "trans": [
+            "adj. 全球的；总体的；球形的"
+        ],
+        "usphone": "[ˈɡloʊbl]",
+        "ukphone": "[ˈɡləʊb(ə)l]"
+    },
+    {
+        "name": "analysis",
+        "trans": [
+            "n. 分析；分解；验定"
+        ],
+        "usphone": "[əˈnæləsɪs]",
+        "ukphone": "[əˈnæləsɪs]"
+    },
+    {
+        "name": "divide",
+        "trans": [
+            "n. [地理] 分水岭，分水线"
+        ],
+        "usphone": "[dɪˈvaɪd]",
+        "ukphone": "[dɪˈvaɪd]"
+    },
+    {
+        "name": "translation",
+        "trans": [
+            "n. 翻译；译文；转化；调任"
+        ],
+        "usphone": "[trænzˈleɪʃn; trænsˈleɪʃn]",
+        "ukphone": "[trænzˈleɪʃn; trænsˈleɪʃn]"
+    },
+    {
+        "name": "originally",
+        "trans": [
+            "adv. 最初，起初；本来"
+        ],
+        "usphone": "[əˈrɪdʒənəli]",
+        "ukphone": "[əˈrɪdʒənəli]"
+    },
+    {
+        "name": "dislike",
+        "trans": [
+            "n. 嫌恶，反感，不喜爱"
+        ],
+        "usphone": "[dɪsˈlaɪk]",
+        "ukphone": "[dɪsˈlaɪk]"
+    },
+    {
+        "name": "continuous",
+        "trans": [
+            "adj. 连续的，持续的；继续的；连绵不断的"
+        ],
+        "usphone": "[kənˈtɪnjuəs]",
+        "ukphone": "[kənˈtɪnjuəs]"
+    },
+    {
+        "name": "dust",
+        "trans": [
+            "n. 灰尘；尘埃；尘土"
+        ],
+        "usphone": "[dʌst]",
+        "ukphone": "[dʌst]"
+    },
+    {
+        "name": "operation",
+        "trans": [
+            "n. 操作；经营；[外科] 手术；[数][计] 运算"
+        ],
+        "usphone": "[ˌɑːpəˈreɪʃ(ə)n]",
+        "ukphone": "[ˌɒpəˈreɪʃ(ə)n]"
+    },
+    {
+        "name": "ban",
+        "trans": [
+            "n. 禁令，禁忌"
+        ],
+        "usphone": "[bæn]",
+        "ukphone": "[bæn]"
+    },
+    {
+        "name": "host",
+        "trans": [
+            "n. [计] 主机；主人；主持人；许多"
+        ],
+        "usphone": "[hoʊst]",
+        "ukphone": "[həʊst]"
+    },
+    {
+        "name": "spoken",
+        "trans": [
+            "v. 说（speak的过去分词）"
+        ],
+        "usphone": "[ˈspoʊkən]",
+        "ukphone": "[ˈspəʊkən]"
+    },
+    {
+        "name": "technical",
+        "trans": [
+            "adj. 工艺的，科技的；技术上的；专门的"
+        ],
+        "usphone": "[ˈteknɪkl]",
+        "ukphone": "[ˈteknɪk(ə)l]"
+    },
+    {
+        "name": "label",
+        "trans": [
+            "vt. 标注；贴标签于"
+        ],
+        "usphone": "[ˈleɪbl]",
+        "ukphone": "[ˈleɪb(ə)l]"
+    },
+    {
+        "name": "sink",
+        "trans": [
+            "n. 水槽；洗涤槽；污水坑"
+        ],
+        "usphone": "[sɪŋk]",
+        "ukphone": "[sɪŋk]"
+    },
+    {
+        "name": "literature",
+        "trans": [
+            "n. 文学；文献；文艺；著作"
+        ],
+        "usphone": "[ˈlɪtrətʃər; ˈlɪtrətʃʊr; ˈlɪtərətʃʊr]",
+        "ukphone": "[ˈlɪtrətʃə(r)]"
+    },
+    {
+        "name": "access",
+        "trans": [
+            "n. 进入；使用权；通路"
+        ],
+        "usphone": "[ˈækses]",
+        "ukphone": "[ˈækses]"
+    },
+    {
+        "name": "located",
+        "trans": [
+            "adj. 处于，位于；坐落的"
+        ],
+        "usphone": "[ˈloʊkeɪtɪd]",
+        "ukphone": "[ləʊˈkeɪtɪd]"
+    },
+    {
+        "name": "except",
+        "trans": [
+            "conj. 除了；要不是"
+        ],
+        "usphone": "[ɪkˈsept]",
+        "ukphone": "[ɪkˈsept]"
+    },
+    {
+        "name": "leisure",
+        "trans": [
+            "n. 闲暇；空闲；安逸"
+        ],
+        "usphone": "[ˈliːʒər]",
+        "ukphone": "[ˈleʒə(r)]"
+    },
+    {
+        "name": "centre",
+        "trans": [
+            "n. 中心"
+        ],
+        "usphone": "[ˈsentər]",
+        "ukphone": "[ˈsentə(r)]"
+    },
+    {
+        "name": "reality",
+        "trans": [
+            "n. 现实；实际；真实"
+        ],
+        "usphone": "[riˈæləti]",
+        "ukphone": "[riˈæləti]"
+    },
+    {
+        "name": "bee",
+        "trans": [
+            "n. 蜜蜂，蜂；勤劳的人"
+        ],
+        "usphone": "[biː]",
+        "ukphone": "[biː]"
+    },
+    {
+        "name": "participate",
+        "trans": [
+            "vi. 参与，参加；分享"
+        ],
+        "usphone": "[pɑːrˈtɪsɪpeɪt]",
+        "ukphone": "[pɑːˈtɪsɪpeɪt]"
+    },
+    {
+        "name": "element",
+        "trans": [
+            "n. 元素；要素；原理；成分；自然环境"
+        ],
+        "usphone": "[ˈelɪmənt]",
+        "ukphone": "[ˈelɪmənt]"
+    },
+    {
+        "name": "arrest",
+        "trans": [
+            "n. 逮捕；监禁"
+        ],
+        "usphone": "[əˈrest]",
+        "ukphone": "[əˈrest]"
+    },
+    {
+        "name": "victim",
+        "trans": [
+            "n. 受害人；牺牲品；牺牲者"
+        ],
+        "usphone": "[ˈvɪktɪm]",
+        "ukphone": "[ˈvɪktɪm]"
+    },
+    {
+        "name": "reaction",
+        "trans": [
+            "n. 反应，感应；反动，复古；反作用"
+        ],
+        "usphone": "[riˈækʃn]",
+        "ukphone": "[riˈækʃn]"
+    },
+    {
+        "name": "chain",
+        "trans": [
+            "n. 链；束缚；枷锁"
+        ],
+        "usphone": "[tʃeɪn]",
+        "ukphone": "[tʃeɪn]"
+    },
+    {
+        "name": "due",
+        "trans": [
+            "n. 应付款；应得之物"
+        ],
+        "usphone": "[duː]",
+        "ukphone": "[djuː]"
+    },
+    {
+        "name": "previously",
+        "trans": [
+            "adv. 以前；预先；仓促地"
+        ],
+        "usphone": "[ˈpriːviəsli]",
+        "ukphone": "[ˈpriːviəsli]"
+    },
+    {
+        "name": "layer",
+        "trans": [
+            "n. 层，层次；膜；[植]压条；放置者，计划者"
+        ],
+        "usphone": "[ˈleɪər]",
+        "ukphone": "[ˈleɪə(r)]"
+    },
+    {
+        "name": "accommodation",
+        "trans": [
+            "n. 住处，膳宿；调节；和解；预订铺位"
+        ],
+        "usphone": "[əˌkɑːməˈdeɪʃn]",
+        "ukphone": "[əˌkɒməˈdeɪʃ(ə)n]"
+    },
+    {
+        "name": "guard",
+        "trans": [
+            "n. 守卫；警戒；护卫队；防护装置"
+        ],
+        "usphone": "[ɡɑːrd]",
+        "ukphone": "[ɡɑːd]"
+    },
+    {
+        "name": "clue",
+        "trans": [
+            "n. 线索；（故事等的）情节"
+        ],
+        "usphone": "[kluː]",
+        "ukphone": "[kluː]"
+    },
+    {
+        "name": "announcement",
+        "trans": [
+            "n. 公告；宣告；发表；通告"
+        ],
+        "usphone": "[əˈnaʊnsmənt]",
+        "ukphone": "[əˈnaʊnsmənt]"
+    },
+    {
+        "name": "disappointed",
+        "trans": [
+            "adj. 失望的，沮丧的；受挫折的"
+        ],
+        "usphone": "[ˌdɪsəˈpɔɪntɪd]",
+        "ukphone": "[ˌdɪsəˈpɔɪntɪd]"
+    },
+    {
+        "name": "pleasant",
+        "trans": [
+            "adj. 令人愉快的，舒适的；讨人喜欢的，和蔼可亲的"
+        ],
+        "usphone": "[ˈpleznt]",
+        "ukphone": "[ˈplez(ə)nt]"
+    },
+    {
+        "name": "admit",
+        "trans": [
+            "vi. 承认；容许"
+        ],
+        "usphone": "[ədˈmɪt]",
+        "ukphone": "[ədˈmɪt]"
+    },
+    {
+        "name": "painful",
+        "trans": [
+            "adj. 痛苦的；疼痛的；令人不快的"
+        ],
+        "usphone": "[ˈpeɪnfl]",
+        "ukphone": "[ˈpeɪnf(ə)l]"
+    },
+    {
+        "name": "chemical",
+        "trans": [
+            "n. 化学制品，化学药品"
+        ],
+        "usphone": "[ˈkemɪkl]",
+        "ukphone": "[ˈkemɪkl]"
+    },
+    {
+        "name": "rarely",
+        "trans": [
+            "adv. 很少地；难得；罕有地"
+        ],
+        "usphone": "[ˈrerli]",
+        "ukphone": "[ˈreəli]"
+    },
+    {
+        "name": "reservation",
+        "trans": [
+            "n. 预约，预订；保留"
+        ],
+        "usphone": "[ˌrezərˈveɪʃn]",
+        "ukphone": "[ˌrezəˈveɪʃn]"
+    },
+    {
+        "name": "like",
+        "trans": [
+            "vt. 喜欢；想；愿意"
+        ],
+        "usphone": "[laɪk]",
+        "ukphone": "[laɪk]"
+    },
+    {
+        "name": "cottage",
+        "trans": [
+            "n. 小屋；村舍；（农舍式的）小别墅"
+        ],
+        "usphone": "[ˈkɑːtɪdʒ]",
+        "ukphone": "[ˈkɒtɪdʒ]"
+    },
+    {
+        "name": "exhibition",
+        "trans": [
+            "n. 展览，显示；展览会；展览品"
+        ],
+        "usphone": "[ˌeksɪˈbɪʃn]",
+        "ukphone": "[ˌeksɪˈbɪʃ(ə)n]"
+    },
+    {
+        "name": "package",
+        "trans": [
+            "n. 包，包裹；套装软件，[计] 程序包"
+        ],
+        "usphone": "[ˈpækɪdʒ]",
+        "ukphone": "[ˈpækɪdʒ]"
+    },
+    {
+        "name": "spirit",
+        "trans": [
+            "n. 精神；心灵；情绪；志气；烈酒"
+        ],
+        "usphone": "[ˈspɪrɪt]",
+        "ukphone": "[ˈspɪrɪt]"
+    },
+    {
+        "name": "political",
+        "trans": [
+            "adj. 政治的；党派的"
+        ],
+        "usphone": "[pəˈlɪtɪkl]",
+        "ukphone": "[pəˈlɪtɪk(ə)l]"
+    },
+    {
+        "name": "uncomfortable",
+        "trans": [
+            "adj. 不舒服的；不安的"
+        ],
+        "usphone": "[ʌnˈkʌmftəbl; ʌnˈkʌmfərtəbl]",
+        "ukphone": "[ʌnˈkʌmftəb(ə)l]"
+    },
+    {
+        "name": "benefit",
+        "trans": [
+            "n. 利益，好处；救济金"
+        ],
+        "usphone": "[ˈbenɪfɪt]",
+        "ukphone": "[ˈbenɪfɪt]"
+    },
+    {
+        "name": "cotton",
+        "trans": [
+            "n. 棉花；棉布；棉线"
+        ],
+        "usphone": "[ˈkɑːtn]",
+        "ukphone": "[ˈkɒtn]"
+    },
+    {
+        "name": "politician",
+        "trans": [
+            "n. 政治家，政客"
+        ],
+        "usphone": "[ˌpɑːləˈtɪʃn]",
+        "ukphone": "[ˌpɒləˈtɪʃn]"
+    },
+    {
+        "name": "fairly",
+        "trans": [
+            "adv. 相当地；公平地；简直"
+        ],
+        "usphone": "[ˈferli]",
+        "ukphone": "[ˈfeəli]"
+    },
+    {
+        "name": "prove",
+        "trans": [
+            "vi. 证明是"
+        ],
+        "usphone": "[pruːv]",
+        "ukphone": "[pruːv]"
+    },
+    {
+        "name": "equal",
+        "trans": [
+            "n. 对手；匹敌；同辈；相等的事物"
+        ],
+        "usphone": "[ˈiːkwəl]",
+        "ukphone": "[ˈiːkwəl]"
+    },
+    {
+        "name": "prepared",
+        "trans": [
+            "v. 准备（prepare的过去分词）"
+        ],
+        "usphone": "[prɪˈperd]",
+        "ukphone": "[prɪˈpeəd]"
+    },
+    {
+        "name": "admire",
+        "trans": [
+            "vt. 钦佩；赞美"
+        ],
+        "usphone": "[ədˈmaɪər]",
+        "ukphone": "[ədˈmaɪə(r)]"
+    },
+    {
+        "name": "update",
+        "trans": [
+            "n. 更新；现代化"
+        ],
+        "usphone": "[ˌʌpˈdeɪt]",
+        "ukphone": "[ˌʌpˈdeɪt]"
+    },
+    {
+        "name": "giant",
+        "trans": [
+            "n. 巨人；伟人；[动] 巨大的动物"
+        ],
+        "usphone": "[ˈdʒaɪənt]",
+        "ukphone": "[ˈdʒaɪənt]"
+    },
+    {
+        "name": "previous",
+        "trans": [
+            "adj. 以前的；早先的；过早的"
+        ],
+        "usphone": "[ˈpriːviəs]",
+        "ukphone": "[ˈpriːviəs]"
+    },
+    {
+        "name": "tight",
+        "trans": [
+            "adj. 紧的；密封的；绷紧的；麻烦的；严厉的；没空的；吝啬的"
+        ],
+        "usphone": "[taɪt]",
+        "ukphone": "[taɪt]"
+    },
+    {
+        "name": "till",
+        "trans": [
+            "prep. 直到"
+        ],
+        "usphone": "[tɪl]",
+        "ukphone": "[tɪl]"
+    },
+    {
+        "name": "define",
+        "trans": [
+            "vt. 定义；使明确；规定"
+        ],
+        "usphone": "[dɪˈfaɪn]",
+        "ukphone": "[dɪˈfaɪn]"
+    },
+    {
+        "name": "beauty",
+        "trans": [
+            "n. 美；美丽；美人；美好的东西"
+        ],
+        "usphone": "[ˈbjuːti]",
+        "ukphone": "[ˈbjuːti]"
+    },
+    {
+        "name": "note",
+        "trans": [
+            "n. 笔记；音符；票据；注解；纸币；便笺；照会；调子"
+        ],
+        "usphone": "[noʊt]",
+        "ukphone": "[nəʊt]"
+    },
+    {
+        "name": "addition",
+        "trans": [
+            "n. 添加；[数] 加法；增加物"
+        ],
+        "usphone": "[əˈdɪʃn]",
+        "ukphone": "[əˈdɪʃn]"
+    },
+    {
+        "name": "native",
+        "trans": [
+            "adj. 本国的；土著的；天然的；与生俱来的；天赋的"
+        ],
+        "usphone": "[ˈneɪtɪv]",
+        "ukphone": "[ˈneɪtɪv]"
+    },
+    {
+        "name": "generally",
+        "trans": [
+            "adv. 通常；普遍地，一般地"
+        ],
+        "usphone": "[ˈdʒenrəli]",
+        "ukphone": "[ˈdʒenrəli]"
+    },
+    {
+        "name": "within",
+        "trans": [
+            "prep. 在…之内"
+        ],
+        "usphone": "[wɪˈðɪn]",
+        "ukphone": "[wɪˈðɪn]"
+    },
+    {
+        "name": "cloth",
+        "trans": [
+            "n. 布；织物；桌布"
+        ],
+        "usphone": "[klɔːθ]",
+        "ukphone": "[klɒθ]"
+    },
+    {
+        "name": "deep",
+        "trans": [
+            "n. 深处；深渊"
+        ],
+        "usphone": "[diːp]",
+        "ukphone": "[diːp]"
+    },
+    {
+        "name": "clear",
+        "trans": [
+            "n. 清除；空隙"
+        ],
+        "usphone": "[klɪr]",
+        "ukphone": "[klɪə(r)]"
+    },
+    {
+        "name": "head",
+        "trans": [
+            "n. 头；头痛；上端；最前的部分；理解力"
+        ],
+        "usphone": "[hed]",
+        "ukphone": "[hed]"
     },
     {
         "name": "wrong",
@@ -6384,20 +5288,524 @@
         "ukphone": "[rɒŋ]"
     },
     {
-        "name": "yard",
+        "name": "better",
         "trans": [
-            "n. 院子；码（英制中丈量长度单位，1码=3英尺）；庭院；帆桁"
+            "n. 长辈；较好者；打赌的人（等于bettor）"
         ],
-        "usphone": "[jɑːrd]",
-        "ukphone": "[jɑːd]"
+        "usphone": "[ˈbetər]",
+        "ukphone": "[ˈbetə(r)]"
     },
     {
-        "name": "young",
+        "name": "ignore",
         "trans": [
-            "n. 年轻人；（动物的）崽，仔"
+            "vt. 驳回诉讼；忽视；不理睬"
         ],
-        "usphone": "[jʌŋ]",
-        "ukphone": "[jʌŋ]"
+        "usphone": "[ɪɡˈnɔːr]",
+        "ukphone": "[ɪɡˈnɔː(r)]"
+    },
+    {
+        "name": "currently",
+        "trans": [
+            "adv. 当前；一般地"
+        ],
+        "usphone": "[ˈkɜːrəntli]",
+        "ukphone": "[ˈkʌrəntli]"
+    },
+    {
+        "name": "once",
+        "trans": [
+            "adv. 一次；曾经"
+        ],
+        "usphone": "[wʌns]",
+        "ukphone": "[wʌns]"
+    },
+    {
+        "name": "clause",
+        "trans": [
+            "n. 条款；[计] 子句"
+        ],
+        "usphone": "[klɔːz]",
+        "ukphone": "[klɔːz]"
+    },
+    {
+        "name": "organizer",
+        "trans": [
+            "n. 组织者；承办单位；[生物] 组织导体"
+        ],
+        "usphone": "[ˈɔːrɡənaɪzər]",
+        "ukphone": "[ˈɔːɡənaɪzə(r)]"
+    },
+    {
+        "name": "achievement",
+        "trans": [
+            "n. 成就；完成；达到；成绩"
+        ],
+        "usphone": "[əˈtʃiːvmənt]",
+        "ukphone": "[əˈtʃiːvmənt]"
+    },
+    {
+        "name": "dressed",
+        "trans": [
+            "v. 装饰；给…穿衣；布置（dress的过去分词）"
+        ],
+        "usphone": "[drest]",
+        "ukphone": "[drest]"
+    },
+    {
+        "name": "aged",
+        "trans": [
+            "v. 老化（age的过去式）；成熟；变老"
+        ],
+        "usphone": "[eɪdʒd; ˈeɪdʒɪd]",
+        "ukphone": "[eɪdʒd]"
+    },
+    {
+        "name": "direct",
+        "trans": [
+            "adj. 直接的；直系的；亲身的；恰好的"
+        ],
+        "usphone": "[dəˈrekt; daɪˈrekt]",
+        "ukphone": "[dəˈrekt]"
+    },
+    {
+        "name": "length",
+        "trans": [
+            "n. 长度，长；时间的长短；（语）音长"
+        ],
+        "usphone": "[leŋkθ]",
+        "ukphone": "[leŋkθ]"
+    },
+    {
+        "name": "innocent",
+        "trans": [
+            "n. 天真的人；笨蛋"
+        ],
+        "usphone": "[ˈɪnəsnt]",
+        "ukphone": "[ˈɪnəs(ə)nt]"
+    },
+    {
+        "name": "ingredient",
+        "trans": [
+            "n. 原料；要素；组成部分"
+        ],
+        "usphone": "[ɪnˈɡriːdiənt]",
+        "ukphone": "[ɪnˈɡriːdiənt]"
+    },
+    {
+        "name": "medium",
+        "trans": [
+            "adj. 中间的，中等的；半生熟的"
+        ],
+        "usphone": "[ˈmiːdiəm]",
+        "ukphone": "[ˈmiːdiəm]"
+    },
+    {
+        "name": "tiny",
+        "trans": [
+            "adj. 微小的；很少的"
+        ],
+        "usphone": "[ˈtaɪni]",
+        "ukphone": "[ˈtaɪni]"
+    },
+    {
+        "name": "lead",
+        "trans": [
+            "n. 领导；铅；导线；榜样"
+        ],
+        "usphone": "[liːd; led]",
+        "ukphone": "[liːd]"
+    },
+    {
+        "name": "definite",
+        "trans": [
+            "adj. 一定的；确切的"
+        ],
+        "usphone": "[ˈdefɪnət]",
+        "ukphone": "[ˈdefɪnət]"
+    },
+    {
+        "name": "script",
+        "trans": [
+            "n. 脚本；手迹；书写用的字母"
+        ],
+        "usphone": "[skrɪpt]",
+        "ukphone": "[skrɪpt]"
+    },
+    {
+        "name": "old-fashioned",
+        "trans": [
+            "adj. 老式的；过时的；守旧的"
+        ],
+        "usphone": "[ˌoʊld ˈfæʃnd]",
+        "ukphone": "[ˌəʊld ˈfæʃnd]"
+    },
+    {
+        "name": "challenge",
+        "trans": [
+            "n. 挑战；怀疑"
+        ],
+        "usphone": "[ˈtʃælɪndʒ]",
+        "ukphone": "[ˈtʃælɪndʒ]"
+    },
+    {
+        "name": "cheerful",
+        "trans": [
+            "adj. 快乐的；愉快的；高兴的"
+        ],
+        "usphone": "[ˈtʃɪrfl]",
+        "ukphone": "[ˈtʃɪəf(ə)l]"
+    },
+    {
+        "name": "whenever",
+        "trans": [
+            "conj. 每当；无论何时"
+        ],
+        "usphone": "[wenˈevər]",
+        "ukphone": "[wenˈevə(r)]"
+    },
+    {
+        "name": "expedition",
+        "trans": [
+            "n. 远征；探险队；迅速"
+        ],
+        "usphone": "[ˌekspəˈdɪʃn]",
+        "ukphone": "[ˌekspəˈdɪʃ(ə)n]"
+    },
+    {
+        "name": "swim",
+        "trans": [
+            "n. 游泳；漂浮；眩晕"
+        ],
+        "usphone": "[swɪm]",
+        "ukphone": "[swɪm]"
+    },
+    {
+        "name": "exchange",
+        "trans": [
+            "n. 交换；交流；交易所；兑换"
+        ],
+        "usphone": "[ɪksˈtʃeɪndʒ]",
+        "ukphone": "[ɪksˈtʃeɪndʒ]"
+    },
+    {
+        "name": "by",
+        "trans": [
+            "prep. 通过；被；依据；经由；在附近；在……之前"
+        ],
+        "usphone": "[baɪ]",
+        "ukphone": "[baɪ]"
+    },
+    {
+        "name": "obviously",
+        "trans": [
+            "adv. 明显地"
+        ],
+        "usphone": "[ˈɑːbviəsli]",
+        "ukphone": "[ˈɒbviəsli]"
+    },
+    {
+        "name": "risk",
+        "trans": [
+            "n. 风险；危险；冒险"
+        ],
+        "usphone": "[rɪsk]",
+        "ukphone": "[rɪsk]"
+    },
+    {
+        "name": "brave",
+        "trans": [
+            "n. 勇士"
+        ],
+        "usphone": "[breɪv]",
+        "ukphone": "[breɪv]"
+    },
+    {
+        "name": "talent",
+        "trans": [
+            "n. 才能；天才；天资"
+        ],
+        "usphone": "[ˈtælənt]",
+        "ukphone": "[ˈtælənt]"
+    },
+    {
+        "name": "historic",
+        "trans": [
+            "adj. 有历史意义的；历史上著名的"
+        ],
+        "usphone": "[hɪˈstɔːrɪk]",
+        "ukphone": "[hɪˈstɒrɪk]"
+    },
+    {
+        "name": "bomb",
+        "trans": [
+            "n. 炸弹"
+        ],
+        "usphone": "[bɑːm]",
+        "ukphone": "[bɒm]"
+    },
+    {
+        "name": "complaint",
+        "trans": [
+            "n. 抱怨；诉苦；疾病；委屈"
+        ],
+        "usphone": "[kəmˈpleɪnt]",
+        "ukphone": "[kəmˈpleɪnt]"
+    },
+    {
+        "name": "covered",
+        "trans": [
+            "v. 覆盖；包括；掩护（cover的过去分词）"
+        ],
+        "usphone": "[ˈkʌvərd]",
+        "ukphone": "[ˈkʌvəd]"
+    },
+    {
+        "name": "sample",
+        "trans": [
+            "n. 样品；样本；例子"
+        ],
+        "usphone": "[ˈsæmpl]",
+        "ukphone": "[ˈsɑːmp(ə)l]"
+    },
+    {
+        "name": "policy",
+        "trans": [
+            "n. 政策，方针；保险单"
+        ],
+        "usphone": "[ˈpɑːləsi]",
+        "ukphone": "[ˈpɒləsi]"
+    },
+    {
+        "name": "racing",
+        "trans": [
+            "n. 赛马；竞赛"
+        ],
+        "usphone": "[ˈreɪsɪŋ]",
+        "ukphone": "[ˈreɪsɪŋ]"
+    },
+    {
+        "name": "export",
+        "trans": [
+            "n. 输出，出口；出口商品"
+        ],
+        "usphone": "[ɪkˈspɔːrt; ˈekspɔːrt]",
+        "ukphone": "[ɪkˈspɔːt; ˈekspɔːt]"
+    },
+    {
+        "name": "sight",
+        "trans": [
+            "n. 视力；景象；眼界；见解"
+        ],
+        "usphone": "[saɪt]",
+        "ukphone": "[saɪt]"
+    },
+    {
+        "name": "whether",
+        "trans": [
+            "conj. 是否；不论"
+        ],
+        "usphone": "[ˈweðər]",
+        "ukphone": "[ˈweðə(r)]"
+    },
+    {
+        "name": "leaf",
+        "trans": [
+            "n. 叶子；（书籍等的）一张；扇页"
+        ],
+        "usphone": "[liːf]",
+        "ukphone": "[liːf]"
+    },
+    {
+        "name": "printing",
+        "trans": [
+            "n. 印刷；印刷术"
+        ],
+        "usphone": "[ˈprɪntɪŋ]",
+        "ukphone": "[ˈprɪntɪŋ]"
+    },
+    {
+        "name": "worry",
+        "trans": [
+            "n. 担心；烦恼；撕咬"
+        ],
+        "usphone": "[ˈwɜːri]",
+        "ukphone": "[ˈwʌri]"
+    },
+    {
+        "name": "poetry",
+        "trans": [
+            "n. 诗；诗意，诗情；诗歌艺术"
+        ],
+        "usphone": "[ˈpoʊətri]",
+        "ukphone": "[ˈpəʊətri]"
+    },
+    {
+        "name": "duty",
+        "trans": [
+            "n. 责任；[税收] 关税；职务"
+        ],
+        "usphone": "[ˈduːti]",
+        "ukphone": "[ˈdjuːti]"
+    },
+    {
+        "name": "basis",
+        "trans": [
+            "n. 基础；底部；主要成分；基本原则或原理"
+        ],
+        "usphone": "[ˈbeɪsɪs]",
+        "ukphone": "[ˈbeɪsɪs]"
+    },
+    {
+        "name": "unemployed",
+        "trans": [
+            "adj. 失业的；未被利用的"
+        ],
+        "usphone": "[ˌʌnɪmˈplɔɪd]",
+        "ukphone": "[ˌʌnɪmˈplɔɪd]"
+    },
+    {
+        "name": "result",
+        "trans": [
+            "n. 结果；成绩；答案；比赛结果"
+        ],
+        "usphone": "[rɪˈzʌlt]",
+        "ukphone": "[rɪˈzʌlt]"
+    },
+    {
+        "name": "responsible",
+        "trans": [
+            "adj. 负责的，可靠的；有责任的"
+        ],
+        "usphone": "[rɪˈspɑːnsəbl]",
+        "ukphone": "[rɪˈspɒnsəb(ə)l]"
+    },
+    {
+        "name": "plenty",
+        "trans": [
+            "n. 丰富，大量；充足"
+        ],
+        "usphone": "[ˈplenti]",
+        "ukphone": "[ˈplenti]"
+    },
+    {
+        "name": "now",
+        "trans": [
+            "adv. 现在；如今；立刻"
+        ],
+        "usphone": "[naʊ]",
+        "ukphone": "[naʊ]"
+    },
+    {
+        "name": "coloured",
+        "trans": [
+            "n. 混血人；有色人种的人"
+        ],
+        "usphone": "[ˈkʌlərd]",
+        "ukphone": "[ˈkʌləd]"
+    },
+    {
+        "name": "atmosphere",
+        "trans": [
+            "n. 气氛；大气；空气"
+        ],
+        "usphone": "[ˈætməsfɪr]",
+        "ukphone": "[ˈætməsfɪə(r)]"
+    },
+    {
+        "name": "deliver",
+        "trans": [
+            "n. 投球"
+        ],
+        "usphone": "[dɪˈlɪvər]",
+        "ukphone": "[dɪˈlɪvə(r)]"
+    },
+    {
+        "name": "private",
+        "trans": [
+            "n. 列兵；二等兵"
+        ],
+        "usphone": "[ˈpraɪvət]",
+        "ukphone": "[ˈpraɪvət]"
+    },
+    {
+        "name": "development",
+        "trans": [
+            "n. 发展；开发；发育；住宅小区（专指由同一开发商开发的）；[摄] 显影"
+        ],
+        "usphone": "[dɪˈveləpmənt]",
+        "ukphone": "[dɪˈveləpmənt]"
+    },
+    {
+        "name": "mood",
+        "trans": [
+            "n. 情绪，语气；心境；气氛"
+        ],
+        "usphone": "[muːd]",
+        "ukphone": "[muːd]"
+    },
+    {
+        "name": "bride",
+        "trans": [
+            "n. 新娘；姑娘，女朋友"
+        ],
+        "usphone": "[braɪd]",
+        "ukphone": "[braɪd]"
+    },
+    {
+        "name": "difficulty",
+        "trans": [
+            "n. 困难，困境"
+        ],
+        "usphone": "[ˈdɪfɪkəlti]",
+        "ukphone": "[ˈdɪfɪkəlti]"
+    },
+    {
+        "name": "glove",
+        "trans": [
+            "n. 手套"
+        ],
+        "usphone": "[ɡlʌv]",
+        "ukphone": "[ɡlʌv]"
+    },
+    {
+        "name": "combine",
+        "trans": [
+            "n. 联合收割机；联合企业"
+        ],
+        "usphone": "[kəmˈbaɪn]",
+        "ukphone": "[kəmˈbaɪn]"
+    },
+    {
+        "name": "equally",
+        "trans": [
+            "adv. 同样地；相等地，平等地；公平地"
+        ],
+        "usphone": "[ˈiːkwəli]",
+        "ukphone": "[ˈiːkwəli]"
+    },
+    {
+        "name": "underwear",
+        "trans": [
+            "n. 内衣物"
+        ],
+        "usphone": "[ˈʌndərwer]",
+        "ukphone": "[ˈʌndəweə(r)]"
+    },
+    {
+        "name": "touch",
+        "trans": [
+            "n. 接触；触觉；格调；少许"
+        ],
+        "usphone": "[tʌtʃ]",
+        "ukphone": "[tʌtʃ]"
+    },
+    {
+        "name": "translate",
+        "trans": [
+            "vt. 翻译；转化；解释；转变为；调动"
+        ],
+        "usphone": "[trænzˈleɪt; trænsˈleɪt]",
+        "ukphone": "[trænzˈleɪt]"
     },
     {
         "name": "youth",
@@ -6406,5 +5814,597 @@
         ],
         "usphone": "[juːθ]",
         "ukphone": "[juːθ]"
+    },
+    {
+        "name": "trade",
+        "trans": [
+            "n. 贸易，交易；行业；职业"
+        ],
+        "usphone": "[treɪd]",
+        "ukphone": "[treɪd]"
+    },
+    {
+        "name": "valuable",
+        "trans": [
+            "n. 贵重物品"
+        ],
+        "usphone": "[ˈvæljuəbl]",
+        "ukphone": "[ˈvæljuəbl]"
+    },
+    {
+        "name": "mix",
+        "trans": [
+            "vt. 配制；混淆；使混和；使结交"
+        ],
+        "usphone": "[mɪks]",
+        "ukphone": "[mɪks]"
+    },
+    {
+        "name": "battery",
+        "trans": [
+            "n. [电] 电池，蓄电池"
+        ],
+        "usphone": "[ˈbætəri]",
+        "ukphone": "[ˈbætri; ˈbætəri]"
+    },
+    {
+        "name": "hardly",
+        "trans": [
+            "adv. 几乎不，简直不；刚刚"
+        ],
+        "usphone": "[ˈhɑːrdli]",
+        "ukphone": "[ˈhɑːdli]"
+    },
+    {
+        "name": "educated",
+        "trans": [
+            "v. 训练；教导；培育（educate的过去分词形式）"
+        ],
+        "usphone": "[ˈedʒukeɪtɪd]",
+        "ukphone": "[ˈedʒukeɪtɪd]"
+    },
+    {
+        "name": "treatment",
+        "trans": [
+            "n. 治疗，疗法；处理；对待"
+        ],
+        "usphone": "[ˈtriːtmənt]",
+        "ukphone": "[ˈtriːtmənt]"
+    },
+    {
+        "name": "strongly",
+        "trans": [
+            "adv. 强有力地；坚强地；激烈地；气味浓地"
+        ],
+        "usphone": "[ˈstrɔːŋli]",
+        "ukphone": "[ˈstrɒŋli]"
+    },
+    {
+        "name": "illegal",
+        "trans": [
+            "n. 非法移民，非法劳工"
+        ],
+        "usphone": "[ɪˈliːɡl]",
+        "ukphone": "[ɪˈliːɡ(ə)l]"
+    },
+    {
+        "name": "fence",
+        "trans": [
+            "n. 栅栏；围墙；剑术"
+        ],
+        "usphone": "[fens]",
+        "ukphone": "[fens]"
+    },
+    {
+        "name": "alternative",
+        "trans": [
+            "n. 二中择一；供替代的选择"
+        ],
+        "usphone": "[ɔːlˈtɜːrnətɪv]",
+        "ukphone": "[ɔːlˈtɜːnətɪv]"
+    },
+    {
+        "name": "educate",
+        "trans": [
+            "vt. 教育；培养；训练"
+        ],
+        "usphone": "[ˈedʒukeɪt]",
+        "ukphone": "[ˈedʒukeɪt]"
+    },
+    {
+        "name": "sex",
+        "trans": [
+            "n. 性；性别；性行为；色情"
+        ],
+        "usphone": "[seks]",
+        "ukphone": "[seks]"
+    },
+    {
+        "name": "weigh",
+        "trans": [
+            "n. 权衡；称重量"
+        ],
+        "usphone": "[weɪ]",
+        "ukphone": "[weɪ]"
+    },
+    {
+        "name": "talented",
+        "trans": [
+            "adj. 有才能的；多才的"
+        ],
+        "usphone": "[ˈtæləntɪd]",
+        "ukphone": "[ˈtæləntɪd]"
+    },
+    {
+        "name": "wonder",
+        "trans": [
+            "n. 惊奇；奇迹；惊愕"
+        ],
+        "usphone": "[ˈwʌndər]",
+        "ukphone": "[ˈwʌndə(r)]"
+    },
+    {
+        "name": "calm",
+        "trans": [
+            "n. 风平浪静"
+        ],
+        "usphone": "[kɑːm]",
+        "ukphone": "[kɑːm]"
+    },
+    {
+        "name": "following",
+        "trans": [
+            "n. 下列事物；一批追随者"
+        ],
+        "usphone": "[ˈfɑːloʊɪŋ]",
+        "ukphone": "[ˈfɒləʊɪŋ]"
+    },
+    {
+        "name": "cap",
+        "trans": [
+            "n. 盖；帽子"
+        ],
+        "usphone": "[kæp]",
+        "ukphone": "[kæp]"
+    },
+    {
+        "name": "silly",
+        "trans": [
+            "n. 傻瓜"
+        ],
+        "usphone": "[ˈsɪli]",
+        "ukphone": "[ˈsɪli]"
+    },
+    {
+        "name": "comparison",
+        "trans": [
+            "n. 比较；对照；比喻；比较关系"
+        ],
+        "usphone": "[kəmˈpærɪsn]",
+        "ukphone": "[kəmˈpærɪs(ə)n]"
+    },
+    {
+        "name": "cheat",
+        "trans": [
+            "n. 欺骗，作弊；骗子"
+        ],
+        "usphone": "[tʃiːt]",
+        "ukphone": "[tʃiːt]"
+    },
+    {
+        "name": "proper",
+        "trans": [
+            "adj. 适当的；本身的；特有的；正派的"
+        ],
+        "usphone": "[ˈprɑːpər]",
+        "ukphone": "[ˈprɒpə(r)]"
+    },
+    {
+        "name": "naturally",
+        "trans": [
+            "adv. 自然地"
+        ],
+        "usphone": "[ˈnætʃrəli]",
+        "ukphone": "[ˈnætʃ(ə)rəli]"
+    },
+    {
+        "name": "passion",
+        "trans": [
+            "n. 激情；热情；酷爱；盛怒"
+        ],
+        "usphone": "[ˈpæʃ(ə)n]",
+        "ukphone": "[ˈpæʃ(ə)n]"
+    },
+    {
+        "name": "typically",
+        "trans": [
+            "adv. 代表性地；作为特色地"
+        ],
+        "usphone": "[ˈtɪpɪkli]",
+        "ukphone": "[ˈtɪpɪkli]"
+    },
+    {
+        "name": "proud",
+        "trans": [
+            "adj. 自豪的；得意的；自负的"
+        ],
+        "usphone": "[praʊd]",
+        "ukphone": "[praʊd]"
+    },
+    {
+        "name": "gentleman",
+        "trans": [
+            "n. 先生；绅士；有身份的人"
+        ],
+        "usphone": "[ˈdʒent(ə)lmən]",
+        "ukphone": "[ˈdʒentlmən]"
+    },
+    {
+        "name": "signal",
+        "trans": [
+            "n. 信号；暗号；导火线"
+        ],
+        "usphone": "[ˈsɪɡnəl]",
+        "ukphone": "[ˈsɪɡnəl]"
+    },
+    {
+        "name": "location",
+        "trans": [
+            "n. 位置（形容词locational）；地点；外景拍摄场地"
+        ],
+        "usphone": "[loʊˈkeɪʃn]",
+        "ukphone": "[ləʊˈkeɪʃn]"
+    },
+    {
+        "name": "program",
+        "trans": [
+            "n. 程序；计划；大纲"
+        ],
+        "usphone": "[ˈproʊɡræm]",
+        "ukphone": "[ˈprəʊɡræm]"
+    },
+    {
+        "name": "setting",
+        "trans": [
+            "n. 环境；安装；布置；[天] 沉落"
+        ],
+        "usphone": "[ˈsetɪŋ]",
+        "ukphone": "[ˈsetɪŋ]"
+    },
+    {
+        "name": "repeated",
+        "trans": [
+            "adj. 再三的，反复的"
+        ],
+        "usphone": "[rɪˈpiːtɪd]",
+        "ukphone": "[rɪˈpiːtɪd]"
+    },
+    {
+        "name": "immigrant",
+        "trans": [
+            "n. 移民，侨民"
+        ],
+        "usphone": "[ˈɪmɪɡrənt]",
+        "ukphone": "[ˈɪmɪɡrənt]"
+    },
+    {
+        "name": "fear",
+        "trans": [
+            "n. 害怕；恐惧；敬畏；担心"
+        ],
+        "usphone": "[fɪr]",
+        "ukphone": "[fɪə(r)]"
+    },
+    {
+        "name": "repair",
+        "trans": [
+            "n. 修理，修补；修补部位"
+        ],
+        "usphone": "[rɪˈper]",
+        "ukphone": "[rɪˈpeə(r)]"
+    },
+    {
+        "name": "economic",
+        "trans": [
+            "adj. 经济的，经济上的；经济学的"
+        ],
+        "usphone": "[ˌiːkəˈnɑːmɪk; ˌekəˈnɑːmɪk]",
+        "ukphone": "[ˌiːkəˈnɒmɪk]"
+    },
+    {
+        "name": "indicate",
+        "trans": [
+            "vt. 表明；指出；预示；象征"
+        ],
+        "usphone": "[ˈɪndɪkeɪt]",
+        "ukphone": "[ˈɪndɪkeɪt]"
+    },
+    {
+        "name": "slow",
+        "trans": [
+            "adj. 慢的；减速的；迟钝的"
+        ],
+        "usphone": "[sloʊ]",
+        "ukphone": "[sləʊ]"
+    },
+    {
+        "name": "immediate",
+        "trans": [
+            "adj. 立即的；直接的；最接近的"
+        ],
+        "usphone": "[ɪˈmiːdiət]",
+        "ukphone": "[ɪˈmiːdiət]"
+    },
+    {
+        "name": "prisoner",
+        "trans": [
+            "n. 囚犯，犯人；俘虏；刑事被告"
+        ],
+        "usphone": "[ˈprɪznər]",
+        "ukphone": "[ˈprɪznə(r)]"
+    },
+    {
+        "name": "qualification",
+        "trans": [
+            "n. 资格；条件；限制；赋予资格"
+        ],
+        "usphone": "[ˌkwɑːlɪfɪˈkeɪʃn]",
+        "ukphone": "[ˌkwɒlɪfɪˈkeɪʃn]"
+    },
+    {
+        "name": "worst",
+        "trans": [
+            "n. 最坏；最坏的时候"
+        ],
+        "usphone": "[wɜːrst]",
+        "ukphone": "[wɜːst]"
+    },
+    {
+        "name": "close",
+        "trans": [
+            "n. 结束"
+        ],
+        "usphone": "[kloʊz; kloʊs]",
+        "ukphone": "[kləʊz]"
+    },
+    {
+        "name": "need",
+        "trans": [
+            "n. 需要，要求；缺乏；必要之物"
+        ],
+        "usphone": "[niːd]",
+        "ukphone": "[niːd]"
+    },
+    {
+        "name": "bell",
+        "trans": [
+            "n. 铃，钟；钟声，铃声；钟状物"
+        ],
+        "usphone": "[bel]",
+        "ukphone": "[bel]"
+    },
+    {
+        "name": "sail",
+        "trans": [
+            "n. 帆，篷；航行"
+        ],
+        "usphone": "[seɪl]",
+        "ukphone": "[seɪl]"
+    },
+    {
+        "name": "outdoor",
+        "trans": [
+            "adj. 户外的；露天的；野外的（等于out-of-door）"
+        ],
+        "usphone": "[ˈaʊtdɔːr]",
+        "ukphone": "[ˈaʊtdɔː(r)]"
+    },
+    {
+        "name": "shy",
+        "trans": [
+            "n. 投掷；惊跳"
+        ],
+        "usphone": "[ʃaɪ]",
+        "ukphone": "[ʃaɪ]"
+    },
+    {
+        "name": "fire",
+        "trans": [
+            "n. 火；火灾；炮火；炉火；热情；激情；磨难"
+        ],
+        "usphone": "[ˈfaɪər]",
+        "ukphone": "[ˈfaɪə(r)]"
+    },
+    {
+        "name": "definition",
+        "trans": [
+            "n. 定义；[物] 清晰度；解说"
+        ],
+        "usphone": "[ˌdefɪˈnɪʃn]",
+        "ukphone": "[ˌdefɪˈnɪʃn]"
+    },
+    {
+        "name": "powerful",
+        "trans": [
+            "adj. 强大的；强有力的"
+        ],
+        "usphone": "[ˈpaʊərfl]",
+        "ukphone": "[ˈpaʊəf(ə)l]"
+    },
+    {
+        "name": "properly",
+        "trans": [
+            "adv. 适当地；正确地；恰当地"
+        ],
+        "usphone": "[ˈprɑːpərli]",
+        "ukphone": "[ˈprɒpəli]"
+    },
+    {
+        "name": "murder",
+        "trans": [
+            "vt. 谋杀，凶杀"
+        ],
+        "usphone": "[ˈmɜːrdər]",
+        "ukphone": "[ˈmɜːdə(r)]"
+    },
+    {
+        "name": "consumer",
+        "trans": [
+            "n. 消费者；用户，顾客"
+        ],
+        "usphone": "[kənˈsuːmər]",
+        "ukphone": "[kənˈsjuːmə(r)]"
+    },
+    {
+        "name": "celebration",
+        "trans": [
+            "n. 庆典，庆祝会；庆祝；颂扬"
+        ],
+        "usphone": "[ˌselɪˈbreɪʃn]",
+        "ukphone": "[ˌselɪˈbreɪʃn]"
+    },
+    {
+        "name": "forever",
+        "trans": [
+            "adv. 永远；不断地；常常"
+        ],
+        "usphone": "[fərˈevər]",
+        "ukphone": "[fərˈevə(r)]"
+    },
+    {
+        "name": "row",
+        "trans": [
+            "n. 行，排；划船；街道；吵闹"
+        ],
+        "usphone": "[roʊ; raʊ]",
+        "ukphone": "[rəʊ; raʊ]"
+    },
+    {
+        "name": "tip",
+        "trans": [
+            "n. 小费；尖端；小建议，小窍门；轻拍"
+        ],
+        "usphone": "[tɪp]",
+        "ukphone": "[tɪp]"
+    },
+    {
+        "name": "entertainment",
+        "trans": [
+            "n. 娱乐；消遣；款待"
+        ],
+        "usphone": "[ˌentərˈteɪnmənt]",
+        "ukphone": "[ˌentəˈteɪnmənt]"
+    },
+    {
+        "name": "shoot",
+        "trans": [
+            "n. 射击；摄影；狩猎；急流"
+        ],
+        "usphone": "[ʃuːt]",
+        "ukphone": "[ʃuːt]"
+    },
+    {
+        "name": "encourage",
+        "trans": [
+            "vt. 鼓励，怂恿；激励；支持"
+        ],
+        "usphone": "[ɪnˈkɜːrɪdʒ]",
+        "ukphone": "[ɪnˈkʌrɪdʒ]"
+    },
+    {
+        "name": "economy",
+        "trans": [
+            "n. 经济；节约；理财"
+        ],
+        "usphone": "[ɪˈkɑːnəmi]",
+        "ukphone": "[ɪˈkɒnəmi]"
+    },
+    {
+        "name": "that",
+        "trans": [
+            "conj. 因为；以至于"
+        ],
+        "usphone": "[ðæt]",
+        "ukphone": "[ðæt]"
+    },
+    {
+        "name": "pan",
+        "trans": [
+            "n. 平底锅；盘状的器皿；淘盘子，金盘，秤盘"
+        ],
+        "usphone": "[pæn]",
+        "ukphone": "[pæn]"
+    },
+    {
+        "name": "relation",
+        "trans": [
+            "n. 关系；叙述；故事；亲属关系"
+        ],
+        "usphone": "[rɪˈleɪʃn]",
+        "ukphone": "[rɪˈleɪʃn]"
+    },
+    {
+        "name": "planning",
+        "trans": [
+            "n. 规划；计划编制"
+        ],
+        "usphone": "[ˈplænɪŋ]",
+        "ukphone": "[ˈplænɪŋ]"
+    },
+    {
+        "name": "written",
+        "trans": [
+            "adj. 书面的，成文的；文字的"
+        ],
+        "usphone": "[ˈrɪtn]",
+        "ukphone": "[ˈrɪt(ə)n]"
+    },
+    {
+        "name": "used",
+        "trans": [
+            "v. 用（use的过去式）；（used to）过去常做"
+        ],
+        "usphone": "[juːst; juːzd]",
+        "ukphone": "[juːst]"
+    },
+    {
+        "name": "cool",
+        "trans": [
+            "n. 凉爽；凉爽的空气"
+        ],
+        "usphone": "[kuːl]",
+        "ukphone": "[kuːl]"
+    },
+    {
+        "name": "pressure",
+        "trans": [
+            "n. 压力；压迫，[物] 压强"
+        ],
+        "usphone": "[ˈpreʃər]",
+        "ukphone": "[ˈpreʃə(r)]"
+    },
+    {
+        "name": "base",
+        "trans": [
+            "n. 基础；底部；垒"
+        ],
+        "usphone": "[beɪs]",
+        "ukphone": "[beɪs]"
+    },
+    {
+        "name": "breathing",
+        "trans": [
+            "n. 呼吸；瞬间；微风"
+        ],
+        "usphone": "[ˈbriːðɪŋ]",
+        "ukphone": "[ˈbriːðɪŋ]"
+    },
+    {
+        "name": "nuclear",
+        "trans": [
+            "adj. 原子能的；[细胞] 细胞核的；中心的；原子核的"
+        ],
+        "usphone": "[ˈnuːkliər]",
+        "ukphone": "[ˈnjuːkliə(r)]"
     }
 ]

--- a/public/dicts/Duolingo_Vocabulary_B2.json
+++ b/public/dicts/Duolingo_Vocabulary_B2.json
@@ -1,5899 +1,11 @@
 [
     {
-        "name": "absolute",
+        "name": "rub",
         "trans": [
-            "n. 绝对；绝对事物"
+            "n. 摩擦；障碍；磨损处"
         ],
-        "usphone": "[ˈæbsəluːt]",
-        "ukphone": "[ˈæbsəluːt]"
-    },
-    {
-        "name": "absorb",
-        "trans": [
-            "vt. 吸收；吸引；承受；理解；使…全神贯注"
-        ],
-        "usphone": "[əbˈzɔːrb]",
-        "ukphone": "[əbˈzɔːb]"
-    },
-    {
-        "name": "abstract",
-        "trans": [
-            "n. 摘要；抽象；抽象的概念"
-        ],
-        "usphone": "[ˈæbstrækt]",
-        "ukphone": "[ˈæbstrækt]"
-    },
-    {
-        "name": "academic",
-        "trans": [
-            "n. 大学生，大学教师；学者"
-        ],
-        "usphone": "[ˌækəˈdemɪk]",
-        "ukphone": "[ˌækəˈdemɪk]"
-    },
-    {
-        "name": "accent",
-        "trans": [
-            "n. 口音；重音；强调；特点；重音符号"
-        ],
-        "usphone": "[ˈæksent]",
-        "ukphone": "[ˈæksent]"
-    },
-    {
-        "name": "acceptable",
-        "trans": [
-            "adj. 可接受的；合意的；可忍受的"
-        ],
-        "usphone": "[əkˈseptəbl]",
-        "ukphone": "[əkˈseptəb(ə)l]"
-    },
-    {
-        "name": "accidentally",
-        "trans": [
-            "adv. 意外地；偶然地"
-        ],
-        "usphone": "[ˌæksɪˈdentəli]",
-        "ukphone": "[ˌæksɪˈdentəli]"
-    },
-    {
-        "name": "accommodate",
-        "trans": [
-            "vi. 适应；调解"
-        ],
-        "usphone": "[əˈkɑːmədeɪt]",
-        "ukphone": "[əˈkɒmədeɪt]"
-    },
-    {
-        "name": "accompany",
-        "trans": [
-            "vt. 陪伴，伴随；伴奏"
-        ],
-        "usphone": "[əˈkʌmpəni]",
-        "ukphone": "[əˈkʌmpəni]"
-    },
-    {
-        "name": "accomplish",
-        "trans": [
-            "vt. 完成；实现；达到"
-        ],
-        "usphone": "[əˈkɑːmplɪʃ]",
-        "ukphone": "[əˈkʌmplɪʃ]"
-    },
-    {
-        "name": "account",
-        "trans": [
-            "n. 账户；解释；账目，账单；理由；描述"
-        ],
-        "usphone": "[əˈkaʊnt]",
-        "ukphone": "[əˈkaʊnt]"
-    },
-    {
-        "name": "accountant",
-        "trans": [
-            "n. 会计师；会计人员"
-        ],
-        "usphone": "[əˈkaʊntənt]",
-        "ukphone": "[əˈkaʊntənt]"
-    },
-    {
-        "name": "accuracy",
-        "trans": [
-            "n. [数] 精确度，准确性"
-        ],
-        "usphone": "[ˈækjərəsi]",
-        "ukphone": "[ˈækjərəsi]"
-    },
-    {
-        "name": "accurate",
-        "trans": [
-            "adj. 精确的"
-        ],
-        "usphone": "[ˈækjərət]",
-        "ukphone": "[ˈækjərət]"
-    },
-    {
-        "name": "accurately",
-        "trans": [
-            "adv. 精确地，准确地"
-        ],
-        "usphone": "[ˈækjərətli]",
-        "ukphone": "[ˈækjərətli]"
-    },
-    {
-        "name": "accuse",
-        "trans": [
-            "vt. 控告，指控；谴责；归咎于"
-        ],
-        "usphone": "[əˈkjuːz]",
-        "ukphone": "[əˈkjuːz]"
-    },
-    {
-        "name": "acid",
-        "trans": [
-            "n. 酸；<俚>迷幻药"
-        ],
-        "usphone": "[ˈæsɪd]",
-        "ukphone": "[ˈæsɪd]"
-    },
-    {
-        "name": "acknowledge",
-        "trans": [
-            "vt. 承认；答谢；报偿；告知已收到"
-        ],
-        "usphone": "[əkˈnɑːlɪdʒ]",
-        "ukphone": "[əkˈnɒlɪdʒ]"
-    },
-    {
-        "name": "acquire",
-        "trans": [
-            "vt. 获得；取得；学到；捕获"
-        ],
-        "usphone": "[əˈkwaɪər]",
-        "ukphone": "[əˈkwaɪə(r)]"
-    },
-    {
-        "name": "activate",
-        "trans": [
-            "vt. 刺激；使活动；使活泼；使产生放射性"
-        ],
-        "usphone": "[ˈæktɪveɪt]",
-        "ukphone": "[ˈæktɪveɪt]"
-    },
-    {
-        "name": "actual",
-        "trans": [
-            "adj. 真实的，实际的；现行的，目前的"
-        ],
-        "usphone": "[ˈæktʃuəl]",
-        "ukphone": "[ˈæktʃuəl]"
-    },
-    {
-        "name": "adapt",
-        "trans": [
-            "vi. 适应"
-        ],
-        "usphone": "[əˈdæpt]",
-        "ukphone": "[əˈdæpt]"
-    },
-    {
-        "name": "addiction",
-        "trans": [
-            "n. 上瘾，沉溺；癖嗜"
-        ],
-        "usphone": "[əˈdɪkʃn]",
-        "ukphone": "[əˈdɪkʃ(ə)n]"
-    },
-    {
-        "name": "additional",
-        "trans": [
-            "adj. 附加的，额外的"
-        ],
-        "usphone": "[əˈdɪʃənl]",
-        "ukphone": "[əˈdɪʃən(ə)l]"
-    },
-    {
-        "name": "additionally",
-        "trans": [
-            "adv. 此外；又，加之"
-        ],
-        "usphone": "[əˈdɪʃənəli]",
-        "ukphone": "[əˈdɪʃənəli]"
-    },
-    {
-        "name": "address",
-        "trans": [
-            "n. 地址；演讲；致辞；说话的技巧；称呼"
-        ],
-        "usphone": "[əˈdres; ˈædres]",
-        "ukphone": "[əˈdres]"
-    },
-    {
-        "name": "adequate",
-        "trans": [
-            "adj. 充足的；适当的；胜任的"
-        ],
-        "usphone": "[ˈædɪkwət]",
-        "ukphone": "[ˈædɪkwət]"
-    },
-    {
-        "name": "adequately",
-        "trans": [
-            "adv. 充分地；足够地；适当地"
-        ],
-        "usphone": "[ˈædɪkwətli]",
-        "ukphone": "[ˈædɪkwətli]"
-    },
-    {
-        "name": "adjust",
-        "trans": [
-            "vt. 调整，使…适合；校准"
-        ],
-        "usphone": "[əˈdʒʌst]",
-        "ukphone": "[əˈdʒʌst]"
-    },
-    {
-        "name": "administration",
-        "trans": [
-            "n. 管理；行政；实施；行政机构"
-        ],
-        "usphone": "[ədˌmɪnɪˈstreɪʃn]",
-        "ukphone": "[ədˌmɪnɪˈstreɪʃ(ə)n]"
-    },
-    {
-        "name": "adopt",
-        "trans": [
-            "vi. 采取；过继"
-        ],
-        "usphone": "[əˈdɑːpt]",
-        "ukphone": "[əˈdɒpt]"
-    },
-    {
-        "name": "advance",
-        "trans": [
-            "n. 发展；前进；增长；预付款"
-        ],
-        "usphone": "[ədˈvæns]",
-        "ukphone": "[ədˈvɑːns]"
-    },
-    {
-        "name": "affair",
-        "trans": [
-            "n. 事情；事务；私事；（尤指关系不长久的）风流韵事"
-        ],
-        "usphone": "[əˈfer]",
-        "ukphone": "[əˈfeə(r)]"
-    },
-    {
-        "name": "affordable",
-        "trans": [
-            "adj. 负担得起的"
-        ],
-        "usphone": "[əˈfɔːrdəbl]",
-        "ukphone": "[əˈfɔːdəb(ə)l]"
-    },
-    {
-        "name": "afterwards",
-        "trans": [
-            "adv. 后来；然后"
-        ],
-        "usphone": "[ˈæftərwərdz]",
-        "ukphone": "[ˈɑːftəwədz]"
-    },
-    {
-        "name": "agency",
-        "trans": [
-            "n. 代理，中介；代理处，经销处"
-        ],
-        "usphone": "[ˈeɪdʒənsi]",
-        "ukphone": "[ˈeɪdʒənsi]"
-    },
-    {
-        "name": "agenda",
-        "trans": [
-            "n. 议程；日常工作事项；日程表"
-        ],
-        "usphone": "[əˈdʒendə]",
-        "ukphone": "[əˈdʒendə]"
-    },
-    {
-        "name": "aggressive",
-        "trans": [
-            "adj. 侵略性的；好斗的；有进取心的；有闯劲的"
-        ],
-        "usphone": "[əˈɡresɪv]",
-        "ukphone": "[əˈɡresɪv]"
-    },
-    {
-        "name": "agriculture",
-        "trans": [
-            "n. 农业；农耕；农业生产；农艺，农学"
-        ],
-        "usphone": "[ˈæɡrɪkʌltʃər]",
-        "ukphone": "[ˈæɡrɪkʌltʃə(r)]"
-    },
-    {
-        "name": "aid",
-        "trans": [
-            "n. 援助；帮助；助手；帮助者"
-        ],
-        "usphone": "[eɪd]",
-        "ukphone": "[eɪd]"
-    },
-    {
-        "name": "AIDS",
-        "trans": [
-            "abbr. 获得性免疫缺乏综合征；爱滋病（Acquired Immune Deficiency Syndrome）"
-        ],
-        "usphone": "[eɪdz]",
-        "ukphone": "[eɪdz]"
-    },
-    {
-        "name": "aircraft",
-        "trans": [
-            "n. 飞机，航空器"
-        ],
-        "usphone": "[ˈerkræft]",
-        "ukphone": "[ˈeəkrɑːft]"
-    },
-    {
-        "name": "alarm",
-        "trans": [
-            "n. 闹钟；警报，警告器；惊慌"
-        ],
-        "usphone": "[əˈlɑːrm]",
-        "ukphone": "[əˈlɑːm]"
-    },
-    {
-        "name": "alien",
-        "trans": [
-            "n. 外国人，外侨；外星人"
-        ],
-        "usphone": "[ˈeɪliən]",
-        "ukphone": "[ˈeɪliən]"
-    },
-    {
-        "name": "alongside",
-        "trans": [
-            "prep. 在……旁边"
-        ],
-        "usphone": "[əˌlɔːŋˈsaɪd]",
-        "ukphone": "[əˌlɒŋˈsaɪd]"
-    },
-    {
-        "name": "alter",
-        "trans": [
-            "vt. 改变，更改"
-        ],
-        "usphone": "[ˈɔːltər]",
-        "ukphone": "[ˈɔːltə(r)]"
-    },
-    {
-        "name": "altogether",
-        "trans": [
-            "n. 整个；裸体"
-        ],
-        "usphone": "[ˌɔːltəˈɡeðər]",
-        "ukphone": "[ˌɔːltəˈɡeðə(r)]"
-    },
-    {
-        "name": "ambulance",
-        "trans": [
-            "n. [车辆][医] 救护车；战时流动医院"
-        ],
-        "usphone": "[ˈæmbjələns]",
-        "ukphone": "[ˈæmbjələns]"
-    },
-    {
-        "name": "amount",
-        "trans": [
-            "n. 数量；总额，总数"
-        ],
-        "usphone": "[əˈmaʊnt]",
-        "ukphone": "[əˈmaʊnt]"
-    },
-    {
-        "name": "amusing",
-        "trans": [
-            "adj. 有趣的，好玩的；引人发笑的"
-        ],
-        "usphone": "[əˈmjuːzɪŋ]",
-        "ukphone": "[əˈmjuːzɪŋ]"
-    },
-    {
-        "name": "analyst",
-        "trans": [
-            "n. 分析者；精神分析医师；分解者"
-        ],
-        "usphone": "[ˈænəlɪst]",
-        "ukphone": "[ˈænəlɪst]"
-    },
-    {
-        "name": "ancestor",
-        "trans": [
-            "n. 始祖，祖先；被继承人"
-        ],
-        "usphone": "[ˈænsestər]",
-        "ukphone": "[ˈænsestə(r)]"
-    },
-    {
-        "name": "anger",
-        "trans": [
-            "n. 怒，愤怒；忿怒"
-        ],
-        "usphone": "[ˈæŋɡər]",
-        "ukphone": "[ˈæŋɡə(r)]"
-    },
-    {
-        "name": "angle",
-        "trans": [
-            "n. 角度，角，方面"
-        ],
-        "usphone": "[ˈæŋɡ(ə)l]",
-        "ukphone": "[ˈæŋɡ(ə)l]"
-    },
-    {
-        "name": "animation",
-        "trans": [
-            "n. 活泼，生气；激励；卡通片绘制"
-        ],
-        "usphone": "[ˌænɪˈmeɪʃ(ə)n]",
-        "ukphone": "[ˌænɪˈmeɪʃ(ə)n]"
-    },
-    {
-        "name": "anniversary",
-        "trans": [
-            "n. 周年纪念日"
-        ],
-        "usphone": "[ˌænɪˈvɜːrsəri]",
-        "ukphone": "[ˌænɪˈvɜːsəri]"
-    },
-    {
-        "name": "annual",
-        "trans": [
-            "n. 年刊，年鉴；一年生植物"
-        ],
-        "usphone": "[ˈænjuəl]",
-        "ukphone": "[ˈænjuəl]"
-    },
-    {
-        "name": "annually",
-        "trans": [
-            "adv. 每年；一年一次"
-        ],
-        "usphone": "[ˈænjuəli]",
-        "ukphone": "[ˈænjuəli]"
-    },
-    {
-        "name": "anticipate",
-        "trans": [
-            "vt. 预期，期望；占先，抢先；提前使用"
-        ],
-        "usphone": "[ænˈtɪsɪpeɪt]",
-        "ukphone": "[ænˈtɪsɪpeɪt]"
-    },
-    {
-        "name": "anxiety",
-        "trans": [
-            "n. 焦虑；渴望；挂念；令人焦虑的事"
-        ],
-        "usphone": "[æŋˈzaɪəti]",
-        "ukphone": "[æŋˈzaɪəti]"
-    },
-    {
-        "name": "anxious",
-        "trans": [
-            "adj. 焦虑的；担忧的；渴望的；急切的"
-        ],
-        "usphone": "[ˈæŋkʃəs]",
-        "ukphone": "[ˈæŋkʃəs]"
-    },
-    {
-        "name": "apology",
-        "trans": [
-            "n. 道歉；谢罪；辩护；勉强的替代物"
-        ],
-        "usphone": "[əˈpɑːlədʒi]",
-        "ukphone": "[əˈpɒlədʒi]"
-    },
-    {
-        "name": "apparent",
-        "trans": [
-            "adj. 显然的；表面上的"
-        ],
-        "usphone": "[əˈpærənt]",
-        "ukphone": "[əˈpærənt]"
-    },
-    {
-        "name": "apparently",
-        "trans": [
-            "adv. 显然地；似乎，表面上"
-        ],
-        "usphone": "[əˈpærəntli]",
-        "ukphone": "[əˈpærəntli]"
-    },
-    {
-        "name": "appeal",
-        "trans": [
-            "n. 呼吁，请求；吸引力，感染力；上诉；诉诸裁判"
-        ],
-        "usphone": "[əˈpiːl]",
-        "ukphone": "[əˈpiːl]"
-    },
-    {
-        "name": "applicant",
-        "trans": [
-            "n. 申请人，申请者；请求者"
-        ],
-        "usphone": "[ˈæplɪkənt]",
-        "ukphone": "[ˈæplɪkənt]"
-    },
-    {
-        "name": "approach",
-        "trans": [
-            "n. 方法；途径；接近"
-        ],
-        "usphone": "[əˈproʊtʃ]",
-        "ukphone": "[əˈprəʊtʃ]"
-    },
-    {
-        "name": "appropriate",
-        "trans": [
-            "adj. 适当的；恰当的；合适的"
-        ],
-        "usphone": "[əˈproʊpriət; əˈproʊprieɪt]",
-        "ukphone": "[əˈprəʊpriət]"
-    },
-    {
-        "name": "appropriately",
-        "trans": [
-            "adv. 适当地；合适地；相称地"
-        ],
-        "usphone": "[əˈproʊpriətli]",
-        "ukphone": "[əˈprəʊpriətli]"
-    },
-    {
-        "name": "approval",
-        "trans": [
-            "n. 批准；认可；赞成"
-        ],
-        "usphone": "[əˈpruːvl]",
-        "ukphone": "[əˈpruːv(ə)l]"
-    },
-    {
-        "name": "approve",
-        "trans": [
-            "vi. 批准；赞成；满意"
-        ],
-        "usphone": "[əˈpruːv]",
-        "ukphone": "[əˈpruːv]"
-    },
-    {
-        "name": "arise",
-        "trans": [
-            "vi. 出现；上升；起立"
-        ],
-        "usphone": "[əˈraɪz]",
-        "ukphone": "[əˈraɪz]"
-    },
-    {
-        "name": "armed",
-        "trans": [
-            "adj. 武装的；有扶手的；有防卫器官的（指动物）"
-        ],
-        "usphone": "[ɑːrmd]",
-        "ukphone": "[ɑːmd]"
-    },
-    {
-        "name": "arms",
-        "trans": [
-            "n. 臂（arm的复数）；[军] 武器；纹章"
-        ],
-        "usphone": "[ɑːrmz]",
-        "ukphone": "[ɑːmz]"
-    },
-    {
-        "name": "arrow",
-        "trans": [
-            "n. 箭，箭头；箭状物；箭头记号"
-        ],
-        "usphone": "[ˈæroʊ]",
-        "ukphone": "[ˈærəʊ]"
-    },
-    {
-        "name": "artificial",
-        "trans": [
-            "adj. 人造的；仿造的；虚伪的；非原产地的；武断的"
-        ],
-        "usphone": "[ˌɑːrtɪˈfɪʃ(ə)l]",
-        "ukphone": "[ˌɑːtɪˈfɪʃl]"
-    },
-    {
-        "name": "artistic",
-        "trans": [
-            "adj. 艺术的；风雅的；有美感的"
-        ],
-        "usphone": "[ɑːrˈtɪstɪk]",
-        "ukphone": "[ɑːˈtɪstɪk]"
-    },
-    {
-        "name": "artwork",
-        "trans": [
-            "n. 艺术品；插图；美术品"
-        ],
-        "usphone": "[ˈɑːrtwɜːrk]",
-        "ukphone": "[ˈɑːtwɜːk]"
-    },
-    {
-        "name": "ashamed",
-        "trans": [
-            "adj. 惭愧的，感到难为情的；耻于……的"
-        ],
-        "usphone": "[əˈʃeɪmd]",
-        "ukphone": "[əˈʃeɪmd]"
-    },
-    {
-        "name": "aside",
-        "trans": [
-            "prep. 在…旁边"
-        ],
-        "usphone": "[əˈsaɪd]",
-        "ukphone": "[əˈsaɪd]"
-    },
-    {
-        "name": "aspect",
-        "trans": [
-            "n. 方面；方向；形势；外貌"
-        ],
-        "usphone": "[ˈæspekt]",
-        "ukphone": "[ˈæspekt]"
-    },
-    {
-        "name": "assess",
-        "trans": [
-            "vt. 评定；估价；对…征税"
-        ],
-        "usphone": "[əˈses]",
-        "ukphone": "[əˈses]"
-    },
-    {
-        "name": "assessment",
-        "trans": [
-            "n. 评定；估价"
-        ],
-        "usphone": "[əˈsesmənt]",
-        "ukphone": "[əˈsesmənt]"
-    },
-    {
-        "name": "asset",
-        "trans": [
-            "n. 资产；优点；有用的东西；有利条件；财产；有价值的人或物"
-        ],
-        "usphone": "[ˈæset]",
-        "ukphone": "[ˈæset]"
-    },
-    {
-        "name": "assign",
-        "trans": [
-            "vt. 分配；指派；[计][数] 赋值"
-        ],
-        "usphone": "[əˈsaɪn]",
-        "ukphone": "[əˈsaɪn]"
-    },
-    {
-        "name": "assistance",
-        "trans": [
-            "n. 援助，帮助；辅助设备"
-        ],
-        "usphone": "[əˈsɪstəns]",
-        "ukphone": "[əˈsɪstəns]"
-    },
-    {
-        "name": "associate",
-        "trans": [
-            "n. 同事，伙伴；关联的事物"
-        ],
-        "usphone": "[əˈsoʊsieɪt; əˈsoʊʃieɪt]",
-        "ukphone": "[əˈsəʊsieɪt]"
-    },
-    {
-        "name": "associated",
-        "trans": [
-            "v. 联系（associate的过去式和过去分词）"
-        ],
-        "usphone": "[əˈsoʊsieɪtɪdˌəˈsoʊʃieɪtɪd]",
-        "ukphone": "[əˈsəʊsieɪtɪd]"
-    },
-    {
-        "name": "association",
-        "trans": [
-            "n. 协会，联盟，社团；联合；联想"
-        ],
-        "usphone": "[əˌsoʊsiˈeɪʃn; əˌsoʊʃiˈeɪʃn]",
-        "ukphone": "[əˌsəʊsiˈeɪʃn; əˌsəʊʃiˈeɪʃn]"
-    },
-    {
-        "name": "assume",
-        "trans": [
-            "vt. 僭取；篡夺；夺取；擅用；侵占"
-        ],
-        "usphone": "[əˈsuːm]",
-        "ukphone": "[əˈsjuːm]"
-    },
-    {
-        "name": "assumption",
-        "trans": [
-            "n. 假定；设想；担任；采取"
-        ],
-        "usphone": "[əˈsʌmpʃn]",
-        "ukphone": "[əˈsʌmpʃn]"
-    },
-    {
-        "name": "assure",
-        "trans": [
-            "vt. 保证；担保；使确信；弄清楚"
-        ],
-        "usphone": "[əˈʃʊr]",
-        "ukphone": "[əˈʃʊə(r)]"
-    },
-    {
-        "name": "astonishing",
-        "trans": [
-            "adj. 惊人的；令人惊讶的"
-        ],
-        "usphone": "[əˈstɑːnɪʃɪŋ]",
-        "ukphone": "[əˈstɒnɪʃɪŋ]"
-    },
-    {
-        "name": "attachment",
-        "trans": [
-            "n. 附件；依恋；连接物；扣押财产"
-        ],
-        "usphone": "[əˈtætʃmənt]",
-        "ukphone": "[əˈtætʃmənt]"
-    },
-    {
-        "name": "attempt",
-        "trans": [
-            "n. 企图，试图；攻击"
-        ],
-        "usphone": "[əˈtempt]",
-        "ukphone": "[əˈtempt]"
-    },
-    {
-        "name": "auction",
-        "trans": [
-            "n. 拍卖"
-        ],
-        "usphone": "[ˈɔːkʃn]",
-        "ukphone": "[ˈɔːkʃ(ə)n]"
-    },
-    {
-        "name": "audio",
-        "trans": [
-            "adj. 声音的；[声] 音频的，[声] 声频的"
-        ],
-        "usphone": "[ˈɔːdioʊ]",
-        "ukphone": "[ˈɔːdiəʊ]"
-    },
-    {
-        "name": "automatic",
-        "trans": [
-            "n. 自动机械；自动手枪"
-        ],
-        "usphone": "[ˌɔːtəˈmætɪk]",
-        "ukphone": "[ˌɔːtəˈmætɪk]"
-    },
-    {
-        "name": "automatically",
-        "trans": [
-            "adj. 不经思索的"
-        ],
-        "usphone": "[ˌɔːtəˈmætɪkli]",
-        "ukphone": "[ˌɔːtəˈmætɪkli]"
-    },
-    {
-        "name": "awareness",
-        "trans": [
-            "n. 意识，认识；明白，知道"
-        ],
-        "usphone": "[əˈwernəs]",
-        "ukphone": "[əˈweənəs]"
-    },
-    {
-        "name": "awkward",
-        "trans": [
-            "adj. 尴尬的；笨拙的；棘手的；不合适的"
-        ],
-        "usphone": "[ˈɔːkwərd]",
-        "ukphone": "[ˈɔːkwəd]"
-    },
-    {
-        "name": "back",
-        "trans": [
-            "n. 后面；背部；靠背；足球等的后卫；书报等的末尾"
-        ],
-        "usphone": "[bæk]",
-        "ukphone": "[bæk]"
-    },
-    {
-        "name": "bacteria",
-        "trans": [
-            "n. [微] 细菌"
-        ],
-        "usphone": "[bækˈtɪriə]",
-        "ukphone": "[bækˈtɪəriə]"
-    },
-    {
-        "name": "badge",
-        "trans": [
-            "n. 徽章；证章；标记"
-        ],
-        "usphone": "[bædʒ]",
-        "ukphone": "[bædʒ]"
-    },
-    {
-        "name": "balanced",
-        "trans": [
-            "adj. 平衡的；和谐的；安定的"
-        ],
-        "usphone": "[ˈbælənst]",
-        "ukphone": "[ˈbælənst]"
-    },
-    {
-        "name": "ballet",
-        "trans": [
-            "n. 芭蕾舞剧；芭蕾舞乐曲"
-        ],
-        "usphone": "[bæˈleɪ]",
-        "ukphone": "[ˈbæleɪ]"
-    },
-    {
-        "name": "balloon",
-        "trans": [
-            "n. 气球"
-        ],
-        "usphone": "[bəˈluːn]",
-        "ukphone": "[bəˈluːn]"
-    },
-    {
-        "name": "bar",
-        "trans": [
-            "n. 条，棒；酒吧；障碍；法庭"
-        ],
-        "usphone": "[bɑːr]",
-        "ukphone": "[bɑː(r)]"
-    },
-    {
-        "name": "barely",
-        "trans": [
-            "adv. 仅仅，勉强；几乎不；公开地；贫乏地"
-        ],
-        "usphone": "[ˈberli]",
-        "ukphone": "[ˈbeəli]"
-    },
-    {
-        "name": "bargain",
-        "trans": [
-            "n. 交易；便宜货；契约"
-        ],
-        "usphone": "[ˈbɑːrɡən]",
-        "ukphone": "[ˈbɑːɡən]"
-    },
-    {
-        "name": "barrier",
-        "trans": [
-            "n. 障碍物，屏障；界线"
-        ],
-        "usphone": "[ˈbæriər]",
-        "ukphone": "[ˈbæriə(r)]"
-    },
-    {
-        "name": "basement",
-        "trans": [
-            "n. 地下室；地窖"
-        ],
-        "usphone": "[ˈbeɪsmənt]",
-        "ukphone": "[ˈbeɪsmənt]"
-    },
-    {
-        "name": "basically",
-        "trans": [
-            "adv. 主要地，基本上"
-        ],
-        "usphone": "[ˈbeɪsɪkli]",
-        "ukphone": "[ˈbeɪsɪkli]"
-    },
-    {
-        "name": "basket",
-        "trans": [
-            "n. 篮子；（篮球比赛的）得分；一篮之量；篮筐"
-        ],
-        "usphone": "[ˈbæskɪt]",
-        "ukphone": "[ˈbɑːskɪt]"
-    },
-    {
-        "name": "bat",
-        "trans": [
-            "n. 蝙蝠；球棒；球拍；批处理文件的扩展名"
-        ],
-        "usphone": "[bæt]",
-        "ukphone": "[bæt]"
-    },
-    {
-        "name": "battle",
-        "trans": [
-            "n. 战役；斗争"
-        ],
-        "usphone": "[ˈbætl]",
-        "ukphone": "[ˈbæt(ə)l]"
-    },
-    {
-        "name": "bear",
-        "trans": [
-            "n. 熊"
-        ],
-        "usphone": "[ber]",
-        "ukphone": "[beə(r)]"
-    },
-    {
-        "name": "beat",
-        "trans": [
-            "n. 拍子；敲击；有规律的一连串敲打"
-        ],
-        "usphone": "[biːt]",
-        "ukphone": "[biːt]"
-    },
-    {
-        "name": "beg",
-        "trans": [
-            "vi. 乞讨；请求"
-        ],
-        "usphone": "[beɡ]",
-        "ukphone": "[beɡ]"
-    },
-    {
-        "name": "being",
-        "trans": [
-            "n. 存在；生命；本质；品格"
-        ],
-        "usphone": "[ˈbiːɪŋ]",
-        "ukphone": "[ˈbiːɪŋ]"
-    },
-    {
-        "name": "beneficial",
-        "trans": [
-            "adj. 有益的，有利的；可享利益的"
-        ],
-        "usphone": "[ˌbenɪˈfɪʃl]",
-        "ukphone": "[ˌbenɪˈfɪʃ(ə)l]"
-    },
-    {
-        "name": "bent",
-        "trans": [
-            "n. 爱好，嗜好"
-        ],
-        "usphone": "[bent]",
-        "ukphone": "[bent]"
-    },
-    {
-        "name": "beside",
-        "trans": [
-            "prep. 在旁边；与…相比；和…无关"
-        ],
-        "usphone": "[bɪˈsaɪd]",
-        "ukphone": "[bɪˈsaɪd]"
-    },
-    {
-        "name": "besides",
-        "trans": [
-            "prep. 除…之外"
-        ],
-        "usphone": "[bɪˈsaɪdz]",
-        "ukphone": "[bɪˈsaɪdz]"
-    },
-    {
-        "name": "bet",
-        "trans": [
-            "n. 打赌，赌注；被打赌的事物"
-        ],
-        "usphone": "[bet]",
-        "ukphone": "[bet]"
-    },
-    {
-        "name": "beyond",
-        "trans": [
-            "prep. 超过；越过；那一边；在...较远的一边"
-        ],
-        "usphone": "[bɪˈjɑːnd]",
-        "ukphone": "[bɪˈjɒnd]"
-    },
-    {
-        "name": "bias",
-        "trans": [
-            "n. 偏见；偏爱；斜纹；乖离率"
-        ],
-        "usphone": "[ˈbaɪəs]",
-        "ukphone": "[ˈbaɪəs]"
-    },
-    {
-        "name": "bid",
-        "trans": [
-            "n. 出价；叫牌；努力争取"
-        ],
-        "usphone": "[bɪd]",
-        "ukphone": "[bɪd]"
-    },
-    {
-        "name": "bill",
-        "trans": [
-            "n. [法] 法案；广告；账单；[金融] 票据；钞票；清单"
-        ],
-        "usphone": "[bɪl]",
-        "ukphone": "[bɪl]"
-    },
-    {
-        "name": "biological",
-        "trans": [
-            "adj. 生物的；生物学的"
-        ],
-        "usphone": "[ˌbaɪəˈlɑːdʒɪkl]",
-        "ukphone": "[ˌbaɪəˈlɒdʒɪk(ə)l]"
-    },
-    {
-        "name": "bitter",
-        "trans": [
-            "n. 苦味；苦啤酒"
-        ],
-        "usphone": "[ˈbɪtər]",
-        "ukphone": "[ˈbɪtə(r)]"
-    },
-    {
-        "name": "blame",
-        "trans": [
-            "n. 责备；责任；过失"
-        ],
-        "usphone": "[bleɪm]",
-        "ukphone": "[bleɪm]"
-    },
-    {
-        "name": "blanket",
-        "trans": [
-            "n. 毛毯，毯子；毯状物，覆盖层"
-        ],
-        "usphone": "[ˈblæŋkɪt]",
-        "ukphone": "[ˈblæŋkɪt]"
-    },
-    {
-        "name": "blind",
-        "trans": [
-            "n. 掩饰，借口；百叶窗"
-        ],
-        "usphone": "[blaɪnd]",
-        "ukphone": "[blaɪnd]"
-    },
-    {
-        "name": "blow",
-        "trans": [
-            "n. 吹；打击；殴打"
-        ],
-        "usphone": "[bloʊ]",
-        "ukphone": "[bləʊ]"
-    },
-    {
-        "name": "bold",
-        "trans": [
-            "adj. 大胆的，英勇的；黑体的；厚颜无耻的；险峻的"
-        ],
-        "usphone": "[boʊld]",
-        "ukphone": "[bəʊld]"
-    },
-    {
-        "name": "bombing",
-        "trans": [
-            "n. [军] 轰炸，[军] 投弹"
-        ],
-        "usphone": "[ˈbɑːmɪŋ]",
-        "ukphone": "[ˈbɒmɪŋ]"
-    },
-    {
-        "name": "bond",
-        "trans": [
-            "n. 债券；结合；约定；粘合剂；纽带"
-        ],
-        "usphone": "[bɑːnd]",
-        "ukphone": "[bɒnd]"
-    },
-    {
-        "name": "booking",
-        "trans": [
-            "n. 预订；预约；演出契约"
-        ],
-        "usphone": "[ˈbʊkɪŋ]",
-        "ukphone": "[ˈbʊkɪŋ]"
-    },
-    {
-        "name": "boost",
-        "trans": [
-            "n. 推动；帮助；宣扬"
-        ],
-        "usphone": "[buːst]",
-        "ukphone": "[buːst]"
-    },
-    {
-        "name": "border",
-        "trans": [
-            "n. 边境；边界；国界"
-        ],
-        "usphone": "[ˈbɔːrdər]",
-        "ukphone": "[ˈbɔːdə(r)]"
-    },
-    {
-        "name": "bound",
-        "trans": [
-            "n. 范围；跳跃"
-        ],
-        "usphone": "[baʊnd]",
-        "ukphone": "[baʊnd]"
-    },
-    {
-        "name": "breast",
-        "trans": [
-            "n. 乳房，胸部；胸怀；心情"
-        ],
-        "usphone": "[brest]",
-        "ukphone": "[brest]"
-    },
-    {
-        "name": "brick",
-        "trans": [
-            "n. 砖，砖块；砖形物；心肠好的人"
-        ],
-        "usphone": "[brɪk]",
-        "ukphone": "[brɪk]"
-    },
-    {
-        "name": "brief",
-        "trans": [
-            "n. 摘要，简报；概要，诉书"
-        ],
-        "usphone": "[briːf]",
-        "ukphone": "[briːf]"
-    },
-    {
-        "name": "briefly",
-        "trans": [
-            "adv. 短暂地；简略地；暂时地"
-        ],
-        "usphone": "[ˈbriːfli]",
-        "ukphone": "[ˈbriːfli]"
-    },
-    {
-        "name": "broad",
-        "trans": [
-            "n. 宽阔部分"
-        ],
-        "usphone": "[brɔːd]",
-        "ukphone": "[brɔːd]"
-    },
-    {
-        "name": "broadcast",
-        "trans": [
-            "n. 广播；播音；广播节目"
-        ],
-        "usphone": "[ˈbrɔːdkæst]",
-        "ukphone": "[ˈbrɔːdkɑːst]"
-    },
-    {
-        "name": "broadcaster",
-        "trans": [
-            "n. 广播公司；广播员；播送设备；撒播物"
-        ],
-        "usphone": "[ˈbrɔːdkæstər]",
-        "ukphone": "[ˈbrɔːdkɑːstə(r)]"
-    },
-    {
-        "name": "broadly",
-        "trans": [
-            "adv. 明显地；宽广地；概括地；露骨地；粗鄙地"
-        ],
-        "usphone": "[ˈbrɔːdli]",
-        "ukphone": "[ˈbrɔːdli]"
-    },
-    {
-        "name": "budget",
-        "trans": [
-            "n. 预算，预算费"
-        ],
-        "usphone": "[ˈbʌdʒɪt]",
-        "ukphone": "[ˈbʌdʒɪt]"
-    },
-    {
-        "name": "bug",
-        "trans": [
-            "n. 臭虫，小虫；故障；窃听器"
-        ],
-        "usphone": "[bʌɡ]",
-        "ukphone": "[bʌɡ]"
-    },
-    {
-        "name": "bullet",
-        "trans": [
-            "n. 子弹；只选某党全部候选人的投票；豆子"
-        ],
-        "usphone": "[ˈbʊlɪt]",
-        "ukphone": "[ˈbʊlɪt]"
-    },
-    {
-        "name": "bunch",
-        "trans": [
-            "n. 群；串；突出物"
-        ],
-        "usphone": "[bʌntʃ]",
-        "ukphone": "[bʌntʃ]"
-    },
-    {
-        "name": "burn",
-        "trans": [
-            "n. 灼伤，烧伤；烙印"
-        ],
-        "usphone": "[bɜːrn]",
-        "ukphone": "[bɜːn]"
-    },
-    {
-        "name": "bush",
-        "trans": [
-            "n. 灌木；矮树丛"
-        ],
-        "usphone": "[bʊʃ]",
-        "ukphone": "[bʊʃ]"
-    },
-    {
-        "name": "but",
-        "trans": [
-            "conj. 但是；而是；然而"
-        ],
-        "usphone": "[bʌt; bət]",
-        "ukphone": "[bʌt; bət]"
-    },
-    {
-        "name": "cabin",
-        "trans": [
-            "n. 小屋；客舱；船舱"
-        ],
-        "usphone": "[ˈkæbɪn]",
-        "ukphone": "[ˈkæbɪn]"
-    },
-    {
-        "name": "cable",
-        "trans": [
-            "n. 缆绳；电缆；海底电报"
-        ],
-        "usphone": "[ˈkeɪbl]",
-        "ukphone": "[ˈkeɪb(ə)l]"
-    },
-    {
-        "name": "calculate",
-        "trans": [
-            "vt. 计算；预测；认为；打算"
-        ],
-        "usphone": "[ˈkælkjuleɪt]",
-        "ukphone": "[ˈkælkjuleɪt]"
-    },
-    {
-        "name": "canal",
-        "trans": [
-            "n. 运河；[地理] 水道；[建] 管道；灌溉水渠"
-        ],
-        "usphone": "[kəˈnæl]",
-        "ukphone": "[kəˈnæl]"
-    },
-    {
-        "name": "cancel",
-        "trans": [
-            "vi. 取消，撤销"
-        ],
-        "usphone": "[ˈkænsl]",
-        "ukphone": "[ˈkæns(ə)l]"
-    },
-    {
-        "name": "cancer",
-        "trans": [
-            "[天] 巨蟹座"
-        ],
-        "usphone": "[ˈkænsər]",
-        "ukphone": "[ˈkænsə(r)]"
-    },
-    {
-        "name": "candle",
-        "trans": [
-            "n. 蜡烛；烛光；烛形物"
-        ],
-        "usphone": "[ˈkændl]",
-        "ukphone": "[ˈkænd(ə)l]"
-    },
-    {
-        "name": "capable",
-        "trans": [
-            "adj. 能干的，能胜任的；有才华的"
-        ],
-        "usphone": "[ˈkeɪpəbl]",
-        "ukphone": "[ˈkeɪpəb(ə)l]"
-    },
-    {
-        "name": "capacity",
-        "trans": [
-            "n. 能力；容量；资格，地位；生产力"
-        ],
-        "usphone": "[kəˈpæsəti]",
-        "ukphone": "[kəˈpæsəti]"
-    },
-    {
-        "name": "capture",
-        "trans": [
-            "n. 捕获；战利品，俘虏"
-        ],
-        "usphone": "[ˈkæptʃər]",
-        "ukphone": "[ˈkæptʃə(r)]"
-    },
-    {
-        "name": "carbon",
-        "trans": [
-            "n. [化学] 碳；碳棒；复写纸"
-        ],
-        "usphone": "[ˈkɑːrbən]",
-        "ukphone": "[ˈkɑːbən]"
-    },
-    {
-        "name": "cast",
-        "trans": [
-            "n. 投掷，抛；铸件，[古生] 铸型；演员阵容；脱落物"
-        ],
-        "usphone": "[kæst]",
-        "ukphone": "[kɑːst]"
-    },
-    {
-        "name": "casual",
-        "trans": [
-            "n. 便装；临时工人；待命士兵"
-        ],
-        "usphone": "[ˈkæʒuəl]",
-        "ukphone": "[ˈkæʒuəl]"
-    },
-    {
-        "name": "catch",
-        "trans": [
-            "n. 捕捉；捕获物；窗钩"
-        ],
-        "usphone": "[kætʃ]",
-        "ukphone": "[kætʃ]"
-    },
-    {
-        "name": "cave",
-        "trans": [
-            "n. 洞穴，窑洞"
-        ],
-        "usphone": "[keɪv]",
-        "ukphone": "[keɪv]"
-    },
-    {
-        "name": "cell",
-        "trans": [
-            "n. 细胞；电池；蜂房的巢室；单人小室"
-        ],
-        "usphone": "[sel]",
-        "ukphone": "[sel]"
-    },
-    {
-        "name": "certainty",
-        "trans": [
-            "n. 必然；确实；确实的事情"
-        ],
-        "usphone": "[ˈsɜːrtnti]",
-        "ukphone": "[ˈsɜːt(ə)nti]"
-    },
-    {
-        "name": "certificate",
-        "trans": [
-            "n. 证书；执照，文凭"
-        ],
-        "usphone": "[sərˈtɪfɪkət]",
-        "ukphone": "[səˈtɪfɪkət]"
-    },
-    {
-        "name": "chain",
-        "trans": [
-            "n. 链；束缚；枷锁"
-        ],
-        "usphone": "[tʃeɪn]",
-        "ukphone": "[tʃeɪn]"
-    },
-    {
-        "name": "chair",
-        "trans": [
-            "n. 椅子；讲座；（会议的）主席位；大学教授的职位"
-        ],
-        "usphone": "[tʃer]",
-        "ukphone": "[tʃeə(r)]"
-    },
-    {
-        "name": "chairman",
-        "trans": [
-            "n. 主席，会长；董事长"
-        ],
-        "usphone": "[ˈtʃermən]",
-        "ukphone": "[ˈtʃeəmən]"
-    },
-    {
-        "name": "challenge",
-        "trans": [
-            "n. 挑战；怀疑"
-        ],
-        "usphone": "[ˈtʃælɪndʒ]",
-        "ukphone": "[ˈtʃælɪndʒ]"
-    },
-    {
-        "name": "challenging",
-        "trans": [
-            "v. 要求；质疑；反对；向…挑战；盘问（challenge的ing形式）"
-        ],
-        "usphone": "[ˈtʃælɪndʒɪŋ]",
-        "ukphone": "[ˈtʃælɪndʒɪŋ]"
-    },
-    {
-        "name": "championship",
-        "trans": [
-            "n. 锦标赛；冠军称号；冠军的地位"
-        ],
-        "usphone": "[ˈtʃæmpiənʃɪp]",
-        "ukphone": "[ˈtʃæmpiənʃɪp]"
-    },
-    {
-        "name": "characteristic",
-        "trans": [
-            "n. 特征；特性；特色"
-        ],
-        "usphone": "[ˌkærəktəˈrɪstɪk]",
-        "ukphone": "[ˌkærəktəˈrɪstɪk]"
-    },
-    {
-        "name": "charming",
-        "trans": [
-            "adj. 迷人的；可爱的"
-        ],
-        "usphone": "[ˈtʃɑːrmɪŋ]",
-        "ukphone": "[ˈtʃɑːmɪŋ]"
-    },
-    {
-        "name": "chart",
-        "trans": [
-            "n. 图表；海图；图纸；排行榜"
-        ],
-        "usphone": "[tʃɑːrt]",
-        "ukphone": "[tʃɑːt]"
-    },
-    {
-        "name": "chase",
-        "trans": [
-            "n. 追逐；追赶；追击"
-        ],
-        "usphone": "[tʃeɪs]",
-        "ukphone": "[tʃeɪs]"
-    },
-    {
-        "name": "cheek",
-        "trans": [
-            "n. 面颊，脸颊；臀部"
-        ],
-        "usphone": "[tʃiːk]",
-        "ukphone": "[tʃiːk]"
-    },
-    {
-        "name": "cheer",
-        "trans": [
-            "n. 欢呼；愉快；心情；令人愉快的事"
-        ],
-        "usphone": "[tʃɪr]",
-        "ukphone": "[tʃɪə(r)]"
-    },
-    {
-        "name": "chief",
-        "trans": [
-            "n. 首领；酋长；主要部分"
-        ],
-        "usphone": "[tʃiːf]",
-        "ukphone": "[tʃiːf]"
-    },
-    {
-        "name": "choir",
-        "trans": [
-            "n. 唱诗班；合唱队；舞蹈队"
-        ],
-        "usphone": "[ˈkwaɪər]",
-        "ukphone": "[ˈkwaɪə(r)]"
-    },
-    {
-        "name": "chop",
-        "trans": [
-            "n. 砍；排骨；商标；削球"
-        ],
-        "usphone": "[tʃɑːp]",
-        "ukphone": "[tʃɒp]"
-    },
-    {
-        "name": "circuit",
-        "trans": [
-            "n. [电子] 电路，回路；巡回；一圈；环道"
-        ],
-        "usphone": "[ˈsɜːrkɪt]",
-        "ukphone": "[ˈsɜːkɪt]"
-    },
-    {
-        "name": "circumstance",
-        "trans": [
-            "n. 环境，情况；事件；境遇"
-        ],
-        "usphone": "[ˈsɜːrkəmstæns]",
-        "ukphone": "[ˈsɜːkəmstəns]"
-    },
-    {
-        "name": "cite",
-        "trans": [
-            "vt. 引用；传讯；想起；表彰"
-        ],
-        "usphone": "[saɪt]",
-        "ukphone": "[saɪt]"
-    },
-    {
-        "name": "citizen",
-        "trans": [
-            "n. 公民；市民；老百姓"
-        ],
-        "usphone": "[ˈsɪtɪzn]",
-        "ukphone": "[ˈsɪtɪz(ə)n]"
-    },
-    {
-        "name": "civil",
-        "trans": [
-            "adj. 公民的；民间的；文职的；有礼貌的；根据民法的"
-        ],
-        "usphone": "[ˈsɪvl]",
-        "ukphone": "[ˈsɪv(ə)l]"
-    },
-    {
-        "name": "civilization",
-        "trans": [
-            "n. 文明；文化"
-        ],
-        "usphone": "[ˌsɪvələˈzeɪʃn]",
-        "ukphone": "[ˌsɪvəlaɪˈzeɪʃ(ə)n]"
-    },
-    {
-        "name": "clarify",
-        "trans": [
-            "vt. 澄清；阐明"
-        ],
-        "usphone": "[ˈklærəfaɪ]",
-        "ukphone": "[ˈklærəfaɪ]"
-    },
-    {
-        "name": "classic",
-        "trans": [
-            "n. 名著；经典著作；大艺术家"
-        ],
-        "usphone": "[ˈklæsɪk]",
-        "ukphone": "[ˈklæsɪk]"
-    },
-    {
-        "name": "classify",
-        "trans": [
-            "vt. 分类；分等"
-        ],
-        "usphone": "[ˈklæsɪfaɪ]",
-        "ukphone": "[ˈklæsɪfaɪ]"
-    },
-    {
-        "name": "clerk",
-        "trans": [
-            "n. 职员，办事员；店员；书记；记账员；<古>牧师，教士"
-        ],
-        "usphone": "[klɜːrk]",
-        "ukphone": "[klɑːk]"
-    },
-    {
-        "name": "cliff",
-        "trans": [
-            "n. 悬崖；绝壁"
-        ],
-        "usphone": "[klɪf]",
-        "ukphone": "[klɪf]"
-    },
-    {
-        "name": "clinic",
-        "trans": [
-            "n. 临床；诊所"
-        ],
-        "usphone": "[ˈklɪnɪk]",
-        "ukphone": "[ˈklɪnɪk]"
-    },
-    {
-        "name": "close",
-        "trans": [
-            "n. 结束"
-        ],
-        "usphone": "[kloʊz; kloʊs]",
-        "ukphone": "[kləʊz]"
-    },
-    {
-        "name": "closely",
-        "trans": [
-            "adv. 紧密地；接近地；严密地；亲近地"
-        ],
-        "usphone": "[ˈkloʊsli]",
-        "ukphone": "[ˈkləʊsli]"
-    },
-    {
-        "name": "coincidence",
-        "trans": [
-            "n. 巧合；一致；同时发生"
-        ],
-        "usphone": "[koʊˈɪnsɪdəns]",
-        "ukphone": "[kəʊˈɪnsɪdəns]"
-    },
-    {
-        "name": "collapse",
-        "trans": [
-            "n. 倒塌；失败；衰竭"
-        ],
-        "usphone": "[kəˈlæps]",
-        "ukphone": "[kəˈlæps]"
-    },
-    {
-        "name": "collector",
-        "trans": [
-            "n. 收藏家；[电子] 集电极；收税员；征收者"
-        ],
-        "usphone": "[kəˈlektər]",
-        "ukphone": "[kəˈlektə(r)]"
-    },
-    {
-        "name": "colony",
-        "trans": [
-            "n. 殖民地；移民队；种群；动物栖息地"
-        ],
-        "usphone": "[ˈkɑːləni]",
-        "ukphone": "[ˈkɒləni]"
-    },
-    {
-        "name": "colourful",
-        "trans": [
-            "adj. 鲜艳的；生动的；色彩丰富的；富有趣味的"
-        ],
-        "usphone": "[ˈkʌlərfl]",
-        "ukphone": "[ˈkʌləf(ə)l]"
-    },
-    {
-        "name": "combination",
-        "trans": [
-            "n. 结合；组合；联合；[化学] 化合"
-        ],
-        "usphone": "[ˌkɑːmbɪˈneɪʃn]",
-        "ukphone": "[ˌkɒmbɪˈneɪʃ(ə)n]"
-    },
-    {
-        "name": "comfort",
-        "trans": [
-            "n. 安慰；舒适；安慰者"
-        ],
-        "usphone": "[ˈkʌmfərt]",
-        "ukphone": "[ˈkʌmfət]"
-    },
-    {
-        "name": "comic",
-        "trans": [
-            "n. 连环漫画；喜剧演员；滑稽人物"
-        ],
-        "usphone": "[ˈkɑːmɪk]",
-        "ukphone": "[ˈkɒmɪk]"
-    },
-    {
-        "name": "command",
-        "trans": [
-            "n. 指挥，控制；命令；司令部"
-        ],
-        "usphone": "[kəˈmænd]",
-        "ukphone": "[kəˈmɑːnd]"
-    },
-    {
-        "name": "commander",
-        "trans": [
-            "n. 指挥官；司令官"
-        ],
-        "usphone": "[kəˈmændər]",
-        "ukphone": "[kəˈmɑːndə(r)]"
-    },
-    {
-        "name": "commission",
-        "trans": [
-            "n. 委员会；佣金；犯；委任；委任状"
-        ],
-        "usphone": "[kəˈmɪʃn]",
-        "ukphone": "[kəˈmɪʃn]"
-    },
-    {
-        "name": "commitment",
-        "trans": [
-            "n. 承诺，保证；委托；承担义务；献身"
-        ],
-        "usphone": "[kəˈmɪtmənt]",
-        "ukphone": "[kəˈmɪtmənt]"
-    },
-    {
-        "name": "committee",
-        "trans": [
-            "n. 委员会"
-        ],
-        "usphone": "[kəˈmɪti]",
-        "ukphone": "[kəˈmɪti]"
-    },
-    {
-        "name": "commonly",
-        "trans": [
-            "adv. 一般地；通常地；普通地"
-        ],
-        "usphone": "[ˈkɑːmənli]",
-        "ukphone": "[ˈkɒmənli]"
-    },
-    {
-        "name": "comparative",
-        "trans": [
-            "n. 比较级；对手"
-        ],
-        "usphone": "[kəmˈpærətɪv]",
-        "ukphone": "[kəmˈpærətɪv]"
-    },
-    {
-        "name": "completion",
-        "trans": [
-            "n. 完成，结束；实现"
-        ],
-        "usphone": "[kəmˈpliːʃn]",
-        "ukphone": "[kəmˈpliːʃn]"
-    },
-    {
-        "name": "complex",
-        "trans": [
-            "n. 复合体；综合设施"
-        ],
-        "usphone": "[kəmˈpleks; ˈkɑːmpleks]",
-        "ukphone": "[ˈkɒmpleks]"
-    },
-    {
-        "name": "complicated",
-        "trans": [
-            "adj. 难懂的，复杂的"
-        ],
-        "usphone": "[ˈkɑːmplɪkeɪtɪd]",
-        "ukphone": "[ˈkɒmplɪkeɪtɪd]"
-    },
-    {
-        "name": "component",
-        "trans": [
-            "n. 成分；组件；[电子] 元件"
-        ],
-        "usphone": "[kəmˈpoʊnənt]",
-        "ukphone": "[kəmˈpəʊnənt]"
-    },
-    {
-        "name": "compose",
-        "trans": [
-            "vt. 构成；写作；使平静；排…的版"
-        ],
-        "usphone": "[kəmˈpoʊz]",
-        "ukphone": "[kəmˈpəʊz]"
-    },
-    {
-        "name": "composer",
-        "trans": [
-            "n. 作曲家；作家，著作者；设计者"
-        ],
-        "usphone": "[kəmˈpoʊzər]",
-        "ukphone": "[kəmˈpəʊzə(r)]"
-    },
-    {
-        "name": "compound",
-        "trans": [
-            "n. [化学] 化合物；混合物；复合词"
-        ],
-        "usphone": "[ˈkɑːmpaʊnd]",
-        "ukphone": "[ˈkɒmpaʊnd]"
-    },
-    {
-        "name": "comprehensive",
-        "trans": [
-            "n. 综合学校；专业综合测验"
-        ],
-        "usphone": "[ˌkɑːmprɪˈhensɪv]",
-        "ukphone": "[ˌkɒmprɪˈhensɪv]"
-    },
-    {
-        "name": "comprise",
-        "trans": [
-            "vt. 包含；由…组成"
-        ],
-        "usphone": "[kəmˈpraɪz]",
-        "ukphone": "[kəmˈpraɪz]"
-    },
-    {
-        "name": "compulsory",
-        "trans": [
-            "n. （花样滑冰、竞技体操等的）规定动作"
-        ],
-        "usphone": "[kəmˈpʌlsəri]",
-        "ukphone": "[kəmˈpʌlsəri]"
-    },
-    {
-        "name": "concentration",
-        "trans": [
-            "n. 浓度；集中；浓缩；专心；集合"
-        ],
-        "usphone": "[ˌkɑːnsnˈtreɪʃn]",
-        "ukphone": "[ˌkɒns(ə)nˈtreɪʃ(ə)n]"
-    },
-    {
-        "name": "concept",
-        "trans": [
-            "n. 观念，概念"
-        ],
-        "usphone": "[ˈkɑːnsept]",
-        "ukphone": "[ˈkɒnsept]"
-    },
-    {
-        "name": "concern",
-        "trans": [
-            "n. 关系；关心；关心的事；忧虑"
-        ],
-        "usphone": "[kənˈsɜːrn]",
-        "ukphone": "[kənˈsɜː(r)n]"
-    },
-    {
-        "name": "concerned",
-        "trans": [
-            "v. 关心（concern的过去时和过去分词）；与…有关"
-        ],
-        "usphone": "[kənˈsɜːrnd]",
-        "ukphone": "[kənˈsɜːnd]"
-    },
-    {
-        "name": "concrete",
-        "trans": [
-            "n. 具体物；凝结物"
-        ],
-        "usphone": "[ˈkɑːnkriːt]",
-        "ukphone": "[ˈkɒŋkriːt]"
-    },
-    {
-        "name": "conduct",
-        "trans": [
-            "n. 进行；行为；实施"
-        ],
-        "usphone": "[kənˈdʌkt; ˈkɑːndʌkt]",
-        "ukphone": "[kənˈdʌkt; ˈkɒndʌkt]"
-    },
-    {
-        "name": "confess",
-        "trans": [
-            "vi. 承认；坦白；忏悔；供认"
-        ],
-        "usphone": "[kənˈfes]",
-        "ukphone": "[kənˈfes]"
-    },
-    {
-        "name": "confidence",
-        "trans": [
-            "n. 信心；信任；秘密"
-        ],
-        "usphone": "[ˈkɑːnfɪdəns]",
-        "ukphone": "[ˈkɒnfɪdəns]"
-    },
-    {
-        "name": "conflict",
-        "trans": [
-            "n. 冲突，矛盾；斗争；争执"
-        ],
-        "usphone": "[ˈkɑːnflɪkt]",
-        "ukphone": "[ˈkɒnflɪkt]"
-    },
-    {
-        "name": "confusing",
-        "trans": [
-            "v. 使迷惑；使混乱不清；使困窘（confuse的ing形式）"
-        ],
-        "usphone": "[kənˈfjuːzɪŋ]",
-        "ukphone": "[kənˈfjuːzɪŋ]"
-    },
-    {
-        "name": "confusion",
-        "trans": [
-            "n. 混淆，混乱；困惑"
-        ],
-        "usphone": "[kənˈfjuːʒn]",
-        "ukphone": "[kənˈfjuːʒn]"
-    },
-    {
-        "name": "conscious",
-        "trans": [
-            "adj. 意识到的；故意的；神志清醒的"
-        ],
-        "usphone": "[ˈkɑːnʃəs]",
-        "ukphone": "[ˈkɒnʃəs]"
-    },
-    {
-        "name": "consequently",
-        "trans": [
-            "adv. 因此；结果；所以"
-        ],
-        "usphone": "[ˈkɑːnsɪkwentli]",
-        "ukphone": "[ˈkɒnsɪkwəntli]"
-    },
-    {
-        "name": "conservation",
-        "trans": [
-            "n. 保存，保持；保护"
-        ],
-        "usphone": "[ˌkɑːnsərˈveɪʃn]",
-        "ukphone": "[ˌkɒnsəˈveɪʃ(ə)n]"
-    },
-    {
-        "name": "conservative",
-        "trans": [
-            "n. 保守派，守旧者"
-        ],
-        "usphone": "[kənˈsɜːrvətɪv]",
-        "ukphone": "[kənˈsɜːvətɪv]"
-    },
-    {
-        "name": "considerable",
-        "trans": [
-            "adj. 相当大的；重要的，值得考虑的"
-        ],
-        "usphone": "[kənˈsɪdərəbl]",
-        "ukphone": "[kənˈsɪdərəb(ə)l]"
-    },
-    {
-        "name": "considerably",
-        "trans": [
-            "adv. 相当地；非常地"
-        ],
-        "usphone": "[kənˈsɪdərəbli]",
-        "ukphone": "[kənˈsɪdərəbli]"
-    },
-    {
-        "name": "consideration",
-        "trans": [
-            "n. 考虑；原因；关心；报酬"
-        ],
-        "usphone": "[kənˌsɪdəˈreɪʃn]",
-        "ukphone": "[kənˌsɪdəˈreɪʃn]"
-    },
-    {
-        "name": "consistent",
-        "trans": [
-            "adj. 始终如一的，一致的；坚持的"
-        ],
-        "usphone": "[kənˈsɪstənt]",
-        "ukphone": "[kənˈsɪstənt]"
-    },
-    {
-        "name": "consistently",
-        "trans": [
-            "adv. 一贯地；一致地；坚实地"
-        ],
-        "usphone": "[kənˈsɪstəntli]",
-        "ukphone": "[kənˈsɪstəntli]"
-    },
-    {
-        "name": "conspiracy",
-        "trans": [
-            "n. 阴谋；共谋；阴谋集团"
-        ],
-        "usphone": "[kənˈspɪrəsi]",
-        "ukphone": "[kənˈspɪrəsi]"
-    },
-    {
-        "name": "constant",
-        "trans": [
-            "n. [数] 常数；恒量"
-        ],
-        "usphone": "[ˈkɑːnstənt]",
-        "ukphone": "[ˈkɒnstənt]"
-    },
-    {
-        "name": "constantly",
-        "trans": [
-            "adv. 不断地；时常地"
-        ],
-        "usphone": "[ˈkɑːnstəntli]",
-        "ukphone": "[ˈkɒnstəntli]"
-    },
-    {
-        "name": "construct",
-        "trans": [
-            "n. 构想，概念"
-        ],
-        "usphone": "[kənˈstrʌkt]",
-        "ukphone": "[kənˈstrʌkt]"
-    },
-    {
-        "name": "construction",
-        "trans": [
-            "n. 建设；建筑物；解释；造句"
-        ],
-        "usphone": "[kənˈstrʌkʃn]",
-        "ukphone": "[kənˈstrʌkʃn]"
-    },
-    {
-        "name": "consult",
-        "trans": [
-            "vi. 请教；商议；当顾问"
-        ],
-        "usphone": "[kənˈsʌlt]",
-        "ukphone": "[kənˈsʌlt]"
-    },
-    {
-        "name": "consultant",
-        "trans": [
-            "n. 顾问；咨询者；会诊医生"
-        ],
-        "usphone": "[kənˈsʌltənt]",
-        "ukphone": "[kənˈsʌltənt]"
-    },
-    {
-        "name": "consumption",
-        "trans": [
-            "n. 消费；消耗；肺痨"
-        ],
-        "usphone": "[kənˈsʌmpʃn]",
-        "ukphone": "[kənˈsʌmpʃn]"
-    },
-    {
-        "name": "contemporary",
-        "trans": [
-            "n. 同时代的人；同时期的东西"
-        ],
-        "usphone": "[kənˈtempəreri]",
-        "ukphone": "[kənˈtemprəri]"
-    },
-    {
-        "name": "contest",
-        "trans": [
-            "n. 竞赛；争夺；争论"
-        ],
-        "usphone": "[ˈkɑːntest]",
-        "ukphone": "[ˈkɒntest]"
-    },
-    {
-        "name": "contract",
-        "trans": [
-            "n. 合同；婚约"
-        ],
-        "usphone": "[ˈkɑːntrækt; kənˈtrækt]",
-        "ukphone": "[ˈkɒntrækt; kənˈtrækt]"
-    },
-    {
-        "name": "contribute",
-        "trans": [
-            "vt. 贡献，出力；投稿；捐献"
-        ],
-        "usphone": "[kənˈtrɪbjuːt]",
-        "ukphone": "[kənˈtrɪbjuːt]"
-    },
-    {
-        "name": "contribution",
-        "trans": [
-            "n. 贡献；捐献；投稿"
-        ],
-        "usphone": "[ˌkɑːntrɪˈbjuːʃn]",
-        "ukphone": "[ˌkɒntrɪˈbjuːʃ(ə)n]"
-    },
-    {
-        "name": "controversial",
-        "trans": [
-            "adj. 有争议的；有争论的"
-        ],
-        "usphone": "[ˌkɑːntrəˈvɜːrʃl]",
-        "ukphone": "[ˌkɒntrəˈvɜːʃ(ə)l]"
-    },
-    {
-        "name": "controversy",
-        "trans": [
-            "n. 争论；论战；辩论"
-        ],
-        "usphone": "[ˈkɑːntrəvɜːrsi]",
-        "ukphone": "[ˈkɒntrəvɜːsi]"
-    },
-    {
-        "name": "convenience",
-        "trans": [
-            "n. 便利；厕所；便利的事物"
-        ],
-        "usphone": "[kənˈviːniəns]",
-        "ukphone": "[kənˈviːniəns]"
-    },
-    {
-        "name": "convention",
-        "trans": [
-            "n. 大会；[法] 惯例；[计] 约定；[法] 协定；习俗"
-        ],
-        "usphone": "[kənˈvenʃn]",
-        "ukphone": "[kənˈvenʃn]"
-    },
-    {
-        "name": "conventional",
-        "trans": [
-            "adj. 符合习俗的，传统的；常见的；惯例的"
-        ],
-        "usphone": "[kənˈvenʃənl]",
-        "ukphone": "[kənˈvenʃən(ə)l]"
-    },
-    {
-        "name": "convert",
-        "trans": [
-            "n. 皈依者；改变宗教信仰者"
-        ],
-        "usphone": "[kənˈvɜːrt]",
-        "ukphone": "[kənˈvɜːt]"
-    },
-    {
-        "name": "convey",
-        "trans": [
-            "vt. 传达；运输；让与"
-        ],
-        "usphone": "[kənˈveɪ]",
-        "ukphone": "[kənˈveɪ]"
-    },
-    {
-        "name": "convinced",
-        "trans": [
-            "v. 使确信（convince的过去分词）；说服"
-        ],
-        "usphone": "[kənˈvɪnst]",
-        "ukphone": "[kənˈvɪnst]"
-    },
-    {
-        "name": "convincing",
-        "trans": [
-            "v. 使相信；使明白（convince的现在分词）"
-        ],
-        "usphone": "[kənˈvɪnsɪŋ]",
-        "ukphone": "[kənˈvɪnsɪŋ]"
-    },
-    {
-        "name": "cope",
-        "trans": [
-            "n. 长袍"
-        ],
-        "usphone": "[koʊp]",
-        "ukphone": "[kəʊp]"
-    },
-    {
-        "name": "core",
-        "trans": [
-            "n. 核心；要点；果心；[计] 磁心"
-        ],
-        "usphone": "[kɔːr]",
-        "ukphone": "[kɔː(r)]"
-    },
-    {
-        "name": "corporate",
-        "trans": [
-            "adj. 法人的；共同的，全体的；社团的；公司的；企业的"
-        ],
-        "usphone": "[ˈkɔːrpərət]",
-        "ukphone": "[ˈkɔːpərət]"
-    },
-    {
-        "name": "corporation",
-        "trans": [
-            "n. 公司；法人（团体）；社团；大腹便便；市政当局"
-        ],
-        "usphone": "[ˌkɔːrpəˈreɪʃ(ə)n]",
-        "ukphone": "[ˌkɔːpəˈreɪʃn]"
-    },
-    {
-        "name": "corridor",
-        "trans": [
-            "走廊"
-        ],
-        "usphone": "[ˈkɔːrɪdɔːr]",
-        "ukphone": "[ˈkɒrɪdɔː(r)]"
-    },
-    {
-        "name": "council",
-        "trans": [
-            "n. 委员会；会议；理事会；地方议会；顾问班子"
-        ],
-        "usphone": "[ˈkaʊnsl]",
-        "ukphone": "[ˈkaʊns(ə)l]"
-    },
-    {
-        "name": "counter",
-        "trans": [
-            "n. 柜台；对立面；计数器；（某些棋盘游戏的）筹码"
-        ],
-        "usphone": "[ˈkaʊntər]",
-        "ukphone": "[ˈkaʊntə(r)]"
-    },
-    {
-        "name": "county",
-        "trans": [
-            "n. 郡，县"
-        ],
-        "usphone": "[ˈkaʊnti]",
-        "ukphone": "[ˈkaʊnti]"
-    },
-    {
-        "name": "courage",
-        "trans": [
-            "n. 勇气；胆量"
-        ],
-        "usphone": "[ˈkɜːrɪdʒ]",
-        "ukphone": "[ˈkʌrɪdʒ]"
-    },
-    {
-        "name": "coverage",
-        "trans": [
-            "n. 覆盖，覆盖范围；新闻报道"
-        ],
-        "usphone": "[ˈkʌvərɪdʒ]",
-        "ukphone": "[ˈkʌvərɪdʒ]"
-    },
-    {
-        "name": "crack",
-        "trans": [
-            "n. 裂缝；声变；噼啪声"
-        ],
-        "usphone": "[kræk]",
-        "ukphone": "[kræk]"
-    },
-    {
-        "name": "craft",
-        "trans": [
-            "n. 工艺；手艺；太空船"
-        ],
-        "usphone": "[kræft]",
-        "ukphone": "[krɑːft]"
-    },
-    {
-        "name": "crash",
-        "trans": [
-            "n. 撞碎；坠毁；破产；轰隆声；睡觉"
-        ],
-        "usphone": "[kræʃ]",
-        "ukphone": "[kræʃ]"
-    },
-    {
-        "name": "creation",
-        "trans": [
-            "n. 创造，创作；创作物，产物"
-        ],
-        "usphone": "[kriˈeɪʃn]",
-        "ukphone": "[kriˈeɪʃ(ə)n]"
-    },
-    {
-        "name": "creativity",
-        "trans": [
-            "n. 创造力；创造性"
-        ],
-        "usphone": "[ˌkriːeɪˈtɪvəti]",
-        "ukphone": "[ˌkriːeɪˈtɪvəti]"
-    },
-    {
-        "name": "creature",
-        "trans": [
-            "n. 动物，生物；人；创造物"
-        ],
-        "usphone": "[ˈkriːtʃər]",
-        "ukphone": "[ˈkriːtʃə(r)]"
-    },
-    {
-        "name": "credit",
-        "trans": [
-            "n. 信用，信誉；[金融] 贷款；学分；信任；声望"
-        ],
-        "usphone": "[ˈkredɪt]",
-        "ukphone": "[ˈkredɪt]"
-    },
-    {
-        "name": "crew",
-        "trans": [
-            "n. 队，组；全体人员，全体船员"
-        ],
-        "usphone": "[kruː]",
-        "ukphone": "[kruː]"
-    },
-    {
-        "name": "crisis",
-        "trans": [
-            "n. 危机；危险期；决定性时刻"
-        ],
-        "usphone": "[ˈkraɪsɪs]",
-        "ukphone": "[ˈkraɪsɪs]"
-    },
-    {
-        "name": "criterion",
-        "trans": [
-            "n. （批评判断的）标准；准则；规范；准据"
-        ],
-        "usphone": "[kraɪˈtɪriən]",
-        "ukphone": "[kraɪˈtɪəriən]"
-    },
-    {
-        "name": "critic",
-        "trans": [
-            "n. 批评家，评论家；爱挑剔的人"
-        ],
-        "usphone": "[ˈkrɪtɪk]",
-        "ukphone": "[ˈkrɪtɪk]"
-    },
-    {
-        "name": "critical",
-        "trans": [
-            "adj. 鉴定的；[核] 临界的；批评的，爱挑剔的；危险的；决定性的；评论的"
-        ],
-        "usphone": "[ˈkrɪtɪkl]",
-        "ukphone": "[ˈkrɪtɪk(ə)l]"
-    },
-    {
-        "name": "critically",
-        "trans": [
-            "adv. 精密地；危急地；严重地；批评性地；用钻研眼光地；很大程度上；极为重要地"
-        ],
-        "usphone": "[ˈkrɪtɪkli]",
-        "ukphone": "[ˈkrɪtɪkli]"
-    },
-    {
-        "name": "criticism",
-        "trans": [
-            "n. 批评；考证；苛求"
-        ],
-        "usphone": "[ˈkrɪtɪsɪzəm]",
-        "ukphone": "[ˈkrɪtɪsɪzəm]"
-    },
-    {
-        "name": "criticize",
-        "trans": [
-            "vi. 批评；评论；苛求"
-        ],
-        "usphone": "[ˈkrɪtɪsaɪz]",
-        "ukphone": "[ˈkrɪtɪsaɪz]"
-    },
-    {
-        "name": "crop",
-        "trans": [
-            "n. 产量；农作物；庄稼；平头"
-        ],
-        "usphone": "[krɑːp]",
-        "ukphone": "[krɒp]"
-    },
-    {
-        "name": "crucial",
-        "trans": [
-            "adj. 重要的；决定性的；定局的；决断的"
-        ],
-        "usphone": "[ˈkruːʃl]",
-        "ukphone": "[ˈkruːʃ(ə)l]"
-    },
-    {
-        "name": "cruise",
-        "trans": [
-            "n. 巡航，巡游；乘船游览"
-        ],
-        "usphone": "[kruːz]",
-        "ukphone": "[kruːz]"
-    },
-    {
-        "name": "cry",
-        "trans": [
-            "n. 叫喊；叫声；口号；呼叫"
-        ],
-        "usphone": "[kraɪ]",
-        "ukphone": "[kraɪ]"
-    },
-    {
-        "name": "cue",
-        "trans": [
-            "n. 提示，暗示；线索"
-        ],
-        "usphone": "[kjuː]",
-        "ukphone": "[kjuː]"
-    },
-    {
-        "name": "cure",
-        "trans": [
-            "n. 治疗；治愈；[临床] 疗法"
-        ],
-        "usphone": "[kjʊr]",
-        "ukphone": "[kjʊə(r)]"
-    },
-    {
-        "name": "curious",
-        "trans": [
-            "adj. 好奇的，有求知欲的；古怪的；爱挑剔的"
-        ],
-        "usphone": "[ˈkjʊriəs]",
-        "ukphone": "[ˈkjʊəriəs]"
-    },
-    {
-        "name": "current",
-        "trans": [
-            "n. （水，气，电）流；趋势；涌流"
-        ],
-        "usphone": "[ˈkɜːrənt]",
-        "ukphone": "[ˈkʌrənt]"
-    },
-    {
-        "name": "curriculum",
-        "trans": [
-            "n. 课程"
-        ],
-        "usphone": "[kəˈrɪkjələm]",
-        "ukphone": "[kəˈrɪkjələm]"
-    },
-    {
-        "name": "curve",
-        "trans": [
-            "n. 曲线；弯曲；曲线球；曲线图表"
-        ],
-        "usphone": "[kɜːrv]",
-        "ukphone": "[kɜːv]"
-    },
-    {
-        "name": "curved",
-        "trans": [
-            "n. 倒弧角"
-        ],
-        "usphone": "[kɜːrvd]",
-        "ukphone": "[kɜːvd]"
-    },
-    {
-        "name": "cute",
-        "trans": [
-            "adj. 可爱的；漂亮的；聪明的，伶俐的"
-        ],
-        "usphone": "[kjuːt]",
-        "ukphone": "[kjuːt]"
-    },
-    {
-        "name": "dairy",
-        "trans": [
-            "n. 奶制品；乳牛；制酪场；乳品店；牛奶及乳品业"
-        ],
-        "usphone": "[ˈderi]",
-        "ukphone": "[ˈdeəri]"
-    },
-    {
-        "name": "dare",
-        "trans": [
-            "n. 挑战；挑动"
-        ],
-        "usphone": "[der]",
-        "ukphone": "[deə(r)]"
-    },
-    {
-        "name": "darkness",
-        "trans": [
-            "n. 黑暗；模糊；无知；阴郁"
-        ],
-        "usphone": "[ˈdɑːrknəs]",
-        "ukphone": "[ˈdɑːknəs]"
-    },
-    {
-        "name": "database",
-        "trans": [
-            "n. 数据库，资料库"
-        ],
-        "usphone": "[ˈdeɪtəbeɪs; ˈdætəbeɪs]",
-        "ukphone": "[ˈdeɪtəbeɪs]"
-    },
-    {
-        "name": "date",
-        "trans": [
-            "n. 日期；约会；年代；枣椰子"
-        ],
-        "usphone": "[deɪt]",
-        "ukphone": "[deɪt]"
-    },
-    {
-        "name": "deadline",
-        "trans": [
-            "n. 截止期限，最后期限"
-        ],
-        "usphone": "[ˈdedlaɪn]",
-        "ukphone": "[ˈdedlaɪn]"
-    },
-    {
-        "name": "deadly",
-        "trans": [
-            "adj. 致命的；非常的；死一般的"
-        ],
-        "usphone": "[ˈdedli]",
-        "ukphone": "[ˈdedli]"
-    },
-    {
-        "name": "dealer",
-        "trans": [
-            "n. 经销商；商人"
-        ],
-        "usphone": "[ˈdiːlər]",
-        "ukphone": "[ˈdiːlə(r)]"
-    },
-    {
-        "name": "debate",
-        "trans": [
-            "n. 辩论；辩论会"
-        ],
-        "usphone": "[dɪˈbeɪt]",
-        "ukphone": "[dɪˈbeɪt]"
-    },
-    {
-        "name": "debt",
-        "trans": [
-            "n. 债务；借款；罪过"
-        ],
-        "usphone": "[det]",
-        "ukphone": "[det]"
-    },
-    {
-        "name": "decent",
-        "trans": [
-            "adj. 正派的；得体的；相当好的"
-        ],
-        "usphone": "[ˈdiːsnt]",
-        "ukphone": "[ˈdiːs(ə)nt]"
-    },
-    {
-        "name": "deck",
-        "trans": [
-            "n. 甲板；行李仓；露天平台"
-        ],
-        "usphone": "[dek]",
-        "ukphone": "[dek]"
-    },
-    {
-        "name": "declare",
-        "trans": [
-            "vt. 宣布，声明；断言，宣称"
-        ],
-        "usphone": "[dɪˈkler]",
-        "ukphone": "[dɪˈkleə(r)]"
-    },
-    {
-        "name": "decline",
-        "trans": [
-            "n. 下降；衰退；斜面"
-        ],
-        "usphone": "[dɪˈklaɪn]",
-        "ukphone": "[dɪˈklaɪn]"
-    },
-    {
-        "name": "decoration",
-        "trans": [
-            "n. 装饰，装潢；装饰品；奖章"
-        ],
-        "usphone": "[ˌdekəˈreɪʃn]",
-        "ukphone": "[ˌdekəˈreɪʃn]"
-    },
-    {
-        "name": "decrease",
-        "trans": [
-            "n. 减少，减小；减少量"
-        ],
-        "usphone": "[dɪˈkriːs; ˈdiːkriːs]",
-        "ukphone": "[dɪˈkriːs]"
-    },
-    {
-        "name": "deeply",
-        "trans": [
-            "adv. 深刻地；浓浓地；在深处"
-        ],
-        "usphone": "[ˈdiːpli]",
-        "ukphone": "[ˈdiːpli]"
-    },
-    {
-        "name": "defeat",
-        "trans": [
-            "n. 失败的事实；击败的行为"
-        ],
-        "usphone": "[dɪˈfiːt]",
-        "ukphone": "[dɪˈfiːt]"
-    },
-    {
-        "name": "defence",
-        "trans": [
-            "n. 防御；防卫；答辩；防卫设备"
-        ],
-        "usphone": "[dɪˈfens]",
-        "ukphone": "[dɪˈfens]"
-    },
-    {
-        "name": "defend",
-        "trans": [
-            "vi. 保卫；防守"
-        ],
-        "usphone": "[dɪˈfend]",
-        "ukphone": "[dɪˈfend]"
-    },
-    {
-        "name": "defender",
-        "trans": [
-            "n. 防卫者，守卫者；辩护者；拥护者；卫冕者"
-        ],
-        "usphone": "[dɪˈfendər]",
-        "ukphone": "[dɪˈfendə(r)]"
-    },
-    {
-        "name": "delay",
-        "trans": [
-            "n. 延期；耽搁；被耽搁或推迟的时间"
-        ],
-        "usphone": "[dɪˈleɪ]",
-        "ukphone": "[dɪˈleɪ]"
-    },
-    {
-        "name": "delete",
-        "trans": [
-            "vt. 删除"
-        ],
-        "usphone": "[dɪˈliːt]",
-        "ukphone": "[dɪˈliːt]"
-    },
-    {
-        "name": "deliberate",
-        "trans": [
-            "adj. 故意的；深思熟虑的；从容的"
-        ],
-        "usphone": "[dɪˈlɪbərət]",
-        "ukphone": "[dɪˈlɪbərət]"
-    },
-    {
-        "name": "deliberately",
-        "trans": [
-            "adv. 故意地；谨慎地；慎重地"
-        ],
-        "usphone": "[dɪˈlɪbərətli]",
-        "ukphone": "[dɪˈlɪbərətli]"
-    },
-    {
-        "name": "delight",
-        "trans": [
-            "n. 高兴"
-        ],
-        "usphone": "[dɪˈlaɪt]",
-        "ukphone": "[dɪˈlaɪt]"
-    },
-    {
-        "name": "delighted",
-        "trans": [
-            "adj. 高兴的；欣喜的"
-        ],
-        "usphone": "[dɪˈlaɪtɪd]",
-        "ukphone": "[dɪˈlaɪtɪd]"
-    },
-    {
-        "name": "delivery",
-        "trans": [
-            "n. [贸易] 交付；分娩；递送"
-        ],
-        "usphone": "[dɪˈlɪvəri]",
-        "ukphone": "[dɪˈlɪvəri]"
-    },
-    {
-        "name": "demand",
-        "trans": [
-            "n. [经] 需求；要求；需要"
-        ],
-        "usphone": "[dɪˈmænd]",
-        "ukphone": "[dɪˈmɑːnd]"
-    },
-    {
-        "name": "democracy",
-        "trans": [
-            "n. 民主，民主主义；民主政治"
-        ],
-        "usphone": "[dɪˈmɑːkrəsi]",
-        "ukphone": "[dɪˈmɒkrəsi]"
-    },
-    {
-        "name": "democratic",
-        "trans": [
-            "adj. 民主的；民主政治的；大众的"
-        ],
-        "usphone": "[ˌdeməˈkrætɪk]",
-        "ukphone": "[ˌdeməˈkrætɪk]"
-    },
-    {
-        "name": "demonstrate",
-        "trans": [
-            "vt. 证明；展示；论证"
-        ],
-        "usphone": "[ˈdemənstreɪt]",
-        "ukphone": "[ˈdemənstreɪt]"
-    },
-    {
-        "name": "demonstration",
-        "trans": [
-            "n. 示范；证明；示威游行"
-        ],
-        "usphone": "[ˌdemənˈstreɪʃn]",
-        "ukphone": "[ˌdemənˈstreɪʃn]"
-    },
-    {
-        "name": "deny",
-        "trans": [
-            "vi. 否认；拒绝"
-        ],
-        "usphone": "[dɪˈnaɪ]",
-        "ukphone": "[dɪˈnaɪ]"
-    },
-    {
-        "name": "depart",
-        "trans": [
-            "adj. 逝世的"
-        ],
-        "usphone": "[dɪˈpɑːrt]",
-        "ukphone": "[dɪˈpɑːt]"
-    },
-    {
-        "name": "dependent",
-        "trans": [
-            "n. 依赖他人者；受赡养者"
-        ],
-        "usphone": "[dɪˈpendənt]",
-        "ukphone": "[dɪˈpendənt]"
-    },
-    {
-        "name": "deposit",
-        "trans": [
-            "n. 存款；押金；订金；保证金；沉淀物"
-        ],
-        "usphone": "[dɪˈpɑːzɪt]",
-        "ukphone": "[dɪˈpɒzɪt]"
-    },
-    {
-        "name": "depressed",
-        "trans": [
-            "adj. 沮丧的；萧条的；压低的"
-        ],
-        "usphone": "[dɪˈprest]",
-        "ukphone": "[dɪˈprest]"
-    },
-    {
-        "name": "depressing",
-        "trans": [
-            "adj. 压抑的；使人沮丧的"
-        ],
-        "usphone": "[dɪˈpresɪŋ]",
-        "ukphone": "[dɪˈpresɪŋ]"
-    },
-    {
-        "name": "depression",
-        "trans": [
-            "n. 沮丧；洼地；不景气；忧愁；低气压区"
-        ],
-        "usphone": "[dɪˈpreʃn]",
-        "ukphone": "[dɪˈpreʃn]"
-    },
-    {
-        "name": "depth",
-        "trans": [
-            "n. [海洋] 深度；深奥"
-        ],
-        "usphone": "[depθ]",
-        "ukphone": "[depθ]"
-    },
-    {
-        "name": "derive",
-        "trans": [
-            "vt. 源于；得自；获得"
-        ],
-        "usphone": "[dɪˈraɪv]",
-        "ukphone": "[dɪˈraɪv]"
-    },
-    {
-        "name": "desert",
-        "trans": [
-            "n. 沙漠；荒原；应得的赏罚"
-        ],
-        "usphone": "[ˈdezərt; dɪˈzɜːrt]",
-        "ukphone": "[ˈdezət]"
-    },
-    {
-        "name": "deserve",
-        "trans": [
-            "vi. 应受，应得"
-        ],
-        "usphone": "[dɪˈzɜːrv]",
-        "ukphone": "[dɪˈzɜːv]"
-    },
-    {
-        "name": "desire",
-        "trans": [
-            "n. 欲望；要求，心愿；性欲"
-        ],
-        "usphone": "[dɪˈzaɪər]",
-        "ukphone": "[dɪˈzaɪə(r)]"
-    },
-    {
-        "name": "desperate",
-        "trans": [
-            "adj. 不顾一切的；令人绝望的；极度渴望的"
-        ],
-        "usphone": "[ˈdespərət]",
-        "ukphone": "[ˈdespərət]"
-    },
-    {
-        "name": "desperately",
-        "trans": [
-            "adv. 拼命地；绝望地；极度地"
-        ],
-        "usphone": "[ˈdespərətli]",
-        "ukphone": "[ˈdespərətli]"
-    },
-    {
-        "name": "destruction",
-        "trans": [
-            "n. 破坏，毁灭；摧毁"
-        ],
-        "usphone": "[dɪˈstrʌkʃn]",
-        "ukphone": "[dɪˈstrʌkʃ(ə)n]"
-    },
-    {
-        "name": "detail",
-        "trans": [
-            "n. 细节，详情"
-        ],
-        "usphone": "[ˈdiːteɪlˌdɪˈteɪl]",
-        "ukphone": "[ˈdiːteɪl]"
-    },
-    {
-        "name": "detailed",
-        "trans": [
-            "adj. 详细的，精细的；复杂的，详尽的"
-        ],
-        "usphone": "[ˈdiːteɪldˌdɪˈteɪld]",
-        "ukphone": "[ˈdiːteɪld]"
-    },
-    {
-        "name": "detect",
-        "trans": [
-            "vt. 察觉；发现；探测"
-        ],
-        "usphone": "[dɪˈtekt]",
-        "ukphone": "[dɪˈtekt]"
-    },
-    {
-        "name": "determination",
-        "trans": [
-            "n. 决心；果断；测定"
-        ],
-        "usphone": "[dɪˌtɜːrmɪˈneɪʃn]",
-        "ukphone": "[dɪˌtɜːmɪˈneɪʃ(ə)n]"
-    },
-    {
-        "name": "devote",
-        "trans": [
-            "vt. 致力于；奉献"
-        ],
-        "usphone": "[dɪˈvoʊt]",
-        "ukphone": "[dɪˈvəʊt]"
-    },
-    {
-        "name": "differ",
-        "trans": [
-            "vi. 相异；意见分歧"
-        ],
-        "usphone": "[ˈdɪfər]",
-        "ukphone": "[ˈdɪfə(r)]"
-    },
-    {
-        "name": "dig",
-        "trans": [
-            "n. 戳，刺；挖苦"
-        ],
-        "usphone": "[dɪɡ]",
-        "ukphone": "[dɪɡ]"
-    },
-    {
-        "name": "disability",
-        "trans": [
-            "n. 残疾；无能；无资格；不利条件"
-        ],
-        "usphone": "[ˌdɪsəˈbɪləti]",
-        "ukphone": "[ˌdɪsəˈbɪləti]"
-    },
-    {
-        "name": "disabled",
-        "trans": [
-            "adj. 残废的，有缺陷的"
-        ],
-        "usphone": "[dɪsˈeɪbld]",
-        "ukphone": "[dɪsˈeɪb(ə)ld]"
-    },
-    {
-        "name": "disagreement",
-        "trans": [
-            "n. 不一致；争论；意见不同"
-        ],
-        "usphone": "[ˌdɪsəˈɡriːmənt]",
-        "ukphone": "[ˌdɪsəˈɡriːmənt]"
-    },
-    {
-        "name": "disappoint",
-        "trans": [
-            "vt. 使失望"
-        ],
-        "usphone": "[ˌdɪsəˈpɔɪnt]",
-        "ukphone": "[ˌdɪsəˈpɔɪnt]"
-    },
-    {
-        "name": "disappointment",
-        "trans": [
-            "n. 失望；沮丧"
-        ],
-        "usphone": "[ˌdɪsəˈpɔɪntmənt]",
-        "ukphone": "[ˌdɪsəˈpɔɪntmənt]"
-    },
-    {
-        "name": "disc",
-        "trans": [
-            "n. 圆盘，[电子] 唱片（等于disk）"
-        ],
-        "usphone": "[dɪsk]",
-        "ukphone": "[dɪsk]"
-    },
-    {
-        "name": "discipline",
-        "trans": [
-            "n. 学科；纪律；训练；惩罚"
-        ],
-        "usphone": "[ˈdɪsəplɪn]",
-        "ukphone": "[ˈdɪsəplɪn]"
-    },
-    {
-        "name": "discount",
-        "trans": [
-            "n. 折扣；贴现率"
-        ],
-        "usphone": "[ˈdɪskaʊnt]",
-        "ukphone": "[ˈdɪskaʊnt]"
-    },
-    {
-        "name": "discourage",
-        "trans": [
-            "vt. 阻止；使气馁"
-        ],
-        "usphone": "[dɪsˈkɜːrɪdʒ]",
-        "ukphone": "[dɪsˈkʌrɪdʒ]"
-    },
-    {
-        "name": "dishonest",
-        "trans": [
-            "adj. 不诚实的；欺诈的"
-        ],
-        "usphone": "[dɪsˈɑːnɪst]",
-        "ukphone": "[dɪsˈɒnɪst]"
-    },
-    {
-        "name": "disk",
-        "trans": [
-            "n. [计] 磁盘，磁碟片；圆盘，盘状物；唱片"
-        ],
-        "usphone": "[dɪsk]",
-        "ukphone": "[dɪsk]"
-    },
-    {
-        "name": "dismiss",
-        "trans": [
-            "vt. 解散；解雇；开除；让...离开；不予理会、不予考虑"
-        ],
-        "usphone": "[dɪsˈmɪs]",
-        "ukphone": "[dɪsˈmɪs]"
-    },
-    {
-        "name": "disorder",
-        "trans": [
-            "n. 混乱；骚乱"
-        ],
-        "usphone": "[dɪsˈɔːrdər]",
-        "ukphone": "[dɪsˈɔːdə(r)]"
-    },
-    {
-        "name": "display",
-        "trans": [
-            "n. 显示；炫耀"
-        ],
-        "usphone": "[dɪˈspleɪ]",
-        "ukphone": "[dɪˈspleɪ]"
-    },
-    {
-        "name": "distant",
-        "trans": [
-            "adj. 遥远的；冷漠的；远隔的；不友好的，冷淡的"
-        ],
-        "usphone": "[ˈdɪstənt]",
-        "ukphone": "[ˈdɪstənt]"
-    },
-    {
-        "name": "distinct",
-        "trans": [
-            "adj. 明显的；独特的；清楚的；有区别的"
-        ],
-        "usphone": "[dɪˈstɪŋkt]",
-        "ukphone": "[dɪˈstɪŋkt]"
-    },
-    {
-        "name": "distinguish",
-        "trans": [
-            "vi. 区别，区分；辨别"
-        ],
-        "usphone": "[dɪˈstɪŋɡwɪʃ]",
-        "ukphone": "[dɪˈstɪŋɡwɪʃ]"
-    },
-    {
-        "name": "distract",
-        "trans": [
-            "vt. 转移；分心"
-        ],
-        "usphone": "[dɪˈstrækt]",
-        "ukphone": "[dɪˈstrækt]"
-    },
-    {
-        "name": "distribute",
-        "trans": [
-            "vt. 分配；散布；分开；把…分类"
-        ],
-        "usphone": "[dɪˈstrɪbjuːt]",
-        "ukphone": "[dɪˈstrɪbjuːt]"
-    },
-    {
-        "name": "distribution",
-        "trans": [
-            "n. 分布；分配"
-        ],
-        "usphone": "[ˌdɪstrɪˈbjuːʃn]",
-        "ukphone": "[ˌdɪstrɪˈbjuːʃn]"
-    },
-    {
-        "name": "district",
-        "trans": [
-            "n. 区域；地方；行政区"
-        ],
-        "usphone": "[ˈdɪstrɪkt]",
-        "ukphone": "[ˈdɪstrɪkt]"
-    },
-    {
-        "name": "disturb",
-        "trans": [
-            "vt. 打扰；妨碍；使不安；弄乱；使恼怒"
-        ],
-        "usphone": "[dɪˈstɜːrb]",
-        "ukphone": "[dɪˈstɜːb]"
-    },
-    {
-        "name": "dive",
-        "trans": [
-            "n. 潜水；跳水；俯冲；扑"
-        ],
-        "usphone": "[daɪv]",
-        "ukphone": "[daɪv]"
-    },
-    {
-        "name": "diverse",
-        "trans": [
-            "adj. 不同的；多种多样的；变化多的"
-        ],
-        "usphone": "[daɪˈvɜːrs]",
-        "ukphone": "[daɪˈvɜːs]"
-    },
-    {
-        "name": "diversity",
-        "trans": [
-            "n. 多样性；差异"
-        ],
-        "usphone": "[daɪˈvɜːrsəti; dɪˈvɜːsɪti]",
-        "ukphone": "[daɪˈvɜːsəti]"
-    },
-    {
-        "name": "divide",
-        "trans": [
-            "n. [地理] 分水岭，分水线"
-        ],
-        "usphone": "[dɪˈvaɪd]",
-        "ukphone": "[dɪˈvaɪd]"
-    },
-    {
-        "name": "division",
-        "trans": [
-            "n. [数] 除法；部门；分配；分割；师（军队）；赛区"
-        ],
-        "usphone": "[dɪˈvɪʒn]",
-        "ukphone": "[dɪˈvɪʒ(ə)n]"
-    },
-    {
-        "name": "divorce",
-        "trans": [
-            "n. 离婚；分离"
-        ],
-        "usphone": "[dɪˈvɔːrs]",
-        "ukphone": "[dɪˈvɔːs]"
-    },
-    {
-        "name": "document",
-        "trans": [
-            "n. 文件，公文；[计] 文档；证件"
-        ],
-        "usphone": "[ˈdɑːkjumənt]",
-        "ukphone": "[ˈdɒkjumənt]"
-    },
-    {
-        "name": "domestic",
-        "trans": [
-            "n. 国货；佣人"
-        ],
-        "usphone": "[dəˈmestɪk]",
-        "ukphone": "[dəˈmestɪk]"
-    },
-    {
-        "name": "dominant",
-        "trans": [
-            "n. 显性"
-        ],
-        "usphone": "[ˈdɑːmɪnənt]",
-        "ukphone": "[ˈdɒmɪnənt]"
-    },
-    {
-        "name": "dominate",
-        "trans": [
-            "vt. 控制；支配；占优势；在…中占主要地位"
-        ],
-        "usphone": "[ˈdɑːmɪneɪt]",
-        "ukphone": "[ˈdɒmɪneɪt]"
-    },
-    {
-        "name": "donation",
-        "trans": [
-            "n. 捐款，捐赠物；捐赠"
-        ],
-        "usphone": "[doʊˈneɪʃn]",
-        "ukphone": "[dəʊˈneɪʃ(ə)n]"
-    },
-    {
-        "name": "dot",
-        "trans": [
-            "n. 点，圆点；嫁妆"
-        ],
-        "usphone": "[dɑːt]",
-        "ukphone": "[dɒt]"
-    },
-    {
-        "name": "downtown",
-        "trans": [
-            "n. 市中心区；三分线以外"
-        ],
-        "usphone": "[ˌdaʊnˈtaʊn]",
-        "ukphone": "[ˌdaʊnˈtaʊn]"
-    },
-    {
-        "name": "downwards",
-        "trans": [
-            "adv. 向下，往下"
-        ],
-        "usphone": "[ˈdaʊnwərdz]",
-        "ukphone": "[ˈdaʊnwədz]"
-    },
-    {
-        "name": "dozen",
-        "trans": [
-            "n. 十二个，一打"
-        ],
-        "usphone": "[ˈdʌzn]",
-        "ukphone": "[ˈdʌz(ə)n]"
-    },
-    {
-        "name": "draft",
-        "trans": [
-            "n. 汇票；草稿；选派；（尤指房间、烟囱、炉子等供暖系统中的）（小股）气流"
-        ],
-        "usphone": "[dræft]",
-        "ukphone": "[drɑːft]"
-    },
-    {
-        "name": "drag",
-        "trans": [
-            "n. 拖；拖累"
-        ],
-        "usphone": "[dræɡ]",
-        "ukphone": "[dræɡ]"
-    },
-    {
-        "name": "dramatic",
-        "trans": [
-            "adj. 戏剧的；急剧的；引人注目的；激动人心的"
-        ],
-        "usphone": "[drəˈmætɪk]",
-        "ukphone": "[drəˈmætɪk]"
-    },
-    {
-        "name": "dramatically",
-        "trans": [
-            "adv. 戏剧地；引人注目地"
-        ],
-        "usphone": "[drəˈmætɪkli]",
-        "ukphone": "[drəˈmætɪkli]"
-    },
-    {
-        "name": "drought",
-        "trans": [
-            "n. 干旱；缺乏"
-        ],
-        "usphone": "[draʊt]",
-        "ukphone": "[draʊt]"
-    },
-    {
-        "name": "dull",
-        "trans": [
-            "adj. 钝的；迟钝的；无趣的；呆滞的；阴暗的"
-        ],
-        "usphone": "[dʌl]",
-        "ukphone": "[dʌl]"
-    },
-    {
-        "name": "dump",
-        "trans": [
-            "n. 垃圾场；仓库；无秩序地累积"
-        ],
-        "usphone": "[dʌmp]",
-        "ukphone": "[dʌmp]"
-    },
-    {
-        "name": "duration",
-        "trans": [
-            "n. 持续，持续的时间，期间"
-        ],
-        "usphone": "[duˈreɪʃn]",
-        "ukphone": "[djuˈreɪʃn]"
-    },
-    {
-        "name": "dynamic",
-        "trans": [
-            "n. 动态；动力"
-        ],
-        "usphone": "[daɪˈnæmɪk]",
-        "ukphone": "[daɪˈnæmɪk]"
-    },
-    {
-        "name": "economics",
-        "trans": [
-            "n. 经济学；国家的经济状况"
-        ],
-        "usphone": "[ˌiːkəˈnɑːmɪks; ˌekəˈnɑːmɪks]",
-        "ukphone": "[ˌiːkəˈnɒmɪks]"
-    },
-    {
-        "name": "economist",
-        "trans": [
-            "n. 经济学者；节俭的人"
-        ],
-        "usphone": "[ɪˈkɑːnəmɪst]",
-        "ukphone": "[ɪˈkɒnəmɪst]"
-    },
-    {
-        "name": "edit",
-        "trans": [
-            "vt. 编辑；校订"
-        ],
-        "usphone": "[ˈedɪt]",
-        "ukphone": "[ˈedɪt]"
-    },
-    {
-        "name": "edition",
-        "trans": [
-            "n. 版本"
-        ],
-        "usphone": "[ɪˈdɪʃn]",
-        "ukphone": "[ɪˈdɪʃ(ə)n]"
-    },
-    {
-        "name": "editorial",
-        "trans": [
-            "n. 社论"
-        ],
-        "usphone": "[ˌedɪˈtɔːriəl]",
-        "ukphone": "[ˌedɪˈtɔːriəl]"
-    },
-    {
-        "name": "efficient",
-        "trans": [
-            "adj. 有效率的；有能力的；生效的"
-        ],
-        "usphone": "[ɪˈfɪʃnt]",
-        "ukphone": "[ɪˈfɪʃnt]"
-    },
-    {
-        "name": "efficiently",
-        "trans": [
-            "adv. 有效地；效率高地（efficient的副词形式）"
-        ],
-        "usphone": "[ɪˈfɪʃntli]",
-        "ukphone": "[ɪˈfɪʃ(ə)ntli]"
-    },
-    {
-        "name": "elbow",
-        "trans": [
-            "n. 肘部；弯头；扶手"
-        ],
-        "usphone": "[ˈelboʊ]",
-        "ukphone": "[ˈelbəʊ]"
-    },
-    {
-        "name": "elderly",
-        "trans": [
-            "adj. 上了年纪的；过了中年的；稍老的"
-        ],
-        "usphone": "[ˈeldərli]",
-        "ukphone": "[ˈeldəli]"
-    },
-    {
-        "name": "elect",
-        "trans": [
-            "n. 被选的人；特殊阶层；上帝的选民"
-        ],
-        "usphone": "[ɪˈlekt]",
-        "ukphone": "[ɪˈlekt]"
-    },
-    {
-        "name": "electronics",
-        "trans": [
-            "n. 电子学；电子工业"
-        ],
-        "usphone": "[ɪˌlekˈtrɑːnɪks]",
-        "ukphone": "[ɪˌlekˈtrɒnɪks]"
-    },
-    {
-        "name": "elegant",
-        "trans": [
-            "adj. 高雅的，优雅的；讲究的；简炼的；简洁的"
-        ],
-        "usphone": "[ˈelɪɡənt]",
-        "ukphone": "[ˈelɪɡənt]"
-    },
-    {
-        "name": "elementary",
-        "trans": [
-            "adj. 基本的；初级的；[化学] 元素的"
-        ],
-        "usphone": "[ˌelɪˈmentri]",
-        "ukphone": "[ˌelɪˈmentri]"
-    },
-    {
-        "name": "eliminate",
-        "trans": [
-            "vt. 消除；排除"
-        ],
-        "usphone": "[ɪˈlɪmɪneɪt]",
-        "ukphone": "[ɪˈlɪmɪneɪt]"
-    },
-    {
-        "name": "elsewhere",
-        "trans": [
-            "adv. 在别处；到别处"
-        ],
-        "usphone": "[ˌelsˈwer]",
-        "ukphone": "[ˌelsˈweə(r)]"
-    },
-    {
-        "name": "embrace",
-        "trans": [
-            "n. 拥抱"
-        ],
-        "usphone": "[ɪmˈbreɪs]",
-        "ukphone": "[ɪmˈbreɪs]"
-    },
-    {
-        "name": "emerge",
-        "trans": [
-            "vi. 浮现；摆脱；暴露"
-        ],
-        "usphone": "[ɪˈmɜːrdʒ]",
-        "ukphone": "[ɪˈmɜːdʒ]"
-    },
-    {
-        "name": "emission",
-        "trans": [
-            "n. （光、热等的）发射，散发；喷射；发行"
-        ],
-        "usphone": "[ɪˈmɪʃn]",
-        "ukphone": "[ɪˈmɪʃ(ə)n]"
-    },
-    {
-        "name": "emotional",
-        "trans": [
-            "adj. 情绪的；易激动的；感动人的"
-        ],
-        "usphone": "[ɪˈmoʊʃənl]",
-        "ukphone": "[ɪˈməʊʃən(ə)l]"
-    },
-    {
-        "name": "emotionally",
-        "trans": [
-            "adv. 感情上；情绪上；令人激动地；情绪冲动地"
-        ],
-        "usphone": "[ɪˈmoʊʃənəli]",
-        "ukphone": "[ɪˈməʊʃənəli]"
-    },
-    {
-        "name": "emphasis",
-        "trans": [
-            "n. 重点；强调；加强语气"
-        ],
-        "usphone": "[ˈemfəsɪs]",
-        "ukphone": "[ˈemfəsɪs]"
-    },
-    {
-        "name": "emphasize",
-        "trans": [
-            "vt. 强调，着重"
-        ],
-        "usphone": "[ˈemfəsaɪz]",
-        "ukphone": "[ˈemfəsaɪz]"
-    },
-    {
-        "name": "empire",
-        "trans": [
-            "n. 帝国；帝王统治，君权"
-        ],
-        "usphone": "[ˈempaɪər]",
-        "ukphone": "[ˈempaɪə(r)]"
-    },
-    {
-        "name": "enable",
-        "trans": [
-            "vt. 使能够，使成为可能；授予权利或方法"
-        ],
-        "usphone": "[ɪˈneɪbl]",
-        "ukphone": "[ɪˈneɪbl]"
-    },
-    {
-        "name": "encounter",
-        "trans": [
-            "n. 遭遇，偶然碰见"
-        ],
-        "usphone": "[ɪnˈkaʊntər]",
-        "ukphone": "[ɪnˈkaʊntə(r)]"
-    },
-    {
-        "name": "engage",
-        "trans": [
-            "vi. 从事；答应，保证；交战；啮合"
-        ],
-        "usphone": "[ɪnˈɡeɪdʒ]",
-        "ukphone": "[ɪnˈɡeɪdʒ]"
-    },
-    {
-        "name": "enhance",
-        "trans": [
-            "vt. 提高；加强；增加"
-        ],
-        "usphone": "[ɪnˈhæns]",
-        "ukphone": "[ɪnˈhɑːns]"
-    },
-    {
-        "name": "enjoyable",
-        "trans": [
-            "adj. 快乐的；有乐趣的；令人愉快的"
-        ],
-        "usphone": "[ɪnˈdʒɔɪəbl]",
-        "ukphone": "[ɪnˈdʒɔɪəbl]"
-    },
-    {
-        "name": "enquiry",
-        "trans": [
-            "n. [计] 询问，[贸易] 询盘"
-        ],
-        "usphone": "[ˈɪnkwəri]",
-        "ukphone": "[ɪnˈkwaɪəri]"
-    },
-    {
-        "name": "ensure",
-        "trans": [
-            "vt. 保证，确保；使安全"
-        ],
-        "usphone": "[ɪnˈʃʊr]",
-        "ukphone": "[ɪnˈʃʊə(r)]"
-    },
-    {
-        "name": "entertaining",
-        "trans": [
-            "v. 款待（entertain的ing形式）"
-        ],
-        "usphone": "[ˌentərˈteɪnɪŋ]",
-        "ukphone": "[ˌentəˈteɪnɪŋ]"
-    },
-    {
-        "name": "enthusiasm",
-        "trans": [
-            "n. 热心，热忱，热情"
-        ],
-        "usphone": "[ɪnˈθuːziæzəm]",
-        "ukphone": "[ɪnˈθjuːziæzəm]"
-    },
-    {
-        "name": "enthusiastic",
-        "trans": [
-            "adj. 热情的；热心的；狂热的"
-        ],
-        "usphone": "[ɪnˌθuːziˈæstɪk]",
-        "ukphone": "[ɪnˌθjuːziˈæstɪk]"
-    },
-    {
-        "name": "entire",
-        "trans": [
-            "adj. 全部的，整个的；全体的"
-        ],
-        "usphone": "[ɪnˈtaɪər]",
-        "ukphone": "[ɪnˈtaɪə(r)]"
-    },
-    {
-        "name": "entirely",
-        "trans": [
-            "adv. 完全地，彻底地"
-        ],
-        "usphone": "[ɪnˈtaɪərli]",
-        "ukphone": "[ɪnˈtaɪəli]"
-    },
-    {
-        "name": "entrepreneur",
-        "trans": [
-            "n. 企业家；承包人；主办者"
-        ],
-        "usphone": "[ˌɑːntrəprəˈnɜːr]",
-        "ukphone": "[ˌɒntrəprəˈnɜː(r)]"
-    },
-    {
-        "name": "envelope",
-        "trans": [
-            "n. 信封，封皮；包膜；[天] 包层；包迹"
-        ],
-        "usphone": "[ˈenvəloʊp; ˈɑːnvəloʊp]",
-        "ukphone": "[ˈenvələʊp]"
-    },
-    {
-        "name": "equal",
-        "trans": [
-            "n. 对手；匹敌；同辈；相等的事物"
-        ],
-        "usphone": "[ˈiːkwəl]",
-        "ukphone": "[ˈiːkwəl]"
-    },
-    {
-        "name": "equip",
-        "trans": [
-            "vt. 装备，配备"
-        ],
-        "usphone": "[ɪˈkwɪp]",
-        "ukphone": "[ɪˈkwɪp]"
-    },
-    {
-        "name": "equivalent",
-        "trans": [
-            "n. 等价物，相等物"
-        ],
-        "usphone": "[ɪˈkwɪvələnt]",
-        "ukphone": "[ɪˈkwɪvələnt]"
-    },
-    {
-        "name": "era",
-        "trans": [
-            "n. 时代；年代；纪元"
-        ],
-        "usphone": "[ˈɪrə; ˈerə]",
-        "ukphone": "[ˈɪərə]"
-    },
-    {
-        "name": "erupt",
-        "trans": [
-            "vi. 爆发；喷出；发疹；长牙"
-        ],
-        "usphone": "[ɪˈrʌpt]",
-        "ukphone": "[ɪˈrʌpt]"
-    },
-    {
-        "name": "essentially",
-        "trans": [
-            "adv. 本质上；本来"
-        ],
-        "usphone": "[ɪˈsenʃəli]",
-        "ukphone": "[ɪˈsenʃəli]"
-    },
-    {
-        "name": "establish",
-        "trans": [
-            "vi. 植物定植"
-        ],
-        "usphone": "[ɪˈstæblɪʃ]",
-        "ukphone": "[ɪˈstæblɪʃ]"
-    },
-    {
-        "name": "estate",
-        "trans": [
-            "n. 房地产；财产；身份"
-        ],
-        "usphone": "[ɪˈsteɪt]",
-        "ukphone": "[ɪˈsteɪt]"
-    },
-    {
-        "name": "estimate",
-        "trans": [
-            "n. 估计，估价；判断，看法"
-        ],
-        "usphone": "[ˈestɪmeɪt]",
-        "ukphone": "[ˈestɪmət]"
-    },
-    {
-        "name": "ethic",
-        "trans": [
-            "n. 伦理；道德规范"
-        ],
-        "usphone": "[ˈeθɪk]",
-        "ukphone": "[ˈeθɪk]"
-    },
-    {
-        "name": "ethical",
-        "trans": [
-            "n. 处方药"
-        ],
-        "usphone": "[ˈeθɪkl]",
-        "ukphone": "[ˈeθɪk(ə)l]"
-    },
-    {
-        "name": "ethnic",
-        "trans": [
-            "adj. 种族的；人种的"
-        ],
-        "usphone": "[ˈeθnɪk]",
-        "ukphone": "[ˈeθnɪk]"
-    },
-    {
-        "name": "evaluate",
-        "trans": [
-            "vt. 评价；估价；求…的值"
-        ],
-        "usphone": "[ɪˈvæljueɪt]",
-        "ukphone": "[ɪˈvæljueɪt]"
-    },
-    {
-        "name": "evaluation",
-        "trans": [
-            "n. 评价；[审计] 评估；估价；求值"
-        ],
-        "usphone": "[ɪˌvæljuˈeɪʃn]",
-        "ukphone": "[ɪˌvæljuˈeɪʃn]"
-    },
-    {
-        "name": "even",
-        "trans": [
-            "adj. [数] 偶数的；平坦的；相等的"
-        ],
-        "usphone": "[ˈiːvn]",
-        "ukphone": "[ˈiːv(ə)n]"
-    },
-    {
-        "name": "evident",
-        "trans": [
-            "adj. 明显的；明白的"
-        ],
-        "usphone": "[ˈevɪdənt]",
-        "ukphone": "[ˈevɪdənt]"
-    },
-    {
-        "name": "evil",
-        "trans": [
-            "n. 罪恶，邪恶；不幸"
-        ],
-        "usphone": "[ˈiːvl]",
-        "ukphone": "[ˈiːv(ə)l]"
-    },
-    {
-        "name": "evolution",
-        "trans": [
-            "n. 演变；进化论；进展"
-        ],
-        "usphone": "[ˌevəˈluːʃn]",
-        "ukphone": "[ˌiːvəˈluːʃ(ə)n]"
-    },
-    {
-        "name": "evolve",
-        "trans": [
-            "vi. 发展，进展；进化；逐步形成"
-        ],
-        "usphone": "[ɪˈvɑːlv]",
-        "ukphone": "[ɪˈvɒlv]"
-    },
-    {
-        "name": "examination",
-        "trans": [
-            "n. 考试；检查；查问"
-        ],
-        "usphone": "[ɪɡˌzæmɪˈneɪʃn]",
-        "ukphone": "[ɪɡˌzæmɪˈneɪʃ(ə)n]"
-    },
-    {
-        "name": "exceed",
-        "trans": [
-            "vt. 超过；胜过"
-        ],
-        "usphone": "[ɪkˈsiːd]",
-        "ukphone": "[ɪkˈsiːd]"
-    },
-    {
-        "name": "exception",
-        "trans": [
-            "n. 例外；异议"
-        ],
-        "usphone": "[ɪkˈsepʃn]",
-        "ukphone": "[ɪkˈsepʃn]"
-    },
-    {
-        "name": "excessive",
-        "trans": [
-            "adj. 过多的，极度的；过分的"
-        ],
-        "usphone": "[ɪkˈsesɪv]",
-        "ukphone": "[ɪkˈsesɪv]"
-    },
-    {
-        "name": "exclude",
-        "trans": [
-            "vt. 排除；排斥；拒绝接纳；逐出"
-        ],
-        "usphone": "[ɪkˈskluːd]",
-        "ukphone": "[ɪkˈskluːd]"
-    },
-    {
-        "name": "excuse",
-        "trans": [
-            "n. 借口；理由"
-        ],
-        "usphone": "[ɪkˈskjuːs]",
-        "ukphone": "[ɪkˈskjuːs]"
-    },
-    {
-        "name": "executive",
-        "trans": [
-            "n. 总经理；执行委员会；执行者；经理主管人员"
-        ],
-        "usphone": "[ɪɡˈzekjətɪv]",
-        "ukphone": "[ɪɡˈzekjətɪv]"
-    },
-    {
-        "name": "exhibit",
-        "trans": [
-            "n. 展览品；证据；展示会"
-        ],
-        "usphone": "[ɪɡˈzɪbɪt]",
-        "ukphone": "[ɪɡˈzɪbɪt]"
-    },
-    {
-        "name": "existence",
-        "trans": [
-            "n. 存在，实在；生存，生活；存在物，实在物"
-        ],
-        "usphone": "[ɪɡˈzɪstəns]",
-        "ukphone": "[ɪɡˈzɪstəns]"
-    },
-    {
-        "name": "exit",
-        "trans": [
-            "n. 出口，通道；退场"
-        ],
-        "usphone": "[ˈeksɪt; ˈeɡzɪt]",
-        "ukphone": "[ˈeksɪt]"
-    },
-    {
-        "name": "exotic",
-        "trans": [
-            "adj. 异国的；外来的；异国情调的"
-        ],
-        "usphone": "[ɪɡˈzɑːtɪk]",
-        "ukphone": "[ɪɡˈzɒtɪk]"
-    },
-    {
-        "name": "expansion",
-        "trans": [
-            "n. 膨胀；阐述；扩张物"
-        ],
-        "usphone": "[ɪkˈspænʃn]",
-        "ukphone": "[ɪkˈspænʃ(ə)n]"
-    },
-    {
-        "name": "expectation",
-        "trans": [
-            "n. 期待；预期；指望"
-        ],
-        "usphone": "[ˌekspekˈteɪʃn]",
-        "ukphone": "[ˌekspekˈteɪʃ(ə)n]"
-    },
-    {
-        "name": "expense",
-        "trans": [
-            "n. 损失，代价；消费；开支"
-        ],
-        "usphone": "[ɪkˈspens]",
-        "ukphone": "[ɪkˈspens]"
-    },
-    {
-        "name": "expertise",
-        "trans": [
-            "n. 专门知识；专门技术；专家的意见"
-        ],
-        "usphone": "[ˌekspɜːrˈtiːz]",
-        "ukphone": "[ˌekspɜːˈtiːz]"
-    },
-    {
-        "name": "exploit",
-        "trans": [
-            "n. 勋绩；功绩"
-        ],
-        "usphone": "[ɪkˈsplɔɪt]",
-        "ukphone": "[ɪkˈsplɔɪt]"
-    },
-    {
-        "name": "exploration",
-        "trans": [
-            "n. 探测；探究；踏勘"
-        ],
-        "usphone": "[ˌekspləˈreɪʃn]",
-        "ukphone": "[ˌekspləˈreɪʃ(ə)n]"
-    },
-    {
-        "name": "expose",
-        "trans": [
-            "vt. 揭露，揭发；使曝光；显示"
-        ],
-        "usphone": "[ɪkˈspoʊz]",
-        "ukphone": "[ɪkˈspəʊz]"
-    },
-    {
-        "name": "exposure",
-        "trans": [
-            "n. 暴露；曝光；揭露；陈列"
-        ],
-        "usphone": "[ɪkˈspoʊʒər]",
-        "ukphone": "[ɪkˈspəʊʒə(r)]"
-    },
-    {
-        "name": "extend",
-        "trans": [
-            "vt. 延伸；扩大；推广；伸出；给予；使竭尽全力；对…估价"
-        ],
-        "usphone": "[ɪkˈstend]",
-        "ukphone": "[ɪkˈstend]"
-    },
-    {
-        "name": "extension",
-        "trans": [
-            "n. 延长；延期；扩大；伸展；电话分机"
-        ],
-        "usphone": "[ɪkˈstenʃn]",
-        "ukphone": "[ɪkˈstenʃ(ə)n]"
-    },
-    {
-        "name": "extensive",
-        "trans": [
-            "adj. 广泛的；大量的；广阔的"
-        ],
-        "usphone": "[ɪkˈstensɪv]",
-        "ukphone": "[ɪkˈstensɪv]"
-    },
-    {
-        "name": "extensively",
-        "trans": [
-            "adv. 广阔地；广大地"
-        ],
-        "usphone": "[ɪkˈstensɪvli]",
-        "ukphone": "[ɪkˈstensɪvli]"
-    },
-    {
-        "name": "extent",
-        "trans": [
-            "n. 程度；范围；长度"
-        ],
-        "usphone": "[ɪkˈstent]",
-        "ukphone": "[ɪkˈstent]"
-    },
-    {
-        "name": "external",
-        "trans": [
-            "n. 外部；外观；外面"
-        ],
-        "usphone": "[ɪkˈstɜːrnl]",
-        "ukphone": "[ɪkˈstɜːn(ə)l]"
-    },
-    {
-        "name": "extract",
-        "trans": [
-            "n. 汁；摘录；榨出物；选粹"
-        ],
-        "usphone": "[ˈekstrækt]",
-        "ukphone": "[ˈekstrækt]"
-    },
-    {
-        "name": "extraordinary",
-        "trans": [
-            "adj. 非凡的；特别的；离奇的；临时的；特派的"
-        ],
-        "usphone": "[ɪkˈstrɔːrdəneri]",
-        "ukphone": "[ɪkˈstrɔːdnri]"
-    },
-    {
-        "name": "extreme",
-        "trans": [
-            "n. 极端；末端；最大程度；极端的事物"
-        ],
-        "usphone": "[ɪkˈstriːm]",
-        "ukphone": "[ɪkˈstriːm]"
-    },
-    {
-        "name": "fabric",
-        "trans": [
-            "n. 织物；布；组织；构造；建筑物"
-        ],
-        "usphone": "[ˈfæbrɪk]",
-        "ukphone": "[ˈfæbrɪk]"
-    },
-    {
-        "name": "fabulous",
-        "trans": [
-            "adj. 难以置信的；传说的，寓言中的；极好的"
-        ],
-        "usphone": "[ˈfæbjələs]",
-        "ukphone": "[ˈfæbjələs]"
-    },
-    {
-        "name": "facility",
-        "trans": [
-            "n. 设施；设备；容易；灵巧"
-        ],
-        "usphone": "[fəˈsɪləti]",
-        "ukphone": "[fəˈsɪləti]"
-    },
-    {
-        "name": "failed",
-        "trans": [
-            "v. 失败，不成功（fail的过去式和过去分词）"
-        ],
-        "usphone": "[feɪld]",
-        "ukphone": "[feɪld]"
-    },
-    {
-        "name": "failure",
-        "trans": [
-            "n. 失败；故障；失败者；破产"
-        ],
-        "usphone": "[ˈfeɪljər]",
-        "ukphone": "[ˈfeɪljə(r)]"
-    },
-    {
-        "name": "faith",
-        "trans": [
-            "n. 信仰；信念；信任；忠实"
-        ],
-        "usphone": "[feɪθ]",
-        "ukphone": "[feɪθ]"
-    },
-    {
-        "name": "fake",
-        "trans": [
-            "n. 假货；骗子；假动作"
-        ],
-        "usphone": "[feɪk]",
-        "ukphone": "[feɪk]"
-    },
-    {
-        "name": "fame",
-        "trans": [
-            "n. 名声，名望；传闻，传说"
-        ],
-        "usphone": "[feɪm]",
-        "ukphone": "[feɪm]"
-    },
-    {
-        "name": "fantasy",
-        "trans": [
-            "n. 幻想；白日梦；幻觉"
-        ],
-        "usphone": "[ˈfæntəsi]",
-        "ukphone": "[ˈfæntəsi]"
-    },
-    {
-        "name": "fare",
-        "trans": [
-            "n. 票价；费用；旅客；食物"
-        ],
-        "usphone": "[fer]",
-        "ukphone": "[feə(r)]"
-    },
-    {
-        "name": "fault",
-        "trans": [
-            "n. 故障；[地质] 断层；错误；缺点；毛病；（网球等）发球失误"
-        ],
-        "usphone": "[fɔːlt]",
-        "ukphone": "[fɔːlt]"
-    },
-    {
-        "name": "favour",
-        "trans": [
-            "n. 偏爱；赞同；善行"
-        ],
-        "usphone": "[ˈfeɪvər]",
-        "ukphone": "[ˈfeɪvə(r)]"
-    },
-    {
-        "name": "feather",
-        "trans": [
-            "n. 羽毛"
-        ],
-        "usphone": "[ˈfeðər]",
-        "ukphone": "[ˈfeðə(r)]"
-    },
-    {
-        "name": "federal",
-        "trans": [
-            "adv. 联邦政府地"
-        ],
-        "usphone": "[ˈfedərəl]",
-        "ukphone": "[ˈfedərəl]"
-    },
-    {
-        "name": "fee",
-        "trans": [
-            "n. 费用；酬金；小费"
-        ],
-        "usphone": "[fiː]",
-        "ukphone": "[fiː]"
-    },
-    {
-        "name": "feed",
-        "trans": [
-            "n. 饲料；饲养；（动物或婴儿的）一餐"
-        ],
-        "usphone": "[fiːd]",
-        "ukphone": "[fiːd]"
-    },
-    {
-        "name": "feedback",
-        "trans": [
-            "n. 反馈；成果，资料；回复"
-        ],
-        "usphone": "[ˈfiːdbæk]",
-        "ukphone": "[ˈfiːdbæk]"
-    },
-    {
-        "name": "feel",
-        "trans": [
-            "n. 感觉；触摸"
-        ],
-        "usphone": "[fiːl]",
-        "ukphone": "[fiːl]"
-    },
-    {
-        "name": "fellow",
-        "trans": [
-            "n. 家伙；朋友；同事；会员"
-        ],
-        "usphone": "[ˈfeloʊ]",
-        "ukphone": "[ˈfeləʊ]"
-    },
-    {
-        "name": "fever",
-        "trans": [
-            "n. 发烧，发热；狂热"
-        ],
-        "usphone": "[ˈfiːvər]",
-        "ukphone": "[ˈfiːvə(r)]"
-    },
-    {
-        "name": "figure",
-        "trans": [
-            "n. 数字；人物；图形；价格；（人的）体形；画像"
-        ],
-        "usphone": "[ˈfɪɡjər]",
-        "ukphone": "[ˈfɪɡə(r)]"
-    },
-    {
-        "name": "file",
-        "trans": [
-            "n. 文件；档案；文件夹；锉刀"
-        ],
-        "usphone": "[faɪl]",
-        "ukphone": "[faɪl]"
-    },
-    {
-        "name": "finance",
-        "trans": [
-            "n. 财政，财政学；金融"
-        ],
-        "usphone": "[ˈfaɪnæns; faɪˈnæns; fəˈnæns]",
-        "ukphone": "[ˈfaɪnæns]"
-    },
-    {
-        "name": "finding",
-        "trans": [
-            "n. 发现；裁决；发现物"
-        ],
-        "usphone": "[ˈfaɪndɪŋ]",
-        "ukphone": "[ˈfaɪndɪŋ]"
-    },
-    {
-        "name": "firefighter",
-        "trans": [
-            "n. 消防队员"
-        ],
-        "usphone": "[ˈfaɪərfaɪtər]",
-        "ukphone": "[ˈfaɪəfaɪtə(r)]"
-    },
-    {
-        "name": "firework",
-        "trans": [
-            "n. 烟火；激烈情绪"
-        ],
-        "usphone": "[ˈfaɪərwɜːrk]",
-        "ukphone": "[ˈfaɪəwɜːk]"
-    },
-    {
-        "name": "firm",
-        "trans": [
-            "n. 公司；商号"
-        ],
-        "usphone": "[fɜːrm]",
-        "ukphone": "[fɜːm]"
-    },
-    {
-        "name": "firmly",
-        "trans": [
-            "adv. 坚定地，坚决地；坚固地，稳固地"
-        ],
-        "usphone": "[ˈfɜːrmli]",
-        "ukphone": "[ˈfɜːmli]"
-    },
-    {
-        "name": "fix",
-        "trans": [
-            "n. 困境；方位；贿赂"
-        ],
-        "usphone": "[fɪks]",
-        "ukphone": "[fɪks]"
-    },
-    {
-        "name": "flame",
-        "trans": [
-            "n. 火焰；热情；光辉"
-        ],
-        "usphone": "[fleɪm]",
-        "ukphone": "[fleɪm]"
-    },
-    {
-        "name": "flash",
-        "trans": [
-            "n. 闪光，闪现；一瞬间"
-        ],
-        "usphone": "[flæʃ]",
-        "ukphone": "[flæʃ]"
-    },
-    {
-        "name": "flavour",
-        "trans": [
-            "n. 香味；滋味"
-        ],
-        "usphone": "[ˈfleɪvər]",
-        "ukphone": "[ˈfleɪvə(r)]"
-    },
-    {
-        "name": "flexible",
-        "trans": [
-            "adj. 灵活的；柔韧的；易弯曲的"
-        ],
-        "usphone": "[ˈfleksəbl]",
-        "ukphone": "[ˈfleksəb(ə)l]"
-    },
-    {
-        "name": "float",
-        "trans": [
-            "n. 彩车，花车；漂流物；浮舟；浮萍"
-        ],
-        "usphone": "[floʊt]",
-        "ukphone": "[fləʊt]"
-    },
-    {
-        "name": "fold",
-        "trans": [
-            "n. 折痕；信徒；羊栏"
-        ],
-        "usphone": "[foʊld]",
-        "ukphone": "[fəʊld]"
-    },
-    {
-        "name": "folding",
-        "trans": [
-            "adj. 可折叠的"
-        ],
-        "usphone": "[ˈfoʊldɪŋ]",
-        "ukphone": "[ˈfəʊldɪŋ]"
-    },
-    {
-        "name": "following",
-        "trans": [
-            "n. 下列事物；一批追随者"
-        ],
-        "usphone": "[ˈfɑːloʊɪŋ]",
-        "ukphone": "[ˈfɒləʊɪŋ]"
-    },
-    {
-        "name": "fond",
-        "trans": [
-            "adj. 喜欢的；温柔的；宠爱的"
-        ],
-        "usphone": "[fɑːnd]",
-        "ukphone": "[fɒnd]"
-    },
-    {
-        "name": "fool",
-        "trans": [
-            "n. 傻瓜；愚人；受骗者"
-        ],
-        "usphone": "[fuːl]",
-        "ukphone": "[fuːl]"
-    },
-    {
-        "name": "forbid",
-        "trans": [
-            "vt. 禁止；不准；不允许；〈正式〉严禁"
-        ],
-        "usphone": "[fərˈbɪd]",
-        "ukphone": "[fəˈbɪd]"
-    },
-    {
-        "name": "forecast",
-        "trans": [
-            "n. 预测，预报；预想"
-        ],
-        "usphone": "[ˈfɔːrkæst]",
-        "ukphone": "[ˈfɔːkɑːst]"
-    },
-    {
-        "name": "forgive",
-        "trans": [
-            "vt. 原谅；免除（债务、义务等）"
-        ],
-        "usphone": "[fərˈɡɪv]",
-        "ukphone": "[fəˈɡɪv]"
-    },
-    {
-        "name": "format",
-        "trans": [
-            "n. 格式；版式；开本"
-        ],
-        "usphone": "[ˈfɔːrmæt]",
-        "ukphone": "[ˈfɔːmæt]"
-    },
-    {
-        "name": "formation",
-        "trans": [
-            "n. 形成；构造；编队"
-        ],
-        "usphone": "[fɔːrˈmeɪʃn]",
-        "ukphone": "[fɔːˈmeɪʃn]"
-    },
-    {
-        "name": "former",
-        "trans": [
-            "n. 模型，样板；起形成作用的人"
-        ],
-        "usphone": "[ˈfɔːrmər]",
-        "ukphone": "[ˈfɔːmə(r)]"
-    },
-    {
-        "name": "formerly",
-        "trans": [
-            "adv. 以前；原来"
-        ],
-        "usphone": "[ˈfɔːrmərli]",
-        "ukphone": "[ˈfɔːməli]"
-    },
-    {
-        "name": "fortunate",
-        "trans": [
-            "adj. 幸运的；侥幸的；吉祥的；带来幸运的"
-        ],
-        "usphone": "[ˈfɔːrtʃənət]",
-        "ukphone": "[ˈfɔːtʃənət]"
-    },
-    {
-        "name": "fortune",
-        "trans": [
-            "n. 财富；命运；运气"
-        ],
-        "usphone": "[ˈfɔːrtʃən]",
-        "ukphone": "[ˈfɔːtʃuːn]"
-    },
-    {
-        "name": "forum",
-        "trans": [
-            "n. 论坛，讨论会；法庭；公开讨论的广场"
-        ],
-        "usphone": "[ˈfɔːrəm]",
-        "ukphone": "[ˈfɔːrəm]"
-    },
-    {
-        "name": "forward",
-        "trans": [
-            "n. 前锋"
-        ],
-        "usphone": "[ˈfɔːrwərd]",
-        "ukphone": "[ˈfɔːwəd]"
-    },
-    {
-        "name": "fossil",
-        "trans": [
-            "n. 化石；僵化的事物；顽固不化的人"
-        ],
-        "usphone": "[ˈfɑːsl]",
-        "ukphone": "[ˈfɒsl]"
-    },
-    {
-        "name": "found",
-        "trans": [
-            "v. 找到（find的过去分词）"
-        ],
-        "usphone": "[faʊnd]",
-        "ukphone": "[faʊnd]"
-    },
-    {
-        "name": "foundation",
-        "trans": [
-            "n. 基础；地基；基金会；根据；创立"
-        ],
-        "usphone": "[faʊnˈdeɪʃn]",
-        "ukphone": "[faʊnˈdeɪʃn]"
-    },
-    {
-        "name": "founder",
-        "trans": [
-            "n. 创始人；建立者；翻沙工"
-        ],
-        "usphone": "[ˈfaʊndər]",
-        "ukphone": "[ˈfaʊndə(r)]"
-    },
-    {
-        "name": "fraction",
-        "trans": [
-            "n. 分数；部分；小部分；稍微"
-        ],
-        "usphone": "[ˈfrækʃn]",
-        "ukphone": "[ˈfrækʃn]"
-    },
-    {
-        "name": "fragment",
-        "trans": [
-            "n. 碎片；片断或不完整部分"
-        ],
-        "usphone": "[ˈfræɡmənt; fræɡˈment]",
-        "ukphone": "[ˈfræɡmənt]"
-    },
-    {
-        "name": "framework",
-        "trans": [
-            "n. 框架，骨架；结构，构架"
-        ],
-        "usphone": "[ˈfreɪmwɜːrk]",
-        "ukphone": "[ˈfreɪmwɜːk]"
-    },
-    {
-        "name": "fraud",
-        "trans": [
-            "n. 欺骗；骗子；诡计"
-        ],
-        "usphone": "[frɔːd]",
-        "ukphone": "[frɔːd]"
-    },
-    {
-        "name": "free",
-        "trans": [
-            "adj. 免费的；自由的，不受约束的；[化学] 游离的"
-        ],
-        "usphone": "[friː]",
-        "ukphone": "[friː]"
-    },
-    {
-        "name": "freedom",
-        "trans": [
-            "n. 自由，自主；直率"
-        ],
-        "usphone": "[ˈfriːdəm]",
-        "ukphone": "[ˈfriːdəm]"
-    },
-    {
-        "name": "freely",
-        "trans": [
-            "adv. 自由地；免费地；大量地；慷慨地；直率地"
-        ],
-        "usphone": "[ˈfriːli]",
-        "ukphone": "[ˈfriːli]"
-    },
-    {
-        "name": "frequency",
-        "trans": [
-            "n. 频率；频繁"
-        ],
-        "usphone": "[ˈfriːkwənsi]",
-        "ukphone": "[ˈfriːkwənsi]"
-    },
-    {
-        "name": "frequent",
-        "trans": [
-            "adj. 频繁的；时常发生的；惯常的"
-        ],
-        "usphone": "[ˈfriːkwənt; friˈkwent]",
-        "ukphone": "[ˈfriːkwənt]"
-    },
-    {
-        "name": "fuel",
-        "trans": [
-            "n. 燃料；刺激因素"
-        ],
-        "usphone": "[ˈfjuːəl]",
-        "ukphone": "[ˈfjuːəl]"
-    },
-    {
-        "name": "fulfil",
-        "trans": [
-            "vt. 履行；完成；实践；满足"
-        ],
-        "usphone": "[fʊlˈfɪl]",
-        "ukphone": "[fʊlˈfɪl]"
-    },
-    {
-        "name": "full-time",
-        "trans": [
-            "adj. 专职的；全日制的；全部时间的"
-        ],
-        "usphone": "[ˌfʊl ˈtaɪm]",
-        "ukphone": "[ˌfʊl ˈtaɪm]"
-    },
-    {
-        "name": "fully",
-        "trans": [
-            "adv. 充分地；完全地；彻底地"
-        ],
-        "usphone": "[ˈfʊli]",
-        "ukphone": "[ˈfʊli]"
-    },
-    {
-        "name": "function",
-        "trans": [
-            "n. 功能；[数] 函数；职责；盛大的集会"
-        ],
-        "usphone": "[ˈfʌŋkʃn]",
-        "ukphone": "[ˈfʌŋkʃ(ə)n]"
-    },
-    {
-        "name": "fund",
-        "trans": [
-            "n. 基金；资金；存款"
-        ],
-        "usphone": "[fʌnd]",
-        "ukphone": "[fʌnd]"
-    },
-    {
-        "name": "fundamental",
-        "trans": [
-            "n. 基本原理；基本原则"
-        ],
-        "usphone": "[ˌfʌndəˈmentl]",
-        "ukphone": "[ˌfʌndəˈment(ə)l]"
-    },
-    {
-        "name": "fundamentally",
-        "trans": [
-            "adv. 根本地，从根本上；基础地"
-        ],
-        "usphone": "[ˌfʌndəˈmentəli]",
-        "ukphone": "[ˌfʌndəˈmentəli]"
-    },
-    {
-        "name": "funding",
-        "trans": [
-            "n. 提供资金；用发行长期债券的方法来收回短期债券"
-        ],
-        "usphone": "[ˈfʌndɪŋ]",
-        "ukphone": "[ˈfʌndɪŋ]"
-    },
-    {
-        "name": "furious",
-        "trans": [
-            "adj. 激烈的；狂怒的；热烈兴奋的；喧闹的"
-        ],
-        "usphone": "[ˈfjʊriəs]",
-        "ukphone": "[ˈfjʊəriəs]"
-    },
-    {
-        "name": "furthermore",
-        "trans": [
-            "adv. 此外；而且"
-        ],
-        "usphone": "[ˌfɜːrðərˈmɔːr]",
-        "ukphone": "[ˌfɜːðəˈmɔː(r)]"
-    },
-    {
-        "name": "gain",
-        "trans": [
-            "n. 增加；利润；收获"
-        ],
-        "usphone": "[ɡeɪn]",
-        "ukphone": "[ɡeɪn]"
-    },
-    {
-        "name": "gaming",
-        "trans": [
-            "n. 赌博；赌胜负"
-        ],
-        "usphone": "[ˈɡeɪmɪŋ]",
-        "ukphone": "[ˈɡeɪmɪŋ]"
-    },
-    {
-        "name": "gang",
-        "trans": [
-            "n. 群；一伙；一组"
-        ],
-        "usphone": "[ɡæŋ]",
-        "ukphone": "[ɡæŋ]"
-    },
-    {
-        "name": "gay",
-        "trans": [
-            "n. 同性恋者"
-        ],
-        "usphone": "[ɡeɪ]",
-        "ukphone": "[ɡeɪ]"
-    },
-    {
-        "name": "gender",
-        "trans": [
-            "n. 性；性别；性交"
-        ],
-        "usphone": "[ˈdʒendər]",
-        "ukphone": "[ˈdʒendə(r)]"
-    },
-    {
-        "name": "gene",
-        "trans": [
-            "n. [遗] 基因，遗传因子"
-        ],
-        "usphone": "[dʒiːn]",
-        "ukphone": "[dʒiːn]"
-    },
-    {
-        "name": "generate",
-        "trans": [
-            "vt. 使形成；发生；生殖；产生物理反应"
-        ],
-        "usphone": "[ˈdʒenəreɪt]",
-        "ukphone": "[ˈdʒenəreɪt]"
-    },
-    {
-        "name": "genetic",
-        "trans": [
-            "adj. 遗传的；基因的；起源的"
-        ],
-        "usphone": "[dʒəˈnetɪk]",
-        "ukphone": "[dʒəˈnetɪk]"
-    },
-    {
-        "name": "genius",
-        "trans": [
-            "n. 天才，天赋；精神"
-        ],
-        "usphone": "[ˈdʒiːniəs]",
-        "ukphone": "[ˈdʒiːniəs]"
-    },
-    {
-        "name": "genre",
-        "trans": [
-            "n. 类型；种类；体裁；样式；流派；风俗画"
-        ],
-        "usphone": "[ˈʒɑːnrə]",
-        "ukphone": "[ˈʒɒnrə]"
-    },
-    {
-        "name": "genuine",
-        "trans": [
-            "adj. 真实的，真正的；诚恳的"
-        ],
-        "usphone": "[ˈdʒenjuɪn]",
-        "ukphone": "[ˈdʒenjuɪn]"
-    },
-    {
-        "name": "genuinely",
-        "trans": [
-            "adv. 真诚地；诚实地"
-        ],
-        "usphone": "[ˈdʒenjuɪnli]",
-        "ukphone": "[ˈdʒenjuɪnli]"
-    },
-    {
-        "name": "gesture",
-        "trans": [
-            "n. 姿态；手势"
-        ],
-        "usphone": "[ˈdʒestʃər]",
-        "ukphone": "[ˈdʒestʃə(r)]"
-    },
-    {
-        "name": "gig",
-        "trans": [
-            "n. 旋转物；鱼叉；轻便双轮马车；现场演出；临时工作"
-        ],
-        "usphone": "[ɡɪɡ]",
-        "ukphone": "[ɡɪɡ]"
-    },
-    {
-        "name": "globalization",
-        "trans": [
-            "n. 全球化"
-        ],
-        "usphone": "[ˌɡloʊbələˈzeɪʃn]",
-        "ukphone": "[ˌɡləʊbəlaɪˈzeɪʃn]"
-    },
-    {
-        "name": "globe",
-        "trans": [
-            "n. 地球；地球仪；球体"
-        ],
-        "usphone": "[ɡloʊb]",
-        "ukphone": "[ɡləʊb]"
-    },
-    {
-        "name": "golden",
-        "trans": [
-            "adj. 金色的，黄金般的；珍贵的；金制的"
-        ],
-        "usphone": "[ˈɡoʊldən]",
-        "ukphone": "[ˈɡəʊldən]"
-    },
-    {
-        "name": "goodness",
-        "trans": [
-            "n. 善良，优秀 ；精华，养分"
-        ],
-        "usphone": "[ˈɡʊdnəs]",
-        "ukphone": "[ˈɡʊdnəs]"
-    },
-    {
-        "name": "gorgeous",
-        "trans": [
-            "adj. 华丽的，灿烂的；极好的"
-        ],
-        "usphone": "[ˈɡɔːrdʒəs]",
-        "ukphone": "[ˈɡɔːdʒəs]"
-    },
-    {
-        "name": "govern",
-        "trans": [
-            "vt. 管理；支配；统治；控制"
-        ],
-        "usphone": "[ˈɡʌvərn]",
-        "ukphone": "[ˈɡʌv(ə)n]"
-    },
-    {
-        "name": "governor",
-        "trans": [
-            "n. 主管人员；统治者，管理者；[自] 调节器；地方长官"
-        ],
-        "usphone": "[ˈɡʌvərnər]",
-        "ukphone": "[ˈɡʌvənə(r)]"
-    },
-    {
-        "name": "grab",
-        "trans": [
-            "n. 攫取；霸占；夺取之物"
-        ],
-        "usphone": "[ɡræb]",
-        "ukphone": "[ɡræb]"
-    },
-    {
-        "name": "grade",
-        "trans": [
-            "n. 年级；等级；成绩；级别；阶段"
-        ],
-        "usphone": "[ɡreɪd]",
-        "ukphone": "[ɡreɪd]"
-    },
-    {
-        "name": "gradually",
-        "trans": [
-            "adv. 逐步地；渐渐地"
-        ],
-        "usphone": "[ˈɡrædʒuəli]",
-        "ukphone": "[ˈɡrædʒuəli]"
-    },
-    {
-        "name": "grand",
-        "trans": [
-            "n. 大钢琴；一千美元"
-        ],
-        "usphone": "[ɡrænd]",
-        "ukphone": "[ɡrænd]"
-    },
-    {
-        "name": "grant",
-        "trans": [
-            "n. 拨款；[法] 授予物"
-        ],
-        "usphone": "[ɡrænt]",
-        "ukphone": "[ɡrɑːnt]"
-    },
-    {
-        "name": "graphic",
-        "trans": [
-            "adj. 形象的；图表的；绘画似的"
-        ],
-        "usphone": "[ˈɡræfɪk]",
-        "ukphone": "[ˈɡræfɪk]"
-    },
-    {
-        "name": "graphics",
-        "trans": [
-            "n. [测] 制图学；制图法；图表算法"
-        ],
-        "usphone": "[ˈɡræfɪks]",
-        "ukphone": "[ˈɡræfɪks]"
-    },
-    {
-        "name": "greatly",
-        "trans": [
-            "adv. 很，大大地；非常"
-        ],
-        "usphone": "[ˈɡreɪtli]",
-        "ukphone": "[ˈɡreɪtli]"
-    },
-    {
-        "name": "greenhouse",
-        "trans": [
-            "n. 温室"
-        ],
-        "usphone": "[ˈɡriːnhaʊs]",
-        "ukphone": "[ˈɡriːnhaʊs]"
-    },
-    {
-        "name": "grocery",
-        "trans": [
-            "n. 食品杂货店"
-        ],
-        "usphone": "[ˈɡroʊsəri]",
-        "ukphone": "[ˈɡrəʊsəri]"
-    },
-    {
-        "name": "guarantee",
-        "trans": [
-            "n. 保证；担保；保证人；保证书；抵押品"
-        ],
-        "usphone": "[ˌɡærənˈtiː]",
-        "ukphone": "[ˌɡærənˈtiː]"
-    },
-    {
-        "name": "guideline",
-        "trans": [
-            "n. 指导方针"
-        ],
-        "usphone": "[ˈɡaɪdlaɪn]",
-        "ukphone": "[ˈɡaɪdlaɪn]"
-    },
-    {
-        "name": "habitat",
-        "trans": [
-            "n. [生态] 栖息地，产地"
-        ],
-        "usphone": "[ˈhæbɪtæt]",
-        "ukphone": "[ˈhæbɪtæt]"
-    },
-    {
-        "name": "handle",
-        "trans": [
-            "n. [建] 把手；柄；手感；口实"
-        ],
-        "usphone": "[ˈhændl]",
-        "ukphone": "[ˈhænd(ə)l]"
-    },
-    {
-        "name": "harbour",
-        "trans": [
-            "n. 海港（等于harbor）；避难所"
-        ],
-        "usphone": "[ˈhɑːrbər]",
-        "ukphone": "[ˈhɑːbə(r)]"
-    },
-    {
-        "name": "harm",
-        "trans": [
-            "n. 伤害；损害"
-        ],
-        "usphone": "[hɑːrm]",
-        "ukphone": "[hɑːm]"
-    },
-    {
-        "name": "harmful",
-        "trans": [
-            "adj. 有害的；能造成损害的"
-        ],
-        "usphone": "[ˈhɑːrmfl]",
-        "ukphone": "[ˈhɑːmf(ə)l]"
-    },
-    {
-        "name": "headquarters",
-        "trans": [
-            "n. 总部；指挥部；司令部"
-        ],
-        "usphone": "[ˈhedkwɔːrtərz]",
-        "ukphone": "[ˌhedˈkwɔːtəz]"
-    },
-    {
-        "name": "heal",
-        "trans": [
-            "vt. 治愈，痊愈；和解"
-        ],
-        "usphone": "[hiːl]",
-        "ukphone": "[hiːl]"
-    },
-    {
-        "name": "healthcare",
-        "trans": [
-            "n. 医疗保健；健康护理，健康服务；卫生保健"
-        ],
-        "usphone": "[ˈhelθˌker]",
-        "ukphone": "[ˈhelθkeə(r)]"
-    },
-    {
-        "name": "hearing",
-        "trans": [
-            "n. 听力；审讯，听讯"
-        ],
-        "usphone": "[ˈhɪrɪŋ]",
-        "ukphone": "[ˈhɪərɪŋ]"
-    },
-    {
-        "name": "heaven",
-        "trans": [
-            "n. 天堂；天空；极乐"
-        ],
-        "usphone": "[ˈhevn]",
-        "ukphone": "[ˈhevn]"
-    },
-    {
-        "name": "heel",
-        "trans": [
-            "n. 脚后跟；踵"
-        ],
-        "usphone": "[hiːl]",
-        "ukphone": "[hiːl]"
-    },
-    {
-        "name": "hell",
-        "trans": [
-            "n. 地狱；究竟（作加强语气词）；训斥；黑暗势力"
-        ],
-        "usphone": "[helˌˈheləvə]",
-        "ukphone": "[hel]"
-    },
-    {
-        "name": "helmet",
-        "trans": [
-            "n. 钢盔，头盔"
-        ],
-        "usphone": "[ˈhelmɪt]",
-        "ukphone": "[ˈhelmɪt]"
-    },
-    {
-        "name": "hence",
-        "trans": [
-            "adv. 因此；今后"
-        ],
-        "usphone": "[hens]",
-        "ukphone": "[hens]"
-    },
-    {
-        "name": "herb",
-        "trans": [
-            "n. 香草，药草"
-        ],
-        "usphone": "[ɜːrb; hɜːrb]",
-        "ukphone": "[hɜːb]"
-    },
-    {
-        "name": "hesitate",
-        "trans": [
-            "vt. 踌躇，犹豫；有疑虑，不愿意"
-        ],
-        "usphone": "[ˈhezɪteɪt]",
-        "ukphone": "[ˈhezɪteɪt]"
-    },
-    {
-        "name": "hidden",
-        "trans": [
-            "adj. 隐藏的"
-        ],
-        "usphone": "[ˈhɪdn]",
-        "ukphone": "[ˈhɪd(ə)n]"
-    },
-    {
-        "name": "high",
-        "trans": [
-            "n. 高水平；天空；由麻醉品引起的快感；高压地带"
-        ],
-        "usphone": "[haɪ]",
-        "ukphone": "[haɪ]"
-    },
-    {
-        "name": "highway",
-        "trans": [
-            "n. 公路，大路；捷径"
-        ],
-        "usphone": "[ˈhaɪweɪ]",
-        "ukphone": "[ˈhaɪweɪ]"
-    },
-    {
-        "name": "hilarious",
-        "trans": [
-            "adj. 欢闹的；非常滑稽的；喜不自禁的"
-        ],
-        "usphone": "[hɪˈleriəs]",
-        "ukphone": "[hɪˈleəriəs]"
-    },
-    {
-        "name": "hip",
-        "trans": [
-            "n. 臀部；蔷薇果；忧郁"
-        ],
-        "usphone": "[hɪp]",
-        "ukphone": "[hɪp]"
-    },
-    {
-        "name": "hire",
-        "trans": [
-            "n. 雇用，租用；租金，工钱"
-        ],
-        "usphone": "[ˈhaɪər]",
-        "ukphone": "[ˈhaɪə(r)]"
-    },
-    {
-        "name": "historian",
-        "trans": [
-            "n. 历史学家"
-        ],
-        "usphone": "[hɪˈstɔːriən]",
-        "ukphone": "[hɪˈstɔːriən]"
-    },
-    {
-        "name": "hold",
-        "trans": [
-            "n. 控制；保留"
-        ],
-        "usphone": "[hoʊld]",
-        "ukphone": "[həʊld]"
-    },
-    {
-        "name": "hollow",
-        "trans": [
-            "n. 洞；山谷；窟窿"
-        ],
-        "usphone": "[ˈhɑːloʊ]",
-        "ukphone": "[ˈhɒləʊ]"
-    },
-    {
-        "name": "holy",
-        "trans": [
-            "n. 神圣的东西"
-        ],
-        "usphone": "[ˈhoʊli]",
-        "ukphone": "[ˈhəʊli]"
-    },
-    {
-        "name": "homeless",
-        "trans": [
-            "adj. 无家可归的"
-        ],
-        "usphone": "[ˈhoʊmləs]",
-        "ukphone": "[ˈhəʊmləs]"
-    },
-    {
-        "name": "honesty",
-        "trans": [
-            "n. 诚实，正直"
-        ],
-        "usphone": "[ˈɑːnəsti]",
-        "ukphone": "[ˈɒnəsti]"
-    },
-    {
-        "name": "honour",
-        "trans": [
-            "n. 荣誉；尊敬；勋章"
-        ],
-        "usphone": "[ˈɑːnər]",
-        "ukphone": "[ˈɒnə(r)]"
-    },
-    {
-        "name": "hook",
-        "trans": [
-            "n. 挂钩，吊钩"
-        ],
-        "usphone": "[hʊk]",
-        "ukphone": "[hʊk]"
-    },
-    {
-        "name": "hopefully",
-        "trans": [
-            "adv. 有希望地，有前途地"
-        ],
-        "usphone": "[ˈhoʊpfəli]",
-        "ukphone": "[ˈhəʊpfəli]"
-    },
-    {
-        "name": "host",
-        "trans": [
-            "n. [计] 主机；主人；主持人；许多"
-        ],
-        "usphone": "[hoʊst]",
-        "ukphone": "[həʊst]"
-    },
-    {
-        "name": "house",
-        "trans": [
-            "n. 住宅；家庭；机构；议会；某种用途的建筑物"
-        ],
-        "usphone": "[haʊs]",
-        "ukphone": "[haʊs]"
-    },
-    {
-        "name": "household",
-        "trans": [
-            "n. 全家人，一家人；(包括佣工在内的)家庭，户"
-        ],
-        "usphone": "[ˈhaʊshoʊld]",
-        "ukphone": "[ˈhaʊshəʊld]"
-    },
-    {
-        "name": "housing",
-        "trans": [
-            "n. 房屋；住房供给；[机] 外壳；遮盖物；机器等的防护外壳或外罩"
-        ],
-        "usphone": "[ˈhaʊzɪŋ]",
-        "ukphone": "[ˈhaʊzɪŋ]"
-    },
-    {
-        "name": "humorous",
-        "trans": [
-            "adj. 诙谐的，幽默的；滑稽的，可笑的"
-        ],
-        "usphone": "[ˈhjuːmərəs]",
-        "ukphone": "[ˈhjuːmərəs]"
-    },
-    {
-        "name": "humour",
-        "trans": [
-            "n. 幽默（等于humor）；诙谐"
-        ],
-        "usphone": "[ˈhjuːmər]",
-        "ukphone": "[ˈhjuːmə(r)]"
-    },
-    {
-        "name": "hunger",
-        "trans": [
-            "n. 饿，饥饿；渴望"
-        ],
-        "usphone": "[ˈhʌŋɡər]",
-        "ukphone": "[ˈhʌŋɡə(r)]"
-    },
-    {
-        "name": "hunt",
-        "trans": [
-            "n. 狩猎；搜寻"
-        ],
-        "usphone": "[hʌnt]",
-        "ukphone": "[hʌnt]"
-    },
-    {
-        "name": "hunting",
-        "trans": [
-            "n. 打猎；追逐；搜索"
-        ],
-        "usphone": "[ˈhʌntɪŋ]",
-        "ukphone": "[ˈhʌntɪŋ]"
-    },
-    {
-        "name": "hurt",
-        "trans": [
-            "n. 痛苦；危害；痛苦的原因"
-        ],
-        "usphone": "[hɜːrt]",
-        "ukphone": "[hɜːt]"
-    },
-    {
-        "name": "hypothesis",
-        "trans": [
-            "n. 假设"
-        ],
-        "usphone": "[haɪˈpɑːθəsɪs]",
-        "ukphone": "[haɪˈpɒθəsɪs]"
-    },
-    {
-        "name": "icon",
-        "trans": [
-            "n. 图标；偶像；肖像，画像；圣像"
-        ],
-        "usphone": "[ˈaɪkɑːn]",
-        "ukphone": "[ˈaɪkɒn]"
-    },
-    {
-        "name": "ID",
-        "trans": [
-            "身份证件"
-        ],
-        "usphone": "[ˌaɪ ˈdiː]",
-        "ukphone": "[ˌaɪ ˈdiː]"
-    },
-    {
-        "name": "ideal",
-        "trans": [
-            "n. 理想；典范"
-        ],
-        "usphone": "[aɪˈdiːəl]",
-        "ukphone": "[aɪˈdiːəl]"
-    },
-    {
-        "name": "identical",
-        "trans": [
-            "n. 完全相同的事物"
-        ],
-        "usphone": "[aɪˈdentɪk(ə)l]",
-        "ukphone": "[aɪˈdentɪk(ə)l]"
-    },
-    {
-        "name": "illusion",
-        "trans": [
-            "n. 幻觉，错觉；错误的观念或信仰"
-        ],
-        "usphone": "[ɪˈluːʒn]",
-        "ukphone": "[ɪˈluːʒ(ə)n]"
-    },
-    {
-        "name": "illustrate",
-        "trans": [
-            "vi. 举例"
-        ],
-        "usphone": "[ˈɪləstreɪt]",
-        "ukphone": "[ˈɪləstreɪt]"
-    },
-    {
-        "name": "illustration",
-        "trans": [
-            "n. 说明；插图；例证；图解"
-        ],
-        "usphone": "[ˌɪləˈstreɪʃn]",
-        "ukphone": "[ˌɪləˈstreɪʃ(ə)n]"
-    },
-    {
-        "name": "imagination",
-        "trans": [
-            "n. [心理] 想象力；空想；幻想物"
-        ],
-        "usphone": "[ɪˌmædʒɪˈneɪʃn]",
-        "ukphone": "[ɪˌmædʒɪˈneɪʃ(ə)n]"
-    },
-    {
-        "name": "immigration",
-        "trans": [
-            "n. 外来移民；移居"
-        ],
-        "usphone": "[ˌɪmɪˈɡreɪʃn]",
-        "ukphone": "[ˌɪmɪˈɡreɪʃ(ə)n]"
-    },
-    {
-        "name": "immune",
-        "trans": [
-            "n. 免疫者；免除者"
-        ],
-        "usphone": "[ɪˈmjuːn]",
-        "ukphone": "[ɪˈmjuːn]"
-    },
-    {
-        "name": "impatient",
-        "trans": [
-            "adj. 焦躁的；不耐心的"
-        ],
-        "usphone": "[ɪmˈpeɪʃnt]",
-        "ukphone": "[ɪmˈpeɪʃ(ə)nt]"
-    },
-    {
-        "name": "implement",
-        "trans": [
-            "n. 工具，器具；手段"
-        ],
-        "usphone": "[ˈɪmplɪmənt; ˈɪmpləˌment]",
-        "ukphone": "[ˈɪmplɪment]"
-    },
-    {
-        "name": "implication",
-        "trans": [
-            "n. 含义；暗示；牵连，卷入；可能的结果，影响"
-        ],
-        "usphone": "[ˌɪmplɪˈkeɪʃn]",
-        "ukphone": "[ˌɪmplɪˈkeɪʃn]"
-    },
-    {
-        "name": "imply",
-        "trans": [
-            "vt. 意味；暗示；隐含"
-        ],
-        "usphone": "[ɪmˈplaɪ]",
-        "ukphone": "[ɪmˈplaɪ]"
-    },
-    {
-        "name": "impose",
-        "trans": [
-            "vt. 强加；征税；以…欺骗"
-        ],
-        "usphone": "[ɪmˈpoʊz]",
-        "ukphone": "[ɪmˈpəʊz]"
-    },
-    {
-        "name": "impress",
-        "trans": [
-            "n. 印象，印记；特征，痕迹"
-        ],
-        "usphone": "[ɪmˈpres]",
-        "ukphone": "[ɪmˈpres]"
-    },
-    {
-        "name": "impressed",
-        "trans": [
-            "adj. 印象深刻的；外加的；受感动的；了不起的"
-        ],
-        "usphone": "[ɪmˈprest]",
-        "ukphone": "[ɪmˈprest]"
-    },
-    {
-        "name": "incentive",
-        "trans": [
-            "n. 动机；刺激"
-        ],
-        "usphone": "[ɪnˈsentɪv]",
-        "ukphone": "[ɪnˈsentɪv]"
-    },
-    {
-        "name": "inch",
-        "trans": [
-            "n. 英寸；身高；少许"
-        ],
-        "usphone": "[ɪntʃ]",
-        "ukphone": "[ɪntʃ]"
-    },
-    {
-        "name": "incident",
-        "trans": [
-            "n. 事件，事变；插曲"
-        ],
-        "usphone": "[ˈɪnsɪdənt]",
-        "ukphone": "[ˈɪnsɪdənt]"
-    },
-    {
-        "name": "income",
-        "trans": [
-            "n. 收入，收益；所得"
-        ],
-        "usphone": "[ˈɪnkʌm; ˈɪnkəm]",
-        "ukphone": "[ˈɪnkʌm]"
-    },
-    {
-        "name": "incorporate",
-        "trans": [
-            "vt. 包含，吸收；体现；把……合并"
-        ],
-        "usphone": "[ɪnˈkɔːrpəreɪt]",
-        "ukphone": "[ɪnˈkɔːpəreɪt]"
-    },
-    {
-        "name": "incorrect",
-        "trans": [
-            "adj. 错误的，不正确的；不适当的；不真实的"
-        ],
-        "usphone": "[ˌɪnkəˈrekt]",
-        "ukphone": "[ˌɪnkəˈrekt]"
-    },
-    {
-        "name": "increasingly",
-        "trans": [
-            "adv. 越来越多地；渐增地"
-        ],
-        "usphone": "[ɪnˈkriːsɪŋli]",
-        "ukphone": "[ɪnˈkriːsɪŋli]"
-    },
-    {
-        "name": "independence",
-        "trans": [
-            "n. 独立性，自立性；自主"
-        ],
-        "usphone": "[ˌɪndɪˈpendəns]",
-        "ukphone": "[ˌɪndɪˈpendəns]"
-    },
-    {
-        "name": "index",
-        "trans": [
-            "n. 指标；指数；索引；指针"
-        ],
-        "usphone": "[ˈɪndeks]",
-        "ukphone": "[ˈɪndeks]"
-    },
-    {
-        "name": "indication",
-        "trans": [
-            "n. 指示，指出；迹象；象征"
-        ],
-        "usphone": "[ˌɪndɪˈkeɪʃn]",
-        "ukphone": "[ˌɪndɪˈkeɪʃn]"
-    },
-    {
-        "name": "industrial",
-        "trans": [
-            "n. 工业股票；工业工人"
-        ],
-        "usphone": "[ɪnˈdʌstriəl]",
-        "ukphone": "[ɪnˈdʌstriəl]"
-    },
-    {
-        "name": "inevitable",
-        "trans": [
-            "adj. 必然的，不可避免的"
-        ],
-        "usphone": "[ɪnˈevɪtəbl]",
-        "ukphone": "[ɪnˈevɪtəbl]"
-    },
-    {
-        "name": "inevitably",
-        "trans": [
-            "adv. 不可避免地；必然地"
-        ],
-        "usphone": "[ɪnˈevɪtəbli]",
-        "ukphone": "[ɪnˈevɪtəbli]"
-    },
-    {
-        "name": "infection",
-        "trans": [
-            "n. 感染；传染；影响；传染病"
-        ],
-        "usphone": "[ɪnˈfekʃn]",
-        "ukphone": "[ɪnˈfekʃn]"
-    },
-    {
-        "name": "infer",
-        "trans": [
-            "vi. 推断；作出推论"
-        ],
-        "usphone": "[ɪnˈfɜːr]",
-        "ukphone": "[ɪnˈfɜː(r)]"
-    },
-    {
-        "name": "inflation",
-        "trans": [
-            "n. 膨胀；通货膨胀；夸张；自命不凡"
-        ],
-        "usphone": "[ɪnˈfleɪʃn]",
-        "ukphone": "[ɪnˈfleɪʃn]"
-    },
-    {
-        "name": "info",
-        "trans": [
-            "n. 信息；情报"
-        ],
-        "usphone": "[ˈɪnfoʊ]",
-        "ukphone": "[ˈɪnfəʊ]"
-    },
-    {
-        "name": "inform",
-        "trans": [
-            "vi. 告发；告密"
-        ],
-        "usphone": "[ɪnˈfɔːrm]",
-        "ukphone": "[ɪnˈfɔːm]"
-    },
-    {
-        "name": "infrastructure",
-        "trans": [
-            "n. 基础设施；公共建设；下部构造"
-        ],
-        "usphone": "[ˈɪnfrəstrʌktʃər]",
-        "ukphone": "[ˈɪnfrəstrʌktʃə(r)]"
-    },
-    {
-        "name": "inhabitant",
-        "trans": [
-            "n. 居民；居住者"
-        ],
-        "usphone": "[ɪnˈhæbɪtənt]",
-        "ukphone": "[ɪnˈhæbɪtənt]"
-    },
-    {
-        "name": "inherit",
-        "trans": [
-            "vt. 继承；遗传而得"
-        ],
-        "usphone": "[ɪnˈherɪt]",
-        "ukphone": "[ɪnˈherɪt]"
-    },
-    {
-        "name": "initial",
-        "trans": [
-            "n. 词首大写字母"
-        ],
-        "usphone": "[ɪˈnɪʃl]",
-        "ukphone": "[ɪˈnɪʃl]"
-    },
-    {
-        "name": "initially",
-        "trans": [
-            "adv. 最初，首先；开头"
-        ],
-        "usphone": "[ɪˈnɪʃəli]",
-        "ukphone": "[ɪˈnɪʃəli]"
-    },
-    {
-        "name": "initiative",
-        "trans": [
-            "n. 主动权；首创精神"
-        ],
-        "usphone": "[ɪˈnɪʃətɪv]",
-        "ukphone": "[ɪˈnɪʃətɪv]"
-    },
-    {
-        "name": "ink",
-        "trans": [
-            "n. 墨水，墨汁；油墨"
-        ],
-        "usphone": "[ɪŋk]",
-        "ukphone": "[ɪŋk]"
-    },
-    {
-        "name": "inner",
-        "trans": [
-            "n. 内部"
-        ],
-        "usphone": "[ˈɪnər]",
-        "ukphone": "[ˈɪnə(r)]"
-    },
-    {
-        "name": "innovation",
-        "trans": [
-            "n. 创新，革新；新方法"
-        ],
-        "usphone": "[ˌɪnəˈveɪʃn]",
-        "ukphone": "[ˌɪnəˈveɪʃ(ə)n]"
-    },
-    {
-        "name": "innovative",
-        "trans": [
-            "adj. 革新的，创新的；新颖的；有创新精神的"
-        ],
-        "usphone": "[ˈɪnəveɪtɪv]",
-        "ukphone": "[ˈɪnəveɪtɪv]"
-    },
-    {
-        "name": "input",
-        "trans": [
-            "n. 投入；输入电路"
-        ],
-        "usphone": "[ˈɪnpʊt]",
-        "ukphone": "[ˈɪnpʊt]"
-    },
-    {
-        "name": "inquiry",
-        "trans": [
-            "n. 探究；调查；质询"
-        ],
-        "usphone": "[ˈɪnkwəri; ɪnˈkwaɪəri]",
-        "ukphone": "[ɪnˈkwaɪəri]"
-    },
-    {
-        "name": "insert",
-        "trans": [
-            "n. 插入物；管芯；镶块；[机械]刀片"
-        ],
-        "usphone": "[ɪnˈsɜːrt]",
-        "ukphone": "[ɪnˈsɜːt]"
-    },
-    {
-        "name": "insight",
-        "trans": [
-            "n. 洞察力；洞悉"
-        ],
-        "usphone": "[ˈɪnsaɪt]",
-        "ukphone": "[ˈɪnsaɪt]"
-    },
-    {
-        "name": "insist",
-        "trans": [
-            "vi. 坚持，强调"
-        ],
-        "usphone": "[ɪnˈsɪst]",
-        "ukphone": "[ɪnˈsɪst]"
-    },
-    {
-        "name": "inspector",
-        "trans": [
-            "n. 检查员；巡视员"
-        ],
-        "usphone": "[ɪnˈspektər]",
-        "ukphone": "[ɪnˈspektə(r)]"
-    },
-    {
-        "name": "inspire",
-        "trans": [
-            "vt. 激发；鼓舞；启示；产生；使生灵感"
-        ],
-        "usphone": "[ɪnˈspaɪər]",
-        "ukphone": "[ɪnˈspaɪə(r)]"
-    },
-    {
-        "name": "install",
-        "trans": [
-            "vt. 安装；任命；安顿"
-        ],
-        "usphone": "[ɪnˈstɔːl]",
-        "ukphone": "[ɪnˈstɔːl]"
-    },
-    {
-        "name": "installation",
-        "trans": [
-            "n. 安装，装置；就职"
-        ],
-        "usphone": "[ˌɪnstəˈleɪʃn]",
-        "ukphone": "[ˌɪnstəˈleɪʃn]"
-    },
-    {
-        "name": "instance",
-        "trans": [
-            "n. 实例；情况；建议"
-        ],
-        "usphone": "[ˈɪnstəns]",
-        "ukphone": "[ˈɪnstəns]"
-    },
-    {
-        "name": "instant",
-        "trans": [
-            "n. 瞬间；立即；片刻"
-        ],
-        "usphone": "[ˈɪnstənt]",
-        "ukphone": "[ˈɪnstənt]"
-    },
-    {
-        "name": "instantly",
-        "trans": [
-            "conj. 一…就…"
-        ],
-        "usphone": "[ˈɪnstəntli]",
-        "ukphone": "[ˈɪnstəntli]"
-    },
-    {
-        "name": "institute",
-        "trans": [
-            "n. 学会，协会；学院"
-        ],
-        "usphone": "[ˈɪnstɪtuːt]",
-        "ukphone": "[ˈɪnstɪtjuːt]"
-    },
-    {
-        "name": "institution",
-        "trans": [
-            "n. 制度；建立；（社会或宗教等）公共机构；习俗"
-        ],
-        "usphone": "[ˌɪnstɪˈtuːʃn]",
-        "ukphone": "[ˌɪnstɪˈtjuːʃ(ə)n]"
-    },
-    {
-        "name": "insurance",
-        "trans": [
-            "n. 保险；保险费；保险契约；赔偿金"
-        ],
-        "usphone": "[ɪnˈʃʊrəns]",
-        "ukphone": "[ɪnˈʃʊərəns]"
-    },
-    {
-        "name": "integrate",
-        "trans": [
-            "n. 一体化；集成体"
-        ],
-        "usphone": "[ˈɪntɪɡreɪt]",
-        "ukphone": "[ˈɪntɪɡreɪt]"
-    },
-    {
-        "name": "intellectual",
-        "trans": [
-            "n. 知识分子；凭理智做事者"
-        ],
-        "usphone": "[ˌɪntəˈlektʃuəl]",
-        "ukphone": "[ˌɪntəˈlektʃuəl]"
-    },
-    {
-        "name": "intended",
-        "trans": [
-            "n. 已订婚者"
-        ],
-        "usphone": "[ɪnˈtendɪd]",
-        "ukphone": "[ɪnˈtendɪd]"
-    },
-    {
-        "name": "intense",
-        "trans": [
-            "adj. 强烈的；紧张的；非常的；热情的"
-        ],
-        "usphone": "[ɪnˈtens]",
-        "ukphone": "[ɪnˈtens]"
-    },
-    {
-        "name": "interact",
-        "trans": [
-            "n. 幕间剧；幕间休息"
-        ],
-        "usphone": "[ˌɪntərˈækt]",
-        "ukphone": "[ˌɪntərˈækt]"
-    },
-    {
-        "name": "interaction",
-        "trans": [
-            "n. 相互作用；[数] 交互作用"
-        ],
-        "usphone": "[ˌɪntərˈækʃn]",
-        "ukphone": "[ˌɪntərˈækʃ(ə)n]"
-    },
-    {
-        "name": "internal",
-        "trans": [
-            "n. 内脏；本质"
-        ],
-        "usphone": "[ɪnˈtɜːrn(ə)l]",
-        "ukphone": "[ɪnˈtɜːn(ə)l]"
-    },
-    {
-        "name": "interpret",
-        "trans": [
-            "vi. 解释；翻译"
-        ],
-        "usphone": "[ɪnˈtɜːrprət]",
-        "ukphone": "[ɪnˈtɜːprət]"
-    },
-    {
-        "name": "interpretation",
-        "trans": [
-            "n. 解释；翻译；演出"
-        ],
-        "usphone": "[ɪnˌtɜːrprəˈteɪʃn]",
-        "ukphone": "[ɪnˌtɜːprəˈteɪʃn]"
-    },
-    {
-        "name": "interrupt",
-        "trans": [
-            "n. 中断"
-        ],
-        "usphone": "[ˌɪntəˈrʌpt]",
-        "ukphone": "[ˌɪntəˈrʌpt]"
-    },
-    {
-        "name": "interval",
-        "trans": [
-            "n. 间隔；间距；幕间休息"
-        ],
-        "usphone": "[ˈɪntərv(ə)l]",
-        "ukphone": "[ˈɪntəvl]"
-    },
-    {
-        "name": "invade",
-        "trans": [
-            "vt. 侵略；侵袭；侵扰；涌入"
-        ],
-        "usphone": "[ɪnˈveɪd]",
-        "ukphone": "[ɪnˈveɪd]"
-    },
-    {
-        "name": "invasion",
-        "trans": [
-            "n. 入侵，侵略；侵袭；侵犯"
-        ],
-        "usphone": "[ɪnˈveɪʒn]",
-        "ukphone": "[ɪnˈveɪʒn]"
-    },
-    {
-        "name": "investigation",
-        "trans": [
-            "n. 调查；调查研究"
-        ],
-        "usphone": "[ɪnˌvestɪˈɡeɪʃn]",
-        "ukphone": "[ɪnˌvestɪˈɡeɪʃn]"
-    },
-    {
-        "name": "investment",
-        "trans": [
-            "n. 投资；投入；封锁"
-        ],
-        "usphone": "[ɪnˈvestmənt]",
-        "ukphone": "[ɪnˈvestmənt]"
-    },
-    {
-        "name": "investor",
-        "trans": [
-            "n. 投资者"
-        ],
-        "usphone": "[ɪnˈvestər]",
-        "ukphone": "[ɪnˈvestə(r)]"
-    },
-    {
-        "name": "isolate",
-        "trans": [
-            "n. [生物] 隔离种群"
-        ],
-        "usphone": "[ˈaɪsəleɪt]",
-        "ukphone": "[ˈaɪsəleɪt]"
-    },
-    {
-        "name": "isolated",
-        "trans": [
-            "adj. 孤立的；分离的；单独的；[电] 绝缘的"
-        ],
-        "usphone": "[ˈaɪsəleɪtɪd]",
-        "ukphone": "[ˈaɪsəleɪtɪd]"
-    },
-    {
-        "name": "issue",
-        "trans": [
-            "n. 问题；流出；期号；发行物"
-        ],
-        "usphone": "[ˈɪʃuː]",
-        "ukphone": "[ˈɪʃuː]"
-    },
-    {
-        "name": "jail",
-        "trans": [
-            "n. 监狱；监牢；拘留所"
-        ],
-        "usphone": "[dʒeɪl]",
-        "ukphone": "[dʒeɪl]"
-    },
-    {
-        "name": "jet",
-        "trans": [
-            "n. 喷射，喷嘴；喷气式飞机；黑玉"
-        ],
-        "usphone": "[dʒet]",
-        "ukphone": "[dʒet]"
-    },
-    {
-        "name": "joint",
-        "trans": [
-            "n. 关节；接缝；接合处，接合点；（牛，羊等的腿）大块肉"
-        ],
-        "usphone": "[dʒɔɪnt]",
-        "ukphone": "[dʒɔɪnt]"
-    },
-    {
-        "name": "journalism",
-        "trans": [
-            "n. 新闻业，新闻工作；报章杂志"
-        ],
-        "usphone": "[ˈdʒɜːrnəlɪzəm]",
-        "ukphone": "[ˈdʒɜːnəlɪz(ə)m]"
-    },
-    {
-        "name": "joy",
-        "trans": [
-            "n. 欢乐，快乐；乐趣；高兴"
-        ],
-        "usphone": "[dʒɔɪ]",
-        "ukphone": "[dʒɔɪ]"
-    },
-    {
-        "name": "judgement",
-        "trans": [
-            "n. 意见；判断力；[法] 审判；评价"
-        ],
-        "usphone": "[ˈdʒʌdʒmənt]",
-        "ukphone": "[ˈdʒʌdʒmənt]"
-    },
-    {
-        "name": "junior",
-        "trans": [
-            "adj. 年少的；后进的；下级的"
-        ],
-        "usphone": "[ˈdʒuːniər]",
-        "ukphone": "[ˈdʒuːniə(r)]"
-    },
-    {
-        "name": "jury",
-        "trans": [
-            "n. [法] 陪审团；评判委员会"
-        ],
-        "usphone": "[ˈdʒʊri]",
-        "ukphone": "[ˈdʒʊəri]"
-    },
-    {
-        "name": "justice",
-        "trans": [
-            "n. 司法，法律制裁；正义；法官，审判员"
-        ],
-        "usphone": "[ˈdʒʌstɪs]",
-        "ukphone": "[ˈdʒʌstɪs]"
-    },
-    {
-        "name": "justify",
-        "trans": [
-            "vi. 证明合法；整理版面"
-        ],
-        "usphone": "[ˈdʒʌstɪfaɪ]",
-        "ukphone": "[ˈdʒʌstɪfaɪ]"
-    },
-    {
-        "name": "kit",
-        "trans": [
-            "n. 工具箱；成套工具"
-        ],
-        "usphone": "[kɪt]",
-        "ukphone": "[kɪt]"
-    },
-    {
-        "name": "labour",
-        "trans": [
-            "n. （英国）工党"
-        ],
-        "usphone": "[ˈleɪbər]",
-        "ukphone": "[ˈleɪbə(r)]"
-    },
-    {
-        "name": "ladder",
-        "trans": [
-            "n. 阶梯；途径；梯状物"
-        ],
-        "usphone": "[ˈlædər]",
-        "ukphone": "[ˈlædə(r)]"
-    },
-    {
-        "name": "landing",
-        "trans": [
-            "n. 登陆；码头；楼梯平台"
-        ],
-        "usphone": "[ˈlændɪŋ]",
-        "ukphone": "[ˈlændɪŋ]"
-    },
-    {
-        "name": "landscape",
-        "trans": [
-            "n. 风景；风景画；景色；山水画；乡村风景画；地形；（文件的）横向打印格式"
-        ],
-        "usphone": "[ˈlændskeɪp]",
-        "ukphone": "[ˈlændskeɪp]"
-    },
-    {
-        "name": "lane",
-        "trans": [
-            "n. 小巷；[航][水运] 航线；车道；罚球区"
-        ],
-        "usphone": "[leɪn]",
-        "ukphone": "[leɪn]"
+        "usphone": "[rʌb]",
+        "ukphone": "[rʌb]"
     },
     {
         "name": "largely",
@@ -5904,4702 +16,6 @@
         "ukphone": "[ˈlɑːdʒli]"
     },
     {
-        "name": "lately",
-        "trans": [
-            "adv. 近来，不久前"
-        ],
-        "usphone": "[ˈleɪtli]",
-        "ukphone": "[ˈleɪtli]"
-    },
-    {
-        "name": "latest",
-        "trans": [
-            "adv. 最迟地；最后地"
-        ],
-        "usphone": "[ˈleɪtɪst]",
-        "ukphone": "[ˈleɪtɪst]"
-    },
-    {
-        "name": "launch",
-        "trans": [
-            "vt. 发射（导弹、火箭等）；发起，发动；使…下水"
-        ],
-        "usphone": "[lɔːntʃ]",
-        "ukphone": "[lɔːntʃ]"
-    },
-    {
-        "name": "leadership",
-        "trans": [
-            "n. 领导能力；领导阶层"
-        ],
-        "usphone": "[ˈliːdərʃɪp]",
-        "ukphone": "[ˈliːdəʃɪp]"
-    },
-    {
-        "name": "leaflet",
-        "trans": [
-            "n. 小叶；传单"
-        ],
-        "usphone": "[ˈliːflət]",
-        "ukphone": "[ˈliːflət]"
-    },
-    {
-        "name": "league",
-        "trans": [
-            "n. 联盟；社团；范畴"
-        ],
-        "usphone": "[liːɡ]",
-        "ukphone": "[liːɡ]"
-    },
-    {
-        "name": "lean",
-        "trans": [
-            "vi. 倾斜；倚靠；倾向；依赖"
-        ],
-        "usphone": "[liːn]",
-        "ukphone": "[liːn]"
-    },
-    {
-        "name": "leave",
-        "trans": [
-            "vt. 离开；留下；遗忘；委托"
-        ],
-        "usphone": "[liːv]",
-        "ukphone": "[liːv]"
-    },
-    {
-        "name": "legend",
-        "trans": [
-            "n. 传奇；说明；图例；刻印文字"
-        ],
-        "usphone": "[ˈledʒənd]",
-        "ukphone": "[ˈledʒənd]"
-    },
-    {
-        "name": "lens",
-        "trans": [
-            "n. 透镜，镜头；眼睛中的水晶体；晶状体；隐形眼镜；汽车的灯玻璃"
-        ],
-        "usphone": "[lenz]",
-        "ukphone": "[lenz]"
-    },
-    {
-        "name": "level",
-        "trans": [
-            "n. 水平；标准；水平面"
-        ],
-        "usphone": "[ˈlevl]",
-        "ukphone": "[ˈlev(ə)l]"
-    },
-    {
-        "name": "licence",
-        "trans": [
-            "n. 许可证，执照；特许"
-        ],
-        "usphone": "[ˈlaɪsns]",
-        "ukphone": "[ˈlaɪsns]"
-    },
-    {
-        "name": "lifetime",
-        "trans": [
-            "n. 一生；寿命；终生；使用期"
-        ],
-        "usphone": "[ˈlaɪftaɪm]",
-        "ukphone": "[ˈlaɪftaɪm]"
-    },
-    {
-        "name": "lighting",
-        "trans": [
-            "n. 照明设备，舞台灯光"
-        ],
-        "usphone": "[ˈlaɪtɪŋ]",
-        "ukphone": "[ˈlaɪtɪŋ]"
-    },
-    {
-        "name": "likewise",
-        "trans": [
-            "adv. 同样地；也"
-        ],
-        "usphone": "[ˈlaɪkwaɪz]",
-        "ukphone": "[ˈlaɪkwaɪz]"
-    },
-    {
-        "name": "limitation",
-        "trans": [
-            "n. 限制；限度；极限；追诉时效；有效期限；缺陷"
-        ],
-        "usphone": "[ˌlɪmɪˈteɪʃn]",
-        "ukphone": "[ˌlɪmɪˈteɪʃn]"
-    },
-    {
-        "name": "limited",
-        "trans": [
-            "adj. 有限的"
-        ],
-        "usphone": "[ˈlɪmɪtɪd]",
-        "ukphone": "[ˈlɪmɪtɪd]"
-    },
-    {
-        "name": "line",
-        "trans": [
-            "n. 路线，航线；排；绳"
-        ],
-        "usphone": "[laɪn]",
-        "ukphone": "[laɪn]"
-    },
-    {
-        "name": "literally",
-        "trans": [
-            "adv. 照字面地；逐字地；不夸张地；正确地；简直"
-        ],
-        "usphone": "[ˈlɪtərəli]",
-        "ukphone": "[ˈlɪtərəli]"
-    },
-    {
-        "name": "literary",
-        "trans": [
-            "adj. 文学的；书面的；精通文学的"
-        ],
-        "usphone": "[ˈlɪtəreri]",
-        "ukphone": "[ˈlɪtərəri]"
-    },
-    {
-        "name": "litre",
-        "trans": [
-            "n. [计量] 公升（米制容量单位）"
-        ],
-        "usphone": "[ˈliːtər]",
-        "ukphone": "[ˈliːtə(r)]"
-    },
-    {
-        "name": "litter",
-        "trans": [
-            "n. 垃圾；轿，担架；一窝（动物的幼崽）；凌乱"
-        ],
-        "usphone": "[ˈlɪtər]",
-        "ukphone": "[ˈlɪtə(r)]"
-    },
-    {
-        "name": "lively",
-        "trans": [
-            "adj. 活泼的；生动的；真实的；生气勃勃的"
-        ],
-        "usphone": "[ˈlaɪvli]",
-        "ukphone": "[ˈlaɪvli]"
-    },
-    {
-        "name": "load",
-        "trans": [
-            "n. 负载，负荷；工作量；装载量"
-        ],
-        "usphone": "[loʊd]",
-        "ukphone": "[ləʊd]"
-    },
-    {
-        "name": "loan",
-        "trans": [
-            "n. 贷款；借款"
-        ],
-        "usphone": "[loʊn]",
-        "ukphone": "[ləʊn]"
-    },
-    {
-        "name": "logical",
-        "trans": [
-            "adj. 合逻辑的，合理的；逻辑学的"
-        ],
-        "usphone": "[ˈlɑːdʒɪkl]",
-        "ukphone": "[ˈlɒdʒɪk(ə)l]"
-    },
-    {
-        "name": "logo",
-        "trans": [
-            "n. 商标，徽标；标识语"
-        ],
-        "usphone": "[ˈloʊɡoʊ]",
-        "ukphone": "[ˈləʊɡəʊ]"
-    },
-    {
-        "name": "long-term",
-        "trans": [
-            "adj. 长期的"
-        ],
-        "usphone": "[ˌlɔːŋ ˈtɜːrm]",
-        "ukphone": "[ˌlɒŋ ˈtɜːm]"
-    },
-    {
-        "name": "loose",
-        "trans": [
-            "adj. 宽松的；散漫的；不牢固的；不精确的"
-        ],
-        "usphone": "[luːs]",
-        "ukphone": "[luːs]"
-    },
-    {
-        "name": "lord",
-        "trans": [
-            "n. 主；上帝"
-        ],
-        "usphone": "[lɔːrd]",
-        "ukphone": "[lɔːd]"
-    },
-    {
-        "name": "lottery",
-        "trans": [
-            "n. 彩票；碰运气的事，难算计的事；抽彩给奖法"
-        ],
-        "usphone": "[ˈlɑːtəri]",
-        "ukphone": "[ˈlɒtəri]"
-    },
-    {
-        "name": "low",
-        "trans": [
-            "adj. 低的，浅的；卑贱的；粗俗的；消沉的"
-        ],
-        "usphone": "[loʊ]",
-        "ukphone": "[ləʊ]"
-    },
-    {
-        "name": "lower",
-        "trans": [
-            "vt. 减弱，减少；放下，降下；贬低"
-        ],
-        "usphone": "[ˈloʊər]",
-        "ukphone": "[ˈləʊə(r)]"
-    },
-    {
-        "name": "loyal",
-        "trans": [
-            "adj. 忠诚的，忠心的；忠贞的"
-        ],
-        "usphone": "[ˈlɔɪəl]",
-        "ukphone": "[ˈlɔɪəl]"
-    },
-    {
-        "name": "lung",
-        "trans": [
-            "n. 肺；呼吸器"
-        ],
-        "usphone": "[lʌŋ]",
-        "ukphone": "[lʌŋ]"
-    },
-    {
-        "name": "lyric",
-        "trans": [
-            "adj. 抒情的；吟唱的"
-        ],
-        "usphone": "[ˈlɪrɪk]",
-        "ukphone": "[ˈlɪrɪk]"
-    },
-    {
-        "name": "magnificent",
-        "trans": [
-            "adj. 高尚的；壮丽的；华丽的；宏伟的"
-        ],
-        "usphone": "[mæɡˈnɪfɪsnt]",
-        "ukphone": "[mæɡˈnɪfɪs(ə)nt]"
-    },
-    {
-        "name": "maintain",
-        "trans": [
-            "vt. 维持；继续；维修；主张；供养"
-        ],
-        "usphone": "[meɪnˈteɪn]",
-        "ukphone": "[meɪnˈteɪn]"
-    },
-    {
-        "name": "majority",
-        "trans": [
-            "n. 多数；成年"
-        ],
-        "usphone": "[məˈdʒɔːrəti]",
-        "ukphone": "[məˈdʒɒrəti]"
-    },
-    {
-        "name": "make",
-        "trans": [
-            "vt. 使得；进行；布置，准备，整理；制造；认为；获得；形成；安排；引起；构成"
-        ],
-        "usphone": "[meɪk]",
-        "ukphone": "[meɪk]"
-    },
-    {
-        "name": "make-up",
-        "trans": [
-            "n. 化妆品；（美）补考；性格；构造；排版"
-        ],
-        "usphone": "[ˈmeɪk ʌp]",
-        "ukphone": "[ˈmeɪk ʌp]"
-    },
-    {
-        "name": "manufacture",
-        "trans": [
-            "n. 制造；产品；制造业"
-        ],
-        "usphone": "[ˌmænjuˈfæktʃər]",
-        "ukphone": "[ˌmænjuˈfæktʃə(r)]"
-    },
-    {
-        "name": "manufacturing",
-        "trans": [
-            "adj. 制造的；制造业的"
-        ],
-        "usphone": "[ˌmænjuˈfæktʃərɪŋ]",
-        "ukphone": "[ˌmænjuˈfæktʃərɪŋ]"
-    },
-    {
-        "name": "map",
-        "trans": [
-            "vt. 映射；计划；绘制地图；确定基因在染色体中的位置"
-        ],
-        "usphone": "[mæp]",
-        "ukphone": "[mæp]"
-    },
-    {
-        "name": "marathon",
-        "trans": [
-            "n. 马拉松赛跑；耐力的考验"
-        ],
-        "usphone": "[ˈmærəθɑːn]",
-        "ukphone": "[ˈmærəθən]"
-    },
-    {
-        "name": "margin",
-        "trans": [
-            "n. 边缘；利润，余裕；页边的空白"
-        ],
-        "usphone": "[ˈmɑːrdʒɪn]",
-        "ukphone": "[ˈmɑːdʒɪn]"
-    },
-    {
-        "name": "marker",
-        "trans": [
-            "n. 记分员；书签；标识物；作记号的人"
-        ],
-        "usphone": "[ˈmɑːrkər]",
-        "ukphone": "[ˈmɑːkə(r)]"
-    },
-    {
-        "name": "martial",
-        "trans": [
-            "adj. 军事的；战争的；尚武的"
-        ],
-        "usphone": "[ˈmɑːrʃ(ə)l]",
-        "ukphone": "[ˈmɑːʃ(ə)l]"
-    },
-    {
-        "name": "mass",
-        "trans": [
-            "n. 块，团；群众，民众；大量，众多；质量"
-        ],
-        "usphone": "[mæs]",
-        "ukphone": "[mæs]"
-    },
-    {
-        "name": "massive",
-        "trans": [
-            "adj. 大量的；巨大的，厚重的；魁伟的"
-        ],
-        "usphone": "[ˈmæsɪv]",
-        "ukphone": "[ˈmæsɪv]"
-    },
-    {
-        "name": "master",
-        "trans": [
-            "vt. 控制；精通；征服"
-        ],
-        "usphone": "[ˈmæstər]",
-        "ukphone": "[ˈmɑːstə(r)]"
-    },
-    {
-        "name": "matching",
-        "trans": [
-            "adj. 相配的；一致的；相称的"
-        ],
-        "usphone": "[ˈmætʃɪŋ]",
-        "ukphone": "[ˈmætʃɪŋ]"
-    },
-    {
-        "name": "mate",
-        "trans": [
-            "n. 助手，大副；配偶；同事；配对物"
-        ],
-        "usphone": "[meɪt]",
-        "ukphone": "[meɪt]"
-    },
-    {
-        "name": "material",
-        "trans": [
-            "adj. 重要的；物质的，实质性的；肉体的"
-        ],
-        "usphone": "[məˈtɪriəl]",
-        "ukphone": "[məˈtɪəriəl]"
-    },
-    {
-        "name": "maximum",
-        "trans": [
-            "n. [数] 极大，最大限度；最大量"
-        ],
-        "usphone": "[ˈmæksɪməm]",
-        "ukphone": "[ˈmæksɪməm]"
-    },
-    {
-        "name": "mayor",
-        "trans": [
-            "n. 市长"
-        ],
-        "usphone": "[ˈmeɪər]",
-        "ukphone": "[meə(r)]"
-    },
-    {
-        "name": "means",
-        "trans": [
-            "n. 手段；方法；财产"
-        ],
-        "usphone": "[miːnz]",
-        "ukphone": "[miːnz]"
-    },
-    {
-        "name": "measurement",
-        "trans": [
-            "n. 测量；[计量] 度量；尺寸；量度制"
-        ],
-        "usphone": "[ˈmeʒərmənt]",
-        "ukphone": "[ˈmeʒəmənt]"
-    },
-    {
-        "name": "mechanic",
-        "trans": [
-            "n. 技工，机修工"
-        ],
-        "usphone": "[məˈkænɪk]",
-        "ukphone": "[məˈkænɪk]"
-    },
-    {
-        "name": "mechanical",
-        "trans": [
-            "adj. 机械的；力学的；呆板的；无意识的；手工操作的"
-        ],
-        "usphone": "[məˈkænɪkl]",
-        "ukphone": "[məˈkænɪkl]"
-    },
-    {
-        "name": "mechanism",
-        "trans": [
-            "n. 机制；原理，途径；进程；机械装置；技巧"
-        ],
-        "usphone": "[ˈmekənɪzəm]",
-        "ukphone": "[ˈmekənɪzəm]"
-    },
-    {
-        "name": "medal",
-        "trans": [
-            "n. 勋章，奖章；纪念章"
-        ],
-        "usphone": "[ˈmedl]",
-        "ukphone": "[ˈmedl]"
-    },
-    {
-        "name": "medication",
-        "trans": [
-            "n. 药物；药物治疗；药物处理"
-        ],
-        "usphone": "[ˌmedɪˈkeɪʃn]",
-        "ukphone": "[ˌmedɪˈkeɪʃn]"
-    },
-    {
-        "name": "medium",
-        "trans": [
-            "adj. 中间的，中等的；半生熟的"
-        ],
-        "usphone": "[ˈmiːdiəm]",
-        "ukphone": "[ˈmiːdiəm]"
-    },
-    {
-        "name": "melt",
-        "trans": [
-            "vi. 熔化，溶解；渐混"
-        ],
-        "usphone": "[melt]",
-        "ukphone": "[melt]"
-    },
-    {
-        "name": "membership",
-        "trans": [
-            "n. 资格；成员资格；会员身份"
-        ],
-        "usphone": "[ˈmembərʃɪp]",
-        "ukphone": "[ˈmembəʃɪp]"
-    },
-    {
-        "name": "memorable",
-        "trans": [
-            "adj. 显著的，难忘的；值得纪念的"
-        ],
-        "usphone": "[ˈmemərəbl]",
-        "ukphone": "[ˈmemərəbl]"
-    },
-    {
-        "name": "metaphor",
-        "trans": [
-            "n. 暗喻，隐喻；比喻说法"
-        ],
-        "usphone": "[ˈmetəfərˌˈmetəfɔːr]",
-        "ukphone": "[ˈmetəfə(r); ˈmetəfɔː(r)]"
-    },
-    {
-        "name": "military",
-        "trans": [
-            "adj. 军事的；军人的；适于战争的"
-        ],
-        "usphone": "[ˈmɪləteri]",
-        "ukphone": "[ˈmɪlətri]"
-    },
-    {
-        "name": "miner",
-        "trans": [
-            "n. 矿工；开矿机"
-        ],
-        "usphone": "[ˈmaɪnər]",
-        "ukphone": "[ˈmaɪnə(r)]"
-    },
-    {
-        "name": "mineral",
-        "trans": [
-            "n. 矿物；（英）矿泉水；无机物；苏打水（常用复数表示）"
-        ],
-        "usphone": "[ˈmɪnərəl]",
-        "ukphone": "[ˈmɪnərəl]"
-    },
-    {
-        "name": "minimum",
-        "trans": [
-            "n. 最小值；最低限度；最小化；最小量"
-        ],
-        "usphone": "[ˈmɪnɪməm]",
-        "ukphone": "[ˈmɪnɪməm]"
-    },
-    {
-        "name": "minister",
-        "trans": [
-            "n. 部长；大臣；牧师"
-        ],
-        "usphone": "[ˈmɪnɪstər]",
-        "ukphone": "[ˈmɪnɪstə(r)]"
-    },
-    {
-        "name": "minor",
-        "trans": [
-            "adj. 未成年的；次要的；较小的；小调的；二流的"
-        ],
-        "usphone": "[ˈmaɪnər]",
-        "ukphone": "[ˈmaɪnə(r)]"
-    },
-    {
-        "name": "minority",
-        "trans": [
-            "n. 少数民族；少数派；未成年"
-        ],
-        "usphone": "[maɪˈnɔːrəti]",
-        "ukphone": "[maɪˈnɒrəti]"
-    },
-    {
-        "name": "miserable",
-        "trans": [
-            "adj. 悲惨的；痛苦的；卑鄙的"
-        ],
-        "usphone": "[ˈmɪzrəbl]",
-        "ukphone": "[ˈmɪzrəbl]"
-    },
-    {
-        "name": "mission",
-        "trans": [
-            "n. 使命，任务；代表团；布道"
-        ],
-        "usphone": "[ˈmɪʃn]",
-        "ukphone": "[ˈmɪʃn]"
-    },
-    {
-        "name": "mistake",
-        "trans": [
-            "n. 错误；误会；过失"
-        ],
-        "usphone": "[mɪˈsteɪk]",
-        "ukphone": "[mɪˈsteɪk]"
-    },
-    {
-        "name": "mixed",
-        "trans": [
-            "adj. 混合的；形形色色的；弄糊涂的"
-        ],
-        "usphone": "[mɪkst]",
-        "ukphone": "[mɪkst]"
-    },
-    {
-        "name": "mode",
-        "trans": [
-            "n. 模式；方式；风格；时尚"
-        ],
-        "usphone": "[moʊd]",
-        "ukphone": "[məʊd]"
-    },
-    {
-        "name": "model",
-        "trans": [
-            "n. 模型；典型；模范；模特儿；样式"
-        ],
-        "usphone": "[ˈmɑːdl]",
-        "ukphone": "[ˈmɒd(ə)l]"
-    },
-    {
-        "name": "modest",
-        "trans": [
-            "adj. 谦虚的，谦逊的；适度的；端庄的；羞怯的"
-        ],
-        "usphone": "[ˈmɑːdɪst]",
-        "ukphone": "[ˈmɒdɪst]"
-    },
-    {
-        "name": "modify",
-        "trans": [
-            "vt. 修改，修饰；更改"
-        ],
-        "usphone": "[ˈmɑːdɪfaɪ]",
-        "ukphone": "[ˈmɒdɪfaɪ]"
-    },
-    {
-        "name": "monitor",
-        "trans": [
-            "n. 监视器；监听器；监控器；显示屏；班长"
-        ],
-        "usphone": "[ˈmɑːnɪtər]",
-        "ukphone": "[ˈmɒnɪtə(r)]"
-    },
-    {
-        "name": "monster",
-        "trans": [
-            "n. 怪物；巨人，巨兽；残忍的人"
-        ],
-        "usphone": "[ˈmɑːnstər]",
-        "ukphone": "[ˈmɒnstə(r)]"
-    },
-    {
-        "name": "monthly",
-        "trans": [
-            "adj. 每月的，每月一次的；有效期为一个月的"
-        ],
-        "usphone": "[ˈmʌnθli]",
-        "ukphone": "[ˈmʌnθli]"
-    },
-    {
-        "name": "monument",
-        "trans": [
-            "n. 纪念碑；历史遗迹；不朽的作品"
-        ],
-        "usphone": "[ˈmɑːnjumənt]",
-        "ukphone": "[ˈmɒnjumənt]"
-    },
-    {
-        "name": "moral",
-        "trans": [
-            "adj. 道德的；精神上的；品性端正的"
-        ],
-        "usphone": "[ˈmɔːrəl]",
-        "ukphone": "[ˈmɒrəl]"
-    },
-    {
-        "name": "moreover",
-        "trans": [
-            "adv. 而且；此外"
-        ],
-        "usphone": "[mɔːrˈoʊvər]",
-        "ukphone": "[mɔːrˈəʊvə(r)]"
-    },
-    {
-        "name": "mortgage",
-        "trans": [
-            "vt. 抵押"
-        ],
-        "usphone": "[ˈmɔːrɡɪdʒ]",
-        "ukphone": "[ˈmɔːɡɪdʒ]"
-    },
-    {
-        "name": "mosque",
-        "trans": [
-            "n. 清真寺"
-        ],
-        "usphone": "[mɑːsk]",
-        "ukphone": "[mɒsk]"
-    },
-    {
-        "name": "motion",
-        "trans": [
-            "n. 动作；移动；手势；请求；意向；议案"
-        ],
-        "usphone": "[ˈmoʊʃn]",
-        "ukphone": "[ˈməʊʃn]"
-    },
-    {
-        "name": "motivate",
-        "trans": [
-            "vt. 刺激；使有动机；激发…的积极性"
-        ],
-        "usphone": "[ˈmoʊtɪveɪt]",
-        "ukphone": "[ˈməʊtɪveɪt]"
-    },
-    {
-        "name": "motivation",
-        "trans": [
-            "n. 动机；积极性；推动"
-        ],
-        "usphone": "[ˌmoʊtɪˈveɪʃn]",
-        "ukphone": "[ˌməʊtɪˈveɪʃn]"
-    },
-    {
-        "name": "motor",
-        "trans": [
-            "n. 发动机，马达；汽车"
-        ],
-        "usphone": "[ˈmoʊtər]",
-        "ukphone": "[ˈməʊtə(r)]"
-    },
-    {
-        "name": "mount",
-        "trans": [
-            "vt. 增加；爬上；使骑上马；安装，架置；镶嵌，嵌入；准备上演；成立（军队等）"
-        ],
-        "usphone": "[maʊnt]",
-        "ukphone": "[maʊnt]"
-    },
-    {
-        "name": "moving",
-        "trans": [
-            "adj. 移动的；动人的；活动的"
-        ],
-        "usphone": "[ˈmuːvɪŋ]",
-        "ukphone": "[ˈmuːvɪŋ]"
-    },
-    {
-        "name": "multiple",
-        "trans": [
-            "adj. 多重的；多样的；许多的"
-        ],
-        "usphone": "[ˈmʌltɪpl]",
-        "ukphone": "[ˈmʌltɪpl]"
-    },
-    {
-        "name": "multiply",
-        "trans": [
-            "vt. 乘；使增加；使繁殖；使相乘"
-        ],
-        "usphone": "[ˈmʌltɪplaɪ]",
-        "ukphone": "[ˈmʌltɪplaɪ]"
-    },
-    {
-        "name": "mysterious",
-        "trans": [
-            "adj. 神秘的；不可思议的；难解的"
-        ],
-        "usphone": "[mɪˈstɪriəs]",
-        "ukphone": "[mɪˈstɪəriəs]"
-    },
-    {
-        "name": "myth",
-        "trans": [
-            "n. 神话；虚构的人，虚构的事"
-        ],
-        "usphone": "[mɪθ]",
-        "ukphone": "[mɪθ]"
-    },
-    {
-        "name": "naked",
-        "trans": [
-            "adj. 裸体的；无装饰的；无证据的；直率的"
-        ],
-        "usphone": "[ˈneɪkɪd]",
-        "ukphone": "[ˈneɪkɪd]"
-    },
-    {
-        "name": "narrow",
-        "trans": [
-            "adj. 狭窄的，有限的；勉强的；精密的；度量小的"
-        ],
-        "usphone": "[ˈnæroʊ]",
-        "ukphone": "[ˈnærəʊ]"
-    },
-    {
-        "name": "nasty",
-        "trans": [
-            "adj. 下流的；肮脏的；脾气不好的；险恶的"
-        ],
-        "usphone": "[ˈnæsti]",
-        "ukphone": "[ˈnɑːsti]"
-    },
-    {
-        "name": "national",
-        "trans": [
-            "adj. 国家的；国民的；民族的；国立的"
-        ],
-        "usphone": "[ˈnæʃ(ə)nəl]",
-        "ukphone": "[ˈnæʃ(ə)nəl]"
-    },
-    {
-        "name": "navigation",
-        "trans": [
-            "n. 航行；航海"
-        ],
-        "usphone": "[ˌnævɪˈɡeɪʃn]",
-        "ukphone": "[ˌnævɪˈɡeɪʃn]"
-    },
-    {
-        "name": "nearby",
-        "trans": [
-            "adj. 附近的，邻近的"
-        ],
-        "usphone": "[ˌnɪrˈbaɪ]",
-        "ukphone": "[ˌnɪəˈbaɪ]"
-    },
-    {
-        "name": "neat",
-        "trans": [
-            "adj. 灵巧的；整洁的；优雅的；齐整的；未搀水的；平滑的"
-        ],
-        "usphone": "[niːt]",
-        "ukphone": "[niːt]"
-    },
-    {
-        "name": "necessity",
-        "trans": [
-            "n. 需要；必然性；必需品"
-        ],
-        "usphone": "[nəˈsesəti]",
-        "ukphone": "[nəˈsesəti]"
-    },
-    {
-        "name": "negative",
-        "trans": [
-            "adj. [数] 负的；消极的；否定的；阴性的"
-        ],
-        "usphone": "[ˈneɡətɪv]",
-        "ukphone": "[ˈneɡətɪv]"
-    },
-    {
-        "name": "negotiate",
-        "trans": [
-            "vt. 谈判，商议；转让；越过"
-        ],
-        "usphone": "[nɪˈɡoʊʃieɪt]",
-        "ukphone": "[nɪˈɡəʊʃieɪt]"
-    },
-    {
-        "name": "negotiation",
-        "trans": [
-            "n. 谈判；转让；顺利的通过"
-        ],
-        "usphone": "[nɪˌɡoʊʃiˈeɪʃn]",
-        "ukphone": "[nɪˌɡəʊʃiˈeɪʃn]"
-    },
-    {
-        "name": "nerve",
-        "trans": [
-            "n. 神经；勇气；[植] 叶脉"
-        ],
-        "usphone": "[nɜːrv]",
-        "ukphone": "[nɜːv]"
-    },
-    {
-        "name": "neutral",
-        "trans": [
-            "adj. 中立的，中性的；中立国的；非彩色的"
-        ],
-        "usphone": "[ˈnuːtrəl]",
-        "ukphone": "[ˈnjuːtrəl]"
-    },
-    {
-        "name": "nevertheless",
-        "trans": [
-            "adv. 然而，不过；虽然如此"
-        ],
-        "usphone": "[ˌnevərðəˈles]",
-        "ukphone": "[ˌnevəðəˈles]"
-    },
-    {
-        "name": "newly",
-        "trans": [
-            "adv. 最近；重新；以新的方式"
-        ],
-        "usphone": "[ˈnuːli]",
-        "ukphone": "[ˈnjuːli]"
-    },
-    {
-        "name": "nightmare",
-        "trans": [
-            "n. 恶梦；梦魇般的经历"
-        ],
-        "usphone": "[ˈnaɪtmer]",
-        "ukphone": "[ˈnaɪtmeə(r)]"
-    },
-    {
-        "name": "norm",
-        "trans": [
-            "n. 标准，规范"
-        ],
-        "usphone": "[nɔːrm]",
-        "ukphone": "[nɔːm]"
-    },
-    {
-        "name": "notebook",
-        "trans": [
-            "n. 笔记本，笔记簿；手册"
-        ],
-        "usphone": "[ˈnoʊtbʊk]",
-        "ukphone": "[ˈnəʊtbʊk]"
-    },
-    {
-        "name": "notion",
-        "trans": [
-            "n. 概念；见解；打算"
-        ],
-        "usphone": "[ˈnoʊʃn]",
-        "ukphone": "[ˈnəʊʃn]"
-    },
-    {
-        "name": "novelist",
-        "trans": [
-            "n. 小说家"
-        ],
-        "usphone": "[ˈnɑːvəlɪst]",
-        "ukphone": "[ˈnɒvəlɪst]"
-    },
-    {
-        "name": "nowadays",
-        "trans": [
-            "adv. 现今；时下"
-        ],
-        "usphone": "[ˈnaʊədeɪz]",
-        "ukphone": "[ˈnaʊədeɪz]"
-    },
-    {
-        "name": "numerous",
-        "trans": [
-            "adj. 许多的，很多的"
-        ],
-        "usphone": "[ˈnuːmərəs]",
-        "ukphone": "[ˈnjuːmərəs]"
-    },
-    {
-        "name": "nursing",
-        "trans": [
-            "n. 护理；看护；养育"
-        ],
-        "usphone": "[ˈnɜːrsɪŋ]",
-        "ukphone": "[ˈnɜːsɪŋ]"
-    },
-    {
-        "name": "nutrition",
-        "trans": [
-            "n. 营养，营养学；营养品"
-        ],
-        "usphone": "[nuˈtrɪʃn]",
-        "ukphone": "[njuˈtrɪʃ(ə)n]"
-    },
-    {
-        "name": "obesity",
-        "trans": [
-            "n. 肥大，肥胖"
-        ],
-        "usphone": "[oʊˈbiːsəti]",
-        "ukphone": "[əʊˈbiːsəti]"
-    },
-    {
-        "name": "obey",
-        "trans": [
-            "vt. 服从，听从；按照……行动"
-        ],
-        "usphone": "[əˈbeɪ]",
-        "ukphone": "[əˈbeɪ]"
-    },
-    {
-        "name": "object",
-        "trans": [
-            "n. 目标；物体；客体；宾语"
-        ],
-        "usphone": "[ˈɑːbdʒɪkt; əbˈdʒekt]",
-        "ukphone": "[ˈɒbdʒɪkt; əbˈdʒekt]"
-    },
-    {
-        "name": "objective",
-        "trans": [
-            "adj. 客观的；目标的；宾格的"
-        ],
-        "usphone": "[əbˈdʒektɪv]",
-        "ukphone": "[əbˈdʒektɪv]"
-    },
-    {
-        "name": "obligation",
-        "trans": [
-            "n. 义务；职责；债务"
-        ],
-        "usphone": "[ˌɑːblɪˈɡeɪʃn]",
-        "ukphone": "[ˌɒblɪˈɡeɪʃ(ə)n]"
-    },
-    {
-        "name": "observation",
-        "trans": [
-            "n. 观察；监视；观察报告"
-        ],
-        "usphone": "[ˌɑːbzərˈveɪʃ(ə)n]",
-        "ukphone": "[ˌɒbzəˈveɪʃ(ə)n]"
-    },
-    {
-        "name": "observe",
-        "trans": [
-            "vt. 庆祝"
-        ],
-        "usphone": "[əbˈzɜːrv]",
-        "ukphone": "[əbˈzɜːv]"
-    },
-    {
-        "name": "observer",
-        "trans": [
-            "n. 观察者；[天] 观测者；遵守者"
-        ],
-        "usphone": "[əbˈzɜːrvər]",
-        "ukphone": "[əbˈzɜːvə(r)]"
-    },
-    {
-        "name": "obstacle",
-        "trans": [
-            "n. 障碍，干扰；妨害物"
-        ],
-        "usphone": "[ˈɑːbstək(ə)l]",
-        "ukphone": "[ˈɒbstəkl]"
-    },
-    {
-        "name": "obtain",
-        "trans": [
-            "vi. 获得；流行"
-        ],
-        "usphone": "[əbˈteɪn]",
-        "ukphone": "[əbˈteɪn]"
-    },
-    {
-        "name": "occasionally",
-        "trans": [
-            "adv. 偶尔；间或"
-        ],
-        "usphone": "[əˈkeɪʒnəli]",
-        "ukphone": "[əˈkeɪʒnəli]"
-    },
-    {
-        "name": "occupation",
-        "trans": [
-            "n. 职业；占有；消遣；占有期"
-        ],
-        "usphone": "[ˌɑːkjuˈpeɪʃn]",
-        "ukphone": "[ˌɒkjuˈpeɪʃ(ə)n]"
-    },
-    {
-        "name": "occupy",
-        "trans": [
-            "vt. 占据，占领；居住；使忙碌"
-        ],
-        "usphone": "[ˈɑːkjupaɪ]",
-        "ukphone": "[ˈɒkjupaɪ]"
-    },
-    {
-        "name": "offence",
-        "trans": [
-            "n. 犯罪；违反；过错；攻击"
-        ],
-        "usphone": "[əˈfens]",
-        "ukphone": "[əˈfens]"
-    },
-    {
-        "name": "offend",
-        "trans": [
-            "vt. 冒犯；使…不愉快"
-        ],
-        "usphone": "[əˈfend]",
-        "ukphone": "[əˈfend]"
-    },
-    {
-        "name": "offender",
-        "trans": [
-            "n. 罪犯；冒犯者；违法者"
-        ],
-        "usphone": "[əˈfendər]",
-        "ukphone": "[əˈfendə(r)]"
-    },
-    {
-        "name": "offensive",
-        "trans": [
-            "adj. 攻击的；冒犯的；无礼的；讨厌的"
-        ],
-        "usphone": "[əˈfensɪv]",
-        "ukphone": "[əˈfensɪv]"
-    },
-    {
-        "name": "official",
-        "trans": [
-            "adj. 官方的；正式的；公务的"
-        ],
-        "usphone": "[əˈfɪʃl]",
-        "ukphone": "[əˈfɪʃ(ə)l]"
-    },
-    {
-        "name": "ongoing",
-        "trans": [
-            "adj. 不间断的，进行的；前进的"
-        ],
-        "usphone": "[ˈɑːnɡoʊɪŋ]",
-        "ukphone": "[ˈɒnɡəʊɪŋ]"
-    },
-    {
-        "name": "opening",
-        "trans": [
-            "n. 开始；机会；通路；空缺的职位"
-        ],
-        "usphone": "[ˈoʊpənɪŋ]",
-        "ukphone": "[ˈəʊpənɪŋ]"
-    },
-    {
-        "name": "openly",
-        "trans": [
-            "adv. 公开地；公然地；坦率地"
-        ],
-        "usphone": "[ˈoʊpənli]",
-        "ukphone": "[ˈəʊpənli]"
-    },
-    {
-        "name": "opera",
-        "trans": [
-            "n. 歌剧；歌剧院；歌剧团"
-        ],
-        "usphone": "[ˈɑːprə]",
-        "ukphone": "[ˈɒprə]"
-    },
-    {
-        "name": "operate",
-        "trans": [
-            "vi. 运转；动手术；起作用"
-        ],
-        "usphone": "[ˈɑːpəreɪt]",
-        "ukphone": "[ˈɒpəreɪt]"
-    },
-    {
-        "name": "operator",
-        "trans": [
-            "n. 经营者；操作员；话务员；行家"
-        ],
-        "usphone": "[ˈɑːpəreɪtər]",
-        "ukphone": "[ˈɒpəreɪtə(r)]"
-    },
-    {
-        "name": "opponent",
-        "trans": [
-            "n. 对手；反对者；敌手"
-        ],
-        "usphone": "[əˈpoʊnənt]",
-        "ukphone": "[əˈpəʊnənt]"
-    },
-    {
-        "name": "oppose",
-        "trans": [
-            "vt. 反对；对抗，抗争"
-        ],
-        "usphone": "[əˈpoʊz]",
-        "ukphone": "[əˈpəʊz]"
-    },
-    {
-        "name": "opposed",
-        "trans": [
-            "adj. 相反的；敌对的"
-        ],
-        "usphone": "[əˈpoʊzd]",
-        "ukphone": "[əˈpəʊzd]"
-    },
-    {
-        "name": "opposition",
-        "trans": [
-            "n. 反对；反对派；在野党；敌对"
-        ],
-        "usphone": "[ˌɑːpəˈzɪʃ(ə)n]",
-        "ukphone": "[ˌɒpəˈzɪʃn]"
-    },
-    {
-        "name": "optimistic",
-        "trans": [
-            "adj. 乐观的；乐观主义的"
-        ],
-        "usphone": "[ˌɑːptɪˈmɪstɪk]",
-        "ukphone": "[ˌɒptɪˈmɪstɪk]"
-    },
-    {
-        "name": "orchestra",
-        "trans": [
-            "n. 管弦乐队；乐队演奏处"
-        ],
-        "usphone": "[ˈɔːrkɪstrə]",
-        "ukphone": "[ˈɔːkɪstrə]"
-    },
-    {
-        "name": "organ",
-        "trans": [
-            "n. [生物] 器官；机构；风琴；管风琴；嗓音"
-        ],
-        "usphone": "[ˈɔːrɡən]",
-        "ukphone": "[ˈɔːɡən]"
-    },
-    {
-        "name": "organic",
-        "trans": [
-            "adj. [有化] 有机的；组织的；器官的；根本的"
-        ],
-        "usphone": "[ɔːrˈɡænɪk]",
-        "ukphone": "[ɔːˈɡænɪk]"
-    },
-    {
-        "name": "origin",
-        "trans": [
-            "n. 起源；原点；出身；开端"
-        ],
-        "usphone": "[ˈɔːrɪdʒɪn]",
-        "ukphone": "[ˈɒrɪdʒɪn]"
-    },
-    {
-        "name": "otherwise",
-        "trans": [
-            "adv. 否则；另外；在其他方面"
-        ],
-        "usphone": "[ˈʌðərwaɪz]",
-        "ukphone": "[ˈʌðəwaɪz]"
-    },
-    {
-        "name": "outcome",
-        "trans": [
-            "n. 结果，结局；成果"
-        ],
-        "usphone": "[ˈaʊtkʌm]",
-        "ukphone": "[ˈaʊtkʌm]"
-    },
-    {
-        "name": "outer",
-        "trans": [
-            "adj. 外面的，外部的；远离中心的"
-        ],
-        "usphone": "[ˈaʊtər]",
-        "ukphone": "[ˈaʊtə(r)]"
-    },
-    {
-        "name": "outfit",
-        "trans": [
-            "n. 机构；用具；全套装备"
-        ],
-        "usphone": "[ˈaʊtfɪt]",
-        "ukphone": "[ˈaʊtfɪt]"
-    },
-    {
-        "name": "outline",
-        "trans": [
-            "n. 轮廓；大纲；概要；略图"
-        ],
-        "usphone": "[ˈaʊtlaɪn]",
-        "ukphone": "[ˈaʊtlaɪn]"
-    },
-    {
-        "name": "output",
-        "trans": [
-            "n. 输出，输出量；产量；出产"
-        ],
-        "usphone": "[ˈaʊtpʊt]",
-        "ukphone": "[ˈaʊtpʊt]"
-    },
-    {
-        "name": "outstanding",
-        "trans": [
-            "adj. 杰出的；显著的；未解决的；未偿付的"
-        ],
-        "usphone": "[aʊtˈstændɪŋ]",
-        "ukphone": "[aʊtˈstændɪŋ]"
-    },
-    {
-        "name": "overall",
-        "trans": [
-            "adj. 全部的；全体的；一切在内的"
-        ],
-        "usphone": "[ˌoʊvərˈɔːl; ˈoʊvərɔːl]",
-        "ukphone": "[ˌəʊvərˈɔːl; ˈəʊvərɔːl]"
-    },
-    {
-        "name": "overcome",
-        "trans": [
-            "vt. 克服；胜过"
-        ],
-        "usphone": "[ˌoʊvərˈkʌm]",
-        "ukphone": "[ˌəʊvəˈkʌm]"
-    },
-    {
-        "name": "overnight",
-        "trans": [
-            "adv. 通宵；突然；昨晚"
-        ],
-        "usphone": "[ˌoʊvərˈnaɪt]",
-        "ukphone": "[ˌəʊvəˈnaɪt]"
-    },
-    {
-        "name": "overseas",
-        "trans": [
-            "adv. 在海外，海外"
-        ],
-        "usphone": "[ˌoʊvərˈsiːz]",
-        "ukphone": "[ˌəʊvəˈsiːz]"
-    },
-    {
-        "name": "owe",
-        "trans": [
-            "vt. 欠；感激；应给予；应该把……归功于"
-        ],
-        "usphone": "[oʊ]",
-        "ukphone": "[əʊ]"
-    },
-    {
-        "name": "ownership",
-        "trans": [
-            "n. 所有权；物主身份"
-        ],
-        "usphone": "[ˈoʊnərʃɪp]",
-        "ukphone": "[ˈəʊnəʃɪp]"
-    },
-    {
-        "name": "oxygen",
-        "trans": [
-            "n. [化学] 氧气，[化学] 氧"
-        ],
-        "usphone": "[ˈɑːksɪdʒən]",
-        "ukphone": "[ˈɒksɪdʒən]"
-    },
-    {
-        "name": "pace",
-        "trans": [
-            "n. 一步；步速；步伐；速度"
-        ],
-        "usphone": "[peɪs]",
-        "ukphone": "[peɪs]"
-    },
-    {
-        "name": "package",
-        "trans": [
-            "n. 包，包裹；套装软件，[计] 程序包"
-        ],
-        "usphone": "[ˈpækɪdʒ]",
-        "ukphone": "[ˈpækɪdʒ]"
-    },
-    {
-        "name": "packet",
-        "trans": [
-            "n. 数据包，信息包；小包，小捆"
-        ],
-        "usphone": "[ˈpækɪt]",
-        "ukphone": "[ˈpækɪt]"
-    },
-    {
-        "name": "palm",
-        "trans": [
-            "n. 手掌；棕榈树；掌状物"
-        ],
-        "usphone": "[pɑːm]",
-        "ukphone": "[pɑːm]"
-    },
-    {
-        "name": "panel",
-        "trans": [
-            "n. 仪表板；嵌板；座谈小组，全体陪审员"
-        ],
-        "usphone": "[ˈpænl]",
-        "ukphone": "[ˈpæn(ə)l]"
-    },
-    {
-        "name": "panic",
-        "trans": [
-            "n. 恐慌，惊慌；大恐慌"
-        ],
-        "usphone": "[ˈpænɪk]",
-        "ukphone": "[ˈpænɪk]"
-    },
-    {
-        "name": "parade",
-        "trans": [
-            "n. 游行；阅兵；炫耀；行进；阅兵场"
-        ],
-        "usphone": "[pəˈreɪd]",
-        "ukphone": "[pəˈreɪd]"
-    },
-    {
-        "name": "parallel",
-        "trans": [
-            "n. 平行线；对比"
-        ],
-        "usphone": "[ˈpærəlel]",
-        "ukphone": "[ˈpærəlel]"
-    },
-    {
-        "name": "parliament",
-        "trans": [
-            "n. 议会，国会"
-        ],
-        "usphone": "[ˈpɑːrləmənt]",
-        "ukphone": "[ˈpɑːləmənt]"
-    },
-    {
-        "name": "participant",
-        "trans": [
-            "n. 参与者；关系者"
-        ],
-        "usphone": "[pɑːrˈtɪsɪpənt]",
-        "ukphone": "[pɑːˈtɪsɪpənt]"
-    },
-    {
-        "name": "participation",
-        "trans": [
-            "n. 参与；分享；参股"
-        ],
-        "usphone": "[pɑːrˌtɪsɪˈpeɪʃn]",
-        "ukphone": "[pɑːˌtɪsɪˈpeɪʃn]"
-    },
-    {
-        "name": "partly",
-        "trans": [
-            "adv. 部分地；在一定程度上"
-        ],
-        "usphone": "[ˈpɑːrtli]",
-        "ukphone": "[ˈpɑːtli]"
-    },
-    {
-        "name": "partnership",
-        "trans": [
-            "n. 合伙；[经管] 合伙企业；合作关系；合伙契约"
-        ],
-        "usphone": "[ˈpɑːrtnərʃɪp]",
-        "ukphone": "[ˈpɑːtnəʃɪp]"
-    },
-    {
-        "name": "part-time",
-        "trans": [
-            "adj. 兼职的；部分时间的"
-        ],
-        "usphone": "[ˌpɑːrt ˈtaɪm]",
-        "ukphone": "[ˌpɑːt ˈtaɪm]"
-    },
-    {
-        "name": "passage",
-        "trans": [
-            "n. 一段（文章）；走廊；通路"
-        ],
-        "usphone": "[ˈpæsɪdʒ]",
-        "ukphone": "[ˈpæsɪdʒ]"
-    },
-    {
-        "name": "passionate",
-        "trans": [
-            "adj. 热情的；热烈的，激昂的；易怒的"
-        ],
-        "usphone": "[ˈpæʃənət]",
-        "ukphone": "[ˈpæʃənət]"
-    },
-    {
-        "name": "password",
-        "trans": [
-            "n. 密码；口令"
-        ],
-        "usphone": "[ˈpæswɜːrd]",
-        "ukphone": "[ˈpɑːswɜːd]"
-    },
-    {
-        "name": "patience",
-        "trans": [
-            "n. 耐性，耐心；忍耐，容忍"
-        ],
-        "usphone": "[ˈpeɪʃns]",
-        "ukphone": "[ˈpeɪʃ(ə)ns]"
-    },
-    {
-        "name": "patient",
-        "trans": [
-            "n. 病人；患者"
-        ],
-        "usphone": "[ˈpeɪʃnt]",
-        "ukphone": "[ˈpeɪʃ(ə)nt]"
-    },
-    {
-        "name": "pause",
-        "trans": [
-            "n. 暂停；间歇"
-        ],
-        "usphone": "[pɔːz]",
-        "ukphone": "[pɔːz]"
-    },
-    {
-        "name": "peer",
-        "trans": [
-            "vt. 封为贵族；与…同等"
-        ],
-        "usphone": "[pɪr]",
-        "ukphone": "[pɪə(r)]"
-    },
-    {
-        "name": "penalty",
-        "trans": [
-            "n. 罚款，罚金；处罚"
-        ],
-        "usphone": "[ˈpenəlti]",
-        "ukphone": "[ˈpenəlti]"
-    },
-    {
-        "name": "pension",
-        "trans": [
-            "n. 退休金，抚恤金；津贴；膳宿费"
-        ],
-        "usphone": "[ˈpenʃən]",
-        "ukphone": "[ˈpenʃ(ə)n]"
-    },
-    {
-        "name": "perceive",
-        "trans": [
-            "vt. 察觉，感觉；理解；认知"
-        ],
-        "usphone": "[pərˈsiːv]",
-        "ukphone": "[pəˈsiːv]"
-    },
-    {
-        "name": "perception",
-        "trans": [
-            "n. 知觉；[生理] 感觉；看法；洞察力；获取"
-        ],
-        "usphone": "[pərˈsepʃn]",
-        "ukphone": "[pəˈsepʃn]"
-    },
-    {
-        "name": "permanent",
-        "trans": [
-            "n. 烫发（等于permanent wave）"
-        ],
-        "usphone": "[ˈpɜːrmənənt]",
-        "ukphone": "[ˈpɜːmənənt]"
-    },
-    {
-        "name": "permanently",
-        "trans": [
-            "adv. 永久地，长期不变地"
-        ],
-        "usphone": "[ˈpɜːrmənəntli]",
-        "ukphone": "[ˈpɜːmənəntli]"
-    },
-    {
-        "name": "permit",
-        "trans": [
-            "n. 许可证，执照"
-        ],
-        "usphone": "[pərˈmɪt]",
-        "ukphone": "[pəˈmɪt]"
-    },
-    {
-        "name": "perspective",
-        "trans": [
-            "n. 观点；远景；透视图"
-        ],
-        "usphone": "[pərˈspektɪv]",
-        "ukphone": "[pəˈspektɪv]"
-    },
-    {
-        "name": "phase",
-        "trans": [
-            "n. 月相"
-        ],
-        "usphone": "[feɪz]",
-        "ukphone": "[feɪz]"
-    },
-    {
-        "name": "phenomenon",
-        "trans": [
-            "n. 现象；奇迹；杰出的人才"
-        ],
-        "usphone": "[fəˈnɑːmɪnən]",
-        "ukphone": "[fəˈnɒmɪnən]"
-    },
-    {
-        "name": "philosophy",
-        "trans": [
-            "n. 哲学；哲理；人生观"
-        ],
-        "usphone": "[fəˈlɑːsəfi]",
-        "ukphone": "[fəˈlɒsəfi]"
-    },
-    {
-        "name": "pick",
-        "trans": [
-            "n. 选择；鹤嘴锄；挖；掩护"
-        ],
-        "usphone": "[pɪk]",
-        "ukphone": "[pɪk]"
-    },
-    {
-        "name": "picture",
-        "trans": [
-            "n. 照片，图画；影片；景色；化身"
-        ],
-        "usphone": "[ˈpɪktʃər]",
-        "ukphone": "[ˈpɪktʃə(r)]"
-    },
-    {
-        "name": "pile",
-        "trans": [
-            "n. 堆；大量；建筑群"
-        ],
-        "usphone": "[paɪl]",
-        "ukphone": "[paɪl]"
-    },
-    {
-        "name": "pill",
-        "trans": [
-            "n. 药丸；弹丸，子弹；口服避孕药"
-        ],
-        "usphone": "[pɪl]",
-        "ukphone": "[pɪl]"
-    },
-    {
-        "name": "pitch",
-        "trans": [
-            "n. 沥青；音高；程度；树脂；倾斜；投掷；球场"
-        ],
-        "usphone": "[pɪtʃ]",
-        "ukphone": "[pɪtʃ]"
-    },
-    {
-        "name": "pity",
-        "trans": [
-            "n. 怜悯，同情；遗憾"
-        ],
-        "usphone": "[ˈpɪti]",
-        "ukphone": "[ˈpɪti]"
-    },
-    {
-        "name": "placement",
-        "trans": [
-            "n. 布置；定位球；人员配置"
-        ],
-        "usphone": "[ˈpleɪsmənt]",
-        "ukphone": "[ˈpleɪsmənt]"
-    },
-    {
-        "name": "plain",
-        "trans": [
-            "n. 平原；无格式；朴实无华的东西"
-        ],
-        "usphone": "[pleɪn]",
-        "ukphone": "[pleɪn]"
-    },
-    {
-        "name": "plot",
-        "trans": [
-            "n. 情节；图；阴谋"
-        ],
-        "usphone": "[plɑːt]",
-        "ukphone": "[plɒt]"
-    },
-    {
-        "name": "plus",
-        "trans": [
-            "prep. 加，加上"
-        ],
-        "usphone": "[plʌs]",
-        "ukphone": "[plʌs]"
-    },
-    {
-        "name": "pointed",
-        "trans": [
-            "v. 指出；瞄准（point的过去式）"
-        ],
-        "usphone": "[ˈpɔɪntɪd]",
-        "ukphone": "[ˈpɔɪntɪd]"
-    },
-    {
-        "name": "popularity",
-        "trans": [
-            "n. 普及，流行；名气；受大众欢迎"
-        ],
-        "usphone": "[ˌpɑːpjuˈlærəti]",
-        "ukphone": "[ˌpɒpjuˈlærəti]"
-    },
-    {
-        "name": "portion",
-        "trans": [
-            "n. 部分；一份；命运"
-        ],
-        "usphone": "[ˈpɔːrʃn]",
-        "ukphone": "[ˈpɔːʃ(ə)n]"
-    },
-    {
-        "name": "pose",
-        "trans": [
-            "vi. 摆姿势；佯装；矫揉造作"
-        ],
-        "usphone": "[poʊz]",
-        "ukphone": "[pəʊz]"
-    },
-    {
-        "name": "position",
-        "trans": [
-            "n. 位置，方位；职位，工作；姿态；站位"
-        ],
-        "usphone": "[pəˈzɪʃn]",
-        "ukphone": "[pəˈzɪʃn]"
-    },
-    {
-        "name": "positive",
-        "trans": [
-            "n. 正数；[摄] 正片"
-        ],
-        "usphone": "[ˈpɑːzətɪv]",
-        "ukphone": "[ˈpɒzətɪv]"
-    },
-    {
-        "name": "possess",
-        "trans": [
-            "vt. 控制；使掌握；持有；迷住；拥有，具备"
-        ],
-        "usphone": "[pəˈzes]",
-        "ukphone": "[pəˈzes]"
-    },
-    {
-        "name": "potential",
-        "trans": [
-            "n. 潜能；可能性；[电] 电势"
-        ],
-        "usphone": "[pəˈtenʃl]",
-        "ukphone": "[pəˈtenʃ(ə)l]"
-    },
-    {
-        "name": "potentially",
-        "trans": [
-            "adv. 可能地，潜在地"
-        ],
-        "usphone": "[pəˈtenʃəli]",
-        "ukphone": "[pəˈtenʃəli]"
-    },
-    {
-        "name": "power",
-        "trans": [
-            "n. 力量，能力；电力，功率；政权，势力；[数] 幂"
-        ],
-        "usphone": "[ˈpaʊər]",
-        "ukphone": "[ˈpaʊə(r)]"
-    },
-    {
-        "name": "praise",
-        "trans": [
-            "n. 赞扬；称赞；荣耀；崇拜"
-        ],
-        "usphone": "[preɪz]",
-        "ukphone": "[preɪz]"
-    },
-    {
-        "name": "precede",
-        "trans": [
-            "vt. 领先，在…之前；优于，高于"
-        ],
-        "usphone": "[prɪˈsiːd]",
-        "ukphone": "[prɪˈsiːd]"
-    },
-    {
-        "name": "precious",
-        "trans": [
-            "adj. 宝贵的；珍贵的；矫揉造作的"
-        ],
-        "usphone": "[ˈpreʃəs]",
-        "ukphone": "[ˈpreʃəs]"
-    },
-    {
-        "name": "precise",
-        "trans": [
-            "adj. 精确的；明确的；严格的"
-        ],
-        "usphone": "[prɪˈsaɪs]",
-        "ukphone": "[prɪˈsaɪs]"
-    },
-    {
-        "name": "precisely",
-        "trans": [
-            "adv. 精确地；恰恰"
-        ],
-        "usphone": "[prɪˈsaɪsli]",
-        "ukphone": "[prɪˈsaɪsli]"
-    },
-    {
-        "name": "predictable",
-        "trans": [
-            "adj. 可预言的"
-        ],
-        "usphone": "[prɪˈdɪktəbl]",
-        "ukphone": "[prɪˈdɪktəbl]"
-    },
-    {
-        "name": "preference",
-        "trans": [
-            "n. 偏爱，倾向；优先权"
-        ],
-        "usphone": "[ˈprefrəns]",
-        "ukphone": "[ˈprefrəns]"
-    },
-    {
-        "name": "pregnant",
-        "trans": [
-            "adj. 怀孕的；富有意义的"
-        ],
-        "usphone": "[ˈpreɡnənt]",
-        "ukphone": "[ˈpreɡnənt]"
-    },
-    {
-        "name": "preparation",
-        "trans": [
-            "n. 预备；准备"
-        ],
-        "usphone": "[ˌprepəˈreɪʃn]",
-        "ukphone": "[ˌprepəˈreɪʃn]"
-    },
-    {
-        "name": "presence",
-        "trans": [
-            "n. 存在；出席；参加；风度；仪态"
-        ],
-        "usphone": "[ˈprezns]",
-        "ukphone": "[ˈprezns]"
-    },
-    {
-        "name": "preserve",
-        "trans": [
-            "n. 保护区；禁猎地；加工成的食品"
-        ],
-        "usphone": "[prɪˈzɜːrv]",
-        "ukphone": "[prɪˈzɜːv]"
-    },
-    {
-        "name": "price",
-        "trans": [
-            "n. 价格；价值；代价"
-        ],
-        "usphone": "[praɪs]",
-        "ukphone": "[praɪs]"
-    },
-    {
-        "name": "pride",
-        "trans": [
-            "n. 自豪；骄傲；自尊心"
-        ],
-        "usphone": "[praɪd]",
-        "ukphone": "[praɪd]"
-    },
-    {
-        "name": "primarily",
-        "trans": [
-            "adv. 首先；主要地，根本上"
-        ],
-        "usphone": "[praɪˈmerəli]",
-        "ukphone": "[praɪˈmerəli]"
-    },
-    {
-        "name": "prime",
-        "trans": [
-            "n. 初期；青年；精华；全盛时期"
-        ],
-        "usphone": "[praɪm]",
-        "ukphone": "[praɪm]"
-    },
-    {
-        "name": "principal",
-        "trans": [
-            "adj. 主要的；资本的"
-        ],
-        "usphone": "[ˈprɪnsəpl]",
-        "ukphone": "[ˈprɪnsəpl]"
-    },
-    {
-        "name": "principle",
-        "trans": [
-            "n. 原理，原则；主义，道义；本质，本义；根源，源泉"
-        ],
-        "usphone": "[ˈprɪnsəpl]",
-        "ukphone": "[ˈprɪnsəpl]"
-    },
-    {
-        "name": "print",
-        "trans": [
-            "n. 印刷业；印花布；印刷字体；印章；印记"
-        ],
-        "usphone": "[prɪnt]",
-        "ukphone": "[prɪnt]"
-    },
-    {
-        "name": "prior",
-        "trans": [
-            "adj. 优先的；在先的，在前的"
-        ],
-        "usphone": "[ˈpraɪər]",
-        "ukphone": "[ˈpraɪə(r)]"
-    },
-    {
-        "name": "priority",
-        "trans": [
-            "n. 优先；优先权；[数] 优先次序；优先考虑的事"
-        ],
-        "usphone": "[praɪˈɔːrəti]",
-        "ukphone": "[praɪˈɒrəti]"
-    },
-    {
-        "name": "privacy",
-        "trans": [
-            "n. 隐私；秘密；隐居；隐居处"
-        ],
-        "usphone": "[ˈpraɪvəsi]",
-        "ukphone": "[ˈprɪvəsi]"
-    },
-    {
-        "name": "probability",
-        "trans": [
-            "n. 可能性；机率；[数] 或然率"
-        ],
-        "usphone": "[ˌprɑːbəˈbɪləti]",
-        "ukphone": "[ˌprɒbəˈbɪləti]"
-    },
-    {
-        "name": "probable",
-        "trans": [
-            "n. 很可能的事；大有希望的候选者"
-        ],
-        "usphone": "[ˈprɑːbəbl]",
-        "ukphone": "[ˈprɒbəb(ə)l]"
-    },
-    {
-        "name": "procedure",
-        "trans": [
-            "n. 程序，手续；步骤"
-        ],
-        "usphone": "[prəˈsiːdʒər]",
-        "ukphone": "[prəˈsiːdʒə(r)]"
-    },
-    {
-        "name": "proceed",
-        "trans": [
-            "vi. 开始；继续进行；发生；行进"
-        ],
-        "usphone": "[proʊˈsiːd]",
-        "ukphone": "[prəˈsiːd]"
-    },
-    {
-        "name": "process",
-        "trans": [
-            "n. 过程，进行；方法，步骤；作用；程序；推移"
-        ],
-        "usphone": "[prəˈses；ˈprɑːses]",
-        "ukphone": "[prəˈses; ˈprəʊses]"
-    },
-    {
-        "name": "produce",
-        "trans": [
-            "n. 农产品，产品"
-        ],
-        "usphone": "[prəˈduːs]",
-        "ukphone": "[prəˈdjuːs]"
-    },
-    {
-        "name": "professional",
-        "trans": [
-            "n. 专业人员；职业运动员"
-        ],
-        "usphone": "[prəˈfeʃənl]",
-        "ukphone": "[prəˈfeʃənl]"
-    },
-    {
-        "name": "programming",
-        "trans": [
-            "n. 设计，规划；编制程序，[计] 程序编制"
-        ],
-        "usphone": "[ˈproʊɡræmɪŋ]",
-        "ukphone": "[ˈprəʊɡræmɪŋ]"
-    },
-    {
-        "name": "progress",
-        "trans": [
-            "n. 进步，发展；前进"
-        ],
-        "usphone": "[ˈprɑːɡres; ˈprɑːɡrəs]",
-        "ukphone": "[ˈprəʊɡres]"
-    },
-    {
-        "name": "progressive",
-        "trans": [
-            "n. 改革论者；进步分子"
-        ],
-        "usphone": "[prəˈɡresɪv]",
-        "ukphone": "[prəˈɡresɪv]"
-    },
-    {
-        "name": "prohibit",
-        "trans": [
-            "vt. 阻止，禁止"
-        ],
-        "usphone": "[prəˈhɪbɪtˌproʊˈhɪbɪt]",
-        "ukphone": "[prəˈhɪbɪt]"
-    },
-    {
-        "name": "project",
-        "trans": [
-            "n. 工程；计划；事业"
-        ],
-        "usphone": "[ˈprɑːdʒekt]",
-        "ukphone": "[ˈprɒdʒekt]"
-    },
-    {
-        "name": "promising",
-        "trans": [
-            "v. 许诺，答应（promise的现在分词形式）"
-        ],
-        "usphone": "[ˈprɑːmɪsɪŋ]",
-        "ukphone": "[ˈprɒmɪsɪŋ]"
-    },
-    {
-        "name": "promotion",
-        "trans": [
-            "n. 提升，[劳经] 晋升；推销，促销；促进；发扬，振兴"
-        ],
-        "usphone": "[prəˈmoʊʃn]",
-        "ukphone": "[prəˈməʊʃn]"
-    },
-    {
-        "name": "prompt",
-        "trans": [
-            "n. 提示；付款期限；DOS命令：改变DOS系统提示符的风格"
-        ],
-        "usphone": "[prɑːmpt]",
-        "ukphone": "[prɒmpt]"
-    },
-    {
-        "name": "proof",
-        "trans": [
-            "n. 证明；证据；校样；考验；验证；试验"
-        ],
-        "usphone": "[pruːf]",
-        "ukphone": "[pruːf]"
-    },
-    {
-        "name": "proportion",
-        "trans": [
-            "n. 比例，占比；部分；面积；均衡"
-        ],
-        "usphone": "[prəˈpɔːrʃn]",
-        "ukphone": "[prəˈpɔːʃn]"
-    },
-    {
-        "name": "proposal",
-        "trans": [
-            "n. 提议，建议；求婚"
-        ],
-        "usphone": "[prəˈpoʊzl]",
-        "ukphone": "[prəˈpəʊzl]"
-    },
-    {
-        "name": "propose",
-        "trans": [
-            "vi. 建议；求婚；打算"
-        ],
-        "usphone": "[prəˈpoʊz]",
-        "ukphone": "[prəˈpəʊz]"
-    },
-    {
-        "name": "prospect",
-        "trans": [
-            "n. 前途；预期；景色"
-        ],
-        "usphone": "[ˈprɑːspekt]",
-        "ukphone": "[ˈprɒspekt]"
-    },
-    {
-        "name": "protection",
-        "trans": [
-            "n. 保护；防卫；护照"
-        ],
-        "usphone": "[prəˈtekʃn]",
-        "ukphone": "[prəˈtekʃn]"
-    },
-    {
-        "name": "protein",
-        "trans": [
-            "n. 蛋白质；朊"
-        ],
-        "usphone": "[ˈproʊtiːn]",
-        "ukphone": "[ˈprəʊtiːn]"
-    },
-    {
-        "name": "protester",
-        "trans": [
-            "n. 抗议者；反对者；持异议者"
-        ],
-        "usphone": "[prəˈtestərˌˈproʊtestər]",
-        "ukphone": "[prəˈtestə(r); ˈprəʊtestə(r)]"
-    },
-    {
-        "name": "psychological",
-        "trans": [
-            "adj. 心理的；心理学的；精神上的"
-        ],
-        "usphone": "[ˌsaɪkəˈlɑːdʒɪkl]",
-        "ukphone": "[ˌsaɪkəˈlɒdʒɪk(ə)l]"
-    },
-    {
-        "name": "psychologist",
-        "trans": [
-            "n. 心理学家，心理学者"
-        ],
-        "usphone": "[saɪˈkɑːlədʒɪst]",
-        "ukphone": "[saɪˈkɒlədʒɪst]"
-    },
-    {
-        "name": "psychology",
-        "trans": [
-            "n. 心理学；心理状态"
-        ],
-        "usphone": "[saɪˈkɑːlədʒi]",
-        "ukphone": "[saɪˈkɒlədʒi]"
-    },
-    {
-        "name": "publication",
-        "trans": [
-            "n. 出版；出版物；发表"
-        ],
-        "usphone": "[ˌpʌblɪˈkeɪʃn]",
-        "ukphone": "[ˌpʌblɪˈkeɪʃn]"
-    },
-    {
-        "name": "publicity",
-        "trans": [
-            "n. 宣传，宣扬；公开；广告；注意"
-        ],
-        "usphone": "[pʌbˈlɪsəti]",
-        "ukphone": "[pʌbˈlɪsəti]"
-    },
-    {
-        "name": "publishing",
-        "trans": [
-            "n. 出版；出版业"
-        ],
-        "usphone": "[ˈpʌblɪʃɪŋ]",
-        "ukphone": "[ˈpʌblɪʃɪŋ]"
-    },
-    {
-        "name": "punk",
-        "trans": [
-            "n. 废物；小阿飞；年轻无知的人"
-        ],
-        "usphone": "[pʌŋk]",
-        "ukphone": "[pʌŋk]"
-    },
-    {
-        "name": "pupil",
-        "trans": [
-            "n. 学生；[解剖] 瞳孔；未成年人"
-        ],
-        "usphone": "[ˈpjuːpl]",
-        "ukphone": "[ˈpjuːp(ə)l]"
-    },
-    {
-        "name": "purchase",
-        "trans": [
-            "n. 购买；紧握；起重装置"
-        ],
-        "usphone": "[ˈpɜːrtʃəs]",
-        "ukphone": "[ˈpɜːtʃəs]"
-    },
-    {
-        "name": "pure",
-        "trans": [
-            "adj. 纯的；纯粹的；纯洁的；清白的；纯理论的"
-        ],
-        "usphone": "[pjʊr]",
-        "ukphone": "[pjʊə(r)]"
-    },
-    {
-        "name": "purely",
-        "trans": [
-            "adv. 纯粹地；仅仅，只不过；完全地；贞淑地；清洁地"
-        ],
-        "usphone": "[ˈpjʊrli]",
-        "ukphone": "[ˈpjʊəli]"
-    },
-    {
-        "name": "pursue",
-        "trans": [
-            "vi. 追赶；继续进行"
-        ],
-        "usphone": "[pərˈsuː]",
-        "ukphone": "[pəˈsjuː]"
-    },
-    {
-        "name": "pursuit",
-        "trans": [
-            "n. 追赶，追求；职业，工作"
-        ],
-        "usphone": "[pərˈsuːt]",
-        "ukphone": "[pəˈsjuːt]"
-    },
-    {
-        "name": "puzzle",
-        "trans": [
-            "n. 谜；难题；迷惑"
-        ],
-        "usphone": "[ˈpʌzl]",
-        "ukphone": "[ˈpʌzl]"
-    },
-    {
-        "name": "questionnaire",
-        "trans": [
-            "n. 问卷；调查表"
-        ],
-        "usphone": "[ˌkwestʃəˈner]",
-        "ukphone": "[ˌkwestʃəˈneə(r)]"
-    },
-    {
-        "name": "racial",
-        "trans": [
-            "adj. 种族的；人种的"
-        ],
-        "usphone": "[ˈreɪʃl]",
-        "ukphone": "[ˈreɪʃl]"
-    },
-    {
-        "name": "racism",
-        "trans": [
-            "n. 种族主义，种族歧视；人种偏见"
-        ],
-        "usphone": "[ˈreɪsɪzəm]",
-        "ukphone": "[ˈreɪsɪzəm]"
-    },
-    {
-        "name": "racist",
-        "trans": [
-            "n. 种族主义者"
-        ],
-        "usphone": "[ˈreɪsɪst]",
-        "ukphone": "[ˈreɪsɪst]"
-    },
-    {
-        "name": "radiation",
-        "trans": [
-            "n. 辐射；发光；放射物"
-        ],
-        "usphone": "[ˌreɪdiˈeɪʃn]",
-        "ukphone": "[ˌreɪdiˈeɪʃn]"
-    },
-    {
-        "name": "rail",
-        "trans": [
-            "n. 铁轨；扶手；横杆；围栏"
-        ],
-        "usphone": "[reɪl]",
-        "ukphone": "[reɪl]"
-    },
-    {
-        "name": "random",
-        "trans": [
-            "n. 随意"
-        ],
-        "usphone": "[ˈrændəm]",
-        "ukphone": "[ˈrændəm]"
-    },
-    {
-        "name": "range",
-        "trans": [
-            "n. 范围；幅度；排；山脉"
-        ],
-        "usphone": "[reɪndʒ]",
-        "ukphone": "[reɪndʒ]"
-    },
-    {
-        "name": "rank",
-        "trans": [
-            "n. 排；等级；军衔；队列"
-        ],
-        "usphone": "[ræŋk]",
-        "ukphone": "[ræŋk]"
-    },
-    {
-        "name": "rapid",
-        "trans": [
-            "n. 急流；高速交通工具，高速交通网"
-        ],
-        "usphone": "[ˈræpɪd]",
-        "ukphone": "[ˈræpɪd]"
-    },
-    {
-        "name": "rapidly",
-        "trans": [
-            "adv. 迅速地；很快地；立即"
-        ],
-        "usphone": "[ˈræpɪdli]",
-        "ukphone": "[ˈræpɪdli]"
-    },
-    {
-        "name": "rat",
-        "trans": [
-            "n. 鼠；卑鄙小人，叛徒"
-        ],
-        "usphone": "[ræt]",
-        "ukphone": "[ræt]"
-    },
-    {
-        "name": "rate",
-        "trans": [
-            "n. 比率，率；速度；价格；等级"
-        ],
-        "usphone": "[reɪt]",
-        "ukphone": "[reɪt]"
-    },
-    {
-        "name": "rating",
-        "trans": [
-            "n. 等级；等级评定；额定功率"
-        ],
-        "usphone": "[ˈreɪtɪŋ]",
-        "ukphone": "[ˈreɪtɪŋ]"
-    },
-    {
-        "name": "raw",
-        "trans": [
-            "n. 擦伤处"
-        ],
-        "usphone": "[rɔː]",
-        "ukphone": "[rɔː]"
-    },
-    {
-        "name": "reach",
-        "trans": [
-            "n. 范围；延伸；河段；横风行驶"
-        ],
-        "usphone": "[riːtʃ]",
-        "ukphone": "[riːtʃ]"
-    },
-    {
-        "name": "realistic",
-        "trans": [
-            "adj. 现实的；现实主义的；逼真的；实在论的"
-        ],
-        "usphone": "[ˌriːəˈlɪstɪk]",
-        "ukphone": "[ˌriːəˈlɪstɪk]"
-    },
-    {
-        "name": "reasonable",
-        "trans": [
-            "adj. 合理的，公道的；通情达理的"
-        ],
-        "usphone": "[ˈriːz(ə)nəb(ə)l]",
-        "ukphone": "[ˈriːznəbl]"
-    },
-    {
-        "name": "reasonably",
-        "trans": [
-            "adv. 合理地；相当地；适度地"
-        ],
-        "usphone": "[ˈriːznəbli]",
-        "ukphone": "[ˈriːz(ə)nəbli]"
-    },
-    {
-        "name": "rebuild",
-        "trans": [
-            "vt. 重建；改造，重新组装；复原"
-        ],
-        "usphone": "[ˌriːˈbɪld]",
-        "ukphone": "[ˌriːˈbɪld]"
-    },
-    {
-        "name": "recall",
-        "trans": [
-            "n. 召回；回忆；撤消"
-        ],
-        "usphone": "[rɪˈkɔːl]",
-        "ukphone": "[rɪˈkɔːl]"
-    },
-    {
-        "name": "receiver",
-        "trans": [
-            "n. 接收器；接受者；收信机；收款员，接待者"
-        ],
-        "usphone": "[rɪˈsiːvər]",
-        "ukphone": "[rɪˈsiːvə(r)]"
-    },
-    {
-        "name": "recession",
-        "trans": [
-            "n. 衰退；不景气；后退；凹处"
-        ],
-        "usphone": "[rɪˈseʃn]",
-        "ukphone": "[rɪˈseʃn]"
-    },
-    {
-        "name": "reckon",
-        "trans": [
-            "vi. 估计；计算；猜想，料想"
-        ],
-        "usphone": "[ˈrekən]",
-        "ukphone": "[ˈrekən]"
-    },
-    {
-        "name": "recognition",
-        "trans": [
-            "n. 识别；承认，认出；重视；赞誉；公认"
-        ],
-        "usphone": "[ˌrekəɡˈnɪʃn]",
-        "ukphone": "[ˌrekəɡˈnɪʃn]"
-    },
-    {
-        "name": "recover",
-        "trans": [
-            "n. 还原至预备姿势"
-        ],
-        "usphone": "[rɪˈkʌvər]",
-        "ukphone": "[rɪˈkʌvə(r)]"
-    },
-    {
-        "name": "recovery",
-        "trans": [
-            "n. 恢复，复原；痊愈；重获"
-        ],
-        "usphone": "[rɪˈkʌvəri]",
-        "ukphone": "[rɪˈkʌvəri]"
-    },
-    {
-        "name": "recruit",
-        "trans": [
-            "n. 招聘；新兵；新成员"
-        ],
-        "usphone": "[rɪˈkruːt]",
-        "ukphone": "[rɪˈkruːt]"
-    },
-    {
-        "name": "recruitment",
-        "trans": [
-            "n. 补充；征募新兵"
-        ],
-        "usphone": "[rɪˈkruːtmənt]",
-        "ukphone": "[rɪˈkruːtmənt]"
-    },
-    {
-        "name": "reduction",
-        "trans": [
-            "n. 减少；下降；缩小；还原反应"
-        ],
-        "usphone": "[rɪˈdʌkʃn]",
-        "ukphone": "[rɪˈdʌkʃn]"
-    },
-    {
-        "name": "referee",
-        "trans": [
-            "n. 裁判员；调解人；介绍人"
-        ],
-        "usphone": "[ˌrefəˈriː]",
-        "ukphone": "[ˌrefəˈriː]"
-    },
-    {
-        "name": "refugee",
-        "trans": [
-            "n. 难民，避难者；流亡者，逃亡者"
-        ],
-        "usphone": "[ˌrefjuˈdʒiː]",
-        "ukphone": "[ˌrefjuˈdʒiː]"
-    },
-    {
-        "name": "regard",
-        "trans": [
-            "n. 注意；尊重；问候；凝视"
-        ],
-        "usphone": "[rɪˈɡɑːrd]",
-        "ukphone": "[rɪˈɡɑːd]"
-    },
-    {
-        "name": "regional",
-        "trans": [
-            "adj. 地区的；局部的；整个地区的"
-        ],
-        "usphone": "[ˈriːdʒənl]",
-        "ukphone": "[ˈriːdʒənl]"
-    },
-    {
-        "name": "register",
-        "trans": [
-            "n. 登记；注册；记录；寄存器；登记簿"
-        ],
-        "usphone": "[ˈredʒɪstər]",
-        "ukphone": "[ˈredʒɪstə(r)]"
-    },
-    {
-        "name": "registration",
-        "trans": [
-            "n. 登记；注册；挂号"
-        ],
-        "usphone": "[ˌredʒɪˈstreɪʃn]",
-        "ukphone": "[ˌredʒɪˈstreɪʃn]"
-    },
-    {
-        "name": "regret",
-        "trans": [
-            "n. 遗憾；抱歉；悲叹"
-        ],
-        "usphone": "[rɪˈɡret]",
-        "ukphone": "[rɪˈɡret]"
-    },
-    {
-        "name": "regulate",
-        "trans": [
-            "vt. 调节，规定；控制；校准；有系统的管理"
-        ],
-        "usphone": "[ˈreɡjuleɪt]",
-        "ukphone": "[ˈreɡjuleɪt]"
-    },
-    {
-        "name": "regulation",
-        "trans": [
-            "n. 管理；规则；校准"
-        ],
-        "usphone": "[ˌreɡjuˈleɪʃn]",
-        "ukphone": "[ˌreɡjuˈleɪʃn]"
-    },
-    {
-        "name": "reinforce",
-        "trans": [
-            "n. 加强；加固物；加固材料"
-        ],
-        "usphone": "[ˌriːɪnˈfɔːrs]",
-        "ukphone": "[ˌriːɪnˈfɔːs]"
-    },
-    {
-        "name": "relatively",
-        "trans": [
-            "adv. 相当地；相对地，比较地"
-        ],
-        "usphone": "[ˈrelətɪvli]",
-        "ukphone": "[ˈrelətɪvli]"
-    },
-    {
-        "name": "relevant",
-        "trans": [
-            "adj. 相关的；切题的；中肯的；有重大关系的；有意义的，目的明确的"
-        ],
-        "usphone": "[ˈreləvənt]",
-        "ukphone": "[ˈreləvənt]"
-    },
-    {
-        "name": "relief",
-        "trans": [
-            "n. 救济；减轻，解除；安慰；浮雕"
-        ],
-        "usphone": "[rɪˈliːf]",
-        "ukphone": "[rɪˈliːf]"
-    },
-    {
-        "name": "relieve",
-        "trans": [
-            "vt. 解除，减轻；使不单调乏味；换…的班；解围；使放心"
-        ],
-        "usphone": "[rɪˈliːv]",
-        "ukphone": "[rɪˈliːv]"
-    },
-    {
-        "name": "rely",
-        "trans": [
-            "vi. 依靠；信赖"
-        ],
-        "usphone": "[rɪˈlaɪ]",
-        "ukphone": "[rɪˈlaɪ]"
-    },
-    {
-        "name": "remark",
-        "trans": [
-            "n. 注意；言辞"
-        ],
-        "usphone": "[rɪˈmɑːrk]",
-        "ukphone": "[rɪˈmɑːk]"
-    },
-    {
-        "name": "remarkable",
-        "trans": [
-            "adj. 卓越的；非凡的；值得注意的"
-        ],
-        "usphone": "[rɪˈmɑːrkəbl]",
-        "ukphone": "[rɪˈmɑːkəbl]"
-    },
-    {
-        "name": "remarkably",
-        "trans": [
-            "adv. 显著地；非常地；引人注目地"
-        ],
-        "usphone": "[rɪˈmɑːrkəbli]",
-        "ukphone": "[rɪˈmɑːkəbli]"
-    },
-    {
-        "name": "reporting",
-        "trans": [
-            "n. 报告；报导"
-        ],
-        "usphone": "",
-        "ukphone": ""
-    },
-    {
-        "name": "representative",
-        "trans": [
-            "n. 代表；典型；众议员"
-        ],
-        "usphone": "[ˌreprɪˈzentətɪv]",
-        "ukphone": "[ˌreprɪˈzentətɪv]"
-    },
-    {
-        "name": "reputation",
-        "trans": [
-            "n. 名声，名誉；声望"
-        ],
-        "usphone": "[ˌrepjuˈteɪʃn]",
-        "ukphone": "[ˌrepjuˈteɪʃn]"
-    },
-    {
-        "name": "requirement",
-        "trans": [
-            "n. 要求；必要条件；必需品"
-        ],
-        "usphone": "[rɪˈkwaɪərmənt]",
-        "ukphone": "[rɪˈkwaɪəmənt]"
-    },
-    {
-        "name": "rescue",
-        "trans": [
-            "n. 营救；援救；解救"
-        ],
-        "usphone": "[ˈreskjuː]",
-        "ukphone": "[ˈreskjuː]"
-    },
-    {
-        "name": "reserve",
-        "trans": [
-            "n. 储备，储存；自然保护区；预备队；缄默；[金融] 储备金"
-        ],
-        "usphone": "[rɪˈzɜːrv]",
-        "ukphone": "[rɪˈzɜːv]"
-    },
-    {
-        "name": "resident",
-        "trans": [
-            "n. 居民；住院医生"
-        ],
-        "usphone": "[ˈrezɪdənt]",
-        "ukphone": "[ˈrezɪdənt]"
-    },
-    {
-        "name": "resign",
-        "trans": [
-            "n. 辞去职务"
-        ],
-        "usphone": "[rɪˈzaɪn]",
-        "ukphone": "[rɪˈzaɪn]"
-    },
-    {
-        "name": "resist",
-        "trans": [
-            "n. [助剂] 抗蚀剂；防染剂"
-        ],
-        "usphone": "[rɪˈzɪst]",
-        "ukphone": "[rɪˈzɪst]"
-    },
-    {
-        "name": "resolution",
-        "trans": [
-            "n. [物] 分辨率；决议；解决；决心"
-        ],
-        "usphone": "[ˌrezəˈluːʃn]",
-        "ukphone": "[ˌrezəˈluːʃn]"
-    },
-    {
-        "name": "resolve",
-        "trans": [
-            "n. 坚决；决定要做的事"
-        ],
-        "usphone": "[rɪˈzɑːlv]",
-        "ukphone": "[rɪˈzɒlv]"
-    },
-    {
-        "name": "resort",
-        "trans": [
-            "n. 凭借，手段；度假胜地；常去之地"
-        ],
-        "usphone": "[rɪˈzɔːrt]",
-        "ukphone": "[rɪˈzɔːt]"
-    },
-    {
-        "name": "restore",
-        "trans": [
-            "vi. 恢复；还原"
-        ],
-        "usphone": "[rɪˈstɔːr]",
-        "ukphone": "[rɪˈstɔː(r)]"
-    },
-    {
-        "name": "restrict",
-        "trans": [
-            "vt. 限制；约束；限定"
-        ],
-        "usphone": "[rɪˈstrɪkt]",
-        "ukphone": "[rɪˈstrɪkt]"
-    },
-    {
-        "name": "restriction",
-        "trans": [
-            "n. 限制；约束；束缚"
-        ],
-        "usphone": "[rɪˈstrɪkʃn]",
-        "ukphone": "[rɪˈstrɪkʃ(ə)n]"
-    },
-    {
-        "name": "retail",
-        "trans": [
-            "n. 零售"
-        ],
-        "usphone": "[ˈriːteɪl]",
-        "ukphone": "[ˈriːteɪl; rɪˈteɪl]"
-    },
-    {
-        "name": "retain",
-        "trans": [
-            "vt. 保持；雇；记住"
-        ],
-        "usphone": "[rɪˈteɪn]",
-        "ukphone": "[rɪˈteɪn]"
-    },
-    {
-        "name": "retirement",
-        "trans": [
-            "n. 退休，退役"
-        ],
-        "usphone": "[rɪˈtaɪərmənt]",
-        "ukphone": "[rɪˈtaɪəmənt]"
-    },
-    {
-        "name": "reveal",
-        "trans": [
-            "n. 揭露；暴露；门侧，窗侧"
-        ],
-        "usphone": "[rɪˈviːl]",
-        "ukphone": "[rɪˈviːl]"
-    },
-    {
-        "name": "revenue",
-        "trans": [
-            "n. 税收，国家的收入；收益"
-        ],
-        "usphone": "[ˈrevənuː]",
-        "ukphone": "[ˈrevənjuː]"
-    },
-    {
-        "name": "revision",
-        "trans": [
-            "n. [印刷] 修正；复习；修订本"
-        ],
-        "usphone": "[rɪˈvɪʒn]",
-        "ukphone": "[rɪˈvɪʒn]"
-    },
-    {
-        "name": "revolution",
-        "trans": [
-            "n. 革命；旋转；运行；循环"
-        ],
-        "usphone": "[ˌrevəˈluːʃn]",
-        "ukphone": "[ˌrevəˈluːʃn]"
-    },
-    {
-        "name": "reward",
-        "trans": [
-            "n. [劳经] 报酬；报答；酬谢"
-        ],
-        "usphone": "[rɪˈwɔːrd]",
-        "ukphone": "[rɪˈwɔːd]"
-    },
-    {
-        "name": "rhythm",
-        "trans": [
-            "n. 节奏；韵律"
-        ],
-        "usphone": "[ˈrɪðəm]",
-        "ukphone": "[ˈrɪðəm]"
-    },
-    {
-        "name": "rid",
-        "trans": [
-            "vt. 使摆脱；使去掉"
-        ],
-        "usphone": "[rɪd]",
-        "ukphone": "[rɪd]"
-    },
-    {
-        "name": "ridiculous",
-        "trans": [
-            "adj. 可笑的；荒谬的"
-        ],
-        "usphone": "[rɪˈdɪkjələs]",
-        "ukphone": "[rɪˈdɪkjələs]"
-    },
-    {
-        "name": "risky",
-        "trans": [
-            "adj. 危险的；冒险的；（作品等）有伤风化的"
-        ],
-        "usphone": "[ˈrɪski]",
-        "ukphone": "[ˈrɪski]"
-    },
-    {
-        "name": "rival",
-        "trans": [
-            "n. 对手；竞争者"
-        ],
-        "usphone": "[ˈraɪvl]",
-        "ukphone": "[ˈraɪv(ə)l]"
-    },
-    {
-        "name": "rob",
-        "trans": [
-            "vt. 抢劫；使…丧失；非法剥夺"
-        ],
-        "usphone": "[rɑːb]",
-        "ukphone": "[rɒb]"
-    },
-    {
-        "name": "robbery",
-        "trans": [
-            "n. 抢劫，盗窃；抢掠"
-        ],
-        "usphone": "[ˈrɑːbəri]",
-        "ukphone": "[ˈrɒbəri]"
-    },
-    {
-        "name": "rocket",
-        "trans": [
-            "n. 火箭"
-        ],
-        "usphone": "[ˈrɑːkɪt]",
-        "ukphone": "[ˈrɒkɪt]"
-    },
-    {
-        "name": "romance",
-        "trans": [
-            "n. 传奇；浪漫史；风流韵事；冒险故事"
-        ],
-        "usphone": "[ˈroʊmæns]",
-        "ukphone": "[rəʊˈmæns; ˈrəʊmæns]"
-    },
-    {
-        "name": "root",
-        "trans": [
-            "n. 根；根源；词根；祖先"
-        ],
-        "usphone": "[ruːt]",
-        "ukphone": "[ruːt]"
-    },
-    {
-        "name": "rose",
-        "trans": [
-            "n. 玫瑰；粉红色；蔷薇（花）；粉红色的葡萄酒"
-        ],
-        "usphone": "[roʊz]",
-        "ukphone": "[rəʊz]"
-    },
-    {
-        "name": "roughly",
-        "trans": [
-            "adv. 粗糙地；概略地"
-        ],
-        "usphone": "[ˈrʌfli]",
-        "ukphone": "[ˈrʌfli]"
-    },
-    {
-        "name": "round",
-        "trans": [
-            "n. 圆；循环；一回合；圆形物"
-        ],
-        "usphone": "[raʊnd]",
-        "ukphone": "[raʊnd]"
-    },
-    {
-        "name": "routine",
-        "trans": [
-            "n. [计] 程序；日常工作；例行公事"
-        ],
-        "usphone": "[ruːˈtiːn]",
-        "ukphone": "[ruːˈtiːn]"
-    },
-    {
-        "name": "rub",
-        "trans": [
-            "n. 摩擦；障碍；磨损处"
-        ],
-        "usphone": "[rʌb]",
-        "ukphone": "[rʌb]"
-    },
-    {
-        "name": "rubber",
-        "trans": [
-            "n. 橡胶；橡皮；合成橡胶；按摩师"
-        ],
-        "usphone": "[ˈrʌbər]",
-        "ukphone": "[ˈrʌbə(r)]"
-    },
-    {
-        "name": "ruin",
-        "trans": [
-            "n. 废墟；毁坏；灭亡"
-        ],
-        "usphone": "[ˈruːɪn]",
-        "ukphone": "[ˈruːɪn]"
-    },
-    {
-        "name": "rural",
-        "trans": [
-            "adj. 农村的，乡下的；田园的，有乡村风味的"
-        ],
-        "usphone": "[ˈrʊrəl]",
-        "ukphone": "[ˈrʊərəl]"
-    },
-    {
-        "name": "rush",
-        "trans": [
-            "n. 冲进；匆促；急流；灯心草"
-        ],
-        "usphone": "[rʌʃ]",
-        "ukphone": "[rʌʃ]"
-    },
-    {
-        "name": "sample",
-        "trans": [
-            "n. 样品；样本；例子"
-        ],
-        "usphone": "[ˈsæmpl]",
-        "ukphone": "[ˈsɑːmp(ə)l]"
-    },
-    {
-        "name": "satellite",
-        "trans": [
-            "n. 卫星；人造卫星；随从；卫星国家"
-        ],
-        "usphone": "[ˈsætəlaɪt]",
-        "ukphone": "[ˈsætəlaɪt]"
-    },
-    {
-        "name": "satisfaction",
-        "trans": [
-            "n. 满意，满足；赔偿；乐事；赎罪"
-        ],
-        "usphone": "[ˌsætɪsˈfækʃn]",
-        "ukphone": "[ˌsætɪsˈfækʃn]"
-    },
-    {
-        "name": "satisfied",
-        "trans": [
-            "v. 使满意（satisfy的过去式）"
-        ],
-        "usphone": "[ˈsætɪsfaɪd]",
-        "ukphone": "[ˈsætɪsfaɪd]"
-    },
-    {
-        "name": "satisfy",
-        "trans": [
-            "vi. 令人满意；令人满足"
-        ],
-        "usphone": "[ˈsætɪsfaɪ]",
-        "ukphone": "[ˈsætɪsfaɪ]"
-    },
-    {
-        "name": "saving",
-        "trans": [
-            "n. 节约；挽救；存款"
-        ],
-        "usphone": "[ˈseɪvɪŋ]",
-        "ukphone": "[ˈseɪvɪŋ]"
-    },
-    {
-        "name": "scale",
-        "trans": [
-            "n. 规模；比例；鳞；刻度；天平；数值范围"
-        ],
-        "usphone": "[skeɪl]",
-        "ukphone": "[skeɪl]"
-    },
-    {
-        "name": "scandal",
-        "trans": [
-            "n. 丑闻；流言蜚语；诽谤；公愤"
-        ],
-        "usphone": "[ˈskændl]",
-        "ukphone": "[ˈskænd(ə)l]"
-    },
-    {
-        "name": "scare",
-        "trans": [
-            "n. 恐慌；惊吓；惊恐"
-        ],
-        "usphone": "[sker]",
-        "ukphone": "[skeə(r)]"
-    },
-    {
-        "name": "scenario",
-        "trans": [
-            "n. 方案；情节；剧本；设想"
-        ],
-        "usphone": "[səˈnærioʊ]",
-        "ukphone": "[səˈnɑːriəʊ]"
-    },
-    {
-        "name": "schedule",
-        "trans": [
-            "n. 时间表；计划表；一览表"
-        ],
-        "usphone": "[ˈskedʒuːl]",
-        "ukphone": "[ˈʃedjuːl]"
-    },
-    {
-        "name": "scheme",
-        "trans": [
-            "n. 计划；组合；体制；诡计"
-        ],
-        "usphone": "[skiːm]",
-        "ukphone": "[skiːm]"
-    },
-    {
-        "name": "scholar",
-        "trans": [
-            "n. 学者；奖学金获得者"
-        ],
-        "usphone": "[ˈskɑːlər]",
-        "ukphone": "[ˈskɒlə(r)]"
-    },
-    {
-        "name": "scholarship",
-        "trans": [
-            "n. 奖学金；学识，学问"
-        ],
-        "usphone": "[ˈskɑːlərʃɪp]",
-        "ukphone": "[ˈskɒləʃɪp]"
-    },
-    {
-        "name": "scratch",
-        "trans": [
-            "n. 擦伤；抓痕；刮擦声；乱写"
-        ],
-        "usphone": "[skrætʃ]",
-        "ukphone": "[skrætʃ]"
-    },
-    {
-        "name": "scream",
-        "trans": [
-            "n. 尖叫声；尖锐刺耳的声音；极其滑稽可笑的人"
-        ],
-        "usphone": "[skriːm]",
-        "ukphone": "[skriːm]"
-    },
-    {
-        "name": "screen",
-        "trans": [
-            "n. 屏，幕；屏风"
-        ],
-        "usphone": "[skriːn]",
-        "ukphone": "[skriːn]"
-    },
-    {
-        "name": "screening",
-        "trans": [
-            "n. 筛选；放映；[物] 屏蔽；审查；防波"
-        ],
-        "usphone": "[ˈskriːnɪŋ]",
-        "ukphone": "[ˈskriːnɪŋ]"
-    },
-    {
-        "name": "seat",
-        "trans": [
-            "n. 座位；所在地；职位"
-        ],
-        "usphone": "[siːt]",
-        "ukphone": "[siːt]"
-    },
-    {
-        "name": "sector",
-        "trans": [
-            "n. 部门；扇形，扇区；象限仪；函数尺"
-        ],
-        "usphone": "[ˈsektər]",
-        "ukphone": "[ˈsektə(r)]"
-    },
-    {
-        "name": "secure",
-        "trans": [
-            "vt. 保护；弄到；招致；缚住"
-        ],
-        "usphone": "[sɪˈkjʊr]",
-        "ukphone": "[sɪˈkjʊə(r)]"
-    },
-    {
-        "name": "seek",
-        "trans": [
-            "vt. 寻求；寻找；探索；搜索"
-        ],
-        "usphone": "[siːk]",
-        "ukphone": "[siːk]"
-    },
-    {
-        "name": "seeker",
-        "trans": [
-            "n. 探求者；搜查人"
-        ],
-        "usphone": "[ˈsiːkər]",
-        "ukphone": "[ˈsiːkə(r)]"
-    },
-    {
-        "name": "select",
-        "trans": [
-            "n. 被挑选者；精萃"
-        ],
-        "usphone": "[sɪˈlekt]",
-        "ukphone": "[sɪˈlekt]"
-    },
-    {
-        "name": "selection",
-        "trans": [
-            "n. 选择，挑选；选集；精选品"
-        ],
-        "usphone": "[sɪˈlekʃn]",
-        "ukphone": "[sɪˈlekʃ(ə)n]"
-    },
-    {
-        "name": "self",
-        "trans": [
-            "n. 自己，自我；本质；私心"
-        ],
-        "usphone": "[self]",
-        "ukphone": "[self]"
-    },
-    {
-        "name": "seminar",
-        "trans": [
-            "n. 讨论会，研讨班"
-        ],
-        "usphone": "[ˈsemɪnɑːr]",
-        "ukphone": "[ˈsemɪnɑː(r)]"
-    },
-    {
-        "name": "senior",
-        "trans": [
-            "n. 上司；较年长者；毕业班学生"
-        ],
-        "usphone": "[ˈsiːniər]",
-        "ukphone": "[ˈsiːniə(r)]"
-    },
-    {
-        "name": "sense",
-        "trans": [
-            "n. 感觉，功能；观念；道理；理智"
-        ],
-        "usphone": "[sens]",
-        "ukphone": "[sens]"
-    },
-    {
-        "name": "sensitive",
-        "trans": [
-            "adj. 敏感的；感觉的；[仪] 灵敏的；感光的；易受伤害的；易受影响的"
-        ],
-        "usphone": "[ˈsensətɪv]",
-        "ukphone": "[ˈsensətɪv]"
-    },
-    {
-        "name": "sentence",
-        "trans": [
-            "n. [语][计] 句子，命题；宣判，判决"
-        ],
-        "usphone": "[ˈsentəns]",
-        "ukphone": "[ˈsentəns]"
-    },
-    {
-        "name": "sequence",
-        "trans": [
-            "n. [数][计] 序列；顺序；续发事件"
-        ],
-        "usphone": "[ˈsiːkwəns]",
-        "ukphone": "[ˈsiːkwəns]"
-    },
-    {
-        "name": "session",
-        "trans": [
-            "n. 会议；（法庭的）开庭；（议会等的）开会；学期；讲习会"
-        ],
-        "usphone": "[ˈseʃn]",
-        "ukphone": "[ˈseʃ(ə)n]"
-    },
-    {
-        "name": "settle",
-        "trans": [
-            "n. 有背长椅"
-        ],
-        "usphone": "[ˈset(ə)l]",
-        "ukphone": "[ˈset(ə)l]"
-    },
-    {
-        "name": "settler",
-        "trans": [
-            "n. 移居者；殖民者"
-        ],
-        "usphone": "[ˈsetlər]",
-        "ukphone": "[ˈsetlə(r)]"
-    },
-    {
-        "name": "severe",
-        "trans": [
-            "adj. 严峻的；严厉的；剧烈的；苛刻的"
-        ],
-        "usphone": "[səˈvɪr]",
-        "ukphone": "[sɪˈvɪə(r)]"
-    },
-    {
-        "name": "severely",
-        "trans": [
-            "adv. 严重地；严格地，严厉地；纯朴地"
-        ],
-        "usphone": "[sɪˈvɪrli]",
-        "ukphone": "[sɪˈvɪəli]"
-    },
-    {
-        "name": "sexy",
-        "trans": [
-            "adj. 性感的；迷人的；色情的"
-        ],
-        "usphone": "[ˈseksi]",
-        "ukphone": "[ˈseksi]"
-    },
-    {
-        "name": "shade",
-        "trans": [
-            "n. 树荫；阴影；阴凉处；遮阳物；（照片等的）明暗度；少量、些微；细微的差别"
-        ],
-        "usphone": "[ʃeɪd]",
-        "ukphone": "[ʃeɪd]"
-    },
-    {
-        "name": "shadow",
-        "trans": [
-            "n. 阴影；影子；幽灵；庇护；隐蔽处"
-        ],
-        "usphone": "[ˈʃædoʊ]",
-        "ukphone": "[ˈʃædəʊ]"
-    },
-    {
-        "name": "shallow",
-        "trans": [
-            "n. [地理] 浅滩"
-        ],
-        "usphone": "[ˈʃæloʊ]",
-        "ukphone": "[ˈʃæləʊ]"
-    },
-    {
-        "name": "shame",
-        "trans": [
-            "n. 羞耻，羞愧；憾事，带来耻辱的人"
-        ],
-        "usphone": "[ʃeɪm]",
-        "ukphone": "[ʃeɪm]"
-    },
-    {
-        "name": "shape",
-        "trans": [
-            "n. 形状；模型；身材；具体化"
-        ],
-        "usphone": "[ʃeɪp]",
-        "ukphone": "[ʃeɪp]"
-    },
-    {
-        "name": "shaped",
-        "trans": [
-            "adj. 合适的；成某种形状的；有计划的"
-        ],
-        "usphone": "[ʃeɪpt]",
-        "ukphone": "[ʃeɪpt]"
-    },
-    {
-        "name": "shelter",
-        "trans": [
-            "n. 庇护；避难所；遮盖物"
-        ],
-        "usphone": "[ˈʃeltər]",
-        "ukphone": "[ˈʃeltə(r)]"
-    },
-    {
-        "name": "shift",
-        "trans": [
-            "n. 移动；变化；手段；轮班"
-        ],
-        "usphone": "[ʃɪft]",
-        "ukphone": "[ʃɪft]"
-    },
-    {
-        "name": "ship",
-        "trans": [
-            "n. 船；舰；太空船"
-        ],
-        "usphone": "[ʃɪp]",
-        "ukphone": "[ʃɪp]"
-    },
-    {
-        "name": "shock",
-        "trans": [
-            "n. 休克；震惊；震动；打击；禾束堆"
-        ],
-        "usphone": "[ʃɑːk]",
-        "ukphone": "[ʃɒk]"
-    },
-    {
-        "name": "shocked",
-        "trans": [
-            "v. 使震动（shock的过去式）"
-        ],
-        "usphone": "[ʃɑːkt]",
-        "ukphone": "[ʃɒkt]"
-    },
-    {
-        "name": "shocking",
-        "trans": [
-            "adj. 令人震惊的；可怕的，令人厌恶的；糟糕的"
-        ],
-        "usphone": "",
-        "ukphone": ""
-    },
-    {
-        "name": "shooting",
-        "trans": [
-            "n. 射击；打猎；摄影；射门"
-        ],
-        "usphone": "[ˈʃuːtɪŋ]",
-        "ukphone": "[ˈʃuːtɪŋ]"
-    },
-    {
-        "name": "shore",
-        "trans": [
-            "n. 海滨；支柱"
-        ],
-        "usphone": "[ʃɔːr]",
-        "ukphone": "[ʃɔː(r)]"
-    },
-    {
-        "name": "shortage",
-        "trans": [
-            "n. 缺乏，缺少；不足"
-        ],
-        "usphone": "[ˈʃɔːrtɪdʒ]",
-        "ukphone": "[ˈʃɔːtɪdʒ]"
-    },
-    {
-        "name": "shortly",
-        "trans": [
-            "adv. 立刻；简短地；唐突地"
-        ],
-        "usphone": "[ˈʃɔːrtli]",
-        "ukphone": "[ˈʃɔːtli]"
-    },
-    {
-        "name": "short-term",
-        "trans": [
-            "adj. 短期的"
-        ],
-        "usphone": "[ˌʃɔːrt ˈtɜːrm]",
-        "ukphone": "[ˌʃɔːt ˈtɜːm]"
-    },
-    {
-        "name": "shot",
-        "trans": [
-            "n. 发射；炮弹；射手；镜头"
-        ],
-        "usphone": "[ʃɑːt]",
-        "ukphone": "[ʃɒt]"
-    },
-    {
-        "name": "sibling",
-        "trans": [
-            "n. 兄弟姊妹；民族成员"
-        ],
-        "usphone": "[ˈsɪblɪŋ]",
-        "ukphone": "[ˈsɪblɪŋ]"
-    },
-    {
-        "name": "signature",
-        "trans": [
-            "n. 署名；签名；信号"
-        ],
-        "usphone": "[ˈsɪɡnətʃər]",
-        "ukphone": "[ˈsɪɡnətʃə(r)]"
-    },
-    {
-        "name": "significance",
-        "trans": [
-            "n. 意义；重要性；意思"
-        ],
-        "usphone": "[sɪɡˈnɪfɪkəns]",
-        "ukphone": "[sɪɡˈnɪfɪkəns]"
-    },
-    {
-        "name": "significant",
-        "trans": [
-            "n. 象征；有意义的事物"
-        ],
-        "usphone": "[sɪɡˈnɪfɪkənt]",
-        "ukphone": "[sɪɡˈnɪfɪkənt]"
-    },
-    {
-        "name": "significantly",
-        "trans": [
-            "adv. 显著地；相当数量地"
-        ],
-        "usphone": "[sɪɡˈnɪfɪkəntli]",
-        "ukphone": "[sɪɡˈnɪfɪkəntli]"
-    },
-    {
-        "name": "silence",
-        "trans": [
-            "n. 沉默；寂静；缄默；不谈；无声状态"
-        ],
-        "usphone": "[ˈsaɪləns]",
-        "ukphone": "[ˈsaɪləns]"
-    },
-    {
-        "name": "silk",
-        "trans": [
-            "n. 丝绸；蚕丝；丝织物"
-        ],
-        "usphone": "[sɪlk]",
-        "ukphone": "[sɪlk]"
-    },
-    {
-        "name": "sincere",
-        "trans": [
-            "adj. 真诚的；诚挚的；真实的"
-        ],
-        "usphone": "[sɪnˈsɪr]",
-        "ukphone": "[sɪnˈsɪə(r)]"
-    },
-    {
-        "name": "skilled",
-        "trans": [
-            "adj. 熟练的；有技能的；需要技能的"
-        ],
-        "usphone": "[skɪld]",
-        "ukphone": "[skɪld]"
-    },
-    {
-        "name": "skull",
-        "trans": [
-            "n. 头盖骨，脑壳"
-        ],
-        "usphone": "[skʌl]",
-        "ukphone": "[skʌl]"
-    },
-    {
-        "name": "slave",
-        "trans": [
-            "n. 奴隶；从动装置"
-        ],
-        "usphone": "[sleɪv]",
-        "ukphone": "[sleɪv]"
-    },
-    {
-        "name": "slide",
-        "trans": [
-            "n. 滑动；幻灯片；滑梯；雪崩"
-        ],
-        "usphone": "[slaɪd]",
-        "ukphone": "[slaɪd]"
-    },
-    {
-        "name": "slight",
-        "trans": [
-            "n. 怠慢；轻蔑"
-        ],
-        "usphone": "[slaɪt]",
-        "ukphone": "[slaɪt]"
-    },
-    {
-        "name": "slip",
-        "trans": [
-            "n. 滑，滑倒；片，纸片；错误；下跌；事故"
-        ],
-        "usphone": "[slɪp]",
-        "ukphone": "[slɪp]"
-    },
-    {
-        "name": "slogan",
-        "trans": [
-            "n. 标语；呐喊声"
-        ],
-        "usphone": "[ˈsloʊɡən]",
-        "ukphone": "[ˈsləʊɡən]"
-    },
-    {
-        "name": "slope",
-        "trans": [
-            "n. 斜坡；倾斜；斜率；扛枪姿势"
-        ],
-        "usphone": "[sloʊp]",
-        "ukphone": "[sləʊp]"
-    },
-    {
-        "name": "so-called",
-        "trans": [
-            "adj. 所谓的；号称的"
-        ],
-        "usphone": "[ˌsoʊ ˈkɔːld]",
-        "ukphone": "[ˌsəʊ ˈkɔːld]"
-    },
-    {
-        "name": "solar",
-        "trans": [
-            "n. 日光浴室"
-        ],
-        "usphone": "[ˈsoʊlər]",
-        "ukphone": "[ˈsəʊlə(r)]"
-    },
-    {
-        "name": "somehow",
-        "trans": [
-            "adv. 以某种方法；莫名其妙地"
-        ],
-        "usphone": "[ˈsʌmhaʊ]",
-        "ukphone": "[ˈsʌmhaʊ]"
-    },
-    {
-        "name": "sometime",
-        "trans": [
-            "adj. 以前的；某一时间的"
-        ],
-        "usphone": "[ˈsʌmtaɪm]",
-        "ukphone": "[ˈsʌmtaɪm]"
-    },
-    {
-        "name": "somewhat",
-        "trans": [
-            "n. 几分；某物"
-        ],
-        "usphone": "[ˈsʌmwʌt]",
-        "ukphone": "[ˈsʌmwɒt]"
-    },
-    {
-        "name": "sophisticated",
-        "trans": [
-            "adj. 复杂的；精致的；久经世故的；富有经验的"
-        ],
-        "usphone": "[səˈfɪstɪkeɪtɪd]",
-        "ukphone": "[səˈfɪstɪkeɪtɪd]"
-    },
-    {
-        "name": "soul",
-        "trans": [
-            "n. 灵魂；心灵；精神；鬼魂"
-        ],
-        "usphone": "[soʊl]",
-        "ukphone": "[səʊl]"
-    },
-    {
-        "name": "spare",
-        "trans": [
-            "n. 剩余；备用零件"
-        ],
-        "usphone": "[sper]",
-        "ukphone": "[speə(r)]"
-    },
-    {
-        "name": "specialist",
-        "trans": [
-            "n. 专家；专门医师"
-        ],
-        "usphone": "[ˈspeʃəlɪst]",
-        "ukphone": "[ˈspeʃəlɪst]"
-    },
-    {
-        "name": "specialize",
-        "trans": [
-            "vi. 专门从事；详细说明；特化"
-        ],
-        "usphone": "[ˈspeʃəlaɪz]",
-        "ukphone": "[ˈspeʃəlaɪz]"
-    },
-    {
-        "name": "species",
-        "trans": [
-            "n. [生物] 物种；种类"
-        ],
-        "usphone": "[ˈspiːʃiːz]",
-        "ukphone": "[ˈspiːʃiːz]"
-    },
-    {
-        "name": "specify",
-        "trans": [
-            "vt. 指定；详细说明；列举；把…列入说明书"
-        ],
-        "usphone": "[ˈspesɪfaɪ]",
-        "ukphone": "[ˈspesɪfaɪ]"
-    },
-    {
-        "name": "spectacular",
-        "trans": [
-            "adj. 壮观的，惊人的；公开展示的"
-        ],
-        "usphone": "[spekˈtækjələr]",
-        "ukphone": "[spekˈtækjələ(r)]"
-    },
-    {
-        "name": "spectator",
-        "trans": [
-            "n. 观众；旁观者"
-        ],
-        "usphone": "[ˈspekteɪtər]",
-        "ukphone": "[spekˈteɪtə(r)]"
-    },
-    {
-        "name": "speculate",
-        "trans": [
-            "vi. 推测；投机；思索"
-        ],
-        "usphone": "[ˈspekjuleɪt]",
-        "ukphone": "[ˈspekjuleɪt]"
-    },
-    {
-        "name": "speculation",
-        "trans": [
-            "n. 投机；推测；思索；投机买卖"
-        ],
-        "usphone": "[ˌspekjuˈleɪʃn]",
-        "ukphone": "[ˌspekjuˈleɪʃ(ə)n]"
-    },
-    {
-        "name": "speed",
-        "trans": [
-            "n. 速度，速率；迅速，快速；昌盛，繁荣"
-        ],
-        "usphone": "[spiːd]",
-        "ukphone": "[spiːd]"
-    },
-    {
-        "name": "spice",
-        "trans": [
-            "n. 香料；情趣；调味品；少许"
-        ],
-        "usphone": "[spaɪs]",
-        "ukphone": "[spaɪs]"
-    },
-    {
-        "name": "spill",
-        "trans": [
-            "n. 溢出，溅出；溢出量；摔下；小塞子"
-        ],
-        "usphone": "[spɪl]",
-        "ukphone": "[spɪl]"
-    },
-    {
-        "name": "spiritual",
-        "trans": [
-            "n. 圣歌（尤指美国南部黑人的）"
-        ],
-        "usphone": "[ˈspɪrɪtʃuəl]",
-        "ukphone": "[ˈspɪrɪtʃuəl]"
-    },
-    {
-        "name": "spite",
-        "trans": [
-            "n. 不顾；恶意；怨恨"
-        ],
-        "usphone": "[spaɪt]",
-        "ukphone": "[spaɪt]"
-    },
-    {
-        "name": "split",
-        "trans": [
-            "n. 劈开；裂缝"
-        ],
-        "usphone": "[splɪt]",
-        "ukphone": "[splɪt]"
-    },
-    {
-        "name": "spoil",
-        "trans": [
-            "n. 次品；奖品"
-        ],
-        "usphone": "[spɔɪl]",
-        "ukphone": "[spɔɪl]"
-    },
-    {
-        "name": "spokesman",
-        "trans": [
-            "n. 发言人；代言人"
-        ],
-        "usphone": "[ˈspoʊksmən]",
-        "ukphone": "[ˈspəʊksmən]"
-    },
-    {
-        "name": "spokesperson",
-        "trans": [
-            "n. 发言人；代言人"
-        ],
-        "usphone": "[ˈspoʊkspɜːrsn]",
-        "ukphone": "[ˈspəʊkspɜːsn]"
-    },
-    {
-        "name": "spokeswoman",
-        "trans": [
-            "n. 女代言人，女代言人"
-        ],
-        "usphone": "[ˈspoʊkswʊmən]",
-        "ukphone": "[ˈspəʊkswʊmən]"
-    },
-    {
-        "name": "sponsor",
-        "trans": [
-            "n. 赞助者；主办者；保证人"
-        ],
-        "usphone": "[ˈspɑːnsər]",
-        "ukphone": "[ˈspɒnsə(r)]"
-    },
-    {
-        "name": "sponsorship",
-        "trans": [
-            "n. 赞助；发起；保证人的地位；教父母身份"
-        ],
-        "usphone": "[ˈspɑːnsərʃɪp]",
-        "ukphone": "[ˈspɒnsəʃɪp]"
-    },
-    {
-        "name": "sporting",
-        "trans": [
-            "adj. 运动的；冒险性的；公正的；喜好运动的"
-        ],
-        "usphone": "[ˈspɔːrtɪŋ]",
-        "ukphone": "[ˈspɔːtɪŋ]"
-    },
-    {
-        "name": "spot",
-        "trans": [
-            "n. 地点；斑点"
-        ],
-        "usphone": "[spɑːt]",
-        "ukphone": "[spɒt]"
-    },
-    {
-        "name": "spread",
-        "trans": [
-            "n. 传播；伸展"
-        ],
-        "usphone": "[spred]",
-        "ukphone": "[spred]"
-    },
-    {
-        "name": "spring",
-        "trans": [
-            "n. 春天；弹簧；泉水；活力；跳跃"
-        ],
-        "usphone": "[sprɪŋ]",
-        "ukphone": "[sprɪŋ]"
-    },
-    {
-        "name": "stable",
-        "trans": [
-            "n. 马厩；牛棚"
-        ],
-        "usphone": "[ˈsteɪbl]",
-        "ukphone": "[ˈsteɪb(ə)l]"
-    },
-    {
-        "name": "stage",
-        "trans": [
-            "n. 阶段；舞台；戏剧；驿站"
-        ],
-        "usphone": "[steɪdʒ]",
-        "ukphone": "[steɪdʒ]"
-    },
-    {
-        "name": "stall",
-        "trans": [
-            "n. 货摊；畜栏；托辞"
-        ],
-        "usphone": "[stɔːl]",
-        "ukphone": "[stɔːl]"
-    },
-    {
-        "name": "stance",
-        "trans": [
-            "n. 立场；姿态；位置；准备击球姿势"
-        ],
-        "usphone": "[stæns]",
-        "ukphone": "[stæns]"
-    },
-    {
-        "name": "stand",
-        "trans": [
-            "n. 站立；立场；看台；停止"
-        ],
-        "usphone": "[stænd]",
-        "ukphone": "[stænd]"
-    },
-    {
-        "name": "stare",
-        "trans": [
-            "n. 凝视；注视"
-        ],
-        "usphone": "[ster]",
-        "ukphone": "[steə(r)]"
-    },
-    {
-        "name": "starve",
-        "trans": [
-            "vi. 饿死；挨饿；渴望"
-        ],
-        "usphone": "[stɑːrv]",
-        "ukphone": "[stɑːv]"
-    },
-    {
-        "name": "status",
-        "trans": [
-            "n. 地位；状态；情形；重要身份"
-        ],
-        "usphone": "[ˈsteɪtəs; ˈstætəs]",
-        "ukphone": "[ˈsteɪtəs]"
-    },
-    {
-        "name": "steadily",
-        "trans": [
-            "adv. 稳定地；稳固地；有规则地"
-        ],
-        "usphone": "[ˈstedəli]",
-        "ukphone": "[ˈstedəli]"
-    },
-    {
-        "name": "steady",
-        "trans": [
-            "n. 关系固定的情侣；固定支架"
-        ],
-        "usphone": "[ˈstedi]",
-        "ukphone": "[ˈstedi]"
-    },
-    {
-        "name": "steam",
-        "trans": [
-            "n. 蒸汽；精力"
-        ],
-        "usphone": "[stiːm]",
-        "ukphone": "[stiːm]"
-    },
-    {
-        "name": "steel",
-        "trans": [
-            "n. 钢铁；钢制品；坚固"
-        ],
-        "usphone": "[stiːl]",
-        "ukphone": "[stiːl]"
-    },
-    {
-        "name": "steep",
-        "trans": [
-            "n. 峭壁；浸渍"
-        ],
-        "usphone": "[stiːp]",
-        "ukphone": "[stiːp]"
-    },
-    {
-        "name": "step",
-        "trans": [
-            "n. 步，脚步；步骤；步伐；梯级"
-        ],
-        "usphone": "[step]",
-        "ukphone": "[step]"
-    },
-    {
-        "name": "sticky",
-        "trans": [
-            "adj. 粘的；粘性的"
-        ],
-        "usphone": "[ˈstɪki]",
-        "ukphone": "[ˈstɪki]"
-    },
-    {
-        "name": "stiff",
-        "trans": [
-            "adj. 呆板的；坚硬的；严厉的；拘谨的"
-        ],
-        "usphone": "[stɪf]",
-        "ukphone": "[stɪf]"
-    },
-    {
-        "name": "stimulate",
-        "trans": [
-            "vi. 起刺激作用；起促进作用"
-        ],
-        "usphone": "[ˈstɪmjuleɪt]",
-        "ukphone": "[ˈstɪmjuleɪt]"
-    },
-    {
-        "name": "stock",
-        "trans": [
-            "n. 股份，股票；库存；血统；树干；家畜"
-        ],
-        "usphone": "[stɑːk]",
-        "ukphone": "[stɒk]"
-    },
-    {
-        "name": "stream",
-        "trans": [
-            "n. 溪流；流动；潮流；光线"
-        ],
-        "usphone": "[striːm]",
-        "ukphone": "[striːm]"
-    },
-    {
-        "name": "stretch",
-        "trans": [
-            "vt. 伸展,张开；（大量地）使用，消耗（金钱，时间）；使竭尽所能；使全力以赴；"
-        ],
-        "usphone": "[stretʃ]",
-        "ukphone": "[stretʃ]"
-    },
-    {
-        "name": "strict",
-        "trans": [
-            "adj. 严格的；绝对的；精确的；详细的"
-        ],
-        "usphone": "[strɪkt]",
-        "ukphone": "[strɪkt]"
-    },
-    {
-        "name": "strictly",
-        "trans": [
-            "adv. 严格地；完全地；确实地"
-        ],
-        "usphone": "[ˈstrɪktli]",
-        "ukphone": "[ˈstrɪktli]"
-    },
-    {
-        "name": "strike",
-        "trans": [
-            "n. 罢工；打击；殴打"
-        ],
-        "usphone": "[straɪk]",
-        "ukphone": "[straɪk]"
-    },
-    {
-        "name": "stroke",
-        "trans": [
-            "n. （游泳或划船的）划；中风；（打、击等的）一下；冲程；（成功的）举动；尝试；轻抚"
-        ],
-        "usphone": "[stroʊk]",
-        "ukphone": "[strəʊk]"
-    },
-    {
-        "name": "structure",
-        "trans": [
-            "n. 结构；构造；建筑物"
-        ],
-        "usphone": "[ˈstrʌktʃər]",
-        "ukphone": "[ˈstrʌktʃə(r)]"
-    },
-    {
-        "name": "struggle",
-        "trans": [
-            "n. 努力，奋斗；竞争"
-        ],
-        "usphone": "[ˈstrʌɡl]",
-        "ukphone": "[ˈstrʌɡ(ə)l]"
-    },
-    {
-        "name": "stuff",
-        "trans": [
-            "n. 东西；材料；填充物；素材资料"
-        ],
-        "usphone": "[stʌf]",
-        "ukphone": "[stʌf]"
-    },
-    {
-        "name": "stunning",
-        "trans": [
-            "adj. 极好的；使人晕倒的；震耳欲聋的"
-        ],
-        "usphone": "[ˈstʌnɪŋ]",
-        "ukphone": "[ˈstʌnɪŋ]"
-    },
-    {
-        "name": "subject",
-        "trans": [
-            "n. 主题；科目；[语] 主语；国民"
-        ],
-        "usphone": "[ˈsʌbdʒɪkt; ˈsʌbdʒekt]",
-        "ukphone": "[ˈsʌbdʒɪkt; ˈsʌbdʒekt]"
-    },
-    {
-        "name": "submit",
-        "trans": [
-            "vi. 提交；服从"
-        ],
-        "usphone": "[səbˈmɪt]",
-        "ukphone": "[səbˈmɪt]"
-    },
-    {
-        "name": "subsequent",
-        "trans": [
-            "adj. 后来的，随后的"
-        ],
-        "usphone": "[ˈsʌbsɪkwənt]",
-        "ukphone": "[ˈsʌbsɪkwənt]"
-    },
-    {
-        "name": "subsequently",
-        "trans": [
-            "adv. 随后，其后；后来"
-        ],
-        "usphone": "[ˈsʌbsɪkwəntli]",
-        "ukphone": "[ˈsʌbsɪkwəntli]"
-    },
-    {
-        "name": "suburb",
-        "trans": [
-            "n. 郊区；边缘"
-        ],
-        "usphone": "[ˈsʌbɜːrb]",
-        "ukphone": "[ˈsʌbɜːb]"
-    },
-    {
-        "name": "suffering",
-        "trans": [
-            "n. 受难；苦楚"
-        ],
-        "usphone": "[ˈsʌfərɪŋ]",
-        "ukphone": "[ˈsʌfərɪŋ]"
-    },
-    {
-        "name": "sufficient",
-        "trans": [
-            "adj. 足够的；充分的"
-        ],
-        "usphone": "[səˈfɪʃnt]",
-        "ukphone": "[səˈfɪʃ(ə)nt]"
-    },
-    {
-        "name": "sufficiently",
-        "trans": [
-            "adv. 充分地；足够地"
-        ],
-        "usphone": "[səˈfɪʃntli]",
-        "ukphone": "[səˈfɪʃntli]"
-    },
-    {
-        "name": "sum",
-        "trans": [
-            "n. 金额；总数"
-        ],
-        "usphone": "[sʌm]",
-        "ukphone": "[sʌm]"
-    },
-    {
-        "name": "super",
-        "trans": [
-            "n. 特级品，特大号；临时雇员"
-        ],
-        "usphone": "[ˈsuːpər]",
-        "ukphone": "[ˈsuːpə(r)]"
-    },
-    {
-        "name": "surgeon",
-        "trans": [
-            "n. 外科医生"
-        ],
-        "usphone": "[ˈsɜːrdʒən]",
-        "ukphone": "[ˈsɜːdʒən]"
-    },
-    {
-        "name": "surgery",
-        "trans": [
-            "n. 外科；外科手术；手术室；诊疗室"
-        ],
-        "usphone": "[ˈsɜːrdʒəri]",
-        "ukphone": "[ˈsɜːdʒəri]"
-    },
-    {
-        "name": "surround",
-        "trans": [
-            "n. 围绕物"
-        ],
-        "usphone": "[səˈraʊnd]",
-        "ukphone": "[səˈraʊnd]"
-    },
-    {
-        "name": "surrounding",
-        "trans": [
-            "n. 环境，周围的事物"
-        ],
-        "usphone": "[səˈraʊndɪŋ]",
-        "ukphone": "[səˈraʊndɪŋ]"
-    },
-    {
-        "name": "survey",
-        "trans": [
-            "n. 调查；测量；审视；纵览"
-        ],
-        "usphone": "[ˈsɜːrveɪ]",
-        "ukphone": "[ˈsɜːveɪ]"
-    },
-    {
-        "name": "survival",
-        "trans": [
-            "n. 幸存，残存；幸存者，残存物"
-        ],
-        "usphone": "[sərˈvaɪvl]",
-        "ukphone": "[səˈvaɪv(ə)l]"
-    },
-    {
-        "name": "survivor",
-        "trans": [
-            "n. 幸存者；生还者；残存物"
-        ],
-        "usphone": "[sərˈvaɪvər]",
-        "ukphone": "[səˈvaɪvə(r)]"
-    },
-    {
-        "name": "suspect",
-        "trans": [
-            "n. 嫌疑犯"
-        ],
-        "usphone": "[səˈspekt]",
-        "ukphone": "[səˈspekt]"
-    },
-    {
-        "name": "suspend",
-        "trans": [
-            "vt. 延缓，推迟；使暂停；使悬浮"
-        ],
-        "usphone": "[səˈspend]",
-        "ukphone": "[səˈspend]"
-    },
-    {
-        "name": "sustainable",
-        "trans": [
-            "adj. 可以忍受的；足可支撑的；养得起的；可持续的"
-        ],
-        "usphone": "[səˈsteɪnəb(ə)l]",
-        "ukphone": "[səˈsteɪnəb(ə)l]"
-    },
-    {
-        "name": "swallow",
-        "trans": [
-            "n. 燕子；一次吞咽的量"
-        ],
-        "usphone": "[ˈswɑːloʊ]",
-        "ukphone": "[ˈswɒləʊ]"
-    },
-    {
-        "name": "swear",
-        "trans": [
-            "n. 宣誓；诅咒"
-        ],
-        "usphone": "[swer]",
-        "ukphone": "[sweə(r)]"
-    },
-    {
-        "name": "sweep",
-        "trans": [
-            "n. 打扫，扫除；范围；全胜"
-        ],
-        "usphone": "[swiːp]",
-        "ukphone": "[swiːp]"
-    },
-    {
-        "name": "switch",
-        "trans": [
-            "n. 开关；转换；鞭子"
-        ],
-        "usphone": "[swɪtʃ]",
-        "ukphone": "[swɪtʃ]"
-    },
-    {
-        "name": "sympathetic",
-        "trans": [
-            "n. 交感神经；容易感受的人"
-        ],
-        "usphone": "[ˌsɪmpəˈθetɪk]",
-        "ukphone": "[ˌsɪmpəˈθetɪk]"
-    },
-    {
-        "name": "sympathy",
-        "trans": [
-            "n. 同情；慰问；赞同"
-        ],
-        "usphone": "[ˈsɪmpəθi]",
-        "ukphone": "[ˈsɪmpəθi]"
-    },
-    {
-        "name": "tackle",
-        "trans": [
-            "n. 滑车；装备；用具；扭倒"
-        ],
-        "usphone": "[ˈtækl]",
-        "ukphone": "[ˈtæk(ə)l]"
-    },
-    {
-        "name": "tag",
-        "trans": [
-            "n. 标签；名称；结束语；附属物"
-        ],
-        "usphone": "[tæɡ]",
-        "ukphone": "[tæɡ]"
-    },
-    {
-        "name": "tale",
-        "trans": [
-            "n. 故事；传说；叙述；流言蜚语"
-        ],
-        "usphone": "[teɪl]",
-        "ukphone": "[teɪl]"
-    },
-    {
-        "name": "tank",
-        "trans": [
-            "n. 坦克；水槽；池塘"
-        ],
-        "usphone": "[tæŋk]",
-        "ukphone": "[tæŋk]"
-    },
-    {
-        "name": "tap",
-        "trans": [
-            "n. 水龙头；轻打"
-        ],
-        "usphone": "[tæp]",
-        "ukphone": "[tæp]"
-    },
-    {
-        "name": "target",
-        "trans": [
-            "n. 目标；靶子"
-        ],
-        "usphone": "[ˈtɑːrɡɪt]",
-        "ukphone": "[ˈtɑːɡɪt]"
-    },
-    {
-        "name": "tear",
-        "trans": [
-            "vi. 流泪, 撕破"
-        ],
-        "usphone": "[ter]",
-        "ukphone": "[teə(r)]"
-    },
-    {
-        "name": "technological",
-        "trans": [
-            "adj. 技术的；工艺的"
-        ],
-        "usphone": "[ˌteknəˈlɑːdʒɪkl]",
-        "ukphone": "[ˌteknəˈlɒdʒɪk(ə)l]"
-    },
-    {
-        "name": "teens",
-        "trans": [
-            "n. 十多岁，十几岁；青少年"
-        ],
-        "usphone": "[tiːnz]",
-        "ukphone": "[tiːnz]"
-    },
-    {
-        "name": "temple",
-        "trans": [
-            "n. 庙宇；寺院；神殿；太阳穴"
-        ],
-        "usphone": "[ˈtempl]",
-        "ukphone": "[ˈtemp(ə)l]"
-    },
-    {
-        "name": "temporarily",
-        "trans": [
-            "adv. 临时地，临时"
-        ],
-        "usphone": "[ˌtempəˈrerəli]",
-        "ukphone": "[ˈtemprərəli]"
-    },
-    {
-        "name": "temporary",
-        "trans": [
-            "n. 临时工，临时雇员"
-        ],
-        "usphone": "[ˈtempəreri]",
-        "ukphone": "[ˈtemprəri]"
-    },
-    {
-        "name": "tendency",
-        "trans": [
-            "n. 倾向，趋势；癖好"
-        ],
-        "usphone": "[ˈtendənsi]",
-        "ukphone": "[ˈtendənsi]"
-    },
-    {
-        "name": "tension",
-        "trans": [
-            "n. 张力，拉力；紧张，不安；电压"
-        ],
-        "usphone": "[ˈtenʃn]",
-        "ukphone": "[ˈtenʃ(ə)n]"
-    },
-    {
-        "name": "term",
-        "trans": [
-            "n. 术语；学期；期限；条款；(代数式等的)项"
-        ],
-        "usphone": "[tɜːrm]",
-        "ukphone": "[tɜːm]"
-    },
-    {
-        "name": "terminal",
-        "trans": [
-            "n. 末端；终点；终端机；极限"
-        ],
-        "usphone": "[ˈtɜːrmɪn(ə)l]",
-        "ukphone": "[ˈtɜːmɪn(ə)l]"
-    },
-    {
-        "name": "terms",
-        "trans": [
-            "n. 地位，关系；[法] 条款；术语；措辞；价钱（term的复数形式）"
-        ],
-        "usphone": "[tɜːrmz]",
-        "ukphone": "[tɜːmz]"
-    },
-    {
-        "name": "terribly",
-        "trans": [
-            "adv. 非常；可怕地；极度地"
-        ],
-        "usphone": "[ˈterəbli]",
-        "ukphone": "[ˈterəbli]"
-    },
-    {
-        "name": "terrify",
-        "trans": [
-            "vt. 恐吓；使恐怖；使害怕"
-        ],
-        "usphone": "[ˈterɪfaɪ]",
-        "ukphone": "[ˈterɪfaɪ]"
-    },
-    {
-        "name": "territory",
-        "trans": [
-            "n. 领土，领域；范围；地域；版图"
-        ],
-        "usphone": "[ˈterətɔːri]",
-        "ukphone": "[ˈterətri]"
-    },
-    {
-        "name": "terror",
-        "trans": [
-            "n. 恐怖；恐怖行动；恐怖时期；可怕的人"
-        ],
-        "usphone": "[ˈterər]",
-        "ukphone": "[ˈterə(r)]"
-    },
-    {
-        "name": "terrorism",
-        "trans": [
-            "n. 恐怖主义；恐怖行动；恐怖统治"
-        ],
-        "usphone": "[ˈterərɪzəm]",
-        "ukphone": "[ˈterərɪzəm]"
-    },
-    {
-        "name": "terrorist",
-        "trans": [
-            "n. 恐怖主义者，恐怖分子"
-        ],
-        "usphone": "[ˈterərɪst]",
-        "ukphone": "[ˈterərɪst]"
-    },
-    {
-        "name": "testing",
-        "trans": [
-            "n. [试验] 测试"
-        ],
-        "usphone": "[ˈtestɪŋ]",
-        "ukphone": "[ˈtestɪŋ]"
-    },
-    {
-        "name": "textbook",
-        "trans": [
-            "n. 教科书，课本"
-        ],
-        "usphone": "[ˈtekstbʊk]",
-        "ukphone": "[ˈtekstbʊk]"
-    },
-    {
-        "name": "theft",
-        "trans": [
-            "n. 盗窃；偷；赃物"
-        ],
-        "usphone": "[θeft]",
-        "ukphone": "[θeft]"
-    },
-    {
-        "name": "therapist",
-        "trans": [
-            "n. 临床医学家；治疗学家"
-        ],
-        "usphone": "[ˈθerəpɪst]",
-        "ukphone": "[ˈθerəpɪst]"
-    },
-    {
-        "name": "therapy",
-        "trans": [
-            "n. 治疗，疗法"
-        ],
-        "usphone": "[ˈθerəpi]",
-        "ukphone": "[ˈθerəpi]"
-    },
-    {
-        "name": "thesis",
-        "trans": [
-            "n. 论文；论点"
-        ],
-        "usphone": "[ˈθiːsɪs]",
-        "ukphone": "[ˈθiːsɪs]"
-    },
-    {
-        "name": "thorough",
-        "trans": [
-            "adj. 彻底的；十分的；周密的"
-        ],
-        "usphone": "[ˈθɜːroʊ]",
-        "ukphone": "[ˈθʌrə]"
-    },
-    {
-        "name": "thoroughly",
-        "trans": [
-            "adv. 彻底地，完全地"
-        ],
-        "usphone": "[ˈθɜːrəli]",
-        "ukphone": "[ˈθʌrəli]"
-    },
-    {
-        "name": "threat",
-        "trans": [
-            "n. 威胁，恐吓；凶兆"
-        ],
-        "usphone": "[θret]",
-        "ukphone": "[θret]"
-    },
-    {
-        "name": "threaten",
-        "trans": [
-            "vt. 威胁；恐吓；预示"
-        ],
-        "usphone": "[ˈθret(ə)n]",
-        "ukphone": "[ˈθret(ə)n]"
-    },
-    {
-        "name": "thumb",
-        "trans": [
-            "n. 拇指"
-        ],
-        "usphone": "[θʌm]",
-        "ukphone": "[θʌm]"
-    },
-    {
-        "name": "thus",
-        "trans": [
-            "conj. 因此"
-        ],
-        "usphone": "[ðʌs]",
-        "ukphone": "[ðʌs]"
-    },
-    {
-        "name": "time",
-        "trans": [
-            "n. 时间；时代；次数；节拍；倍数"
-        ],
-        "usphone": "[taɪm]",
-        "ukphone": "[taɪm]"
-    },
-    {
-        "name": "timing",
-        "trans": [
-            "n. 定时；调速；时间选择"
-        ],
-        "usphone": "[ˈtaɪmɪŋ]",
-        "ukphone": "[ˈtaɪmɪŋ]"
-    },
-    {
-        "name": "tissue",
-        "trans": [
-            "n. 组织；纸巾；薄纱；一套"
-        ],
-        "usphone": "[ˈtɪʃuː]",
-        "ukphone": "[ˈtɪʃuː]"
-    },
-    {
-        "name": "title",
-        "trans": [
-            "n. 冠军；标题；头衔；权利；字幕"
-        ],
-        "usphone": "[ˈtaɪt(ə)l]",
-        "ukphone": "[ˈtaɪt(ə)l]"
-    },
-    {
-        "name": "ton",
-        "trans": [
-            "n. 吨；很多，大量"
-        ],
-        "usphone": "[tʌn]",
-        "ukphone": "[tʌn]"
-    },
-    {
-        "name": "tone",
-        "trans": [
-            "n. 语气；色调；音调；音色"
-        ],
-        "usphone": "[toʊn]",
-        "ukphone": "[təʊn]"
-    },
-    {
-        "name": "tonne",
-        "trans": [
-            "n. [计量] 公吨（1，000公斤，等于metric ton）"
-        ],
-        "usphone": "[tʌn]",
-        "ukphone": "[tʌn]"
-    },
-    {
-        "name": "tough",
-        "trans": [
-            "n. 恶棍"
-        ],
-        "usphone": "[tʌf]",
-        "ukphone": "[tʌf]"
-    },
-    {
-        "name": "tournament",
-        "trans": [
-            "n. 锦标赛，联赛；比赛"
-        ],
-        "usphone": "[ˈtʊrnəmənt; ˈtɜːrnəmənt]",
-        "ukphone": "[ˈtʊənəmənt]"
-    },
-    {
-        "name": "trace",
-        "trans": [
-            "n. 痕迹，踪迹；微量；[仪] 迹线；缰绳"
-        ],
-        "usphone": "[treɪs]",
-        "ukphone": "[treɪs]"
-    },
-    {
-        "name": "track",
-        "trans": [
-            "n. 轨道；足迹，踪迹；小道"
-        ],
-        "usphone": "[træk]",
-        "ukphone": "[træk]"
-    },
-    {
-        "name": "trading",
-        "trans": [
-            "n. 交易；贸易；购物"
-        ],
-        "usphone": "",
-        "ukphone": ""
-    },
-    {
-        "name": "tragedy",
-        "trans": [
-            "n. 悲剧；灾难；惨案"
-        ],
-        "usphone": "[ˈtrædʒədi]",
-        "ukphone": "[ˈtrædʒədi]"
-    },
-    {
-        "name": "tragic",
-        "trans": [
-            "adj. 悲剧的；悲痛的，不幸的"
-        ],
-        "usphone": "[ˈtrædʒɪk]",
-        "ukphone": "[ˈtrædʒɪk]"
-    },
-    {
-        "name": "trait",
-        "trans": [
-            "n. 特性，特点；品质；少许"
-        ],
-        "usphone": "[treɪt]",
-        "ukphone": "[treɪt]"
-    },
-    {
-        "name": "transfer",
-        "trans": [
-            "n. 转让；转移；传递；过户"
-        ],
-        "usphone": "[trænsˈfɜːr]",
-        "ukphone": "[trænsˈfɜː(r)]"
-    },
-    {
-        "name": "transform",
-        "trans": [
-            "vt. 改变，使…变形；转换"
-        ],
-        "usphone": "[trænsˈfɔːrm]",
-        "ukphone": "[trænsˈfɔːm]"
-    },
-    {
-        "name": "transition",
-        "trans": [
-            "n. 过渡；转变；[分子生物] 转换；变调"
-        ],
-        "usphone": "[trænˈzɪʃnˌtrænˈsɪʃn]",
-        "ukphone": "[trænˈzɪʃ(ə)n]"
-    },
-    {
-        "name": "transmit",
-        "trans": [
-            "vt. 传输；传播；发射；传达；遗传"
-        ],
-        "usphone": "[trænzˈmɪtˌtrænsˈmɪt]",
-        "ukphone": "[trænzˈmɪt]"
-    },
-    {
-        "name": "transportation",
-        "trans": [
-            "n. 运输；运输系统；运输工具；流放"
-        ],
-        "usphone": "[ˌtrænspɔːrˈteɪʃn]",
-        "ukphone": "[ˌtrænspɔːˈteɪʃn]"
-    },
-    {
-        "name": "trap",
-        "trans": [
-            "n. 陷阱；圈套；[建] 存水湾"
-        ],
-        "usphone": "[træp]",
-        "ukphone": "[træp]"
-    },
-    {
-        "name": "treasure",
-        "trans": [
-            "n. 财富，财产；财宝；珍品"
-        ],
-        "usphone": "[ˈtreʒər]",
-        "ukphone": "[ˈtreʒə(r)]"
-    },
-    {
         "name": "trial",
         "trans": [
             "n. 试验；审讯；努力；磨炼"
@@ -10608,52 +24,12 @@
         "ukphone": "[ˈtraɪəl]"
     },
     {
-        "name": "tribe",
+        "name": "consumption",
         "trans": [
-            "n. 部落；族；宗族；一伙"
+            "n. 消费；消耗；肺痨"
         ],
-        "usphone": "[traɪb]",
-        "ukphone": "[traɪb]"
-    },
-    {
-        "name": "trigger",
-        "trans": [
-            "n. 扳机；[电子] 触发器；制滑机"
-        ],
-        "usphone": "[ˈtrɪɡər]",
-        "ukphone": "[ˈtrɪɡə(r)]"
-    },
-    {
-        "name": "trillion",
-        "trans": [
-            "num. [数] 万亿"
-        ],
-        "usphone": "[ˈtrɪljən]",
-        "ukphone": "[ˈtrɪljən]"
-    },
-    {
-        "name": "trip",
-        "trans": [
-            "n. 旅行；绊倒；差错"
-        ],
-        "usphone": "[trɪp]",
-        "ukphone": "[trɪp]"
-    },
-    {
-        "name": "troop",
-        "trans": [
-            "vt. 把（骑兵）编成骑兵连"
-        ],
-        "usphone": "[truːp]",
-        "ukphone": "[truːp]"
-    },
-    {
-        "name": "tropical",
-        "trans": [
-            "adj. 热带的；热情的；酷热的"
-        ],
-        "usphone": "[ˈtrɑːpɪkl]",
-        "ukphone": "[ˈtrɒpɪk(ə)l]"
+        "usphone": "[kənˈsʌmpʃn]",
+        "ukphone": "[kənˈsʌmpʃn]"
     },
     {
         "name": "trouble",
@@ -10664,396 +40,204 @@
         "ukphone": "[ˈtrʌb(ə)l]"
     },
     {
-        "name": "truly",
+        "name": "potentially",
         "trans": [
-            "adv. 真实地，不假；真诚地"
+            "adv. 可能地，潜在地"
         ],
-        "usphone": "[ˈtruːli]",
-        "ukphone": "[ˈtruːli]"
+        "usphone": "[pəˈtenʃəli]",
+        "ukphone": "[pəˈtenʃəli]"
     },
     {
-        "name": "trust",
+        "name": "demand",
         "trans": [
-            "n. 信任，信赖；责任；托拉斯"
+            "n. [经] 需求；要求；需要"
         ],
-        "usphone": "[trʌst]",
-        "ukphone": "[trʌst]"
+        "usphone": "[dɪˈmænd]",
+        "ukphone": "[dɪˈmɑːnd]"
     },
     {
-        "name": "try",
+        "name": "edit",
         "trans": [
-            "n. 尝试；努力；试验"
+            "vt. 编辑；校订"
         ],
-        "usphone": "[traɪ]",
-        "ukphone": "[traɪ]"
+        "usphone": "[ˈedɪt]",
+        "ukphone": "[ˈedɪt]"
     },
     {
-        "name": "tsunami",
+        "name": "cast",
         "trans": [
-            "n. 海啸"
+            "n. 投掷，抛；铸件，[古生] 铸型；演员阵容；脱落物"
         ],
-        "usphone": "[tsuːˈnɑːmi]",
-        "ukphone": "[tsuːˈnɑːmi]"
+        "usphone": "[kæst]",
+        "ukphone": "[kɑːst]"
     },
     {
-        "name": "tune",
+        "name": "steady",
         "trans": [
-            "n. 曲调；和谐；心情"
+            "n. 关系固定的情侣；固定支架"
         ],
-        "usphone": "[tuːn]",
-        "ukphone": "[tjuːn]"
+        "usphone": "[ˈstedi]",
+        "ukphone": "[ˈstedi]"
     },
     {
-        "name": "tunnel",
+        "name": "eliminate",
         "trans": [
-            "n. 隧道；坑道；洞穴通道"
+            "vt. 消除；排除"
         ],
-        "usphone": "[ˈtʌnl]",
-        "ukphone": "[ˈtʌn(ə)l]"
+        "usphone": "[ɪˈlɪmɪneɪt]",
+        "ukphone": "[ɪˈlɪmɪneɪt]"
     },
     {
-        "name": "ultimate",
+        "name": "frequency",
         "trans": [
-            "n. 终极；根本；基本原则"
+            "n. 频率；频繁"
         ],
-        "usphone": "[ˈʌltɪmət]",
-        "ukphone": "[ˈʌltɪmət]"
+        "usphone": "[ˈfriːkwənsi]",
+        "ukphone": "[ˈfriːkwənsi]"
     },
     {
-        "name": "ultimately",
+        "name": "agriculture",
         "trans": [
-            "adv. 最后；根本；基本上"
+            "n. 农业；农耕；农业生产；农艺，农学"
         ],
-        "usphone": "[ˈʌltɪmətli]",
-        "ukphone": "[ˈʌltɪmətli]"
+        "usphone": "[ˈæɡrɪkʌltʃər]",
+        "ukphone": "[ˈæɡrɪkʌltʃə(r)]"
     },
     {
-        "name": "unacceptable",
+        "name": "colony",
         "trans": [
-            "adj. 不能接受的；不受欢迎的"
+            "n. 殖民地；移民队；种群；动物栖息地"
         ],
-        "usphone": "[ˌʌnəkˈseptəbl]",
-        "ukphone": "[ˌʌnəkˈseptəbl]"
+        "usphone": "[ˈkɑːləni]",
+        "ukphone": "[ˈkɒləni]"
     },
     {
-        "name": "uncertainty",
+        "name": "secure",
         "trans": [
-            "n. 不确定，不可靠"
+            "vt. 保护；弄到；招致；缚住"
         ],
-        "usphone": "[ʌnˈsɜːrtnti]",
-        "ukphone": "[ʌnˈsɜːt(ə)nti]"
+        "usphone": "[sɪˈkjʊr]",
+        "ukphone": "[sɪˈkjʊə(r)]"
     },
     {
-        "name": "unconscious",
+        "name": "hurt",
         "trans": [
-            "adj. 无意识的；失去知觉的；不省人事的；未发觉的"
+            "n. 痛苦；危害；痛苦的原因"
         ],
-        "usphone": "[ʌnˈkɑːnʃəs]",
-        "ukphone": "[ʌnˈkɒnʃəs]"
+        "usphone": "[hɜːrt]",
+        "ukphone": "[hɜːt]"
     },
     {
-        "name": "undergo",
+        "name": "genuine",
         "trans": [
-            "vt. 经历，经受；忍受"
+            "adj. 真实的，真正的；诚恳的"
         ],
-        "usphone": "[ˌʌndərˈɡoʊ]",
-        "ukphone": "[ˌʌndəˈɡəʊ]"
+        "usphone": "[ˈdʒenjuɪn]",
+        "ukphone": "[ˈdʒenjuɪn]"
     },
     {
-        "name": "undertake",
+        "name": "melt",
         "trans": [
-            "vt. 承担，保证；从事；同意；试图"
+            "vi. 熔化，溶解；渐混"
         ],
-        "usphone": "[ˌʌndərˈteɪk]",
-        "ukphone": "[ˌʌndəˈteɪk]"
+        "usphone": "[melt]",
+        "ukphone": "[melt]"
     },
     {
-        "name": "unexpected",
+        "name": "framework",
         "trans": [
-            "adj. 意外的，想不到的"
+            "n. 框架，骨架；结构，构架"
         ],
-        "usphone": "[ˌʌnɪkˈspektɪd]",
-        "ukphone": "[ˌʌnɪkˈspektɪd]"
+        "usphone": "[ˈfreɪmwɜːrk]",
+        "ukphone": "[ˈfreɪmwɜːk]"
     },
     {
-        "name": "unfold",
+        "name": "bombing",
         "trans": [
-            "vi. 展开；显露"
+            "n. [军] 轰炸，[军] 投弹"
         ],
-        "usphone": "[ʌnˈfoʊld]",
-        "ukphone": "[ʌnˈfəʊld]"
+        "usphone": "[ˈbɑːmɪŋ]",
+        "ukphone": "[ˈbɒmɪŋ]"
     },
     {
-        "name": "unfortunate",
+        "name": "selection",
         "trans": [
-            "adj. 不幸的；令人遗憾的；不成功的"
+            "n. 选择，挑选；选集；精选品"
         ],
-        "usphone": "[ʌnˈfɔːrtʃənət]",
-        "ukphone": "[ʌnˈfɔːtʃənət]"
+        "usphone": "[sɪˈlekʃn]",
+        "ukphone": "[sɪˈlekʃ(ə)n]"
     },
     {
-        "name": "unique",
+        "name": "offender",
         "trans": [
-            "n. 独一无二的人或物"
+            "n. 罪犯；冒犯者；违法者"
         ],
-        "usphone": "[juˈniːk]",
-        "ukphone": "[juˈniːk]"
+        "usphone": "[əˈfendər]",
+        "ukphone": "[əˈfendə(r)]"
     },
     {
-        "name": "unite",
+        "name": "anger",
         "trans": [
-            "vi. 团结；联合；混合"
+            "n. 怒，愤怒；忿怒"
         ],
-        "usphone": "[juˈnaɪt]",
-        "ukphone": "[juˈnaɪt]"
+        "usphone": "[ˈæŋɡər]",
+        "ukphone": "[ˈæŋɡə(r)]"
     },
     {
-        "name": "unity",
+        "name": "map",
         "trans": [
-            "n. 团结；一致；联合；个体"
+            "vt. 映射；计划；绘制地图；确定基因在染色体中的位置"
         ],
-        "usphone": "[ˈjuːnəti]",
-        "ukphone": "[ˈjuːnəti]"
+        "usphone": "[mæp]",
+        "ukphone": "[mæp]"
     },
     {
-        "name": "universal",
+        "name": "passage",
         "trans": [
-            "n. 一般概念；普通性"
+            "n. 一段（文章）；走廊；通路"
         ],
-        "usphone": "[ˌjuːnɪˈvɜːrsl]",
-        "ukphone": "[ˌjuːnɪˈvɜːs(ə)l]"
+        "usphone": "[ˈpæsɪdʒ]",
+        "ukphone": "[ˈpæsɪdʒ]"
     },
     {
-        "name": "universe",
+        "name": "sweep",
         "trans": [
-            "n. 宇宙；世界；领域"
+            "n. 打扫，扫除；范围；全胜"
         ],
-        "usphone": "[ˈjuːnɪvɜːrs]",
-        "ukphone": "[ˈjuːnɪvɜːs]"
+        "usphone": "[swiːp]",
+        "ukphone": "[swiːp]"
     },
     {
-        "name": "unknown",
+        "name": "consultant",
         "trans": [
-            "n. 未知数；未知的事物，默默无闻的人"
+            "n. 顾问；咨询者；会诊医生"
         ],
-        "usphone": "[ˌʌnˈnoʊn]",
-        "ukphone": "[ˌʌnˈnəʊn]"
+        "usphone": "[kənˈsʌltənt]",
+        "ukphone": "[kənˈsʌltənt]"
     },
     {
-        "name": "upper",
+        "name": "exotic",
         "trans": [
-            "adj. 上面的，上部的；较高的"
+            "adj. 异国的；外来的；异国情调的"
         ],
-        "usphone": "[ˈʌpər]",
-        "ukphone": "[ˈʌpə(r)]"
+        "usphone": "[ɪɡˈzɑːtɪk]",
+        "ukphone": "[ɪɡˈzɒtɪk]"
     },
     {
-        "name": "upwards",
+        "name": "forgive",
         "trans": [
-            "adv. 向上；在上部；向上游"
+            "vt. 原谅；免除（债务、义务等）"
         ],
-        "usphone": "[ˈʌpwərdz]",
-        "ukphone": "[ˈʌpwədz]"
+        "usphone": "[fərˈɡɪv]",
+        "ukphone": "[fəˈɡɪv]"
     },
     {
-        "name": "urban",
+        "name": "rescue",
         "trans": [
-            "adj. 城市的；住在都市的"
+            "n. 营救；援救；解救"
         ],
-        "usphone": "[ˈɜːrbən]",
-        "ukphone": "[ˈɜːbən]"
-    },
-    {
-        "name": "urge",
-        "trans": [
-            "n. 强烈的欲望，迫切要求；推动力"
-        ],
-        "usphone": "[ɜːrdʒ]",
-        "ukphone": "[ɜːdʒ]"
-    },
-    {
-        "name": "urgent",
-        "trans": [
-            "adj. 紧急的；急迫的"
-        ],
-        "usphone": "[ˈɜːrdʒənt]",
-        "ukphone": "[ˈɜːdʒənt]"
-    },
-    {
-        "name": "usage",
-        "trans": [
-            "n. 使用；用法；惯例"
-        ],
-        "usphone": "[ˈjuːsɪdʒˌˈjuːzɪdʒ]",
-        "ukphone": "[ˈjuːsɪdʒ]"
-    },
-    {
-        "name": "useless",
-        "trans": [
-            "adj. 无用的；无效的"
-        ],
-        "usphone": "[ˈjuːsləs]",
-        "ukphone": "[ˈjuːsləs]"
-    },
-    {
-        "name": "valid",
-        "trans": [
-            "adj. 有效的；有根据的；合法的；正当的"
-        ],
-        "usphone": "[ˈvælɪd]",
-        "ukphone": "[ˈvælɪd]"
-    },
-    {
-        "name": "value",
-        "trans": [
-            "n. 值；价值；价格；重要性；确切涵义"
-        ],
-        "usphone": "[ˈvæljuː]",
-        "ukphone": "[ˈvæljuː]"
-    },
-    {
-        "name": "variation",
-        "trans": [
-            "n. 变化；[生物] 变异，变种"
-        ],
-        "usphone": "[ˌveriˈeɪʃn]",
-        "ukphone": "[ˌveəriˈeɪʃn]"
-    },
-    {
-        "name": "vary",
-        "trans": [
-            "vi. 变化；变异；违反"
-        ],
-        "usphone": "[ˈveri]",
-        "ukphone": "[ˈveəri]"
-    },
-    {
-        "name": "vast",
-        "trans": [
-            "n. 浩瀚；广阔无垠的空间"
-        ],
-        "usphone": "[væst]",
-        "ukphone": "[vɑːst]"
-    },
-    {
-        "name": "venue",
-        "trans": [
-            "n. 审判地；犯罪地点；发生地点；集合地点"
-        ],
-        "usphone": "[ˈvenjuː]",
-        "ukphone": "[ˈvenjuː]"
-    },
-    {
-        "name": "vertical",
-        "trans": [
-            "n. 垂直线，垂直面"
-        ],
-        "usphone": "[ˈvɜːrtɪkl]",
-        "ukphone": "[ˈvɜːtɪk(ə)l]"
-    },
-    {
-        "name": "very",
-        "trans": [
-            "adv. 非常，很；完全"
-        ],
-        "usphone": "[ˈveri]",
-        "ukphone": "[ˈveri]"
-    },
-    {
-        "name": "via",
-        "trans": [
-            "prep. 渠道，通过；经由"
-        ],
-        "usphone": "[ˈvaɪə; ˈviːə]",
-        "ukphone": "[ˈvaɪə]"
-    },
-    {
-        "name": "victory",
-        "trans": [
-            "n. 胜利；成功；克服"
-        ],
-        "usphone": "[ˈvɪktəri]",
-        "ukphone": "[ˈvɪktəri]"
-    },
-    {
-        "name": "viewpoint",
-        "trans": [
-            "n. 观点，看法；视角"
-        ],
-        "usphone": "[ˈvjuːpɔɪnt]",
-        "ukphone": "[ˈvjuːpɔɪnt]"
-    },
-    {
-        "name": "violence",
-        "trans": [
-            "n. 暴力；侵犯；激烈；歪曲"
-        ],
-        "usphone": "[ˈvaɪələns]",
-        "ukphone": "[ˈvaɪələns]"
-    },
-    {
-        "name": "virtual",
-        "trans": [
-            "adj. [计] 虚拟的；实质上的，事实上的（但未在名义上或正式获承认）"
-        ],
-        "usphone": "[ˈvɜːrtʃuəl]",
-        "ukphone": "[ˈvɜːtʃuəl]"
-    },
-    {
-        "name": "visa",
-        "trans": [
-            "n. 签证"
-        ],
-        "usphone": "[ˈviːzə]",
-        "ukphone": "[ˈviːzə]"
-    },
-    {
-        "name": "visible",
-        "trans": [
-            "n. 可见物；进出口贸易中的有形项目"
-        ],
-        "usphone": "[ˈvɪzəb(ə)l]",
-        "ukphone": "[ˈvɪzəb(ə)l]"
-    },
-    {
-        "name": "vision",
-        "trans": [
-            "n. 视力；美景；眼力；幻象；想象力；幻视（漫威漫画旗下超级英雄）"
-        ],
-        "usphone": "[ˈvɪʒn]",
-        "ukphone": "[ˈvɪʒn]"
-    },
-    {
-        "name": "visual",
-        "trans": [
-            "adj. 视觉的，视力的；栩栩如生的"
-        ],
-        "usphone": "[ˈvɪʒuəl]",
-        "ukphone": "[ˈvɪʒuəl]"
-    },
-    {
-        "name": "vital",
-        "trans": [
-            "adj. 至关重要的；生死攸关的；有活力的"
-        ],
-        "usphone": "[ˈvaɪtl]",
-        "ukphone": "[ˈvaɪt(ə)l]"
-    },
-    {
-        "name": "vitamin",
-        "trans": [
-            "n. [生化] 维生素；[生化] 维他命"
-        ],
-        "usphone": "[ˈvaɪtəmɪn]",
-        "ukphone": "[ˈvɪtəmɪn]"
-    },
-    {
-        "name": "volume",
-        "trans": [
-            "n. 量；体积；卷；音量；大量；册"
-        ],
-        "usphone": "[ˈvɑːljuːmˌˈvɑːljəm]",
-        "ukphone": "[ˈvɒljuːm]"
+        "usphone": "[ˈreskjuː]",
+        "ukphone": "[ˈreskjuː]"
     },
     {
         "name": "voluntary",
@@ -11064,300 +248,188 @@
         "ukphone": "[ˈvɒləntri]"
     },
     {
-        "name": "voting",
+        "name": "pause",
         "trans": [
-            "n. 投票；选举"
+            "n. 暂停；间歇"
         ],
-        "usphone": "[ˈvoʊtɪŋ]",
-        "ukphone": "[ˈvəʊtɪŋ]"
+        "usphone": "[pɔːz]",
+        "ukphone": "[pɔːz]"
     },
     {
-        "name": "wage",
+        "name": "mechanic",
         "trans": [
-            "n. 工资；代价；报偿"
+            "n. 技工，机修工"
         ],
-        "usphone": "[weɪdʒ]",
-        "ukphone": "[weɪdʒ]"
+        "usphone": "[məˈkænɪk]",
+        "ukphone": "[məˈkænɪk]"
     },
     {
-        "name": "wander",
+        "name": "restore",
         "trans": [
-            "vi. 徘徊；漫步；迷路；离题"
+            "vi. 恢复；还原"
         ],
-        "usphone": "[ˈwɑːndər]",
-        "ukphone": "[ˈwɒndə(r)]"
+        "usphone": "[rɪˈstɔːr]",
+        "ukphone": "[rɪˈstɔː(r)]"
     },
     {
-        "name": "warming",
+        "name": "opposed",
         "trans": [
-            "n. 加温，暖和；气温升高"
+            "adj. 相反的；敌对的"
         ],
-        "usphone": "[ˈwɔːrmɪŋ]",
-        "ukphone": "[ˈwɔːmɪŋ]"
+        "usphone": "[əˈpoʊzd]",
+        "ukphone": "[əˈpəʊzd]"
     },
     {
-        "name": "way",
+        "name": "perception",
         "trans": [
-            "n. 方法；道路；方向；行业；习惯"
+            "n. 知觉；[生理] 感觉；看法；洞察力；获取"
         ],
-        "usphone": "[weɪ]",
-        "ukphone": "[weɪ]"
+        "usphone": "[pərˈsepʃn]",
+        "ukphone": "[pəˈsepʃn]"
     },
     {
-        "name": "weakness",
+        "name": "miner",
         "trans": [
-            "n. 弱点；软弱；嗜好"
+            "n. 矿工；开矿机"
         ],
-        "usphone": "[ˈwiːknəs]",
-        "ukphone": "[ˈwiːknəs]"
+        "usphone": "[ˈmaɪnər]",
+        "ukphone": "[ˈmaɪnə(r)]"
     },
     {
-        "name": "wealth",
+        "name": "balanced",
         "trans": [
-            "n. 财富；大量；富有"
+            "adj. 平衡的；和谐的；安定的"
         ],
-        "usphone": "[welθ]",
-        "ukphone": "[welθ]"
+        "usphone": "[ˈbælənst]",
+        "ukphone": "[ˈbælənst]"
     },
     {
-        "name": "wealthy",
+        "name": "detail",
         "trans": [
-            "n. 富人"
+            "n. 细节，详情"
         ],
-        "usphone": "[ˈwelθi]",
-        "ukphone": "[ˈwelθi]"
+        "usphone": "[ˈdiːteɪlˌdɪˈteɪl]",
+        "ukphone": "[ˈdiːteɪl]"
     },
     {
-        "name": "weekly",
+        "name": "beside",
         "trans": [
-            "n. 周刊"
+            "prep. 在旁边；与…相比；和…无关"
         ],
-        "usphone": "[ˈwiːkli]",
-        "ukphone": "[ˈwiːkli]"
+        "usphone": "[bɪˈsaɪd]",
+        "ukphone": "[bɪˈsaɪd]"
     },
     {
-        "name": "weird",
+        "name": "accent",
         "trans": [
-            "n. （苏格兰）命运；预言"
+            "n. 口音；重音；强调；特点；重音符号"
         ],
-        "usphone": "[wɪrd]",
-        "ukphone": "[wɪəd]"
+        "usphone": "[ˈæksent]",
+        "ukphone": "[ˈæksent]"
     },
     {
-        "name": "welfare",
+        "name": "launch",
         "trans": [
-            "n. 福利；幸福；福利事业；安宁"
+            "vt. 发射（导弹、火箭等）；发起，发动；使…下水"
         ],
-        "usphone": "[ˈwelfer]",
-        "ukphone": "[ˈwelfeə(r)]"
+        "usphone": "[lɔːntʃ]",
+        "ukphone": "[lɔːntʃ]"
     },
     {
-        "name": "wheat",
+        "name": "comic",
         "trans": [
-            "n. 小麦；小麦色"
+            "n. 连环漫画；喜剧演员；滑稽人物"
         ],
-        "usphone": "[wiːt]",
-        "ukphone": "[wiːt]"
+        "usphone": "[ˈkɑːmɪk]",
+        "ukphone": "[ˈkɒmɪk]"
     },
     {
-        "name": "whereas",
+        "name": "convincing",
         "trans": [
-            "conj. 然而；鉴于；反之"
+            "v. 使相信；使明白（convince的现在分词）"
         ],
-        "usphone": "[ˌwerˈæz]",
-        "ukphone": "[ˌweərˈæz]"
+        "usphone": "[kənˈvɪnsɪŋ]",
+        "ukphone": "[kənˈvɪnsɪŋ]"
     },
     {
-        "name": "wherever",
+        "name": "make-up",
         "trans": [
-            "conj. 无论在哪里；无论什么情况下"
+            "n. 化妆品；（美）补考；性格；构造；排版"
         ],
-        "usphone": "[werˈevər]",
-        "ukphone": "[weərˈevə(r)]"
+        "usphone": "[ˈmeɪk ʌp]",
+        "ukphone": "[ˈmeɪk ʌp]"
     },
     {
-        "name": "whisper",
+        "name": "partnership",
         "trans": [
-            "n. 私语；谣传；飒飒的声音"
+            "n. 合伙；[经管] 合伙企业；合作关系；合伙契约"
         ],
-        "usphone": "[ˈwɪspər]",
-        "ukphone": "[ˈwɪspə(r)]"
+        "usphone": "[ˈpɑːrtnərʃɪp]",
+        "ukphone": "[ˈpɑːtnəʃɪp]"
     },
     {
-        "name": "whoever",
+        "name": "tonne",
         "trans": [
-            "pron. 无论谁；任何人"
+            "n. [计量] 公吨（1，000公斤，等于metric ton）"
         ],
-        "usphone": "[huːˈevər]",
-        "ukphone": "[huːˈevə(r)]"
+        "usphone": "[tʌn]",
+        "ukphone": "[tʌn]"
     },
     {
-        "name": "whom",
+        "name": "participant",
         "trans": [
-            "pron. 谁（who的宾格）"
+            "n. 参与者；关系者"
         ],
-        "usphone": "[huːm]",
-        "ukphone": "[huːm]"
+        "usphone": "[pɑːrˈtɪsɪpənt]",
+        "ukphone": "[pɑːˈtɪsɪpənt]"
     },
     {
-        "name": "widely",
+        "name": "certainty",
         "trans": [
-            "adv. 广泛地"
+            "n. 必然；确实；确实的事情"
         ],
-        "usphone": "[ˈwaɪdli]",
-        "ukphone": "[ˈwaɪdli]"
+        "usphone": "[ˈsɜːrtnti]",
+        "ukphone": "[ˈsɜːt(ə)nti]"
     },
     {
-        "name": "widespread",
+        "name": "bitter",
         "trans": [
-            "adj. 普遍的，广泛的；分布广的"
+            "n. 苦味；苦啤酒"
         ],
-        "usphone": "[ˈwaɪdspred]",
-        "ukphone": "[ˈwaɪdspred]"
+        "usphone": "[ˈbɪtər]",
+        "ukphone": "[ˈbɪtə(r)]"
     },
     {
-        "name": "wildlife",
+        "name": "interact",
         "trans": [
-            "n. 野生动植物"
+            "n. 幕间剧；幕间休息"
         ],
-        "usphone": "[ˈwaɪldlaɪf]",
-        "ukphone": "[ˈwaɪldlaɪf]"
+        "usphone": "[ˌɪntərˈækt]",
+        "ukphone": "[ˌɪntərˈækt]"
     },
     {
-        "name": "willing",
+        "name": "disability",
         "trans": [
-            "adj. 乐意的；自愿的；心甘情愿的"
+            "n. 残疾；无能；无资格；不利条件"
         ],
-        "usphone": "[ˈwɪlɪŋ]",
-        "ukphone": "[ˈwɪlɪŋ]"
+        "usphone": "[ˌdɪsəˈbɪləti]",
+        "ukphone": "[ˌdɪsəˈbɪləti]"
     },
     {
-        "name": "wind",
+        "name": "duration",
         "trans": [
-            "vi. 缠绕；上发条；吹响号角"
+            "n. 持续，持续的时间，期间"
         ],
-        "usphone": "[wɪnd]",
-        "ukphone": "[wɪnd]"
+        "usphone": "[duˈreɪʃn]",
+        "ukphone": "[djuˈreɪʃn]"
     },
     {
-        "name": "wire",
+        "name": "progress",
         "trans": [
-            "n. 电线；金属丝；电报"
+            "n. 进步，发展；前进"
         ],
-        "usphone": "[ˈwaɪər]",
-        "ukphone": "[ˈwaɪə(r)]"
-    },
-    {
-        "name": "wisdom",
-        "trans": [
-            "n. 智慧，才智；明智；学识；至理名言"
-        ],
-        "usphone": "[ˈwɪzdəm]",
-        "ukphone": "[ˈwɪzdəm]"
-    },
-    {
-        "name": "wise",
-        "trans": [
-            "adj. 明智的；聪明的；博学的"
-        ],
-        "usphone": "[waɪz]",
-        "ukphone": "[waɪz]"
-    },
-    {
-        "name": "withdraw",
-        "trans": [
-            "vt. 撤退；收回；撤消；拉开"
-        ],
-        "usphone": "[wɪðˈdrɔː]",
-        "ukphone": "[wɪðˈdrɔː; wɪθˈdrɔː]"
-    },
-    {
-        "name": "witness",
-        "trans": [
-            "n. 证人；目击者；证据"
-        ],
-        "usphone": "[ˈwɪtnəs]",
-        "ukphone": "[ˈwɪtnəs]"
-    },
-    {
-        "name": "workforce",
-        "trans": [
-            "n. 劳动力；工人总数，职工总数"
-        ],
-        "usphone": "[ˈwɜːrkfɔːrs]",
-        "ukphone": "[ˈwɜːkfɔːs]"
-    },
-    {
-        "name": "workplace",
-        "trans": [
-            "n. 工作场所；车间"
-        ],
-        "usphone": "[ˈwɜːrkpleɪs]",
-        "ukphone": "[ˈwɜːkpleɪs]"
-    },
-    {
-        "name": "workshop",
-        "trans": [
-            "n. 车间；研讨会；工场；讲习班"
-        ],
-        "usphone": "[ˈwɜːrkʃɑːp]",
-        "ukphone": "[ˈwɜːkʃɒp]"
-    },
-    {
-        "name": "worm",
-        "trans": [
-            "n. 虫，蠕虫；蜗杆；螺纹；小人物"
-        ],
-        "usphone": "[wɜːrm]",
-        "ukphone": "[wɜːm]"
-    },
-    {
-        "name": "worse",
-        "trans": [
-            "n. 更坏的事；更恶劣的事"
-        ],
-        "usphone": "[wɜːrs]",
-        "ukphone": "[wɜːs]"
-    },
-    {
-        "name": "worst",
-        "trans": [
-            "n. 最坏；最坏的时候"
-        ],
-        "usphone": "[wɜːrst]",
-        "ukphone": "[wɜːst]"
-    },
-    {
-        "name": "worth",
-        "trans": [
-            "n. 价值；财产"
-        ],
-        "usphone": "[wɜːrθ]",
-        "ukphone": "[wɜːθ]"
-    },
-    {
-        "name": "wound",
-        "trans": [
-            "n. 创伤，伤口"
-        ],
-        "usphone": "[wuːnd]",
-        "ukphone": "[wuːnd]"
-    },
-    {
-        "name": "wrap",
-        "trans": [
-            "n. 外套；围巾"
-        ],
-        "usphone": "[ræp]",
-        "ukphone": "[ræp]"
-    },
-    {
-        "name": "wrist",
-        "trans": [
-            "n. 手腕；腕关节"
-        ],
-        "usphone": "[rɪst]",
-        "ukphone": "[rɪst]"
+        "usphone": "[ˈprɑːɡres; ˈprɑːɡrəs]",
+        "ukphone": "[ˈprəʊɡres]"
     },
     {
         "name": "wrong",
@@ -11368,6 +440,5678 @@
         "ukphone": "[rɒŋ]"
     },
     {
+        "name": "desperate",
+        "trans": [
+            "adj. 不顾一切的；令人绝望的；极度渴望的"
+        ],
+        "usphone": "[ˈdespərət]",
+        "ukphone": "[ˈdespərət]"
+    },
+    {
+        "name": "via",
+        "trans": [
+            "prep. 渠道，通过；经由"
+        ],
+        "usphone": "[ˈvaɪə; ˈviːə]",
+        "ukphone": "[ˈvaɪə]"
+    },
+    {
+        "name": "heal",
+        "trans": [
+            "vt. 治愈，痊愈；和解"
+        ],
+        "usphone": "[hiːl]",
+        "ukphone": "[hiːl]"
+    },
+    {
+        "name": "prospect",
+        "trans": [
+            "n. 前途；预期；景色"
+        ],
+        "usphone": "[ˈprɑːspekt]",
+        "ukphone": "[ˈprɒspekt]"
+    },
+    {
+        "name": "phase",
+        "trans": [
+            "n. 月相"
+        ],
+        "usphone": "[feɪz]",
+        "ukphone": "[feɪz]"
+    },
+    {
+        "name": "clarify",
+        "trans": [
+            "vt. 澄清；阐明"
+        ],
+        "usphone": "[ˈklærəfaɪ]",
+        "ukphone": "[ˈklærəfaɪ]"
+    },
+    {
+        "name": "object",
+        "trans": [
+            "n. 目标；物体；客体；宾语"
+        ],
+        "usphone": "[ˈɑːbdʒɪkt; əbˈdʒekt]",
+        "ukphone": "[ˈɒbdʒɪkt; əbˈdʒekt]"
+    },
+    {
+        "name": "super",
+        "trans": [
+            "n. 特级品，特大号；临时雇员"
+        ],
+        "usphone": "[ˈsuːpər]",
+        "ukphone": "[ˈsuːpə(r)]"
+    },
+    {
+        "name": "awkward",
+        "trans": [
+            "adj. 尴尬的；笨拙的；棘手的；不合适的"
+        ],
+        "usphone": "[ˈɔːkwərd]",
+        "ukphone": "[ˈɔːkwəd]"
+    },
+    {
+        "name": "impose",
+        "trans": [
+            "vt. 强加；征税；以…欺骗"
+        ],
+        "usphone": "[ɪmˈpoʊz]",
+        "ukphone": "[ɪmˈpəʊz]"
+    },
+    {
+        "name": "insurance",
+        "trans": [
+            "n. 保险；保险费；保险契约；赔偿金"
+        ],
+        "usphone": "[ɪnˈʃʊrəns]",
+        "ukphone": "[ɪnˈʃʊərəns]"
+    },
+    {
+        "name": "defeat",
+        "trans": [
+            "n. 失败的事实；击败的行为"
+        ],
+        "usphone": "[dɪˈfiːt]",
+        "ukphone": "[dɪˈfiːt]"
+    },
+    {
+        "name": "subsequently",
+        "trans": [
+            "adv. 随后，其后；后来"
+        ],
+        "usphone": "[ˈsʌbsɪkwəntli]",
+        "ukphone": "[ˈsʌbsɪkwəntli]"
+    },
+    {
+        "name": "curriculum",
+        "trans": [
+            "n. 课程"
+        ],
+        "usphone": "[kəˈrɪkjələm]",
+        "ukphone": "[kəˈrɪkjələm]"
+    },
+    {
+        "name": "purely",
+        "trans": [
+            "adv. 纯粹地；仅仅，只不过；完全地；贞淑地；清洁地"
+        ],
+        "usphone": "[ˈpjʊrli]",
+        "ukphone": "[ˈpjʊəli]"
+    },
+    {
+        "name": "raw",
+        "trans": [
+            "n. 擦伤处"
+        ],
+        "usphone": "[rɔː]",
+        "ukphone": "[rɔː]"
+    },
+    {
+        "name": "shift",
+        "trans": [
+            "n. 移动；变化；手段；轮班"
+        ],
+        "usphone": "[ʃɪft]",
+        "ukphone": "[ʃɪft]"
+    },
+    {
+        "name": "publicity",
+        "trans": [
+            "n. 宣传，宣扬；公开；广告；注意"
+        ],
+        "usphone": "[pʌbˈlɪsəti]",
+        "ukphone": "[pʌbˈlɪsəti]"
+    },
+    {
+        "name": "trigger",
+        "trans": [
+            "n. 扳机；[电子] 触发器；制滑机"
+        ],
+        "usphone": "[ˈtrɪɡər]",
+        "ukphone": "[ˈtrɪɡə(r)]"
+    },
+    {
+        "name": "terror",
+        "trans": [
+            "n. 恐怖；恐怖行动；恐怖时期；可怕的人"
+        ],
+        "usphone": "[ˈterər]",
+        "ukphone": "[ˈterə(r)]"
+    },
+    {
+        "name": "mysterious",
+        "trans": [
+            "adj. 神秘的；不可思议的；难解的"
+        ],
+        "usphone": "[mɪˈstɪriəs]",
+        "ukphone": "[mɪˈstɪəriəs]"
+    },
+    {
+        "name": "motivation",
+        "trans": [
+            "n. 动机；积极性；推动"
+        ],
+        "usphone": "[ˌmoʊtɪˈveɪʃn]",
+        "ukphone": "[ˌməʊtɪˈveɪʃn]"
+    },
+    {
+        "name": "stable",
+        "trans": [
+            "n. 马厩；牛棚"
+        ],
+        "usphone": "[ˈsteɪbl]",
+        "ukphone": "[ˈsteɪb(ə)l]"
+    },
+    {
+        "name": "fundamentally",
+        "trans": [
+            "adv. 根本地，从根本上；基础地"
+        ],
+        "usphone": "[ˌfʌndəˈmentəli]",
+        "ukphone": "[ˌfʌndəˈmentəli]"
+    },
+    {
+        "name": "routine",
+        "trans": [
+            "n. [计] 程序；日常工作；例行公事"
+        ],
+        "usphone": "[ruːˈtiːn]",
+        "ukphone": "[ruːˈtiːn]"
+    },
+    {
+        "name": "charming",
+        "trans": [
+            "adj. 迷人的；可爱的"
+        ],
+        "usphone": "[ˈtʃɑːrmɪŋ]",
+        "ukphone": "[ˈtʃɑːmɪŋ]"
+    },
+    {
+        "name": "expertise",
+        "trans": [
+            "n. 专门知识；专门技术；专家的意见"
+        ],
+        "usphone": "[ˌekspɜːrˈtiːz]",
+        "ukphone": "[ˌekspɜːˈtiːz]"
+    },
+    {
+        "name": "publishing",
+        "trans": [
+            "n. 出版；出版业"
+        ],
+        "usphone": "[ˈpʌblɪʃɪŋ]",
+        "ukphone": "[ˈpʌblɪʃɪŋ]"
+    },
+    {
+        "name": "appropriate",
+        "trans": [
+            "adj. 适当的；恰当的；合适的"
+        ],
+        "usphone": "[əˈproʊpriət; əˈproʊprieɪt]",
+        "ukphone": "[əˈprəʊpriət]"
+    },
+    {
+        "name": "empire",
+        "trans": [
+            "n. 帝国；帝王统治，君权"
+        ],
+        "usphone": "[ˈempaɪər]",
+        "ukphone": "[ˈempaɪə(r)]"
+    },
+    {
+        "name": "rate",
+        "trans": [
+            "n. 比率，率；速度；价格；等级"
+        ],
+        "usphone": "[reɪt]",
+        "ukphone": "[reɪt]"
+    },
+    {
+        "name": "mosque",
+        "trans": [
+            "n. 清真寺"
+        ],
+        "usphone": "[mɑːsk]",
+        "ukphone": "[mɒsk]"
+    },
+    {
+        "name": "predictable",
+        "trans": [
+            "adj. 可预言的"
+        ],
+        "usphone": "[prɪˈdɪktəbl]",
+        "ukphone": "[prɪˈdɪktəbl]"
+    },
+    {
+        "name": "nearby",
+        "trans": [
+            "adj. 附近的，邻近的"
+        ],
+        "usphone": "[ˌnɪrˈbaɪ]",
+        "ukphone": "[ˌnɪəˈbaɪ]"
+    },
+    {
+        "name": "drought",
+        "trans": [
+            "n. 干旱；缺乏"
+        ],
+        "usphone": "[draʊt]",
+        "ukphone": "[draʊt]"
+    },
+    {
+        "name": "solar",
+        "trans": [
+            "n. 日光浴室"
+        ],
+        "usphone": "[ˈsoʊlər]",
+        "ukphone": "[ˈsəʊlə(r)]"
+    },
+    {
+        "name": "canal",
+        "trans": [
+            "n. 运河；[地理] 水道；[建] 管道；灌溉水渠"
+        ],
+        "usphone": "[kəˈnæl]",
+        "ukphone": "[kəˈnæl]"
+    },
+    {
+        "name": "thesis",
+        "trans": [
+            "n. 论文；论点"
+        ],
+        "usphone": "[ˈθiːsɪs]",
+        "ukphone": "[ˈθiːsɪs]"
+    },
+    {
+        "name": "worm",
+        "trans": [
+            "n. 虫，蠕虫；蜗杆；螺纹；小人物"
+        ],
+        "usphone": "[wɜːrm]",
+        "ukphone": "[wɜːm]"
+    },
+    {
+        "name": "championship",
+        "trans": [
+            "n. 锦标赛；冠军称号；冠军的地位"
+        ],
+        "usphone": "[ˈtʃæmpiənʃɪp]",
+        "ukphone": "[ˈtʃæmpiənʃɪp]"
+    },
+    {
+        "name": "intended",
+        "trans": [
+            "n. 已订婚者"
+        ],
+        "usphone": "[ɪnˈtendɪd]",
+        "ukphone": "[ɪnˈtendɪd]"
+    },
+    {
+        "name": "activate",
+        "trans": [
+            "vt. 刺激；使活动；使活泼；使产生放射性"
+        ],
+        "usphone": "[ˈæktɪveɪt]",
+        "ukphone": "[ˈæktɪveɪt]"
+    },
+    {
+        "name": "troop",
+        "trans": [
+            "vt. 把（骑兵）编成骑兵连"
+        ],
+        "usphone": "[truːp]",
+        "ukphone": "[truːp]"
+    },
+    {
+        "name": "depressing",
+        "trans": [
+            "adj. 压抑的；使人沮丧的"
+        ],
+        "usphone": "[dɪˈpresɪŋ]",
+        "ukphone": "[dɪˈpresɪŋ]"
+    },
+    {
+        "name": "loose",
+        "trans": [
+            "adj. 宽松的；散漫的；不牢固的；不精确的"
+        ],
+        "usphone": "[luːs]",
+        "ukphone": "[luːs]"
+    },
+    {
+        "name": "gene",
+        "trans": [
+            "n. [遗] 基因，遗传因子"
+        ],
+        "usphone": "[dʒiːn]",
+        "ukphone": "[dʒiːn]"
+    },
+    {
+        "name": "tragedy",
+        "trans": [
+            "n. 悲剧；灾难；惨案"
+        ],
+        "usphone": "[ˈtrædʒədi]",
+        "ukphone": "[ˈtrædʒədi]"
+    },
+    {
+        "name": "initiative",
+        "trans": [
+            "n. 主动权；首创精神"
+        ],
+        "usphone": "[ɪˈnɪʃətɪv]",
+        "ukphone": "[ɪˈnɪʃətɪv]"
+    },
+    {
+        "name": "mount",
+        "trans": [
+            "vt. 增加；爬上；使骑上马；安装，架置；镶嵌，嵌入；准备上演；成立（军队等）"
+        ],
+        "usphone": "[maʊnt]",
+        "ukphone": "[maʊnt]"
+    },
+    {
+        "name": "steep",
+        "trans": [
+            "n. 峭壁；浸渍"
+        ],
+        "usphone": "[stiːp]",
+        "ukphone": "[stiːp]"
+    },
+    {
+        "name": "ID",
+        "trans": [
+            "身份证件"
+        ],
+        "usphone": "[ˌaɪ ˈdiː]",
+        "ukphone": "[ˌaɪ ˈdiː]"
+    },
+    {
+        "name": "long-term",
+        "trans": [
+            "adj. 长期的"
+        ],
+        "usphone": "[ˌlɔːŋ ˈtɜːrm]",
+        "ukphone": "[ˌlɒŋ ˈtɜːm]"
+    },
+    {
+        "name": "input",
+        "trans": [
+            "n. 投入；输入电路"
+        ],
+        "usphone": "[ˈɪnpʊt]",
+        "ukphone": "[ˈɪnpʊt]"
+    },
+    {
+        "name": "detect",
+        "trans": [
+            "vt. 察觉；发现；探测"
+        ],
+        "usphone": "[dɪˈtekt]",
+        "ukphone": "[dɪˈtekt]"
+    },
+    {
+        "name": "gig",
+        "trans": [
+            "n. 旋转物；鱼叉；轻便双轮马车；现场演出；临时工作"
+        ],
+        "usphone": "[ɡɪɡ]",
+        "ukphone": "[ɡɪɡ]"
+    },
+    {
+        "name": "transfer",
+        "trans": [
+            "n. 转让；转移；传递；过户"
+        ],
+        "usphone": "[trænsˈfɜːr]",
+        "ukphone": "[trænsˈfɜː(r)]"
+    },
+    {
+        "name": "firefighter",
+        "trans": [
+            "n. 消防队员"
+        ],
+        "usphone": "[ˈfaɪərfaɪtər]",
+        "ukphone": "[ˈfaɪəfaɪtə(r)]"
+    },
+    {
+        "name": "globe",
+        "trans": [
+            "n. 地球；地球仪；球体"
+        ],
+        "usphone": "[ɡloʊb]",
+        "ukphone": "[ɡləʊb]"
+    },
+    {
+        "name": "govern",
+        "trans": [
+            "vt. 管理；支配；统治；控制"
+        ],
+        "usphone": "[ˈɡʌvərn]",
+        "ukphone": "[ˈɡʌv(ə)n]"
+    },
+    {
+        "name": "root",
+        "trans": [
+            "n. 根；根源；词根；祖先"
+        ],
+        "usphone": "[ruːt]",
+        "ukphone": "[ruːt]"
+    },
+    {
+        "name": "swear",
+        "trans": [
+            "n. 宣誓；诅咒"
+        ],
+        "usphone": "[swer]",
+        "ukphone": "[sweə(r)]"
+    },
+    {
+        "name": "pure",
+        "trans": [
+            "adj. 纯的；纯粹的；纯洁的；清白的；纯理论的"
+        ],
+        "usphone": "[pjʊr]",
+        "ukphone": "[pjʊə(r)]"
+    },
+    {
+        "name": "freedom",
+        "trans": [
+            "n. 自由，自主；直率"
+        ],
+        "usphone": "[ˈfriːdəm]",
+        "ukphone": "[ˈfriːdəm]"
+    },
+    {
+        "name": "elementary",
+        "trans": [
+            "adj. 基本的；初级的；[化学] 元素的"
+        ],
+        "usphone": "[ˌelɪˈmentri]",
+        "ukphone": "[ˌelɪˈmentri]"
+    },
+    {
+        "name": "hollow",
+        "trans": [
+            "n. 洞；山谷；窟窿"
+        ],
+        "usphone": "[ˈhɑːloʊ]",
+        "ukphone": "[ˈhɒləʊ]"
+    },
+    {
+        "name": "flavour",
+        "trans": [
+            "n. 香味；滋味"
+        ],
+        "usphone": "[ˈfleɪvər]",
+        "ukphone": "[ˈfleɪvə(r)]"
+    },
+    {
+        "name": "willing",
+        "trans": [
+            "adj. 乐意的；自愿的；心甘情愿的"
+        ],
+        "usphone": "[ˈwɪlɪŋ]",
+        "ukphone": "[ˈwɪlɪŋ]"
+    },
+    {
+        "name": "proceed",
+        "trans": [
+            "vi. 开始；继续进行；发生；行进"
+        ],
+        "usphone": "[proʊˈsiːd]",
+        "ukphone": "[prəˈsiːd]"
+    },
+    {
+        "name": "emission",
+        "trans": [
+            "n. （光、热等的）发射，散发；喷射；发行"
+        ],
+        "usphone": "[ɪˈmɪʃn]",
+        "ukphone": "[ɪˈmɪʃ(ə)n]"
+    },
+    {
+        "name": "monument",
+        "trans": [
+            "n. 纪念碑；历史遗迹；不朽的作品"
+        ],
+        "usphone": "[ˈmɑːnjumənt]",
+        "ukphone": "[ˈmɒnjumənt]"
+    },
+    {
+        "name": "rush",
+        "trans": [
+            "n. 冲进；匆促；急流；灯心草"
+        ],
+        "usphone": "[rʌʃ]",
+        "ukphone": "[rʌʃ]"
+    },
+    {
+        "name": "specialist",
+        "trans": [
+            "n. 专家；专门医师"
+        ],
+        "usphone": "[ˈspeʃəlɪst]",
+        "ukphone": "[ˈspeʃəlɪst]"
+    },
+    {
+        "name": "publication",
+        "trans": [
+            "n. 出版；出版物；发表"
+        ],
+        "usphone": "[ˌpʌblɪˈkeɪʃn]",
+        "ukphone": "[ˌpʌblɪˈkeɪʃn]"
+    },
+    {
+        "name": "inherit",
+        "trans": [
+            "vt. 继承；遗传而得"
+        ],
+        "usphone": "[ɪnˈherɪt]",
+        "ukphone": "[ɪnˈherɪt]"
+    },
+    {
+        "name": "recession",
+        "trans": [
+            "n. 衰退；不景气；后退；凹处"
+        ],
+        "usphone": "[rɪˈseʃn]",
+        "ukphone": "[rɪˈseʃn]"
+    },
+    {
+        "name": "install",
+        "trans": [
+            "vt. 安装；任命；安顿"
+        ],
+        "usphone": "[ɪnˈstɔːl]",
+        "ukphone": "[ɪnˈstɔːl]"
+    },
+    {
+        "name": "robbery",
+        "trans": [
+            "n. 抢劫，盗窃；抢掠"
+        ],
+        "usphone": "[ˈrɑːbəri]",
+        "ukphone": "[ˈrɒbəri]"
+    },
+    {
+        "name": "venue",
+        "trans": [
+            "n. 审判地；犯罪地点；发生地点；集合地点"
+        ],
+        "usphone": "[ˈvenjuː]",
+        "ukphone": "[ˈvenjuː]"
+    },
+    {
+        "name": "forecast",
+        "trans": [
+            "n. 预测，预报；预想"
+        ],
+        "usphone": "[ˈfɔːrkæst]",
+        "ukphone": "[ˈfɔːkɑːst]"
+    },
+    {
+        "name": "failed",
+        "trans": [
+            "v. 失败，不成功（fail的过去式和过去分词）"
+        ],
+        "usphone": "[feɪld]",
+        "ukphone": "[feɪld]"
+    },
+    {
+        "name": "conservative",
+        "trans": [
+            "n. 保守派，守旧者"
+        ],
+        "usphone": "[kənˈsɜːrvətɪv]",
+        "ukphone": "[kənˈsɜːvətɪv]"
+    },
+    {
+        "name": "realistic",
+        "trans": [
+            "adj. 现实的；现实主义的；逼真的；实在论的"
+        ],
+        "usphone": "[ˌriːəˈlɪstɪk]",
+        "ukphone": "[ˌriːəˈlɪstɪk]"
+    },
+    {
+        "name": "wrist",
+        "trans": [
+            "n. 手腕；腕关节"
+        ],
+        "usphone": "[rɪst]",
+        "ukphone": "[rɪst]"
+    },
+    {
+        "name": "interaction",
+        "trans": [
+            "n. 相互作用；[数] 交互作用"
+        ],
+        "usphone": "[ˌɪntərˈækʃn]",
+        "ukphone": "[ˌɪntərˈækʃ(ə)n]"
+    },
+    {
+        "name": "crash",
+        "trans": [
+            "n. 撞碎；坠毁；破产；轰隆声；睡觉"
+        ],
+        "usphone": "[kræʃ]",
+        "ukphone": "[kræʃ]"
+    },
+    {
+        "name": "impatient",
+        "trans": [
+            "adj. 焦躁的；不耐心的"
+        ],
+        "usphone": "[ɪmˈpeɪʃnt]",
+        "ukphone": "[ɪmˈpeɪʃ(ə)nt]"
+    },
+    {
+        "name": "senior",
+        "trans": [
+            "n. 上司；较年长者；毕业班学生"
+        ],
+        "usphone": "[ˈsiːniər]",
+        "ukphone": "[ˈsiːniə(r)]"
+    },
+    {
+        "name": "rail",
+        "trans": [
+            "n. 铁轨；扶手；横杆；围栏"
+        ],
+        "usphone": "[reɪl]",
+        "ukphone": "[reɪl]"
+    },
+    {
+        "name": "catch",
+        "trans": [
+            "n. 捕捉；捕获物；窗钩"
+        ],
+        "usphone": "[kætʃ]",
+        "ukphone": "[kætʃ]"
+    },
+    {
+        "name": "barrier",
+        "trans": [
+            "n. 障碍物，屏障；界线"
+        ],
+        "usphone": "[ˈbæriər]",
+        "ukphone": "[ˈbæriə(r)]"
+    },
+    {
+        "name": "controversy",
+        "trans": [
+            "n. 争论；论战；辩论"
+        ],
+        "usphone": "[ˈkɑːntrəvɜːrsi]",
+        "ukphone": "[ˈkɒntrəvɜːsi]"
+    },
+    {
+        "name": "imply",
+        "trans": [
+            "vt. 意味；暗示；隐含"
+        ],
+        "usphone": "[ɪmˈplaɪ]",
+        "ukphone": "[ɪmˈplaɪ]"
+    },
+    {
+        "name": "ownership",
+        "trans": [
+            "n. 所有权；物主身份"
+        ],
+        "usphone": "[ˈoʊnərʃɪp]",
+        "ukphone": "[ˈəʊnəʃɪp]"
+    },
+    {
+        "name": "organic",
+        "trans": [
+            "adj. [有化] 有机的；组织的；器官的；根本的"
+        ],
+        "usphone": "[ɔːrˈɡænɪk]",
+        "ukphone": "[ɔːˈɡænɪk]"
+    },
+    {
+        "name": "harbour",
+        "trans": [
+            "n. 海港（等于harbor）；避难所"
+        ],
+        "usphone": "[ˈhɑːrbər]",
+        "ukphone": "[ˈhɑːbə(r)]"
+    },
+    {
+        "name": "organ",
+        "trans": [
+            "n. [生物] 器官；机构；风琴；管风琴；嗓音"
+        ],
+        "usphone": "[ˈɔːrɡən]",
+        "ukphone": "[ˈɔːɡən]"
+    },
+    {
+        "name": "neutral",
+        "trans": [
+            "adj. 中立的，中性的；中立国的；非彩色的"
+        ],
+        "usphone": "[ˈnuːtrəl]",
+        "ukphone": "[ˈnjuːtrəl]"
+    },
+    {
+        "name": "pile",
+        "trans": [
+            "n. 堆；大量；建筑群"
+        ],
+        "usphone": "[paɪl]",
+        "ukphone": "[paɪl]"
+    },
+    {
+        "name": "split",
+        "trans": [
+            "n. 劈开；裂缝"
+        ],
+        "usphone": "[splɪt]",
+        "ukphone": "[splɪt]"
+    },
+    {
+        "name": "monthly",
+        "trans": [
+            "adj. 每月的，每月一次的；有效期为一个月的"
+        ],
+        "usphone": "[ˈmʌnθli]",
+        "ukphone": "[ˈmʌnθli]"
+    },
+    {
+        "name": "stuff",
+        "trans": [
+            "n. 东西；材料；填充物；素材资料"
+        ],
+        "usphone": "[stʌf]",
+        "ukphone": "[stʌf]"
+    },
+    {
+        "name": "lean",
+        "trans": [
+            "vi. 倾斜；倚靠；倾向；依赖"
+        ],
+        "usphone": "[liːn]",
+        "ukphone": "[liːn]"
+    },
+    {
+        "name": "title",
+        "trans": [
+            "n. 冠军；标题；头衔；权利；字幕"
+        ],
+        "usphone": "[ˈtaɪt(ə)l]",
+        "ukphone": "[ˈtaɪt(ə)l]"
+    },
+    {
+        "name": "scholarship",
+        "trans": [
+            "n. 奖学金；学识，学问"
+        ],
+        "usphone": "[ˈskɑːlərʃɪp]",
+        "ukphone": "[ˈskɒləʃɪp]"
+    },
+    {
+        "name": "threat",
+        "trans": [
+            "n. 威胁，恐吓；凶兆"
+        ],
+        "usphone": "[θret]",
+        "ukphone": "[θret]"
+    },
+    {
+        "name": "adapt",
+        "trans": [
+            "vi. 适应"
+        ],
+        "usphone": "[əˈdæpt]",
+        "ukphone": "[əˈdæpt]"
+    },
+    {
+        "name": "means",
+        "trans": [
+            "n. 手段；方法；财产"
+        ],
+        "usphone": "[miːnz]",
+        "ukphone": "[miːnz]"
+    },
+    {
+        "name": "completion",
+        "trans": [
+            "n. 完成，结束；实现"
+        ],
+        "usphone": "[kəmˈpliːʃn]",
+        "ukphone": "[kəmˈpliːʃn]"
+    },
+    {
+        "name": "sufficient",
+        "trans": [
+            "adj. 足够的；充分的"
+        ],
+        "usphone": "[səˈfɪʃnt]",
+        "ukphone": "[səˈfɪʃ(ə)nt]"
+    },
+    {
+        "name": "shape",
+        "trans": [
+            "n. 形状；模型；身材；具体化"
+        ],
+        "usphone": "[ʃeɪp]",
+        "ukphone": "[ʃeɪp]"
+    },
+    {
+        "name": "freely",
+        "trans": [
+            "adv. 自由地；免费地；大量地；慷慨地；直率地"
+        ],
+        "usphone": "[ˈfriːli]",
+        "ukphone": "[ˈfriːli]"
+    },
+    {
+        "name": "opposition",
+        "trans": [
+            "n. 反对；反对派；在野党；敌对"
+        ],
+        "usphone": "[ˌɑːpəˈzɪʃ(ə)n]",
+        "ukphone": "[ˌɒpəˈzɪʃn]"
+    },
+    {
+        "name": "committee",
+        "trans": [
+            "n. 委员会"
+        ],
+        "usphone": "[kəˈmɪti]",
+        "ukphone": "[kəˈmɪti]"
+    },
+    {
+        "name": "expose",
+        "trans": [
+            "vt. 揭露，揭发；使曝光；显示"
+        ],
+        "usphone": "[ɪkˈspoʊz]",
+        "ukphone": "[ɪkˈspəʊz]"
+    },
+    {
+        "name": "asset",
+        "trans": [
+            "n. 资产；优点；有用的东西；有利条件；财产；有价值的人或物"
+        ],
+        "usphone": "[ˈæset]",
+        "ukphone": "[ˈæset]"
+    },
+    {
+        "name": "status",
+        "trans": [
+            "n. 地位；状态；情形；重要身份"
+        ],
+        "usphone": "[ˈsteɪtəs; ˈstætəs]",
+        "ukphone": "[ˈsteɪtəs]"
+    },
+    {
+        "name": "fond",
+        "trans": [
+            "adj. 喜欢的；温柔的；宠爱的"
+        ],
+        "usphone": "[fɑːnd]",
+        "ukphone": "[fɒnd]"
+    },
+    {
+        "name": "miserable",
+        "trans": [
+            "adj. 悲惨的；痛苦的；卑鄙的"
+        ],
+        "usphone": "[ˈmɪzrəbl]",
+        "ukphone": "[ˈmɪzrəbl]"
+    },
+    {
+        "name": "otherwise",
+        "trans": [
+            "adv. 否则；另外；在其他方面"
+        ],
+        "usphone": "[ˈʌðərwaɪz]",
+        "ukphone": "[ˈʌðəwaɪz]"
+    },
+    {
+        "name": "dig",
+        "trans": [
+            "n. 戳，刺；挖苦"
+        ],
+        "usphone": "[dɪɡ]",
+        "ukphone": "[dɪɡ]"
+    },
+    {
+        "name": "trust",
+        "trans": [
+            "n. 信任，信赖；责任；托拉斯"
+        ],
+        "usphone": "[trʌst]",
+        "ukphone": "[trʌst]"
+    },
+    {
+        "name": "wisdom",
+        "trans": [
+            "n. 智慧，才智；明智；学识；至理名言"
+        ],
+        "usphone": "[ˈwɪzdəm]",
+        "ukphone": "[ˈwɪzdəm]"
+    },
+    {
+        "name": "ink",
+        "trans": [
+            "n. 墨水，墨汁；油墨"
+        ],
+        "usphone": "[ɪŋk]",
+        "ukphone": "[ɪŋk]"
+    },
+    {
+        "name": "league",
+        "trans": [
+            "n. 联盟；社团；范畴"
+        ],
+        "usphone": "[liːɡ]",
+        "ukphone": "[liːɡ]"
+    },
+    {
+        "name": "terrify",
+        "trans": [
+            "vt. 恐吓；使恐怖；使害怕"
+        ],
+        "usphone": "[ˈterɪfaɪ]",
+        "ukphone": "[ˈterɪfaɪ]"
+    },
+    {
+        "name": "basement",
+        "trans": [
+            "n. 地下室；地窖"
+        ],
+        "usphone": "[ˈbeɪsmənt]",
+        "ukphone": "[ˈbeɪsmənt]"
+    },
+    {
+        "name": "fortune",
+        "trans": [
+            "n. 财富；命运；运气"
+        ],
+        "usphone": "[ˈfɔːrtʃən]",
+        "ukphone": "[ˈfɔːtʃuːn]"
+    },
+    {
+        "name": "internal",
+        "trans": [
+            "n. 内脏；本质"
+        ],
+        "usphone": "[ɪnˈtɜːrn(ə)l]",
+        "ukphone": "[ɪnˈtɜːn(ə)l]"
+    },
+    {
+        "name": "envelope",
+        "trans": [
+            "n. 信封，封皮；包膜；[天] 包层；包迹"
+        ],
+        "usphone": "[ˈenvəloʊp; ˈɑːnvəloʊp]",
+        "ukphone": "[ˈenvələʊp]"
+    },
+    {
+        "name": "lighting",
+        "trans": [
+            "n. 照明设备，舞台灯光"
+        ],
+        "usphone": "[ˈlaɪtɪŋ]",
+        "ukphone": "[ˈlaɪtɪŋ]"
+    },
+    {
+        "name": "entertaining",
+        "trans": [
+            "v. 款待（entertain的ing形式）"
+        ],
+        "usphone": "[ˌentərˈteɪnɪŋ]",
+        "ukphone": "[ˌentəˈteɪnɪŋ]"
+    },
+    {
+        "name": "necessity",
+        "trans": [
+            "n. 需要；必然性；必需品"
+        ],
+        "usphone": "[nəˈsesəti]",
+        "ukphone": "[nəˈsesəti]"
+    },
+    {
+        "name": "withdraw",
+        "trans": [
+            "vt. 撤退；收回；撤消；拉开"
+        ],
+        "usphone": "[wɪðˈdrɔː]",
+        "ukphone": "[wɪðˈdrɔː; wɪθˈdrɔː]"
+    },
+    {
+        "name": "nerve",
+        "trans": [
+            "n. 神经；勇气；[植] 叶脉"
+        ],
+        "usphone": "[nɜːrv]",
+        "ukphone": "[nɜːv]"
+    },
+    {
+        "name": "accountant",
+        "trans": [
+            "n. 会计师；会计人员"
+        ],
+        "usphone": "[əˈkaʊntənt]",
+        "ukphone": "[əˈkaʊntənt]"
+    },
+    {
+        "name": "blanket",
+        "trans": [
+            "n. 毛毯，毯子；毯状物，覆盖层"
+        ],
+        "usphone": "[ˈblæŋkɪt]",
+        "ukphone": "[ˈblæŋkɪt]"
+    },
+    {
+        "name": "sentence",
+        "trans": [
+            "n. [语][计] 句子，命题；宣判，判决"
+        ],
+        "usphone": "[ˈsentəns]",
+        "ukphone": "[ˈsentəns]"
+    },
+    {
+        "name": "short-term",
+        "trans": [
+            "adj. 短期的"
+        ],
+        "usphone": "[ˌʃɔːrt ˈtɜːrm]",
+        "ukphone": "[ˌʃɔːt ˈtɜːm]"
+    },
+    {
+        "name": "colourful",
+        "trans": [
+            "adj. 鲜艳的；生动的；色彩丰富的；富有趣味的"
+        ],
+        "usphone": "[ˈkʌlərfl]",
+        "ukphone": "[ˈkʌləf(ə)l]"
+    },
+    {
+        "name": "temporary",
+        "trans": [
+            "n. 临时工，临时雇员"
+        ],
+        "usphone": "[ˈtempəreri]",
+        "ukphone": "[ˈtemprəri]"
+    },
+    {
+        "name": "regulate",
+        "trans": [
+            "vt. 调节，规定；控制；校准；有系统的管理"
+        ],
+        "usphone": "[ˈreɡjuleɪt]",
+        "ukphone": "[ˈreɡjuleɪt]"
+    },
+    {
+        "name": "amusing",
+        "trans": [
+            "adj. 有趣的，好玩的；引人发笑的"
+        ],
+        "usphone": "[əˈmjuːzɪŋ]",
+        "ukphone": "[əˈmjuːzɪŋ]"
+    },
+    {
+        "name": "exhibit",
+        "trans": [
+            "n. 展览品；证据；展示会"
+        ],
+        "usphone": "[ɪɡˈzɪbɪt]",
+        "ukphone": "[ɪɡˈzɪbɪt]"
+    },
+    {
+        "name": "scenario",
+        "trans": [
+            "n. 方案；情节；剧本；设想"
+        ],
+        "usphone": "[səˈnærioʊ]",
+        "ukphone": "[səˈnɑːriəʊ]"
+    },
+    {
+        "name": "cable",
+        "trans": [
+            "n. 缆绳；电缆；海底电报"
+        ],
+        "usphone": "[ˈkeɪbl]",
+        "ukphone": "[ˈkeɪb(ə)l]"
+    },
+    {
+        "name": "register",
+        "trans": [
+            "n. 登记；注册；记录；寄存器；登记簿"
+        ],
+        "usphone": "[ˈredʒɪstər]",
+        "ukphone": "[ˈredʒɪstə(r)]"
+    },
+    {
+        "name": "minor",
+        "trans": [
+            "adj. 未成年的；次要的；较小的；小调的；二流的"
+        ],
+        "usphone": "[ˈmaɪnər]",
+        "ukphone": "[ˈmaɪnə(r)]"
+    },
+    {
+        "name": "screen",
+        "trans": [
+            "n. 屏，幕；屏风"
+        ],
+        "usphone": "[skriːn]",
+        "ukphone": "[skriːn]"
+    },
+    {
+        "name": "differ",
+        "trans": [
+            "vi. 相异；意见分歧"
+        ],
+        "usphone": "[ˈdɪfər]",
+        "ukphone": "[ˈdɪfə(r)]"
+    },
+    {
+        "name": "regulation",
+        "trans": [
+            "n. 管理；规则；校准"
+        ],
+        "usphone": "[ˌreɡjuˈleɪʃn]",
+        "ukphone": "[ˌreɡjuˈleɪʃn]"
+    },
+    {
+        "name": "brick",
+        "trans": [
+            "n. 砖，砖块；砖形物；心肠好的人"
+        ],
+        "usphone": "[brɪk]",
+        "ukphone": "[brɪk]"
+    },
+    {
+        "name": "technological",
+        "trans": [
+            "adj. 技术的；工艺的"
+        ],
+        "usphone": "[ˌteknəˈlɑːdʒɪkl]",
+        "ukphone": "[ˌteknəˈlɒdʒɪk(ə)l]"
+    },
+    {
+        "name": "wind",
+        "trans": [
+            "vi. 缠绕；上发条；吹响号角"
+        ],
+        "usphone": "[wɪnd]",
+        "ukphone": "[wɪnd]"
+    },
+    {
+        "name": "cruise",
+        "trans": [
+            "n. 巡航，巡游；乘船游览"
+        ],
+        "usphone": "[kruːz]",
+        "ukphone": "[kruːz]"
+    },
+    {
+        "name": "tribe",
+        "trans": [
+            "n. 部落；族；宗族；一伙"
+        ],
+        "usphone": "[traɪb]",
+        "ukphone": "[traɪb]"
+    },
+    {
+        "name": "stage",
+        "trans": [
+            "n. 阶段；舞台；戏剧；驿站"
+        ],
+        "usphone": "[steɪdʒ]",
+        "ukphone": "[steɪdʒ]"
+    },
+    {
+        "name": "criticism",
+        "trans": [
+            "n. 批评；考证；苛求"
+        ],
+        "usphone": "[ˈkrɪtɪsɪzəm]",
+        "ukphone": "[ˈkrɪtɪsɪzəm]"
+    },
+    {
+        "name": "demonstrate",
+        "trans": [
+            "vt. 证明；展示；论证"
+        ],
+        "usphone": "[ˈdemənstreɪt]",
+        "ukphone": "[ˈdemənstreɪt]"
+    },
+    {
+        "name": "project",
+        "trans": [
+            "n. 工程；计划；事业"
+        ],
+        "usphone": "[ˈprɑːdʒekt]",
+        "ukphone": "[ˈprɒdʒekt]"
+    },
+    {
+        "name": "delay",
+        "trans": [
+            "n. 延期；耽搁；被耽搁或推迟的时间"
+        ],
+        "usphone": "[dɪˈleɪ]",
+        "ukphone": "[dɪˈleɪ]"
+    },
+    {
+        "name": "sensitive",
+        "trans": [
+            "adj. 敏感的；感觉的；[仪] 灵敏的；感光的；易受伤害的；易受影响的"
+        ],
+        "usphone": "[ˈsensətɪv]",
+        "ukphone": "[ˈsensətɪv]"
+    },
+    {
+        "name": "habitat",
+        "trans": [
+            "n. [生态] 栖息地，产地"
+        ],
+        "usphone": "[ˈhæbɪtæt]",
+        "ukphone": "[ˈhæbɪtæt]"
+    },
+    {
+        "name": "absolute",
+        "trans": [
+            "n. 绝对；绝对事物"
+        ],
+        "usphone": "[ˈæbsəluːt]",
+        "ukphone": "[ˈæbsəluːt]"
+    },
+    {
+        "name": "widely",
+        "trans": [
+            "adv. 广泛地"
+        ],
+        "usphone": "[ˈwaɪdli]",
+        "ukphone": "[ˈwaɪdli]"
+    },
+    {
+        "name": "rid",
+        "trans": [
+            "vt. 使摆脱；使去掉"
+        ],
+        "usphone": "[rɪd]",
+        "ukphone": "[rɪd]"
+    },
+    {
+        "name": "extension",
+        "trans": [
+            "n. 延长；延期；扩大；伸展；电话分机"
+        ],
+        "usphone": "[ɪkˈstenʃn]",
+        "ukphone": "[ɪkˈstenʃ(ə)n]"
+    },
+    {
+        "name": "overcome",
+        "trans": [
+            "vt. 克服；胜过"
+        ],
+        "usphone": "[ˌoʊvərˈkʌm]",
+        "ukphone": "[ˌəʊvəˈkʌm]"
+    },
+    {
+        "name": "mechanism",
+        "trans": [
+            "n. 机制；原理，途径；进程；机械装置；技巧"
+        ],
+        "usphone": "[ˈmekənɪzəm]",
+        "ukphone": "[ˈmekənɪzəm]"
+    },
+    {
+        "name": "cabin",
+        "trans": [
+            "n. 小屋；客舱；船舱"
+        ],
+        "usphone": "[ˈkæbɪn]",
+        "ukphone": "[ˈkæbɪn]"
+    },
+    {
+        "name": "speed",
+        "trans": [
+            "n. 速度，速率；迅速，快速；昌盛，繁荣"
+        ],
+        "usphone": "[spiːd]",
+        "ukphone": "[spiːd]"
+    },
+    {
+        "name": "seminar",
+        "trans": [
+            "n. 讨论会，研讨班"
+        ],
+        "usphone": "[ˈsemɪnɑːr]",
+        "ukphone": "[ˈsemɪnɑː(r)]"
+    },
+    {
+        "name": "dramatic",
+        "trans": [
+            "adj. 戏剧的；急剧的；引人注目的；激动人心的"
+        ],
+        "usphone": "[drəˈmætɪk]",
+        "ukphone": "[drəˈmætɪk]"
+    },
+    {
+        "name": "seek",
+        "trans": [
+            "vt. 寻求；寻找；探索；搜索"
+        ],
+        "usphone": "[siːk]",
+        "ukphone": "[siːk]"
+    },
+    {
+        "name": "wrap",
+        "trans": [
+            "n. 外套；围巾"
+        ],
+        "usphone": "[ræp]",
+        "ukphone": "[ræp]"
+    },
+    {
+        "name": "dozen",
+        "trans": [
+            "n. 十二个，一打"
+        ],
+        "usphone": "[ˈdʌzn]",
+        "ukphone": "[ˈdʌz(ə)n]"
+    },
+    {
+        "name": "refugee",
+        "trans": [
+            "n. 难民，避难者；流亡者，逃亡者"
+        ],
+        "usphone": "[ˌrefjuˈdʒiː]",
+        "ukphone": "[ˌrefjuˈdʒiː]"
+    },
+    {
+        "name": "expense",
+        "trans": [
+            "n. 损失，代价；消费；开支"
+        ],
+        "usphone": "[ɪkˈspens]",
+        "ukphone": "[ɪkˈspens]"
+    },
+    {
+        "name": "embrace",
+        "trans": [
+            "n. 拥抱"
+        ],
+        "usphone": "[ɪmˈbreɪs]",
+        "ukphone": "[ɪmˈbreɪs]"
+    },
+    {
+        "name": "negotiation",
+        "trans": [
+            "n. 谈判；转让；顺利的通过"
+        ],
+        "usphone": "[nɪˌɡoʊʃiˈeɪʃn]",
+        "ukphone": "[nɪˌɡəʊʃiˈeɪʃn]"
+    },
+    {
+        "name": "surrounding",
+        "trans": [
+            "n. 环境，周围的事物"
+        ],
+        "usphone": "[səˈraʊndɪŋ]",
+        "ukphone": "[səˈraʊndɪŋ]"
+    },
+    {
+        "name": "concern",
+        "trans": [
+            "n. 关系；关心；关心的事；忧虑"
+        ],
+        "usphone": "[kənˈsɜːrn]",
+        "ukphone": "[kənˈsɜː(r)n]"
+    },
+    {
+        "name": "manufacture",
+        "trans": [
+            "n. 制造；产品；制造业"
+        ],
+        "usphone": "[ˌmænjuˈfæktʃər]",
+        "ukphone": "[ˌmænjuˈfæktʃə(r)]"
+    },
+    {
+        "name": "bond",
+        "trans": [
+            "n. 债券；结合；约定；粘合剂；纽带"
+        ],
+        "usphone": "[bɑːnd]",
+        "ukphone": "[bɒnd]"
+    },
+    {
+        "name": "surgeon",
+        "trans": [
+            "n. 外科医生"
+        ],
+        "usphone": "[ˈsɜːrdʒən]",
+        "ukphone": "[ˈsɜːdʒən]"
+    },
+    {
+        "name": "afterwards",
+        "trans": [
+            "adv. 后来；然后"
+        ],
+        "usphone": "[ˈæftərwərdz]",
+        "ukphone": "[ˈɑːftəwədz]"
+    },
+    {
+        "name": "phenomenon",
+        "trans": [
+            "n. 现象；奇迹；杰出的人才"
+        ],
+        "usphone": "[fəˈnɑːmɪnən]",
+        "ukphone": "[fəˈnɒmɪnən]"
+    },
+    {
+        "name": "national",
+        "trans": [
+            "adj. 国家的；国民的；民族的；国立的"
+        ],
+        "usphone": "[ˈnæʃ(ə)nəl]",
+        "ukphone": "[ˈnæʃ(ə)nəl]"
+    },
+    {
+        "name": "tag",
+        "trans": [
+            "n. 标签；名称；结束语；附属物"
+        ],
+        "usphone": "[tæɡ]",
+        "ukphone": "[tæɡ]"
+    },
+    {
+        "name": "price",
+        "trans": [
+            "n. 价格；价值；代价"
+        ],
+        "usphone": "[praɪs]",
+        "ukphone": "[praɪs]"
+    },
+    {
+        "name": "moral",
+        "trans": [
+            "adj. 道德的；精神上的；品性端正的"
+        ],
+        "usphone": "[ˈmɔːrəl]",
+        "ukphone": "[ˈmɒrəl]"
+    },
+    {
+        "name": "facility",
+        "trans": [
+            "n. 设施；设备；容易；灵巧"
+        ],
+        "usphone": "[fəˈsɪləti]",
+        "ukphone": "[fəˈsɪləti]"
+    },
+    {
+        "name": "saving",
+        "trans": [
+            "n. 节约；挽救；存款"
+        ],
+        "usphone": "[ˈseɪvɪŋ]",
+        "ukphone": "[ˈseɪvɪŋ]"
+    },
+    {
+        "name": "puzzle",
+        "trans": [
+            "n. 谜；难题；迷惑"
+        ],
+        "usphone": "[ˈpʌzl]",
+        "ukphone": "[ˈpʌzl]"
+    },
+    {
+        "name": "confusing",
+        "trans": [
+            "v. 使迷惑；使混乱不清；使困窘（confuse的ing形式）"
+        ],
+        "usphone": "[kənˈfjuːzɪŋ]",
+        "ukphone": "[kənˈfjuːzɪŋ]"
+    },
+    {
+        "name": "limitation",
+        "trans": [
+            "n. 限制；限度；极限；追诉时效；有效期限；缺陷"
+        ],
+        "usphone": "[ˌlɪmɪˈteɪʃn]",
+        "ukphone": "[ˌlɪmɪˈteɪʃn]"
+    },
+    {
+        "name": "isolate",
+        "trans": [
+            "n. [生物] 隔离种群"
+        ],
+        "usphone": "[ˈaɪsəleɪt]",
+        "ukphone": "[ˈaɪsəleɪt]"
+    },
+    {
+        "name": "punk",
+        "trans": [
+            "n. 废物；小阿飞；年轻无知的人"
+        ],
+        "usphone": "[pʌŋk]",
+        "ukphone": "[pʌŋk]"
+    },
+    {
+        "name": "upwards",
+        "trans": [
+            "adv. 向上；在上部；向上游"
+        ],
+        "usphone": "[ˈʌpwərdz]",
+        "ukphone": "[ˈʌpwədz]"
+    },
+    {
+        "name": "fraction",
+        "trans": [
+            "n. 分数；部分；小部分；稍微"
+        ],
+        "usphone": "[ˈfrækʃn]",
+        "ukphone": "[ˈfrækʃn]"
+    },
+    {
+        "name": "exploit",
+        "trans": [
+            "n. 勋绩；功绩"
+        ],
+        "usphone": "[ɪkˈsplɔɪt]",
+        "ukphone": "[ɪkˈsplɔɪt]"
+    },
+    {
+        "name": "failure",
+        "trans": [
+            "n. 失败；故障；失败者；破产"
+        ],
+        "usphone": "[ˈfeɪljər]",
+        "ukphone": "[ˈfeɪljə(r)]"
+    },
+    {
+        "name": "leaflet",
+        "trans": [
+            "n. 小叶；传单"
+        ],
+        "usphone": "[ˈliːflət]",
+        "ukphone": "[ˈliːflət]"
+    },
+    {
+        "name": "dot",
+        "trans": [
+            "n. 点，圆点；嫁妆"
+        ],
+        "usphone": "[dɑːt]",
+        "ukphone": "[dɒt]"
+    },
+    {
+        "name": "warming",
+        "trans": [
+            "n. 加温，暖和；气温升高"
+        ],
+        "usphone": "[ˈwɔːrmɪŋ]",
+        "ukphone": "[ˈwɔːmɪŋ]"
+    },
+    {
+        "name": "precisely",
+        "trans": [
+            "adv. 精确地；恰恰"
+        ],
+        "usphone": "[prɪˈsaɪsli]",
+        "ukphone": "[prɪˈsaɪsli]"
+    },
+    {
+        "name": "discourage",
+        "trans": [
+            "vt. 阻止；使气馁"
+        ],
+        "usphone": "[dɪsˈkɜːrɪdʒ]",
+        "ukphone": "[dɪsˈkʌrɪdʒ]"
+    },
+    {
+        "name": "transportation",
+        "trans": [
+            "n. 运输；运输系统；运输工具；流放"
+        ],
+        "usphone": "[ˌtrænspɔːrˈteɪʃn]",
+        "ukphone": "[ˌtrænspɔːˈteɪʃn]"
+    },
+    {
+        "name": "occasionally",
+        "trans": [
+            "adv. 偶尔；间或"
+        ],
+        "usphone": "[əˈkeɪʒnəli]",
+        "ukphone": "[əˈkeɪʒnəli]"
+    },
+    {
+        "name": "hidden",
+        "trans": [
+            "adj. 隐藏的"
+        ],
+        "usphone": "[ˈhɪdn]",
+        "ukphone": "[ˈhɪd(ə)n]"
+    },
+    {
+        "name": "monitor",
+        "trans": [
+            "n. 监视器；监听器；监控器；显示屏；班长"
+        ],
+        "usphone": "[ˈmɑːnɪtər]",
+        "ukphone": "[ˈmɒnɪtə(r)]"
+    },
+    {
+        "name": "expectation",
+        "trans": [
+            "n. 期待；预期；指望"
+        ],
+        "usphone": "[ˌekspekˈteɪʃn]",
+        "ukphone": "[ˌekspekˈteɪʃ(ə)n]"
+    },
+    {
+        "name": "wheat",
+        "trans": [
+            "n. 小麦；小麦色"
+        ],
+        "usphone": "[wiːt]",
+        "ukphone": "[wiːt]"
+    },
+    {
+        "name": "acceptable",
+        "trans": [
+            "adj. 可接受的；合意的；可忍受的"
+        ],
+        "usphone": "[əkˈseptəbl]",
+        "ukphone": "[əkˈseptəb(ə)l]"
+    },
+    {
+        "name": "marathon",
+        "trans": [
+            "n. 马拉松赛跑；耐力的考验"
+        ],
+        "usphone": "[ˈmærəθɑːn]",
+        "ukphone": "[ˈmærəθən]"
+    },
+    {
+        "name": "stare",
+        "trans": [
+            "n. 凝视；注视"
+        ],
+        "usphone": "[ster]",
+        "ukphone": "[steə(r)]"
+    },
+    {
+        "name": "corporation",
+        "trans": [
+            "n. 公司；法人（团体）；社团；大腹便便；市政当局"
+        ],
+        "usphone": "[ˌkɔːrpəˈreɪʃ(ə)n]",
+        "ukphone": "[ˌkɔːpəˈreɪʃn]"
+    },
+    {
+        "name": "depth",
+        "trans": [
+            "n. [海洋] 深度；深奥"
+        ],
+        "usphone": "[depθ]",
+        "ukphone": "[depθ]"
+    },
+    {
+        "name": "recruit",
+        "trans": [
+            "n. 招聘；新兵；新成员"
+        ],
+        "usphone": "[rɪˈkruːt]",
+        "ukphone": "[rɪˈkruːt]"
+    },
+    {
+        "name": "pity",
+        "trans": [
+            "n. 怜悯，同情；遗憾"
+        ],
+        "usphone": "[ˈpɪti]",
+        "ukphone": "[ˈpɪti]"
+    },
+    {
+        "name": "peer",
+        "trans": [
+            "vt. 封为贵族；与…同等"
+        ],
+        "usphone": "[pɪr]",
+        "ukphone": "[pɪə(r)]"
+    },
+    {
+        "name": "shocking",
+        "trans": [
+            "adj. 令人震惊的；可怕的，令人厌恶的；糟糕的"
+        ],
+        "usphone": "",
+        "ukphone": ""
+    },
+    {
+        "name": "amount",
+        "trans": [
+            "n. 数量；总额，总数"
+        ],
+        "usphone": "[əˈmaʊnt]",
+        "ukphone": "[əˈmaʊnt]"
+    },
+    {
+        "name": "convention",
+        "trans": [
+            "n. 大会；[法] 惯例；[计] 约定；[法] 协定；习俗"
+        ],
+        "usphone": "[kənˈvenʃn]",
+        "ukphone": "[kənˈvenʃn]"
+    },
+    {
+        "name": "inspire",
+        "trans": [
+            "vt. 激发；鼓舞；启示；产生；使生灵感"
+        ],
+        "usphone": "[ɪnˈspaɪər]",
+        "ukphone": "[ɪnˈspaɪə(r)]"
+    },
+    {
+        "name": "infrastructure",
+        "trans": [
+            "n. 基础设施；公共建设；下部构造"
+        ],
+        "usphone": "[ˈɪnfrəstrʌktʃər]",
+        "ukphone": "[ˈɪnfrəstrʌktʃə(r)]"
+    },
+    {
+        "name": "humorous",
+        "trans": [
+            "adj. 诙谐的，幽默的；滑稽的，可笑的"
+        ],
+        "usphone": "[ˈhjuːmərəs]",
+        "ukphone": "[ˈhjuːmərəs]"
+    },
+    {
+        "name": "unknown",
+        "trans": [
+            "n. 未知数；未知的事物，默默无闻的人"
+        ],
+        "usphone": "[ˌʌnˈnoʊn]",
+        "ukphone": "[ˌʌnˈnəʊn]"
+    },
+    {
+        "name": "grade",
+        "trans": [
+            "n. 年级；等级；成绩；级别；阶段"
+        ],
+        "usphone": "[ɡreɪd]",
+        "ukphone": "[ɡreɪd]"
+    },
+    {
+        "name": "guideline",
+        "trans": [
+            "n. 指导方针"
+        ],
+        "usphone": "[ˈɡaɪdlaɪn]",
+        "ukphone": "[ˈɡaɪdlaɪn]"
+    },
+    {
+        "name": "permit",
+        "trans": [
+            "n. 许可证，执照"
+        ],
+        "usphone": "[pərˈmɪt]",
+        "ukphone": "[pəˈmɪt]"
+    },
+    {
+        "name": "founder",
+        "trans": [
+            "n. 创始人；建立者；翻沙工"
+        ],
+        "usphone": "[ˈfaʊndər]",
+        "ukphone": "[ˈfaʊndə(r)]"
+    },
+    {
+        "name": "literally",
+        "trans": [
+            "adv. 照字面地；逐字地；不夸张地；正确地；简直"
+        ],
+        "usphone": "[ˈlɪtərəli]",
+        "ukphone": "[ˈlɪtərəli]"
+    },
+    {
+        "name": "full-time",
+        "trans": [
+            "adj. 专职的；全日制的；全部时间的"
+        ],
+        "usphone": "[ˌfʊl ˈtaɪm]",
+        "ukphone": "[ˌfʊl ˈtaɪm]"
+    },
+    {
+        "name": "newly",
+        "trans": [
+            "adv. 最近；重新；以新的方式"
+        ],
+        "usphone": "[ˈnuːli]",
+        "ukphone": "[ˈnjuːli]"
+    },
+    {
+        "name": "icon",
+        "trans": [
+            "n. 图标；偶像；肖像，画像；圣像"
+        ],
+        "usphone": "[ˈaɪkɑːn]",
+        "ukphone": "[ˈaɪkɒn]"
+    },
+    {
+        "name": "fool",
+        "trans": [
+            "n. 傻瓜；愚人；受骗者"
+        ],
+        "usphone": "[fuːl]",
+        "ukphone": "[fuːl]"
+    },
+    {
+        "name": "wise",
+        "trans": [
+            "adj. 明智的；聪明的；博学的"
+        ],
+        "usphone": "[waɪz]",
+        "ukphone": "[waɪz]"
+    },
+    {
+        "name": "spring",
+        "trans": [
+            "n. 春天；弹簧；泉水；活力；跳跃"
+        ],
+        "usphone": "[sprɪŋ]",
+        "ukphone": "[sprɪŋ]"
+    },
+    {
+        "name": "decline",
+        "trans": [
+            "n. 下降；衰退；斜面"
+        ],
+        "usphone": "[dɪˈklaɪn]",
+        "ukphone": "[dɪˈklaɪn]"
+    },
+    {
+        "name": "spokesperson",
+        "trans": [
+            "n. 发言人；代言人"
+        ],
+        "usphone": "[ˈspoʊkspɜːrsn]",
+        "ukphone": "[ˈspəʊkspɜːsn]"
+    },
+    {
+        "name": "moving",
+        "trans": [
+            "adj. 移动的；动人的；活动的"
+        ],
+        "usphone": "[ˈmuːvɪŋ]",
+        "ukphone": "[ˈmuːvɪŋ]"
+    },
+    {
+        "name": "bound",
+        "trans": [
+            "n. 范围；跳跃"
+        ],
+        "usphone": "[baʊnd]",
+        "ukphone": "[baʊnd]"
+    },
+    {
+        "name": "relief",
+        "trans": [
+            "n. 救济；减轻，解除；安慰；浮雕"
+        ],
+        "usphone": "[rɪˈliːf]",
+        "ukphone": "[rɪˈliːf]"
+    },
+    {
+        "name": "resign",
+        "trans": [
+            "n. 辞去职务"
+        ],
+        "usphone": "[rɪˈzaɪn]",
+        "ukphone": "[rɪˈzaɪn]"
+    },
+    {
+        "name": "artwork",
+        "trans": [
+            "n. 艺术品；插图；美术品"
+        ],
+        "usphone": "[ˈɑːrtwɜːrk]",
+        "ukphone": "[ˈɑːtwɜːk]"
+    },
+    {
+        "name": "philosophy",
+        "trans": [
+            "n. 哲学；哲理；人生观"
+        ],
+        "usphone": "[fəˈlɑːsəfi]",
+        "ukphone": "[fəˈlɒsəfi]"
+    },
+    {
+        "name": "golden",
+        "trans": [
+            "adj. 金色的，黄金般的；珍贵的；金制的"
+        ],
+        "usphone": "[ˈɡoʊldən]",
+        "ukphone": "[ˈɡəʊldən]"
+    },
+    {
+        "name": "identical",
+        "trans": [
+            "n. 完全相同的事物"
+        ],
+        "usphone": "[aɪˈdentɪk(ə)l]",
+        "ukphone": "[aɪˈdentɪk(ə)l]"
+    },
+    {
+        "name": "collector",
+        "trans": [
+            "n. 收藏家；[电子] 集电极；收税员；征收者"
+        ],
+        "usphone": "[kəˈlektər]",
+        "ukphone": "[kəˈlektə(r)]"
+    },
+    {
+        "name": "beat",
+        "trans": [
+            "n. 拍子；敲击；有规律的一连串敲打"
+        ],
+        "usphone": "[biːt]",
+        "ukphone": "[biːt]"
+    },
+    {
+        "name": "exception",
+        "trans": [
+            "n. 例外；异议"
+        ],
+        "usphone": "[ɪkˈsepʃn]",
+        "ukphone": "[ɪkˈsepʃn]"
+    },
+    {
+        "name": "hence",
+        "trans": [
+            "adv. 因此；今后"
+        ],
+        "usphone": "[hens]",
+        "ukphone": "[hens]"
+    },
+    {
+        "name": "fabulous",
+        "trans": [
+            "adj. 难以置信的；传说的，寓言中的；极好的"
+        ],
+        "usphone": "[ˈfæbjələs]",
+        "ukphone": "[ˈfæbjələs]"
+    },
+    {
+        "name": "installation",
+        "trans": [
+            "n. 安装，装置；就职"
+        ],
+        "usphone": "[ˌɪnstəˈleɪʃn]",
+        "ukphone": "[ˌɪnstəˈleɪʃn]"
+    },
+    {
+        "name": "fragment",
+        "trans": [
+            "n. 碎片；片断或不完整部分"
+        ],
+        "usphone": "[ˈfræɡmənt; fræɡˈment]",
+        "ukphone": "[ˈfræɡmənt]"
+    },
+    {
+        "name": "dominate",
+        "trans": [
+            "vt. 控制；支配；占优势；在…中占主要地位"
+        ],
+        "usphone": "[ˈdɑːmɪneɪt]",
+        "ukphone": "[ˈdɒmɪneɪt]"
+    },
+    {
+        "name": "impress",
+        "trans": [
+            "n. 印象，印记；特征，痕迹"
+        ],
+        "usphone": "[ɪmˈpres]",
+        "ukphone": "[ɪmˈpres]"
+    },
+    {
+        "name": "consequently",
+        "trans": [
+            "adv. 因此；结果；所以"
+        ],
+        "usphone": "[ˈkɑːnsɪkwentli]",
+        "ukphone": "[ˈkɒnsɪkwəntli]"
+    },
+    {
+        "name": "limited",
+        "trans": [
+            "adj. 有限的"
+        ],
+        "usphone": "[ˈlɪmɪtɪd]",
+        "ukphone": "[ˈlɪmɪtɪd]"
+    },
+    {
+        "name": "dive",
+        "trans": [
+            "n. 潜水；跳水；俯冲；扑"
+        ],
+        "usphone": "[daɪv]",
+        "ukphone": "[daɪv]"
+    },
+    {
+        "name": "division",
+        "trans": [
+            "n. [数] 除法；部门；分配；分割；师（军队）；赛区"
+        ],
+        "usphone": "[dɪˈvɪʒn]",
+        "ukphone": "[dɪˈvɪʒ(ə)n]"
+    },
+    {
+        "name": "pose",
+        "trans": [
+            "vi. 摆姿势；佯装；矫揉造作"
+        ],
+        "usphone": "[poʊz]",
+        "ukphone": "[pəʊz]"
+    },
+    {
+        "name": "pupil",
+        "trans": [
+            "n. 学生；[解剖] 瞳孔；未成年人"
+        ],
+        "usphone": "[ˈpjuːpl]",
+        "ukphone": "[ˈpjuːp(ə)l]"
+    },
+    {
+        "name": "conduct",
+        "trans": [
+            "n. 进行；行为；实施"
+        ],
+        "usphone": "[kənˈdʌkt; ˈkɑːndʌkt]",
+        "ukphone": "[kənˈdʌkt; ˈkɒndʌkt]"
+    },
+    {
+        "name": "sexy",
+        "trans": [
+            "adj. 性感的；迷人的；色情的"
+        ],
+        "usphone": "[ˈseksi]",
+        "ukphone": "[ˈseksi]"
+    },
+    {
+        "name": "ton",
+        "trans": [
+            "n. 吨；很多，大量"
+        ],
+        "usphone": "[tʌn]",
+        "ukphone": "[tʌn]"
+    },
+    {
+        "name": "treasure",
+        "trans": [
+            "n. 财富，财产；财宝；珍品"
+        ],
+        "usphone": "[ˈtreʒər]",
+        "ukphone": "[ˈtreʒə(r)]"
+    },
+    {
+        "name": "initial",
+        "trans": [
+            "n. 词首大写字母"
+        ],
+        "usphone": "[ɪˈnɪʃl]",
+        "ukphone": "[ɪˈnɪʃl]"
+    },
+    {
+        "name": "junior",
+        "trans": [
+            "adj. 年少的；后进的；下级的"
+        ],
+        "usphone": "[ˈdʒuːniər]",
+        "ukphone": "[ˈdʒuːniə(r)]"
+    },
+    {
+        "name": "cue",
+        "trans": [
+            "n. 提示，暗示；线索"
+        ],
+        "usphone": "[kjuː]",
+        "ukphone": "[kjuː]"
+    },
+    {
+        "name": "enjoyable",
+        "trans": [
+            "adj. 快乐的；有乐趣的；令人愉快的"
+        ],
+        "usphone": "[ɪnˈdʒɔɪəbl]",
+        "ukphone": "[ɪnˈdʒɔɪəbl]"
+    },
+    {
+        "name": "pride",
+        "trans": [
+            "n. 自豪；骄傲；自尊心"
+        ],
+        "usphone": "[praɪd]",
+        "ukphone": "[praɪd]"
+    },
+    {
+        "name": "violence",
+        "trans": [
+            "n. 暴力；侵犯；激烈；歪曲"
+        ],
+        "usphone": "[ˈvaɪələns]",
+        "ukphone": "[ˈvaɪələns]"
+    },
+    {
+        "name": "graphic",
+        "trans": [
+            "adj. 形象的；图表的；绘画似的"
+        ],
+        "usphone": "[ˈɡræfɪk]",
+        "ukphone": "[ˈɡræfɪk]"
+    },
+    {
+        "name": "function",
+        "trans": [
+            "n. 功能；[数] 函数；职责；盛大的集会"
+        ],
+        "usphone": "[ˈfʌŋkʃn]",
+        "ukphone": "[ˈfʌŋkʃ(ə)n]"
+    },
+    {
+        "name": "nutrition",
+        "trans": [
+            "n. 营养，营养学；营养品"
+        ],
+        "usphone": "[nuˈtrɪʃn]",
+        "ukphone": "[njuˈtrɪʃ(ə)n]"
+    },
+    {
+        "name": "evaluate",
+        "trans": [
+            "vt. 评价；估价；求…的值"
+        ],
+        "usphone": "[ɪˈvæljueɪt]",
+        "ukphone": "[ɪˈvæljueɪt]"
+    },
+    {
+        "name": "operate",
+        "trans": [
+            "vi. 运转；动手术；起作用"
+        ],
+        "usphone": "[ˈɑːpəreɪt]",
+        "ukphone": "[ˈɒpəreɪt]"
+    },
+    {
+        "name": "closely",
+        "trans": [
+            "adv. 紧密地；接近地；严密地；亲近地"
+        ],
+        "usphone": "[ˈkloʊsli]",
+        "ukphone": "[ˈkləʊsli]"
+    },
+    {
+        "name": "challenging",
+        "trans": [
+            "v. 要求；质疑；反对；向…挑战；盘问（challenge的ing形式）"
+        ],
+        "usphone": "[ˈtʃælɪndʒɪŋ]",
+        "ukphone": "[ˈtʃælɪndʒɪŋ]"
+    },
+    {
+        "name": "border",
+        "trans": [
+            "n. 边境；边界；国界"
+        ],
+        "usphone": "[ˈbɔːrdər]",
+        "ukphone": "[ˈbɔːdə(r)]"
+    },
+    {
+        "name": "rebuild",
+        "trans": [
+            "vt. 重建；改造，重新组装；复原"
+        ],
+        "usphone": "[ˌriːˈbɪld]",
+        "ukphone": "[ˌriːˈbɪld]"
+    },
+    {
+        "name": "dependent",
+        "trans": [
+            "n. 依赖他人者；受赡养者"
+        ],
+        "usphone": "[dɪˈpendənt]",
+        "ukphone": "[dɪˈpendənt]"
+    },
+    {
+        "name": "shadow",
+        "trans": [
+            "n. 阴影；影子；幽灵；庇护；隐蔽处"
+        ],
+        "usphone": "[ˈʃædoʊ]",
+        "ukphone": "[ˈʃædəʊ]"
+    },
+    {
+        "name": "arrow",
+        "trans": [
+            "n. 箭，箭头；箭状物；箭头记号"
+        ],
+        "usphone": "[ˈæroʊ]",
+        "ukphone": "[ˈærəʊ]"
+    },
+    {
+        "name": "elect",
+        "trans": [
+            "n. 被选的人；特殊阶层；上帝的选民"
+        ],
+        "usphone": "[ɪˈlekt]",
+        "ukphone": "[ɪˈlekt]"
+    },
+    {
+        "name": "medium",
+        "trans": [
+            "adj. 中间的，中等的；半生熟的"
+        ],
+        "usphone": "[ˈmiːdiəm]",
+        "ukphone": "[ˈmiːdiəm]"
+    },
+    {
+        "name": "mechanical",
+        "trans": [
+            "adj. 机械的；力学的；呆板的；无意识的；手工操作的"
+        ],
+        "usphone": "[məˈkænɪkl]",
+        "ukphone": "[məˈkænɪkl]"
+    },
+    {
+        "name": "sample",
+        "trans": [
+            "n. 样品；样本；例子"
+        ],
+        "usphone": "[ˈsæmpl]",
+        "ukphone": "[ˈsɑːmp(ə)l]"
+    },
+    {
+        "name": "accurate",
+        "trans": [
+            "adj. 精确的"
+        ],
+        "usphone": "[ˈækjərət]",
+        "ukphone": "[ˈækjərət]"
+    },
+    {
+        "name": "notion",
+        "trans": [
+            "n. 概念；见解；打算"
+        ],
+        "usphone": "[ˈnoʊʃn]",
+        "ukphone": "[ˈnəʊʃn]"
+    },
+    {
+        "name": "unite",
+        "trans": [
+            "vi. 团结；联合；混合"
+        ],
+        "usphone": "[juˈnaɪt]",
+        "ukphone": "[juˈnaɪt]"
+    },
+    {
+        "name": "prior",
+        "trans": [
+            "adj. 优先的；在先的，在前的"
+        ],
+        "usphone": "[ˈpraɪər]",
+        "ukphone": "[ˈpraɪə(r)]"
+    },
+    {
+        "name": "fabric",
+        "trans": [
+            "n. 织物；布；组织；构造；建筑物"
+        ],
+        "usphone": "[ˈfæbrɪk]",
+        "ukphone": "[ˈfæbrɪk]"
+    },
+    {
+        "name": "bunch",
+        "trans": [
+            "n. 群；串；突出物"
+        ],
+        "usphone": "[bʌntʃ]",
+        "ukphone": "[bʌntʃ]"
+    },
+    {
+        "name": "slogan",
+        "trans": [
+            "n. 标语；呐喊声"
+        ],
+        "usphone": "[ˈsloʊɡən]",
+        "ukphone": "[ˈsləʊɡən]"
+    },
+    {
+        "name": "scandal",
+        "trans": [
+            "n. 丑闻；流言蜚语；诽谤；公愤"
+        ],
+        "usphone": "[ˈskændl]",
+        "ukphone": "[ˈskænd(ə)l]"
+    },
+    {
+        "name": "greatly",
+        "trans": [
+            "adv. 很，大大地；非常"
+        ],
+        "usphone": "[ˈɡreɪtli]",
+        "ukphone": "[ˈɡreɪtli]"
+    },
+    {
+        "name": "produce",
+        "trans": [
+            "n. 农产品，产品"
+        ],
+        "usphone": "[prəˈduːs]",
+        "ukphone": "[prəˈdjuːs]"
+    },
+    {
+        "name": "very",
+        "trans": [
+            "adv. 非常，很；完全"
+        ],
+        "usphone": "[ˈveri]",
+        "ukphone": "[ˈveri]"
+    },
+    {
+        "name": "visible",
+        "trans": [
+            "n. 可见物；进出口贸易中的有形项目"
+        ],
+        "usphone": "[ˈvɪzəb(ə)l]",
+        "ukphone": "[ˈvɪzəb(ə)l]"
+    },
+    {
+        "name": "interpretation",
+        "trans": [
+            "n. 解释；翻译；演出"
+        ],
+        "usphone": "[ɪnˌtɜːrprəˈteɪʃn]",
+        "ukphone": "[ɪnˌtɜːprəˈteɪʃn]"
+    },
+    {
+        "name": "accuracy",
+        "trans": [
+            "n. [数] 精确度，准确性"
+        ],
+        "usphone": "[ˈækjərəsi]",
+        "ukphone": "[ˈækjərəsi]"
+    },
+    {
+        "name": "infection",
+        "trans": [
+            "n. 感染；传染；影响；传染病"
+        ],
+        "usphone": "[ɪnˈfekʃn]",
+        "ukphone": "[ɪnˈfekʃn]"
+    },
+    {
+        "name": "relatively",
+        "trans": [
+            "adv. 相当地；相对地，比较地"
+        ],
+        "usphone": "[ˈrelətɪvli]",
+        "ukphone": "[ˈrelətɪvli]"
+    },
+    {
+        "name": "construct",
+        "trans": [
+            "n. 构想，概念"
+        ],
+        "usphone": "[kənˈstrʌkt]",
+        "ukphone": "[kənˈstrʌkt]"
+    },
+    {
+        "name": "shallow",
+        "trans": [
+            "n. [地理] 浅滩"
+        ],
+        "usphone": "[ˈʃæloʊ]",
+        "ukphone": "[ˈʃæləʊ]"
+    },
+    {
+        "name": "pill",
+        "trans": [
+            "n. 药丸；弹丸，子弹；口服避孕药"
+        ],
+        "usphone": "[pɪl]",
+        "ukphone": "[pɪl]"
+    },
+    {
+        "name": "leadership",
+        "trans": [
+            "n. 领导能力；领导阶层"
+        ],
+        "usphone": "[ˈliːdərʃɪp]",
+        "ukphone": "[ˈliːdəʃɪp]"
+    },
+    {
+        "name": "cope",
+        "trans": [
+            "n. 长袍"
+        ],
+        "usphone": "[koʊp]",
+        "ukphone": "[kəʊp]"
+    },
+    {
+        "name": "bid",
+        "trans": [
+            "n. 出价；叫牌；努力争取"
+        ],
+        "usphone": "[bɪd]",
+        "ukphone": "[bɪd]"
+    },
+    {
+        "name": "counter",
+        "trans": [
+            "n. 柜台；对立面；计数器；（某些棋盘游戏的）筹码"
+        ],
+        "usphone": "[ˈkaʊntər]",
+        "ukphone": "[ˈkaʊntə(r)]"
+    },
+    {
+        "name": "range",
+        "trans": [
+            "n. 范围；幅度；排；山脉"
+        ],
+        "usphone": "[reɪndʒ]",
+        "ukphone": "[reɪndʒ]"
+    },
+    {
+        "name": "adjust",
+        "trans": [
+            "vt. 调整，使…适合；校准"
+        ],
+        "usphone": "[əˈdʒʌst]",
+        "ukphone": "[əˈdʒʌst]"
+    },
+    {
+        "name": "feed",
+        "trans": [
+            "n. 饲料；饲养；（动物或婴儿的）一餐"
+        ],
+        "usphone": "[fiːd]",
+        "ukphone": "[fiːd]"
+    },
+    {
+        "name": "obtain",
+        "trans": [
+            "vi. 获得；流行"
+        ],
+        "usphone": "[əbˈteɪn]",
+        "ukphone": "[əbˈteɪn]"
+    },
+    {
+        "name": "pension",
+        "trans": [
+            "n. 退休金，抚恤金；津贴；膳宿费"
+        ],
+        "usphone": "[ˈpenʃən]",
+        "ukphone": "[ˈpenʃ(ə)n]"
+    },
+    {
+        "name": "unfold",
+        "trans": [
+            "vi. 展开；显露"
+        ],
+        "usphone": "[ʌnˈfoʊld]",
+        "ukphone": "[ʌnˈfəʊld]"
+    },
+    {
+        "name": "inch",
+        "trans": [
+            "n. 英寸；身高；少许"
+        ],
+        "usphone": "[ɪntʃ]",
+        "ukphone": "[ɪntʃ]"
+    },
+    {
+        "name": "racist",
+        "trans": [
+            "n. 种族主义者"
+        ],
+        "usphone": "[ˈreɪsɪst]",
+        "ukphone": "[ˈreɪsɪst]"
+    },
+    {
+        "name": "classic",
+        "trans": [
+            "n. 名著；经典著作；大艺术家"
+        ],
+        "usphone": "[ˈklæsɪk]",
+        "ukphone": "[ˈklæsɪk]"
+    },
+    {
+        "name": "animation",
+        "trans": [
+            "n. 活泼，生气；激励；卡通片绘制"
+        ],
+        "usphone": "[ˌænɪˈmeɪʃ(ə)n]",
+        "ukphone": "[ˌænɪˈmeɪʃ(ə)n]"
+    },
+    {
+        "name": "speculation",
+        "trans": [
+            "n. 投机；推测；思索；投机买卖"
+        ],
+        "usphone": "[ˌspekjuˈleɪʃn]",
+        "ukphone": "[ˌspekjuˈleɪʃ(ə)n]"
+    },
+    {
+        "name": "implement",
+        "trans": [
+            "n. 工具，器具；手段"
+        ],
+        "usphone": "[ˈɪmplɪmənt; ˈɪmpləˌment]",
+        "ukphone": "[ˈɪmplɪment]"
+    },
+    {
+        "name": "high",
+        "trans": [
+            "n. 高水平；天空；由麻醉品引起的快感；高压地带"
+        ],
+        "usphone": "[haɪ]",
+        "ukphone": "[haɪ]"
+    },
+    {
+        "name": "sum",
+        "trans": [
+            "n. 金额；总数"
+        ],
+        "usphone": "[sʌm]",
+        "ukphone": "[sʌm]"
+    },
+    {
+        "name": "enable",
+        "trans": [
+            "vt. 使能够，使成为可能；授予权利或方法"
+        ],
+        "usphone": "[ɪˈneɪbl]",
+        "ukphone": "[ɪˈneɪbl]"
+    },
+    {
+        "name": "opera",
+        "trans": [
+            "n. 歌剧；歌剧院；歌剧团"
+        ],
+        "usphone": "[ˈɑːprə]",
+        "ukphone": "[ˈɒprə]"
+    },
+    {
+        "name": "blame",
+        "trans": [
+            "n. 责备；责任；过失"
+        ],
+        "usphone": "[bleɪm]",
+        "ukphone": "[bleɪm]"
+    },
+    {
+        "name": "commission",
+        "trans": [
+            "n. 委员会；佣金；犯；委任；委任状"
+        ],
+        "usphone": "[kəˈmɪʃn]",
+        "ukphone": "[kəˈmɪʃn]"
+    },
+    {
+        "name": "purchase",
+        "trans": [
+            "n. 购买；紧握；起重装置"
+        ],
+        "usphone": "[ˈpɜːrtʃəs]",
+        "ukphone": "[ˈpɜːtʃəs]"
+    },
+    {
+        "name": "holy",
+        "trans": [
+            "n. 神圣的东西"
+        ],
+        "usphone": "[ˈhoʊli]",
+        "ukphone": "[ˈhəʊli]"
+    },
+    {
+        "name": "psychology",
+        "trans": [
+            "n. 心理学；心理状态"
+        ],
+        "usphone": "[saɪˈkɑːlədʒi]",
+        "ukphone": "[saɪˈkɒlədʒi]"
+    },
+    {
+        "name": "alter",
+        "trans": [
+            "vt. 改变，更改"
+        ],
+        "usphone": "[ˈɔːltər]",
+        "ukphone": "[ˈɔːltə(r)]"
+    },
+    {
+        "name": "emotionally",
+        "trans": [
+            "adv. 感情上；情绪上；令人激动地；情绪冲动地"
+        ],
+        "usphone": "[ɪˈmoʊʃənəli]",
+        "ukphone": "[ɪˈməʊʃənəli]"
+    },
+    {
+        "name": "isolated",
+        "trans": [
+            "adj. 孤立的；分离的；单独的；[电] 绝缘的"
+        ],
+        "usphone": "[ˈaɪsəleɪtɪd]",
+        "ukphone": "[ˈaɪsəleɪtɪd]"
+    },
+    {
+        "name": "altogether",
+        "trans": [
+            "n. 整个；裸体"
+        ],
+        "usphone": "[ˌɔːltəˈɡeðər]",
+        "ukphone": "[ˌɔːltəˈɡeðə(r)]"
+    },
+    {
+        "name": "severe",
+        "trans": [
+            "adj. 严峻的；严厉的；剧烈的；苛刻的"
+        ],
+        "usphone": "[səˈvɪr]",
+        "ukphone": "[sɪˈvɪə(r)]"
+    },
+    {
+        "name": "foundation",
+        "trans": [
+            "n. 基础；地基；基金会；根据；创立"
+        ],
+        "usphone": "[faʊnˈdeɪʃn]",
+        "ukphone": "[faʊnˈdeɪʃn]"
+    },
+    {
+        "name": "awareness",
+        "trans": [
+            "n. 意识，认识；明白，知道"
+        ],
+        "usphone": "[əˈwernəs]",
+        "ukphone": "[əˈweənəs]"
+    },
+    {
+        "name": "requirement",
+        "trans": [
+            "n. 要求；必要条件；必需品"
+        ],
+        "usphone": "[rɪˈkwaɪərmənt]",
+        "ukphone": "[rɪˈkwaɪəmənt]"
+    },
+    {
+        "name": "stunning",
+        "trans": [
+            "adj. 极好的；使人晕倒的；震耳欲聋的"
+        ],
+        "usphone": "[ˈstʌnɪŋ]",
+        "ukphone": "[ˈstʌnɪŋ]"
+    },
+    {
+        "name": "thus",
+        "trans": [
+            "conj. 因此"
+        ],
+        "usphone": "[ðʌs]",
+        "ukphone": "[ðʌs]"
+    },
+    {
+        "name": "excessive",
+        "trans": [
+            "adj. 过多的，极度的；过分的"
+        ],
+        "usphone": "[ɪkˈsesɪv]",
+        "ukphone": "[ɪkˈsesɪv]"
+    },
+    {
+        "name": "justice",
+        "trans": [
+            "n. 司法，法律制裁；正义；法官，审判员"
+        ],
+        "usphone": "[ˈdʒʌstɪs]",
+        "ukphone": "[ˈdʒʌstɪs]"
+    },
+    {
+        "name": "recovery",
+        "trans": [
+            "n. 恢复，复原；痊愈；重获"
+        ],
+        "usphone": "[rɪˈkʌvəri]",
+        "ukphone": "[rɪˈkʌvəri]"
+    },
+    {
+        "name": "assure",
+        "trans": [
+            "vt. 保证；担保；使确信；弄清楚"
+        ],
+        "usphone": "[əˈʃʊr]",
+        "ukphone": "[əˈʃʊə(r)]"
+    },
+    {
+        "name": "sector",
+        "trans": [
+            "n. 部门；扇形，扇区；象限仪；函数尺"
+        ],
+        "usphone": "[ˈsektər]",
+        "ukphone": "[ˈsektə(r)]"
+    },
+    {
+        "name": "scare",
+        "trans": [
+            "n. 恐慌；惊吓；惊恐"
+        ],
+        "usphone": "[sker]",
+        "ukphone": "[skeə(r)]"
+    },
+    {
+        "name": "litter",
+        "trans": [
+            "n. 垃圾；轿，担架；一窝（动物的幼崽）；凌乱"
+        ],
+        "usphone": "[ˈlɪtər]",
+        "ukphone": "[ˈlɪtə(r)]"
+    },
+    {
+        "name": "landing",
+        "trans": [
+            "n. 登陆；码头；楼梯平台"
+        ],
+        "usphone": "[ˈlændɪŋ]",
+        "ukphone": "[ˈlændɪŋ]"
+    },
+    {
+        "name": "crack",
+        "trans": [
+            "n. 裂缝；声变；噼啪声"
+        ],
+        "usphone": "[kræk]",
+        "ukphone": "[kræk]"
+    },
+    {
+        "name": "lively",
+        "trans": [
+            "adj. 活泼的；生动的；真实的；生气勃勃的"
+        ],
+        "usphone": "[ˈlaɪvli]",
+        "ukphone": "[ˈlaɪvli]"
+    },
+    {
+        "name": "promising",
+        "trans": [
+            "v. 许诺，答应（promise的现在分词形式）"
+        ],
+        "usphone": "[ˈprɑːmɪsɪŋ]",
+        "ukphone": "[ˈprɒmɪsɪŋ]"
+    },
+    {
+        "name": "donation",
+        "trans": [
+            "n. 捐款，捐赠物；捐赠"
+        ],
+        "usphone": "[doʊˈneɪʃn]",
+        "ukphone": "[dəʊˈneɪʃ(ə)n]"
+    },
+    {
+        "name": "vast",
+        "trans": [
+            "n. 浩瀚；广阔无垠的空间"
+        ],
+        "usphone": "[væst]",
+        "ukphone": "[vɑːst]"
+    },
+    {
+        "name": "proposal",
+        "trans": [
+            "n. 提议，建议；求婚"
+        ],
+        "usphone": "[prəˈpoʊzl]",
+        "ukphone": "[prəˈpəʊzl]"
+    },
+    {
+        "name": "conventional",
+        "trans": [
+            "adj. 符合习俗的，传统的；常见的；惯例的"
+        ],
+        "usphone": "[kənˈvenʃənl]",
+        "ukphone": "[kənˈvenʃən(ə)l]"
+    },
+    {
+        "name": "hunger",
+        "trans": [
+            "n. 饿，饥饿；渴望"
+        ],
+        "usphone": "[ˈhʌŋɡər]",
+        "ukphone": "[ˈhʌŋɡə(r)]"
+    },
+    {
+        "name": "contribute",
+        "trans": [
+            "vt. 贡献，出力；投稿；捐献"
+        ],
+        "usphone": "[kənˈtrɪbjuːt]",
+        "ukphone": "[kənˈtrɪbjuːt]"
+    },
+    {
+        "name": "rapidly",
+        "trans": [
+            "adv. 迅速地；很快地；立即"
+        ],
+        "usphone": "[ˈræpɪdli]",
+        "ukphone": "[ˈræpɪdli]"
+    },
+    {
+        "name": "labour",
+        "trans": [
+            "n. （英国）工党"
+        ],
+        "usphone": "[ˈleɪbər]",
+        "ukphone": "[ˈleɪbə(r)]"
+    },
+    {
+        "name": "depressed",
+        "trans": [
+            "adj. 沮丧的；萧条的；压低的"
+        ],
+        "usphone": "[dɪˈprest]",
+        "ukphone": "[dɪˈprest]"
+    },
+    {
+        "name": "evil",
+        "trans": [
+            "n. 罪恶，邪恶；不幸"
+        ],
+        "usphone": "[ˈiːvl]",
+        "ukphone": "[ˈiːv(ə)l]"
+    },
+    {
+        "name": "commander",
+        "trans": [
+            "n. 指挥官；司令官"
+        ],
+        "usphone": "[kəˈmændər]",
+        "ukphone": "[kəˈmɑːndə(r)]"
+    },
+    {
+        "name": "derive",
+        "trans": [
+            "vt. 源于；得自；获得"
+        ],
+        "usphone": "[dɪˈraɪv]",
+        "ukphone": "[dɪˈraɪv]"
+    },
+    {
+        "name": "strike",
+        "trans": [
+            "n. 罢工；打击；殴打"
+        ],
+        "usphone": "[straɪk]",
+        "ukphone": "[straɪk]"
+    },
+    {
+        "name": "resolution",
+        "trans": [
+            "n. [物] 分辨率；决议；解决；决心"
+        ],
+        "usphone": "[ˌrezəˈluːʃn]",
+        "ukphone": "[ˌrezəˈluːʃn]"
+    },
+    {
+        "name": "approval",
+        "trans": [
+            "n. 批准；认可；赞成"
+        ],
+        "usphone": "[əˈpruːvl]",
+        "ukphone": "[əˈpruːv(ə)l]"
+    },
+    {
+        "name": "sincere",
+        "trans": [
+            "adj. 真诚的；诚挚的；真实的"
+        ],
+        "usphone": "[sɪnˈsɪr]",
+        "ukphone": "[sɪnˈsɪə(r)]"
+    },
+    {
+        "name": "dramatically",
+        "trans": [
+            "adv. 戏剧地；引人注目地"
+        ],
+        "usphone": "[drəˈmætɪkli]",
+        "ukphone": "[drəˈmætɪkli]"
+    },
+    {
+        "name": "address",
+        "trans": [
+            "n. 地址；演讲；致辞；说话的技巧；称呼"
+        ],
+        "usphone": "[əˈdres; ˈædres]",
+        "ukphone": "[əˈdres]"
+    },
+    {
+        "name": "emotional",
+        "trans": [
+            "adj. 情绪的；易激动的；感动人的"
+        ],
+        "usphone": "[ɪˈmoʊʃənl]",
+        "ukphone": "[ɪˈməʊʃən(ə)l]"
+    },
+    {
+        "name": "privacy",
+        "trans": [
+            "n. 隐私；秘密；隐居；隐居处"
+        ],
+        "usphone": "[ˈpraɪvəsi]",
+        "ukphone": "[ˈprɪvəsi]"
+    },
+    {
+        "name": "beneficial",
+        "trans": [
+            "adj. 有益的，有利的；可享利益的"
+        ],
+        "usphone": "[ˌbenɪˈfɪʃl]",
+        "ukphone": "[ˌbenɪˈfɪʃ(ə)l]"
+    },
+    {
+        "name": "multiple",
+        "trans": [
+            "adj. 多重的；多样的；许多的"
+        ],
+        "usphone": "[ˈmʌltɪpl]",
+        "ukphone": "[ˈmʌltɪpl]"
+    },
+    {
+        "name": "additional",
+        "trans": [
+            "adj. 附加的，额外的"
+        ],
+        "usphone": "[əˈdɪʃənl]",
+        "ukphone": "[əˈdɪʃən(ə)l]"
+    },
+    {
+        "name": "procedure",
+        "trans": [
+            "n. 程序，手续；步骤"
+        ],
+        "usphone": "[prəˈsiːdʒər]",
+        "ukphone": "[prəˈsiːdʒə(r)]"
+    },
+    {
+        "name": "crisis",
+        "trans": [
+            "n. 危机；危险期；决定性时刻"
+        ],
+        "usphone": "[ˈkraɪsɪs]",
+        "ukphone": "[ˈkraɪsɪs]"
+    },
+    {
+        "name": "tough",
+        "trans": [
+            "n. 恶棍"
+        ],
+        "usphone": "[tʌf]",
+        "ukphone": "[tʌf]"
+    },
+    {
+        "name": "session",
+        "trans": [
+            "n. 会议；（法庭的）开庭；（议会等的）开会；学期；讲习会"
+        ],
+        "usphone": "[ˈseʃn]",
+        "ukphone": "[ˈseʃ(ə)n]"
+    },
+    {
+        "name": "confidence",
+        "trans": [
+            "n. 信心；信任；秘密"
+        ],
+        "usphone": "[ˈkɑːnfɪdəns]",
+        "ukphone": "[ˈkɒnfɪdəns]"
+    },
+    {
+        "name": "construction",
+        "trans": [
+            "n. 建设；建筑物；解释；造句"
+        ],
+        "usphone": "[kənˈstrʌkʃn]",
+        "ukphone": "[kənˈstrʌkʃn]"
+    },
+    {
+        "name": "loan",
+        "trans": [
+            "n. 贷款；借款"
+        ],
+        "usphone": "[loʊn]",
+        "ukphone": "[ləʊn]"
+    },
+    {
+        "name": "observer",
+        "trans": [
+            "n. 观察者；[天] 观测者；遵守者"
+        ],
+        "usphone": "[əbˈzɜːrvər]",
+        "ukphone": "[əbˈzɜːvə(r)]"
+    },
+    {
+        "name": "cure",
+        "trans": [
+            "n. 治疗；治愈；[临床] 疗法"
+        ],
+        "usphone": "[kjʊr]",
+        "ukphone": "[kjʊə(r)]"
+    },
+    {
+        "name": "rank",
+        "trans": [
+            "n. 排；等级；军衔；队列"
+        ],
+        "usphone": "[ræŋk]",
+        "ukphone": "[ræŋk]"
+    },
+    {
+        "name": "acknowledge",
+        "trans": [
+            "vt. 承认；答谢；报偿；告知已收到"
+        ],
+        "usphone": "[əkˈnɑːlɪdʒ]",
+        "ukphone": "[əkˈnɒlɪdʒ]"
+    },
+    {
+        "name": "load",
+        "trans": [
+            "n. 负载，负荷；工作量；装载量"
+        ],
+        "usphone": "[loʊd]",
+        "ukphone": "[ləʊd]"
+    },
+    {
+        "name": "disturb",
+        "trans": [
+            "vt. 打扰；妨碍；使不安；弄乱；使恼怒"
+        ],
+        "usphone": "[dɪˈstɜːrb]",
+        "ukphone": "[dɪˈstɜːb]"
+    },
+    {
+        "name": "assess",
+        "trans": [
+            "vt. 评定；估价；对…征税"
+        ],
+        "usphone": "[əˈses]",
+        "ukphone": "[əˈses]"
+    },
+    {
+        "name": "slip",
+        "trans": [
+            "n. 滑，滑倒；片，纸片；错误；下跌；事故"
+        ],
+        "usphone": "[slɪp]",
+        "ukphone": "[slɪp]"
+    },
+    {
+        "name": "even",
+        "trans": [
+            "adj. [数] 偶数的；平坦的；相等的"
+        ],
+        "usphone": "[ˈiːvn]",
+        "ukphone": "[ˈiːv(ə)n]"
+    },
+    {
+        "name": "negative",
+        "trans": [
+            "adj. [数] 负的；消极的；否定的；阴性的"
+        ],
+        "usphone": "[ˈneɡətɪv]",
+        "ukphone": "[ˈneɡətɪv]"
+    },
+    {
+        "name": "compulsory",
+        "trans": [
+            "n. （花样滑冰、竞技体操等的）规定动作"
+        ],
+        "usphone": "[kəmˈpʌlsəri]",
+        "ukphone": "[kəmˈpʌlsəri]"
+    },
+    {
+        "name": "master",
+        "trans": [
+            "vt. 控制；精通；征服"
+        ],
+        "usphone": "[ˈmæstər]",
+        "ukphone": "[ˈmɑːstə(r)]"
+    },
+    {
+        "name": "tsunami",
+        "trans": [
+            "n. 海啸"
+        ],
+        "usphone": "[tsuːˈnɑːmi]",
+        "ukphone": "[tsuːˈnɑːmi]"
+    },
+    {
+        "name": "herb",
+        "trans": [
+            "n. 香草，药草"
+        ],
+        "usphone": "[ɜːrb; hɜːrb]",
+        "ukphone": "[hɜːb]"
+    },
+    {
+        "name": "lower",
+        "trans": [
+            "vt. 减弱，减少；放下，降下；贬低"
+        ],
+        "usphone": "[ˈloʊər]",
+        "ukphone": "[ˈləʊə(r)]"
+    },
+    {
+        "name": "affair",
+        "trans": [
+            "n. 事情；事务；私事；（尤指关系不长久的）风流韵事"
+        ],
+        "usphone": "[əˈfer]",
+        "ukphone": "[əˈfeə(r)]"
+    },
+    {
+        "name": "fare",
+        "trans": [
+            "n. 票价；费用；旅客；食物"
+        ],
+        "usphone": "[fer]",
+        "ukphone": "[feə(r)]"
+    },
+    {
+        "name": "spill",
+        "trans": [
+            "n. 溢出，溅出；溢出量；摔下；小塞子"
+        ],
+        "usphone": "[spɪl]",
+        "ukphone": "[spɪl]"
+    },
+    {
+        "name": "elegant",
+        "trans": [
+            "adj. 高雅的，优雅的；讲究的；简炼的；简洁的"
+        ],
+        "usphone": "[ˈelɪɡənt]",
+        "ukphone": "[ˈelɪɡənt]"
+    },
+    {
+        "name": "grand",
+        "trans": [
+            "n. 大钢琴；一千美元"
+        ],
+        "usphone": "[ɡrænd]",
+        "ukphone": "[ɡrænd]"
+    },
+    {
+        "name": "shortly",
+        "trans": [
+            "adv. 立刻；简短地；唐突地"
+        ],
+        "usphone": "[ˈʃɔːrtli]",
+        "ukphone": "[ˈʃɔːtli]"
+    },
+    {
+        "name": "transform",
+        "trans": [
+            "vt. 改变，使…变形；转换"
+        ],
+        "usphone": "[trænsˈfɔːrm]",
+        "ukphone": "[trænsˈfɔːm]"
+    },
+    {
+        "name": "formerly",
+        "trans": [
+            "adv. 以前；原来"
+        ],
+        "usphone": "[ˈfɔːrmərli]",
+        "ukphone": "[ˈfɔːməli]"
+    },
+    {
+        "name": "addiction",
+        "trans": [
+            "n. 上瘾，沉溺；癖嗜"
+        ],
+        "usphone": "[əˈdɪkʃn]",
+        "ukphone": "[əˈdɪkʃ(ə)n]"
+    },
+    {
+        "name": "modest",
+        "trans": [
+            "adj. 谦虚的，谦逊的；适度的；端庄的；羞怯的"
+        ],
+        "usphone": "[ˈmɑːdɪst]",
+        "ukphone": "[ˈmɒdɪst]"
+    },
+    {
+        "name": "slave",
+        "trans": [
+            "n. 奴隶；从动装置"
+        ],
+        "usphone": "[sleɪv]",
+        "ukphone": "[sleɪv]"
+    },
+    {
+        "name": "divorce",
+        "trans": [
+            "n. 离婚；分离"
+        ],
+        "usphone": "[dɪˈvɔːrs]",
+        "ukphone": "[dɪˈvɔːs]"
+    },
+    {
+        "name": "feedback",
+        "trans": [
+            "n. 反馈；成果，资料；回复"
+        ],
+        "usphone": "[ˈfiːdbæk]",
+        "ukphone": "[ˈfiːdbæk]"
+    },
+    {
+        "name": "modify",
+        "trans": [
+            "vt. 修改，修饰；更改"
+        ],
+        "usphone": "[ˈmɑːdɪfaɪ]",
+        "ukphone": "[ˈmɒdɪfaɪ]"
+    },
+    {
+        "name": "divide",
+        "trans": [
+            "n. [地理] 分水岭，分水线"
+        ],
+        "usphone": "[dɪˈvaɪd]",
+        "ukphone": "[dɪˈvaɪd]"
+    },
+    {
+        "name": "furthermore",
+        "trans": [
+            "adv. 此外；而且"
+        ],
+        "usphone": "[ˌfɜːrðərˈmɔːr]",
+        "ukphone": "[ˌfɜːðəˈmɔː(r)]"
+    },
+    {
+        "name": "thoroughly",
+        "trans": [
+            "adv. 彻底地，完全地"
+        ],
+        "usphone": "[ˈθɜːrəli]",
+        "ukphone": "[ˈθʌrəli]"
+    },
+    {
+        "name": "fake",
+        "trans": [
+            "n. 假货；骗子；假动作"
+        ],
+        "usphone": "[feɪk]",
+        "ukphone": "[feɪk]"
+    },
+    {
+        "name": "visual",
+        "trans": [
+            "adj. 视觉的，视力的；栩栩如生的"
+        ],
+        "usphone": "[ˈvɪʒuəl]",
+        "ukphone": "[ˈvɪʒuəl]"
+    },
+    {
+        "name": "presence",
+        "trans": [
+            "n. 存在；出席；参加；风度；仪态"
+        ],
+        "usphone": "[ˈprezns]",
+        "ukphone": "[ˈprezns]"
+    },
+    {
+        "name": "consistent",
+        "trans": [
+            "adj. 始终如一的，一致的；坚持的"
+        ],
+        "usphone": "[kənˈsɪstənt]",
+        "ukphone": "[kənˈsɪstənt]"
+    },
+    {
+        "name": "essentially",
+        "trans": [
+            "adv. 本质上；本来"
+        ],
+        "usphone": "[ɪˈsenʃəli]",
+        "ukphone": "[ɪˈsenʃəli]"
+    },
+    {
+        "name": "trace",
+        "trans": [
+            "n. 痕迹，踪迹；微量；[仪] 迹线；缰绳"
+        ],
+        "usphone": "[treɪs]",
+        "ukphone": "[treɪs]"
+    },
+    {
+        "name": "whom",
+        "trans": [
+            "pron. 谁（who的宾格）"
+        ],
+        "usphone": "[huːm]",
+        "ukphone": "[huːm]"
+    },
+    {
+        "name": "fix",
+        "trans": [
+            "n. 困境；方位；贿赂"
+        ],
+        "usphone": "[fɪks]",
+        "ukphone": "[fɪks]"
+    },
+    {
+        "name": "species",
+        "trans": [
+            "n. [生物] 物种；种类"
+        ],
+        "usphone": "[ˈspiːʃiːz]",
+        "ukphone": "[ˈspiːʃiːz]"
+    },
+    {
+        "name": "occupation",
+        "trans": [
+            "n. 职业；占有；消遣；占有期"
+        ],
+        "usphone": "[ˌɑːkjuˈpeɪʃn]",
+        "ukphone": "[ˌɒkjuˈpeɪʃ(ə)n]"
+    },
+    {
+        "name": "apparently",
+        "trans": [
+            "adv. 显然地；似乎，表面上"
+        ],
+        "usphone": "[əˈpærəntli]",
+        "ukphone": "[əˈpærəntli]"
+    },
+    {
+        "name": "federal",
+        "trans": [
+            "adv. 联邦政府地"
+        ],
+        "usphone": "[ˈfedərəl]",
+        "ukphone": "[ˈfedərəl]"
+    },
+    {
+        "name": "AIDS",
+        "trans": [
+            "abbr. 获得性免疫缺乏综合征；爱滋病（Acquired Immune Deficiency Syndrome）"
+        ],
+        "usphone": "[eɪdz]",
+        "ukphone": "[eɪdz]"
+    },
+    {
+        "name": "recruitment",
+        "trans": [
+            "n. 补充；征募新兵"
+        ],
+        "usphone": "[rɪˈkruːtmənt]",
+        "ukphone": "[rɪˈkruːtmənt]"
+    },
+    {
+        "name": "literary",
+        "trans": [
+            "adj. 文学的；书面的；精通文学的"
+        ],
+        "usphone": "[ˈlɪtəreri]",
+        "ukphone": "[ˈlɪtərəri]"
+    },
+    {
+        "name": "considerable",
+        "trans": [
+            "adj. 相当大的；重要的，值得考虑的"
+        ],
+        "usphone": "[kənˈsɪdərəbl]",
+        "ukphone": "[kənˈsɪdərəb(ə)l]"
+    },
+    {
+        "name": "fee",
+        "trans": [
+            "n. 费用；酬金；小费"
+        ],
+        "usphone": "[fiː]",
+        "ukphone": "[fiː]"
+    },
+    {
+        "name": "password",
+        "trans": [
+            "n. 密码；口令"
+        ],
+        "usphone": "[ˈpæswɜːrd]",
+        "ukphone": "[ˈpɑːswɜːd]"
+    },
+    {
+        "name": "slight",
+        "trans": [
+            "n. 怠慢；轻蔑"
+        ],
+        "usphone": "[slaɪt]",
+        "ukphone": "[slaɪt]"
+    },
+    {
+        "name": "tune",
+        "trans": [
+            "n. 曲调；和谐；心情"
+        ],
+        "usphone": "[tuːn]",
+        "ukphone": "[tjuːn]"
+    },
+    {
+        "name": "slope",
+        "trans": [
+            "n. 斜坡；倾斜；斜率；扛枪姿势"
+        ],
+        "usphone": "[sloʊp]",
+        "ukphone": "[sləʊp]"
+    },
+    {
+        "name": "workplace",
+        "trans": [
+            "n. 工作场所；车间"
+        ],
+        "usphone": "[ˈwɜːrkpleɪs]",
+        "ukphone": "[ˈwɜːkpleɪs]"
+    },
+    {
+        "name": "motor",
+        "trans": [
+            "n. 发动机，马达；汽车"
+        ],
+        "usphone": "[ˈmoʊtər]",
+        "ukphone": "[ˈməʊtə(r)]"
+    },
+    {
+        "name": "myth",
+        "trans": [
+            "n. 神话；虚构的人，虚构的事"
+        ],
+        "usphone": "[mɪθ]",
+        "ukphone": "[mɪθ]"
+    },
+    {
+        "name": "clinic",
+        "trans": [
+            "n. 临床；诊所"
+        ],
+        "usphone": "[ˈklɪnɪk]",
+        "ukphone": "[ˈklɪnɪk]"
+    },
+    {
+        "name": "challenge",
+        "trans": [
+            "n. 挑战；怀疑"
+        ],
+        "usphone": "[ˈtʃælɪndʒ]",
+        "ukphone": "[ˈtʃælɪndʒ]"
+    },
+    {
+        "name": "thorough",
+        "trans": [
+            "adj. 彻底的；十分的；周密的"
+        ],
+        "usphone": "[ˈθɜːroʊ]",
+        "ukphone": "[ˈθʌrə]"
+    },
+    {
+        "name": "frequent",
+        "trans": [
+            "adj. 频繁的；时常发生的；惯常的"
+        ],
+        "usphone": "[ˈfriːkwənt; friˈkwent]",
+        "ukphone": "[ˈfriːkwənt]"
+    },
+    {
+        "name": "novelist",
+        "trans": [
+            "n. 小说家"
+        ],
+        "usphone": "[ˈnɑːvəlɪst]",
+        "ukphone": "[ˈnɒvəlɪst]"
+    },
+    {
+        "name": "outline",
+        "trans": [
+            "n. 轮廓；大纲；概要；略图"
+        ],
+        "usphone": "[ˈaʊtlaɪn]",
+        "ukphone": "[ˈaʊtlaɪn]"
+    },
+    {
+        "name": "audio",
+        "trans": [
+            "adj. 声音的；[声] 音频的，[声] 声频的"
+        ],
+        "usphone": "[ˈɔːdioʊ]",
+        "ukphone": "[ˈɔːdiəʊ]"
+    },
+    {
+        "name": "forward",
+        "trans": [
+            "n. 前锋"
+        ],
+        "usphone": "[ˈfɔːrwərd]",
+        "ukphone": "[ˈfɔːwəd]"
+    },
+    {
+        "name": "convinced",
+        "trans": [
+            "v. 使确信（convince的过去分词）；说服"
+        ],
+        "usphone": "[kənˈvɪnst]",
+        "ukphone": "[kənˈvɪnst]"
+    },
+    {
+        "name": "casual",
+        "trans": [
+            "n. 便装；临时工人；待命士兵"
+        ],
+        "usphone": "[ˈkæʒuəl]",
+        "ukphone": "[ˈkæʒuəl]"
+    },
+    {
+        "name": "latest",
+        "trans": [
+            "adv. 最迟地；最后地"
+        ],
+        "usphone": "[ˈleɪtɪst]",
+        "ukphone": "[ˈleɪtɪst]"
+    },
+    {
+        "name": "low",
+        "trans": [
+            "adj. 低的，浅的；卑贱的；粗俗的；消沉的"
+        ],
+        "usphone": "[loʊ]",
+        "ukphone": "[ləʊ]"
+    },
+    {
+        "name": "ethic",
+        "trans": [
+            "n. 伦理；道德规范"
+        ],
+        "usphone": "[ˈeθɪk]",
+        "ukphone": "[ˈeθɪk]"
+    },
+    {
+        "name": "cliff",
+        "trans": [
+            "n. 悬崖；绝壁"
+        ],
+        "usphone": "[klɪf]",
+        "ukphone": "[klɪf]"
+    },
+    {
+        "name": "deadline",
+        "trans": [
+            "n. 截止期限，最后期限"
+        ],
+        "usphone": "[ˈdedlaɪn]",
+        "ukphone": "[ˈdedlaɪn]"
+    },
+    {
+        "name": "complicated",
+        "trans": [
+            "adj. 难懂的，复杂的"
+        ],
+        "usphone": "[ˈkɑːmplɪkeɪtɪd]",
+        "ukphone": "[ˈkɒmplɪkeɪtɪd]"
+    },
+    {
+        "name": "vitamin",
+        "trans": [
+            "n. [生化] 维生素；[生化] 维他命"
+        ],
+        "usphone": "[ˈvaɪtəmɪn]",
+        "ukphone": "[ˈvɪtəmɪn]"
+    },
+    {
+        "name": "accidentally",
+        "trans": [
+            "adv. 意外地；偶然地"
+        ],
+        "usphone": "[ˌæksɪˈdentəli]",
+        "ukphone": "[ˌæksɪˈdentəli]"
+    },
+    {
+        "name": "inform",
+        "trans": [
+            "vi. 告发；告密"
+        ],
+        "usphone": "[ɪnˈfɔːrm]",
+        "ukphone": "[ɪnˈfɔːm]"
+    },
+    {
+        "name": "outcome",
+        "trans": [
+            "n. 结果，结局；成果"
+        ],
+        "usphone": "[ˈaʊtkʌm]",
+        "ukphone": "[ˈaʊtkʌm]"
+    },
+    {
+        "name": "prohibit",
+        "trans": [
+            "vt. 阻止，禁止"
+        ],
+        "usphone": "[prəˈhɪbɪtˌproʊˈhɪbɪt]",
+        "ukphone": "[prəˈhɪbɪt]"
+    },
+    {
+        "name": "tunnel",
+        "trans": [
+            "n. 隧道；坑道；洞穴通道"
+        ],
+        "usphone": "[ˈtʌnl]",
+        "ukphone": "[ˈtʌn(ə)l]"
+    },
+    {
+        "name": "disc",
+        "trans": [
+            "n. 圆盘，[电子] 唱片（等于disk）"
+        ],
+        "usphone": "[dɪsk]",
+        "ukphone": "[dɪsk]"
+    },
+    {
+        "name": "stock",
+        "trans": [
+            "n. 股份，股票；库存；血统；树干；家畜"
+        ],
+        "usphone": "[stɑːk]",
+        "ukphone": "[stɒk]"
+    },
+    {
+        "name": "comfort",
+        "trans": [
+            "n. 安慰；舒适；安慰者"
+        ],
+        "usphone": "[ˈkʌmfərt]",
+        "ukphone": "[ˈkʌmfət]"
+    },
+    {
+        "name": "appropriately",
+        "trans": [
+            "adv. 适当地；合适地；相称地"
+        ],
+        "usphone": "[əˈproʊpriətli]",
+        "ukphone": "[əˈprəʊpriətli]"
+    },
+    {
+        "name": "extent",
+        "trans": [
+            "n. 程度；范围；长度"
+        ],
+        "usphone": "[ɪkˈstent]",
+        "ukphone": "[ɪkˈstent]"
+    },
+    {
+        "name": "precise",
+        "trans": [
+            "adj. 精确的；明确的；严格的"
+        ],
+        "usphone": "[prɪˈsaɪs]",
+        "ukphone": "[prɪˈsaɪs]"
+    },
+    {
+        "name": "demonstration",
+        "trans": [
+            "n. 示范；证明；示威游行"
+        ],
+        "usphone": "[ˌdemənˈstreɪʃn]",
+        "ukphone": "[ˌdemənˈstreɪʃn]"
+    },
+    {
+        "name": "corridor",
+        "trans": [
+            "走廊"
+        ],
+        "usphone": "[ˈkɔːrɪdɔːr]",
+        "ukphone": "[ˈkɒrɪdɔː(r)]"
+    },
+    {
+        "name": "debt",
+        "trans": [
+            "n. 债务；借款；罪过"
+        ],
+        "usphone": "[det]",
+        "ukphone": "[det]"
+    },
+    {
+        "name": "forbid",
+        "trans": [
+            "vt. 禁止；不准；不允许；〈正式〉严禁"
+        ],
+        "usphone": "[fərˈbɪd]",
+        "ukphone": "[fəˈbɪd]"
+    },
+    {
+        "name": "annual",
+        "trans": [
+            "n. 年刊，年鉴；一年生植物"
+        ],
+        "usphone": "[ˈænjuəl]",
+        "ukphone": "[ˈænjuəl]"
+    },
+    {
+        "name": "arise",
+        "trans": [
+            "vi. 出现；上升；起立"
+        ],
+        "usphone": "[əˈraɪz]",
+        "ukphone": "[əˈraɪz]"
+    },
+    {
+        "name": "administration",
+        "trans": [
+            "n. 管理；行政；实施；行政机构"
+        ],
+        "usphone": "[ədˌmɪnɪˈstreɪʃn]",
+        "ukphone": "[ədˌmɪnɪˈstreɪʃ(ə)n]"
+    },
+    {
+        "name": "submit",
+        "trans": [
+            "vi. 提交；服从"
+        ],
+        "usphone": "[səbˈmɪt]",
+        "ukphone": "[səbˈmɪt]"
+    },
+    {
+        "name": "steadily",
+        "trans": [
+            "adv. 稳定地；稳固地；有规则地"
+        ],
+        "usphone": "[ˈstedəli]",
+        "ukphone": "[ˈstedəli]"
+    },
+    {
+        "name": "military",
+        "trans": [
+            "adj. 军事的；军人的；适于战争的"
+        ],
+        "usphone": "[ˈmɪləteri]",
+        "ukphone": "[ˈmɪlətri]"
+    },
+    {
+        "name": "plus",
+        "trans": [
+            "prep. 加，加上"
+        ],
+        "usphone": "[plʌs]",
+        "ukphone": "[plʌs]"
+    },
+    {
+        "name": "free",
+        "trans": [
+            "adj. 免费的；自由的，不受约束的；[化学] 游离的"
+        ],
+        "usphone": "[friː]",
+        "ukphone": "[friː]"
+    },
+    {
+        "name": "process",
+        "trans": [
+            "n. 过程，进行；方法，步骤；作用；程序；推移"
+        ],
+        "usphone": "[prəˈses；ˈprɑːses]",
+        "ukphone": "[prəˈses; ˈprəʊses]"
+    },
+    {
+        "name": "anxious",
+        "trans": [
+            "adj. 焦虑的；担忧的；渴望的；急切的"
+        ],
+        "usphone": "[ˈæŋkʃəs]",
+        "ukphone": "[ˈæŋkʃəs]"
+    },
+    {
+        "name": "step",
+        "trans": [
+            "n. 步，脚步；步骤；步伐；梯级"
+        ],
+        "usphone": "[step]",
+        "ukphone": "[step]"
+    },
+    {
+        "name": "tale",
+        "trans": [
+            "n. 故事；传说；叙述；流言蜚语"
+        ],
+        "usphone": "[teɪl]",
+        "ukphone": "[teɪl]"
+    },
+    {
+        "name": "fever",
+        "trans": [
+            "n. 发烧，发热；狂热"
+        ],
+        "usphone": "[ˈfiːvər]",
+        "ukphone": "[ˈfiːvə(r)]"
+    },
+    {
+        "name": "wire",
+        "trans": [
+            "n. 电线；金属丝；电报"
+        ],
+        "usphone": "[ˈwaɪər]",
+        "ukphone": "[ˈwaɪə(r)]"
+    },
+    {
+        "name": "defence",
+        "trans": [
+            "n. 防御；防卫；答辩；防卫设备"
+        ],
+        "usphone": "[dɪˈfens]",
+        "ukphone": "[dɪˈfens]"
+    },
+    {
+        "name": "distinct",
+        "trans": [
+            "adj. 明显的；独特的；清楚的；有区别的"
+        ],
+        "usphone": "[dɪˈstɪŋkt]",
+        "ukphone": "[dɪˈstɪŋkt]"
+    },
+    {
+        "name": "shelter",
+        "trans": [
+            "n. 庇护；避难所；遮盖物"
+        ],
+        "usphone": "[ˈʃeltər]",
+        "ukphone": "[ˈʃeltə(r)]"
+    },
+    {
+        "name": "terrorist",
+        "trans": [
+            "n. 恐怖主义者，恐怖分子"
+        ],
+        "usphone": "[ˈterərɪst]",
+        "ukphone": "[ˈterərɪst]"
+    },
+    {
+        "name": "sufficiently",
+        "trans": [
+            "adv. 充分地；足够地"
+        ],
+        "usphone": "[səˈfɪʃntli]",
+        "ukphone": "[səˈfɪʃntli]"
+    },
+    {
+        "name": "viewpoint",
+        "trans": [
+            "n. 观点，看法；视角"
+        ],
+        "usphone": "[ˈvjuːpɔɪnt]",
+        "ukphone": "[ˈvjuːpɔɪnt]"
+    },
+    {
+        "name": "stroke",
+        "trans": [
+            "n. （游泳或划船的）划；中风；（打、击等的）一下；冲程；（成功的）举动；尝试；轻抚"
+        ],
+        "usphone": "[stroʊk]",
+        "ukphone": "[strəʊk]"
+    },
+    {
+        "name": "detailed",
+        "trans": [
+            "adj. 详细的，精细的；复杂的，详尽的"
+        ],
+        "usphone": "[ˈdiːteɪldˌdɪˈteɪld]",
+        "ukphone": "[ˈdiːteɪld]"
+    },
+    {
+        "name": "decoration",
+        "trans": [
+            "n. 装饰，装潢；装饰品；奖章"
+        ],
+        "usphone": "[ˌdekəˈreɪʃn]",
+        "ukphone": "[ˌdekəˈreɪʃn]"
+    },
+    {
+        "name": "overall",
+        "trans": [
+            "adj. 全部的；全体的；一切在内的"
+        ],
+        "usphone": "[ˌoʊvərˈɔːl; ˈoʊvərɔːl]",
+        "ukphone": "[ˌəʊvərˈɔːl; ˈəʊvərɔːl]"
+    },
+    {
+        "name": "helmet",
+        "trans": [
+            "n. 钢盔，头盔"
+        ],
+        "usphone": "[ˈhelmɪt]",
+        "ukphone": "[ˈhelmɪt]"
+    },
+    {
+        "name": "specify",
+        "trans": [
+            "vt. 指定；详细说明；列举；把…列入说明书"
+        ],
+        "usphone": "[ˈspesɪfaɪ]",
+        "ukphone": "[ˈspesɪfaɪ]"
+    },
+    {
+        "name": "probability",
+        "trans": [
+            "n. 可能性；机率；[数] 或然率"
+        ],
+        "usphone": "[ˌprɑːbəˈbɪləti]",
+        "ukphone": "[ˌprɒbəˈbɪləti]"
+    },
+    {
+        "name": "objective",
+        "trans": [
+            "adj. 客观的；目标的；宾格的"
+        ],
+        "usphone": "[əbˈdʒektɪv]",
+        "ukphone": "[əbˈdʒektɪv]"
+    },
+    {
+        "name": "dull",
+        "trans": [
+            "adj. 钝的；迟钝的；无趣的；呆滞的；阴暗的"
+        ],
+        "usphone": "[dʌl]",
+        "ukphone": "[dʌl]"
+    },
+    {
+        "name": "capable",
+        "trans": [
+            "adj. 能干的，能胜任的；有才华的"
+        ],
+        "usphone": "[ˈkeɪpəbl]",
+        "ukphone": "[ˈkeɪpəb(ə)l]"
+    },
+    {
+        "name": "automatic",
+        "trans": [
+            "n. 自动机械；自动手枪"
+        ],
+        "usphone": "[ˌɔːtəˈmætɪk]",
+        "ukphone": "[ˌɔːtəˈmætɪk]"
+    },
+    {
+        "name": "official",
+        "trans": [
+            "adj. 官方的；正式的；公务的"
+        ],
+        "usphone": "[əˈfɪʃl]",
+        "ukphone": "[əˈfɪʃ(ə)l]"
+    },
+    {
+        "name": "dismiss",
+        "trans": [
+            "vt. 解散；解雇；开除；让...离开；不予理会、不予考虑"
+        ],
+        "usphone": "[dɪsˈmɪs]",
+        "ukphone": "[dɪsˈmɪs]"
+    },
+    {
+        "name": "assumption",
+        "trans": [
+            "n. 假定；设想；担任；采取"
+        ],
+        "usphone": "[əˈsʌmpʃn]",
+        "ukphone": "[əˈsʌmpʃn]"
+    },
+    {
+        "name": "evident",
+        "trans": [
+            "adj. 明显的；明白的"
+        ],
+        "usphone": "[ˈevɪdənt]",
+        "ukphone": "[ˈevɪdənt]"
+    },
+    {
+        "name": "bush",
+        "trans": [
+            "n. 灌木；矮树丛"
+        ],
+        "usphone": "[bʊʃ]",
+        "ukphone": "[bʊʃ]"
+    },
+    {
+        "name": "propose",
+        "trans": [
+            "vi. 建议；求婚；打算"
+        ],
+        "usphone": "[prəˈpoʊz]",
+        "ukphone": "[prəˈpəʊz]"
+    },
+    {
+        "name": "command",
+        "trans": [
+            "n. 指挥，控制；命令；司令部"
+        ],
+        "usphone": "[kəˈmænd]",
+        "ukphone": "[kəˈmɑːnd]"
+    },
+    {
+        "name": "reserve",
+        "trans": [
+            "n. 储备，储存；自然保护区；预备队；缄默；[金融] 储备金"
+        ],
+        "usphone": "[rɪˈzɜːrv]",
+        "ukphone": "[rɪˈzɜːv]"
+    },
+    {
+        "name": "chase",
+        "trans": [
+            "n. 追逐；追赶；追击"
+        ],
+        "usphone": "[tʃeɪs]",
+        "ukphone": "[tʃeɪs]"
+    },
+    {
+        "name": "existence",
+        "trans": [
+            "n. 存在，实在；生存，生活；存在物，实在物"
+        ],
+        "usphone": "[ɪɡˈzɪstəns]",
+        "ukphone": "[ɪɡˈzɪstəns]"
+    },
+    {
+        "name": "conservation",
+        "trans": [
+            "n. 保存，保持；保护"
+        ],
+        "usphone": "[ˌkɑːnsərˈveɪʃn]",
+        "ukphone": "[ˌkɒnsəˈveɪʃ(ə)n]"
+    },
+    {
+        "name": "preparation",
+        "trans": [
+            "n. 预备；准备"
+        ],
+        "usphone": "[ˌprepəˈreɪʃn]",
+        "ukphone": "[ˌprepəˈreɪʃn]"
+    },
+    {
+        "name": "accompany",
+        "trans": [
+            "vt. 陪伴，伴随；伴奏"
+        ],
+        "usphone": "[əˈkʌmpəni]",
+        "ukphone": "[əˈkʌmpəni]"
+    },
+    {
+        "name": "scale",
+        "trans": [
+            "n. 规模；比例；鳞；刻度；天平；数值范围"
+        ],
+        "usphone": "[skeɪl]",
+        "ukphone": "[skeɪl]"
+    },
+    {
+        "name": "retain",
+        "trans": [
+            "vt. 保持；雇；记住"
+        ],
+        "usphone": "[rɪˈteɪn]",
+        "ukphone": "[rɪˈteɪn]"
+    },
+    {
+        "name": "commonly",
+        "trans": [
+            "adv. 一般地；通常地；普通地"
+        ],
+        "usphone": "[ˈkɑːmənli]",
+        "ukphone": "[ˈkɒmənli]"
+    },
+    {
+        "name": "broadcast",
+        "trans": [
+            "n. 广播；播音；广播节目"
+        ],
+        "usphone": "[ˈbrɔːdkæst]",
+        "ukphone": "[ˈbrɔːdkɑːst]"
+    },
+    {
+        "name": "determination",
+        "trans": [
+            "n. 决心；果断；测定"
+        ],
+        "usphone": "[dɪˌtɜːrmɪˈneɪʃn]",
+        "ukphone": "[dɪˌtɜːmɪˈneɪʃ(ə)n]"
+    },
+    {
+        "name": "besides",
+        "trans": [
+            "prep. 除…之外"
+        ],
+        "usphone": "[bɪˈsaɪdz]",
+        "ukphone": "[bɪˈsaɪdz]"
+    },
+    {
+        "name": "incorrect",
+        "trans": [
+            "adj. 错误的，不正确的；不适当的；不真实的"
+        ],
+        "usphone": "[ˌɪnkəˈrekt]",
+        "ukphone": "[ˌɪnkəˈrekt]"
+    },
+    {
+        "name": "nevertheless",
+        "trans": [
+            "adv. 然而，不过；虽然如此"
+        ],
+        "usphone": "[ˌnevərðəˈles]",
+        "ukphone": "[ˌnevəðəˈles]"
+    },
+    {
+        "name": "illustration",
+        "trans": [
+            "n. 说明；插图；例证；图解"
+        ],
+        "usphone": "[ˌɪləˈstreɪʃn]",
+        "ukphone": "[ˌɪləˈstreɪʃ(ə)n]"
+    },
+    {
+        "name": "severely",
+        "trans": [
+            "adv. 严重地；严格地，严厉地；纯朴地"
+        ],
+        "usphone": "[sɪˈvɪrli]",
+        "ukphone": "[sɪˈvɪəli]"
+    },
+    {
+        "name": "apology",
+        "trans": [
+            "n. 道歉；谢罪；辩护；勉强的替代物"
+        ],
+        "usphone": "[əˈpɑːlədʒi]",
+        "ukphone": "[əˈpɒlədʒi]"
+    },
+    {
+        "name": "scholar",
+        "trans": [
+            "n. 学者；奖学金获得者"
+        ],
+        "usphone": "[ˈskɑːlər]",
+        "ukphone": "[ˈskɒlə(r)]"
+    },
+    {
+        "name": "nasty",
+        "trans": [
+            "adj. 下流的；肮脏的；脾气不好的；险恶的"
+        ],
+        "usphone": "[ˈnæsti]",
+        "ukphone": "[ˈnɑːsti]"
+    },
+    {
+        "name": "accomplish",
+        "trans": [
+            "vt. 完成；实现；达到"
+        ],
+        "usphone": "[əˈkɑːmplɪʃ]",
+        "ukphone": "[əˈkʌmplɪʃ]"
+    },
+    {
+        "name": "unique",
+        "trans": [
+            "n. 独一无二的人或物"
+        ],
+        "usphone": "[juˈniːk]",
+        "ukphone": "[juˈniːk]"
+    },
+    {
+        "name": "scheme",
+        "trans": [
+            "n. 计划；组合；体制；诡计"
+        ],
+        "usphone": "[skiːm]",
+        "ukphone": "[skiːm]"
+    },
+    {
+        "name": "favour",
+        "trans": [
+            "n. 偏爱；赞同；善行"
+        ],
+        "usphone": "[ˈfeɪvər]",
+        "ukphone": "[ˈfeɪvə(r)]"
+    },
+    {
+        "name": "mate",
+        "trans": [
+            "n. 助手，大副；配偶；同事；配对物"
+        ],
+        "usphone": "[meɪt]",
+        "ukphone": "[meɪt]"
+    },
+    {
+        "name": "rocket",
+        "trans": [
+            "n. 火箭"
+        ],
+        "usphone": "[ˈrɑːkɪt]",
+        "ukphone": "[ˈrɒkɪt]"
+    },
+    {
+        "name": "restriction",
+        "trans": [
+            "n. 限制；约束；束缚"
+        ],
+        "usphone": "[rɪˈstrɪkʃn]",
+        "ukphone": "[rɪˈstrɪkʃ(ə)n]"
+    },
+    {
+        "name": "sympathy",
+        "trans": [
+            "n. 同情；慰问；赞同"
+        ],
+        "usphone": "[ˈsɪmpəθi]",
+        "ukphone": "[ˈsɪmpəθi]"
+    },
+    {
+        "name": "collapse",
+        "trans": [
+            "n. 倒塌；失败；衰竭"
+        ],
+        "usphone": "[kəˈlæps]",
+        "ukphone": "[kəˈlæps]"
+    },
+    {
+        "name": "consistently",
+        "trans": [
+            "adv. 一贯地；一致地；坚实地"
+        ],
+        "usphone": "[kənˈsɪstəntli]",
+        "ukphone": "[kənˈsɪstəntli]"
+    },
+    {
+        "name": "welfare",
+        "trans": [
+            "n. 福利；幸福；福利事业；安宁"
+        ],
+        "usphone": "[ˈwelfer]",
+        "ukphone": "[ˈwelfeə(r)]"
+    },
+    {
+        "name": "criterion",
+        "trans": [
+            "n. （批评判断的）标准；准则；规范；准据"
+        ],
+        "usphone": "[kraɪˈtɪriən]",
+        "ukphone": "[kraɪˈtɪəriən]"
+    },
+    {
+        "name": "evolution",
+        "trans": [
+            "n. 演变；进化论；进展"
+        ],
+        "usphone": "[ˌevəˈluːʃn]",
+        "ukphone": "[ˌiːvəˈluːʃ(ə)n]"
+    },
+    {
+        "name": "honesty",
+        "trans": [
+            "n. 诚实，正直"
+        ],
+        "usphone": "[ˈɑːnəsti]",
+        "ukphone": "[ˈɒnəsti]"
+    },
+    {
+        "name": "harm",
+        "trans": [
+            "n. 伤害；损害"
+        ],
+        "usphone": "[hɑːrm]",
+        "ukphone": "[hɑːm]"
+    },
+    {
+        "name": "initially",
+        "trans": [
+            "adv. 最初，首先；开头"
+        ],
+        "usphone": "[ɪˈnɪʃəli]",
+        "ukphone": "[ɪˈnɪʃəli]"
+    },
+    {
+        "name": "primarily",
+        "trans": [
+            "adv. 首先；主要地，根本上"
+        ],
+        "usphone": "[praɪˈmerəli]",
+        "ukphone": "[praɪˈmerəli]"
+    },
+    {
+        "name": "orchestra",
+        "trans": [
+            "n. 管弦乐队；乐队演奏处"
+        ],
+        "usphone": "[ˈɔːrkɪstrə]",
+        "ukphone": "[ˈɔːkɪstrə]"
+    },
+    {
+        "name": "spread",
+        "trans": [
+            "n. 传播；伸展"
+        ],
+        "usphone": "[spred]",
+        "ukphone": "[spred]"
+    },
+    {
+        "name": "exploration",
+        "trans": [
+            "n. 探测；探究；踏勘"
+        ],
+        "usphone": "[ˌekspləˈreɪʃn]",
+        "ukphone": "[ˌekspləˈreɪʃ(ə)n]"
+    },
+    {
+        "name": "offensive",
+        "trans": [
+            "adj. 攻击的；冒犯的；无礼的；讨厌的"
+        ],
+        "usphone": "[əˈfensɪv]",
+        "ukphone": "[əˈfensɪv]"
+    },
+    {
+        "name": "proportion",
+        "trans": [
+            "n. 比例，占比；部分；面积；均衡"
+        ],
+        "usphone": "[prəˈpɔːrʃn]",
+        "ukphone": "[prəˈpɔːʃn]"
+    },
+    {
+        "name": "revenue",
+        "trans": [
+            "n. 税收，国家的收入；收益"
+        ],
+        "usphone": "[ˈrevənuː]",
+        "ukphone": "[ˈrevənjuː]"
+    },
+    {
+        "name": "circumstance",
+        "trans": [
+            "n. 环境，情况；事件；境遇"
+        ],
+        "usphone": "[ˈsɜːrkəmstæns]",
+        "ukphone": "[ˈsɜːkəmstəns]"
+    },
+    {
+        "name": "elsewhere",
+        "trans": [
+            "adv. 在别处；到别处"
+        ],
+        "usphone": "[ˌelsˈwer]",
+        "ukphone": "[ˌelsˈweə(r)]"
+    },
+    {
+        "name": "fully",
+        "trans": [
+            "adv. 充分地；完全地；彻底地"
+        ],
+        "usphone": "[ˈfʊli]",
+        "ukphone": "[ˈfʊli]"
+    },
+    {
+        "name": "intense",
+        "trans": [
+            "adj. 强烈的；紧张的；非常的；热情的"
+        ],
+        "usphone": "[ɪnˈtens]",
+        "ukphone": "[ɪnˈtens]"
+    },
+    {
+        "name": "fraud",
+        "trans": [
+            "n. 欺骗；骗子；诡计"
+        ],
+        "usphone": "[frɔːd]",
+        "ukphone": "[frɔːd]"
+    },
+    {
+        "name": "tank",
+        "trans": [
+            "n. 坦克；水槽；池塘"
+        ],
+        "usphone": "[tæŋk]",
+        "ukphone": "[tæŋk]"
+    },
+    {
+        "name": "trillion",
+        "trans": [
+            "num. [数] 万亿"
+        ],
+        "usphone": "[ˈtrɪljən]",
+        "ukphone": "[ˈtrɪljən]"
+    },
+    {
+        "name": "spite",
+        "trans": [
+            "n. 不顾；恶意；怨恨"
+        ],
+        "usphone": "[spaɪt]",
+        "ukphone": "[spaɪt]"
+    },
+    {
+        "name": "useless",
+        "trans": [
+            "adj. 无用的；无效的"
+        ],
+        "usphone": "[ˈjuːsləs]",
+        "ukphone": "[ˈjuːsləs]"
+    },
+    {
+        "name": "devote",
+        "trans": [
+            "vt. 致力于；奉献"
+        ],
+        "usphone": "[dɪˈvoʊt]",
+        "ukphone": "[dɪˈvəʊt]"
+    },
+    {
+        "name": "hilarious",
+        "trans": [
+            "adj. 欢闹的；非常滑稽的；喜不自禁的"
+        ],
+        "usphone": "[hɪˈleriəs]",
+        "ukphone": "[hɪˈleəriəs]"
+    },
+    {
+        "name": "dynamic",
+        "trans": [
+            "n. 动态；动力"
+        ],
+        "usphone": "[daɪˈnæmɪk]",
+        "ukphone": "[daɪˈnæmɪk]"
+    },
+    {
+        "name": "loyal",
+        "trans": [
+            "adj. 忠诚的，忠心的；忠贞的"
+        ],
+        "usphone": "[ˈlɔɪəl]",
+        "ukphone": "[ˈlɔɪəl]"
+    },
+    {
+        "name": "dishonest",
+        "trans": [
+            "adj. 不诚实的；欺诈的"
+        ],
+        "usphone": "[dɪsˈɑːnɪst]",
+        "ukphone": "[dɪsˈɒnɪst]"
+    },
+    {
+        "name": "interrupt",
+        "trans": [
+            "n. 中断"
+        ],
+        "usphone": "[ˌɪntəˈrʌpt]",
+        "ukphone": "[ˌɪntəˈrʌpt]"
+    },
+    {
+        "name": "joint",
+        "trans": [
+            "n. 关节；接缝；接合处，接合点；（牛，羊等的腿）大块肉"
+        ],
+        "usphone": "[dʒɔɪnt]",
+        "ukphone": "[dʒɔɪnt]"
+    },
+    {
+        "name": "bar",
+        "trans": [
+            "n. 条，棒；酒吧；障碍；法庭"
+        ],
+        "usphone": "[bɑːr]",
+        "ukphone": "[bɑː(r)]"
+    },
+    {
+        "name": "probable",
+        "trans": [
+            "n. 很可能的事；大有希望的候选者"
+        ],
+        "usphone": "[ˈprɑːbəbl]",
+        "ukphone": "[ˈprɒbəb(ə)l]"
+    },
+    {
+        "name": "constant",
+        "trans": [
+            "n. [数] 常数；恒量"
+        ],
+        "usphone": "[ˈkɑːnstənt]",
+        "ukphone": "[ˈkɒnstənt]"
+    },
+    {
+        "name": "candle",
+        "trans": [
+            "n. 蜡烛；烛光；烛形物"
+        ],
+        "usphone": "[ˈkændl]",
+        "ukphone": "[ˈkænd(ə)l]"
+    },
+    {
+        "name": "worse",
+        "trans": [
+            "n. 更坏的事；更恶劣的事"
+        ],
+        "usphone": "[wɜːrs]",
+        "ukphone": "[wɜːs]"
+    },
+    {
+        "name": "convenience",
+        "trans": [
+            "n. 便利；厕所；便利的事物"
+        ],
+        "usphone": "[kənˈviːniəns]",
+        "ukphone": "[kənˈviːniəns]"
+    },
+    {
+        "name": "conspiracy",
+        "trans": [
+            "n. 阴谋；共谋；阴谋集团"
+        ],
+        "usphone": "[kənˈspɪrəsi]",
+        "ukphone": "[kənˈspɪrəsi]"
+    },
+    {
+        "name": "found",
+        "trans": [
+            "v. 找到（find的过去分词）"
+        ],
+        "usphone": "[faʊnd]",
+        "ukphone": "[faʊnd]"
+    },
+    {
+        "name": "protection",
+        "trans": [
+            "n. 保护；防卫；护照"
+        ],
+        "usphone": "[prəˈtekʃn]",
+        "ukphone": "[prəˈtekʃn]"
+    },
+    {
+        "name": "scream",
+        "trans": [
+            "n. 尖叫声；尖锐刺耳的声音；极其滑稽可笑的人"
+        ],
+        "usphone": "[skriːm]",
+        "ukphone": "[skriːm]"
+    },
+    {
+        "name": "romance",
+        "trans": [
+            "n. 传奇；浪漫史；风流韵事；冒险故事"
+        ],
+        "usphone": "[ˈroʊmæns]",
+        "ukphone": "[rəʊˈmæns; ˈrəʊmæns]"
+    },
+    {
+        "name": "principal",
+        "trans": [
+            "adj. 主要的；资本的"
+        ],
+        "usphone": "[ˈprɪnsəpl]",
+        "ukphone": "[ˈprɪnsəpl]"
+    },
+    {
+        "name": "fellow",
+        "trans": [
+            "n. 家伙；朋友；同事；会员"
+        ],
+        "usphone": "[ˈfeloʊ]",
+        "ukphone": "[ˈfeləʊ]"
+    },
+    {
+        "name": "partly",
+        "trans": [
+            "adv. 部分地；在一定程度上"
+        ],
+        "usphone": "[ˈpɑːrtli]",
+        "ukphone": "[ˈpɑːtli]"
+    },
+    {
+        "name": "ridiculous",
+        "trans": [
+            "adj. 可笑的；荒谬的"
+        ],
+        "usphone": "[rɪˈdɪkjələs]",
+        "ukphone": "[rɪˈdɪkjələs]"
+    },
+    {
+        "name": "interpret",
+        "trans": [
+            "vi. 解释；翻译"
+        ],
+        "usphone": "[ɪnˈtɜːrprət]",
+        "ukphone": "[ɪnˈtɜːprət]"
+    },
+    {
+        "name": "invade",
+        "trans": [
+            "vt. 侵略；侵袭；侵扰；涌入"
+        ],
+        "usphone": "[ɪnˈveɪd]",
+        "ukphone": "[ɪnˈveɪd]"
+    },
+    {
+        "name": "enquiry",
+        "trans": [
+            "n. [计] 询问，[贸易] 询盘"
+        ],
+        "usphone": "[ˈɪnkwəri]",
+        "ukphone": "[ɪnˈkwaɪəri]"
+    },
+    {
+        "name": "terminal",
+        "trans": [
+            "n. 末端；终点；终端机；极限"
+        ],
+        "usphone": "[ˈtɜːrmɪn(ə)l]",
+        "ukphone": "[ˈtɜːmɪn(ə)l]"
+    },
+    {
+        "name": "significantly",
+        "trans": [
+            "adv. 显著地；相当数量地"
+        ],
+        "usphone": "[sɪɡˈnɪfɪkəntli]",
+        "ukphone": "[sɪɡˈnɪfɪkəntli]"
+    },
+    {
+        "name": "chain",
+        "trans": [
+            "n. 链；束缚；枷锁"
+        ],
+        "usphone": "[tʃeɪn]",
+        "ukphone": "[tʃeɪn]"
+    },
+    {
+        "name": "observation",
+        "trans": [
+            "n. 观察；监视；观察报告"
+        ],
+        "usphone": "[ˌɑːbzərˈveɪʃ(ə)n]",
+        "ukphone": "[ˌɒbzəˈveɪʃ(ə)n]"
+    },
+    {
+        "name": "tragic",
+        "trans": [
+            "adj. 悲剧的；悲痛的，不幸的"
+        ],
+        "usphone": "[ˈtrædʒɪk]",
+        "ukphone": "[ˈtrædʒɪk]"
+    },
+    {
+        "name": "neat",
+        "trans": [
+            "adj. 灵巧的；整洁的；优雅的；齐整的；未搀水的；平滑的"
+        ],
+        "usphone": "[niːt]",
+        "ukphone": "[niːt]"
+    },
+    {
+        "name": "goodness",
+        "trans": [
+            "n. 善良，优秀 ；精华，养分"
+        ],
+        "usphone": "[ˈɡʊdnəs]",
+        "ukphone": "[ˈɡʊdnəs]"
+    },
+    {
+        "name": "domestic",
+        "trans": [
+            "n. 国货；佣人"
+        ],
+        "usphone": "[dəˈmestɪk]",
+        "ukphone": "[dəˈmestɪk]"
+    },
+    {
+        "name": "feel",
+        "trans": [
+            "n. 感觉；触摸"
+        ],
+        "usphone": "[fiːl]",
+        "ukphone": "[fiːl]"
+    },
+    {
+        "name": "palm",
+        "trans": [
+            "n. 手掌；棕榈树；掌状物"
+        ],
+        "usphone": "[pɑːm]",
+        "ukphone": "[pɑːm]"
+    },
+    {
+        "name": "extensive",
+        "trans": [
+            "adj. 广泛的；大量的；广阔的"
+        ],
+        "usphone": "[ɪkˈstensɪv]",
+        "ukphone": "[ɪkˈstensɪv]"
+    },
+    {
+        "name": "spare",
+        "trans": [
+            "n. 剩余；备用零件"
+        ],
+        "usphone": "[sper]",
+        "ukphone": "[speə(r)]"
+    },
+    {
+        "name": "specialize",
+        "trans": [
+            "vi. 专门从事；详细说明；特化"
+        ],
+        "usphone": "[ˈspeʃəlaɪz]",
+        "ukphone": "[ˈspeʃəlaɪz]"
+    },
+    {
+        "name": "reckon",
+        "trans": [
+            "vi. 估计；计算；猜想，料想"
+        ],
+        "usphone": "[ˈrekən]",
+        "ukphone": "[ˈrekən]"
+    },
+    {
+        "name": "compose",
+        "trans": [
+            "vt. 构成；写作；使平静；排…的版"
+        ],
+        "usphone": "[kəmˈpoʊz]",
+        "ukphone": "[kəmˈpəʊz]"
+    },
+    {
+        "name": "mode",
+        "trans": [
+            "n. 模式；方式；风格；时尚"
+        ],
+        "usphone": "[moʊd]",
+        "ukphone": "[məʊd]"
+    },
+    {
+        "name": "openly",
+        "trans": [
+            "adv. 公开地；公然地；坦率地"
+        ],
+        "usphone": "[ˈoʊpənli]",
+        "ukphone": "[ˈəʊpənli]"
+    },
+    {
+        "name": "wealth",
+        "trans": [
+            "n. 财富；大量；富有"
+        ],
+        "usphone": "[welθ]",
+        "ukphone": "[welθ]"
+    },
+    {
+        "name": "fulfil",
+        "trans": [
+            "vt. 履行；完成；实践；满足"
+        ],
+        "usphone": "[fʊlˈfɪl]",
+        "ukphone": "[fʊlˈfɪl]"
+    },
+    {
+        "name": "plain",
+        "trans": [
+            "n. 平原；无格式；朴实无华的东西"
+        ],
+        "usphone": "[pleɪn]",
+        "ukphone": "[pleɪn]"
+    },
+    {
+        "name": "innovative",
+        "trans": [
+            "adj. 革新的，创新的；新颖的；有创新精神的"
+        ],
+        "usphone": "[ˈɪnəveɪtɪv]",
+        "ukphone": "[ˈɪnəveɪtɪv]"
+    },
+    {
+        "name": "reputation",
+        "trans": [
+            "n. 名声，名誉；声望"
+        ],
+        "usphone": "[ˌrepjuˈteɪʃn]",
+        "ukphone": "[ˌrepjuˈteɪʃn]"
+    },
+    {
+        "name": "promotion",
+        "trans": [
+            "n. 提升，[劳经] 晋升；推销，促销；促进；发扬，振兴"
+        ],
+        "usphone": "[prəˈmoʊʃn]",
+        "ukphone": "[prəˈməʊʃn]"
+    },
+    {
+        "name": "defend",
+        "trans": [
+            "vi. 保卫；防守"
+        ],
+        "usphone": "[dɪˈfend]",
+        "ukphone": "[dɪˈfend]"
+    },
+    {
+        "name": "moreover",
+        "trans": [
+            "adv. 而且；此外"
+        ],
+        "usphone": "[mɔːrˈoʊvər]",
+        "ukphone": "[mɔːrˈəʊvə(r)]"
+    },
+    {
+        "name": "disorder",
+        "trans": [
+            "n. 混乱；骚乱"
+        ],
+        "usphone": "[dɪsˈɔːrdər]",
+        "ukphone": "[dɪsˈɔːdə(r)]"
+    },
+    {
+        "name": "sense",
+        "trans": [
+            "n. 感觉，功能；观念；道理；理智"
+        ],
+        "usphone": "[sens]",
+        "ukphone": "[sens]"
+    },
+    {
+        "name": "deliberately",
+        "trans": [
+            "adv. 故意地；谨慎地；慎重地"
+        ],
+        "usphone": "[dɪˈlɪbərətli]",
+        "ukphone": "[dɪˈlɪbərətli]"
+    },
+    {
+        "name": "beyond",
+        "trans": [
+            "prep. 超过；越过；那一边；在...较远的一边"
+        ],
+        "usphone": "[bɪˈjɑːnd]",
+        "ukphone": "[bɪˈjɒnd]"
+    },
+    {
+        "name": "track",
+        "trans": [
+            "n. 轨道；足迹，踪迹；小道"
+        ],
+        "usphone": "[træk]",
+        "ukphone": "[træk]"
+    },
+    {
+        "name": "bias",
+        "trans": [
+            "n. 偏见；偏爱；斜纹；乖离率"
+        ],
+        "usphone": "[ˈbaɪəs]",
+        "ukphone": "[ˈbaɪəs]"
+    },
+    {
+        "name": "sporting",
+        "trans": [
+            "adj. 运动的；冒险性的；公正的；喜好运动的"
+        ],
+        "usphone": "[ˈspɔːrtɪŋ]",
+        "ukphone": "[ˈspɔːtɪŋ]"
+    },
+    {
+        "name": "aircraft",
+        "trans": [
+            "n. 飞机，航空器"
+        ],
+        "usphone": "[ˈerkræft]",
+        "ukphone": "[ˈeəkrɑːft]"
+    },
+    {
+        "name": "external",
+        "trans": [
+            "n. 外部；外观；外面"
+        ],
+        "usphone": "[ɪkˈstɜːrnl]",
+        "ukphone": "[ɪkˈstɜːn(ə)l]"
+    },
+    {
+        "name": "owe",
+        "trans": [
+            "vt. 欠；感激；应给予；应该把……归功于"
+        ],
+        "usphone": "[oʊ]",
+        "ukphone": "[əʊ]"
+    },
+    {
+        "name": "regret",
+        "trans": [
+            "n. 遗憾；抱歉；悲叹"
+        ],
+        "usphone": "[rɪˈɡret]",
+        "ukphone": "[rɪˈɡret]"
+    },
+    {
+        "name": "association",
+        "trans": [
+            "n. 协会，联盟，社团；联合；联想"
+        ],
+        "usphone": "[əˌsoʊsiˈeɪʃn; əˌsoʊʃiˈeɪʃn]",
+        "ukphone": "[əˌsəʊsiˈeɪʃn; əˌsəʊʃiˈeɪʃn]"
+    },
+    {
+        "name": "weakness",
+        "trans": [
+            "n. 弱点；软弱；嗜好"
+        ],
+        "usphone": "[ˈwiːknəs]",
+        "ukphone": "[ˈwiːknəs]"
+    },
+    {
+        "name": "advance",
+        "trans": [
+            "n. 发展；前进；增长；预付款"
+        ],
+        "usphone": "[ədˈvæns]",
+        "ukphone": "[ədˈvɑːns]"
+    },
+    {
+        "name": "monster",
+        "trans": [
+            "n. 怪物；巨人，巨兽；残忍的人"
+        ],
+        "usphone": "[ˈmɑːnstər]",
+        "ukphone": "[ˈmɒnstə(r)]"
+    },
+    {
+        "name": "associate",
+        "trans": [
+            "n. 同事，伙伴；关联的事物"
+        ],
+        "usphone": "[əˈsoʊsieɪt; əˈsoʊʃieɪt]",
+        "ukphone": "[əˈsəʊsieɪt]"
+    },
+    {
+        "name": "notebook",
+        "trans": [
+            "n. 笔记本，笔记簿；手册"
+        ],
+        "usphone": "[ˈnoʊtbʊk]",
+        "ukphone": "[ˈnəʊtbʊk]"
+    },
+    {
+        "name": "bacteria",
+        "trans": [
+            "n. [微] 细菌"
+        ],
+        "usphone": "[bækˈtɪriə]",
+        "ukphone": "[bækˈtɪəriə]"
+    },
+    {
+        "name": "ethical",
+        "trans": [
+            "n. 处方药"
+        ],
+        "usphone": "[ˈeθɪkl]",
+        "ukphone": "[ˈeθɪk(ə)l]"
+    },
+    {
+        "name": "darkness",
+        "trans": [
+            "n. 黑暗；模糊；无知；阴郁"
+        ],
+        "usphone": "[ˈdɑːrknəs]",
+        "ukphone": "[ˈdɑːknəs]"
+    },
+    {
+        "name": "sequence",
+        "trans": [
+            "n. [数][计] 序列；顺序；续发事件"
+        ],
+        "usphone": "[ˈsiːkwəns]",
+        "ukphone": "[ˈsiːkwəns]"
+    },
+    {
+        "name": "vision",
+        "trans": [
+            "n. 视力；美景；眼力；幻象；想象力；幻视（漫威漫画旗下超级英雄）"
+        ],
+        "usphone": "[ˈvɪʒn]",
+        "ukphone": "[ˈvɪʒn]"
+    },
+    {
+        "name": "value",
+        "trans": [
+            "n. 值；价值；价格；重要性；确切涵义"
+        ],
+        "usphone": "[ˈvæljuː]",
+        "ukphone": "[ˈvæljuː]"
+    },
+    {
+        "name": "aspect",
+        "trans": [
+            "n. 方面；方向；形势；外貌"
+        ],
+        "usphone": "[ˈæspekt]",
+        "ukphone": "[ˈæspekt]"
+    },
+    {
+        "name": "make",
+        "trans": [
+            "vt. 使得；进行；布置，准备，整理；制造；认为；获得；形成；安排；引起；构成"
+        ],
+        "usphone": "[meɪk]",
+        "ukphone": "[meɪk]"
+    },
+    {
+        "name": "blind",
+        "trans": [
+            "n. 掩饰，借口；百叶窗"
+        ],
+        "usphone": "[blaɪnd]",
+        "ukphone": "[blaɪnd]"
+    },
+    {
+        "name": "credit",
+        "trans": [
+            "n. 信用，信誉；[金融] 贷款；学分；信任；声望"
+        ],
+        "usphone": "[ˈkredɪt]",
+        "ukphone": "[ˈkredɪt]"
+    },
+    {
+        "name": "graphics",
+        "trans": [
+            "n. [测] 制图学；制图法；图表算法"
+        ],
+        "usphone": "[ˈɡræfɪks]",
+        "ukphone": "[ˈɡræfɪks]"
+    },
+    {
+        "name": "relevant",
+        "trans": [
+            "adj. 相关的；切题的；中肯的；有重大关系的；有意义的，目的明确的"
+        ],
+        "usphone": "[ˈreləvənt]",
+        "ukphone": "[ˈreləvənt]"
+    },
+    {
+        "name": "wound",
+        "trans": [
+            "n. 创伤，伤口"
+        ],
+        "usphone": "[wuːnd]",
+        "ukphone": "[wuːnd]"
+    },
+    {
+        "name": "struggle",
+        "trans": [
+            "n. 努力，奋斗；竞争"
+        ],
+        "usphone": "[ˈstrʌɡl]",
+        "ukphone": "[ˈstrʌɡ(ə)l]"
+    },
+    {
+        "name": "patience",
+        "trans": [
+            "n. 耐性，耐心；忍耐，容忍"
+        ],
+        "usphone": "[ˈpeɪʃns]",
+        "ukphone": "[ˈpeɪʃ(ə)ns]"
+    },
+    {
+        "name": "bug",
+        "trans": [
+            "n. 臭虫，小虫；故障；窃听器"
+        ],
+        "usphone": "[bʌɡ]",
+        "ukphone": "[bʌɡ]"
+    },
+    {
+        "name": "weird",
+        "trans": [
+            "n. （苏格兰）命运；预言"
+        ],
+        "usphone": "[wɪrd]",
+        "ukphone": "[wɪəd]"
+    },
+    {
+        "name": "restrict",
+        "trans": [
+            "vt. 限制；约束；限定"
+        ],
+        "usphone": "[rɪˈstrɪkt]",
+        "ukphone": "[rɪˈstrɪkt]"
+    },
+    {
+        "name": "valid",
+        "trans": [
+            "adj. 有效的；有根据的；合法的；正当的"
+        ],
+        "usphone": "[ˈvælɪd]",
+        "ukphone": "[ˈvælɪd]"
+    },
+    {
+        "name": "handle",
+        "trans": [
+            "n. [建] 把手；柄；手感；口实"
+        ],
+        "usphone": "[ˈhændl]",
+        "ukphone": "[ˈhænd(ə)l]"
+    },
+    {
+        "name": "humour",
+        "trans": [
+            "n. 幽默（等于humor）；诙谐"
+        ],
+        "usphone": "[ˈhjuːmər]",
+        "ukphone": "[ˈhjuːmə(r)]"
+    },
+    {
+        "name": "parliament",
+        "trans": [
+            "n. 议会，国会"
+        ],
+        "usphone": "[ˈpɑːrləmənt]",
+        "ukphone": "[ˈpɑːləmənt]"
+    },
+    {
+        "name": "nowadays",
+        "trans": [
+            "adv. 现今；时下"
+        ],
+        "usphone": "[ˈnaʊədeɪz]",
+        "ukphone": "[ˈnaʊədeɪz]"
+    },
+    {
+        "name": "close",
+        "trans": [
+            "n. 结束"
+        ],
+        "usphone": "[kloʊz; kloʊs]",
+        "ukphone": "[kləʊz]"
+    },
+    {
+        "name": "rapid",
+        "trans": [
+            "n. 急流；高速交通工具，高速交通网"
+        ],
+        "usphone": "[ˈræpɪd]",
+        "ukphone": "[ˈræpɪd]"
+    },
+    {
+        "name": "rural",
+        "trans": [
+            "adj. 农村的，乡下的；田园的，有乡村风味的"
+        ],
+        "usphone": "[ˈrʊrəl]",
+        "ukphone": "[ˈrʊərəl]"
+    },
+    {
+        "name": "maintain",
+        "trans": [
+            "vt. 维持；继续；维修；主张；供养"
+        ],
+        "usphone": "[meɪnˈteɪn]",
+        "ukphone": "[meɪnˈteɪn]"
+    },
+    {
+        "name": "recover",
+        "trans": [
+            "n. 还原至预备姿势"
+        ],
+        "usphone": "[rɪˈkʌvər]",
+        "ukphone": "[rɪˈkʌvə(r)]"
+    },
+    {
+        "name": "declare",
+        "trans": [
+            "vt. 宣布，声明；断言，宣称"
+        ],
+        "usphone": "[dɪˈkler]",
+        "ukphone": "[dɪˈkleə(r)]"
+    },
+    {
+        "name": "enthusiastic",
+        "trans": [
+            "adj. 热情的；热心的；狂热的"
+        ],
+        "usphone": "[ɪnˌθuːziˈæstɪk]",
+        "ukphone": "[ɪnˌθjuːziˈæstɪk]"
+    },
+    {
+        "name": "curved",
+        "trans": [
+            "n. 倒弧角"
+        ],
+        "usphone": "[kɜːrvd]",
+        "ukphone": "[kɜːvd]"
+    },
+    {
+        "name": "nightmare",
+        "trans": [
+            "n. 恶梦；梦魇般的经历"
+        ],
+        "usphone": "[ˈnaɪtmer]",
+        "ukphone": "[ˈnaɪtmeə(r)]"
+    },
+    {
+        "name": "discount",
+        "trans": [
+            "n. 折扣；贴现率"
+        ],
+        "usphone": "[ˈdɪskaʊnt]",
+        "ukphone": "[ˈdɪskaʊnt]"
+    },
+    {
+        "name": "independence",
+        "trans": [
+            "n. 独立性，自立性；自主"
+        ],
+        "usphone": "[ˌɪndɪˈpendəns]",
+        "ukphone": "[ˌɪndɪˈpendəns]"
+    },
+    {
+        "name": "brief",
+        "trans": [
+            "n. 摘要，简报；概要，诉书"
+        ],
+        "usphone": "[briːf]",
+        "ukphone": "[briːf]"
+    },
+    {
+        "name": "elbow",
+        "trans": [
+            "n. 肘部；弯头；扶手"
+        ],
+        "usphone": "[ˈelboʊ]",
+        "ukphone": "[ˈelbəʊ]"
+    },
+    {
+        "name": "emphasize",
+        "trans": [
+            "vt. 强调，着重"
+        ],
+        "usphone": "[ˈemfəsaɪz]",
+        "ukphone": "[ˈemfəsaɪz]"
+    },
+    {
+        "name": "genre",
+        "trans": [
+            "n. 类型；种类；体裁；样式；流派；风俗画"
+        ],
+        "usphone": "[ˈʒɑːnrə]",
+        "ukphone": "[ˈʒɒnrə]"
+    },
+    {
+        "name": "random",
+        "trans": [
+            "n. 随意"
+        ],
+        "usphone": "[ˈrændəm]",
+        "ukphone": "[ˈrændəm]"
+    },
+    {
+        "name": "shooting",
+        "trans": [
+            "n. 射击；打猎；摄影；射门"
+        ],
+        "usphone": "[ˈʃuːtɪŋ]",
+        "ukphone": "[ˈʃuːtɪŋ]"
+    },
+    {
+        "name": "relieve",
+        "trans": [
+            "vt. 解除，减轻；使不单调乏味；换…的班；解围；使放心"
+        ],
+        "usphone": "[rɪˈliːv]",
+        "ukphone": "[rɪˈliːv]"
+    },
+    {
+        "name": "battle",
+        "trans": [
+            "n. 战役；斗争"
+        ],
+        "usphone": "[ˈbætl]",
+        "ukphone": "[ˈbæt(ə)l]"
+    },
+    {
+        "name": "evaluation",
+        "trans": [
+            "n. 评价；[审计] 评估；估价；求值"
+        ],
+        "usphone": "[ɪˌvæljuˈeɪʃn]",
+        "ukphone": "[ɪˌvæljuˈeɪʃn]"
+    },
+    {
+        "name": "reasonably",
+        "trans": [
+            "adv. 合理地；相当地；适度地"
+        ],
+        "usphone": "[ˈriːznəbli]",
+        "ukphone": "[ˈriːz(ə)nəbli]"
+    },
+    {
+        "name": "tendency",
+        "trans": [
+            "n. 倾向，趋势；癖好"
+        ],
+        "usphone": "[ˈtendənsi]",
+        "ukphone": "[ˈtendənsi]"
+    },
+    {
+        "name": "part-time",
+        "trans": [
+            "adj. 兼职的；部分时间的"
+        ],
+        "usphone": "[ˌpɑːrt ˈtaɪm]",
+        "ukphone": "[ˌpɑːt ˈtaɪm]"
+    },
+    {
+        "name": "universe",
+        "trans": [
+            "n. 宇宙；世界；领域"
+        ],
+        "usphone": "[ˈjuːnɪvɜːrs]",
+        "ukphone": "[ˈjuːnɪvɜːs]"
+    },
+    {
+        "name": "professional",
+        "trans": [
+            "n. 专业人员；职业运动员"
+        ],
+        "usphone": "[prəˈfeʃənl]",
+        "ukphone": "[prəˈfeʃənl]"
+    },
+    {
+        "name": "minority",
+        "trans": [
+            "n. 少数民族；少数派；未成年"
+        ],
+        "usphone": "[maɪˈnɔːrəti]",
+        "ukphone": "[maɪˈnɒrəti]"
+    },
+    {
+        "name": "worst",
+        "trans": [
+            "n. 最坏；最坏的时候"
+        ],
+        "usphone": "[wɜːrst]",
+        "ukphone": "[wɜːst]"
+    },
+    {
+        "name": "citizen",
+        "trans": [
+            "n. 公民；市民；老百姓"
+        ],
+        "usphone": "[ˈsɪtɪzn]",
+        "ukphone": "[ˈsɪtɪz(ə)n]"
+    },
+    {
+        "name": "membership",
+        "trans": [
+            "n. 资格；成员资格；会员身份"
+        ],
+        "usphone": "[ˈmembərʃɪp]",
+        "ukphone": "[ˈmembəʃɪp]"
+    },
+    {
+        "name": "heel",
+        "trans": [
+            "n. 脚后跟；踵"
+        ],
+        "usphone": "[hiːl]",
+        "ukphone": "[hiːl]"
+    },
+    {
+        "name": "edition",
+        "trans": [
+            "n. 版本"
+        ],
+        "usphone": "[ɪˈdɪʃn]",
+        "ukphone": "[ɪˈdɪʃ(ə)n]"
+    },
+    {
+        "name": "increasingly",
+        "trans": [
+            "adv. 越来越多地；渐增地"
+        ],
+        "usphone": "[ɪnˈkriːsɪŋli]",
+        "ukphone": "[ɪnˈkriːsɪŋli]"
+    },
+    {
+        "name": "multiply",
+        "trans": [
+            "vt. 乘；使增加；使繁殖；使相乘"
+        ],
+        "usphone": "[ˈmʌltɪplaɪ]",
+        "ukphone": "[ˈmʌltɪplaɪ]"
+    },
+    {
+        "name": "suburb",
+        "trans": [
+            "n. 郊区；边缘"
+        ],
+        "usphone": "[ˈsʌbɜːrb]",
+        "ukphone": "[ˈsʌbɜːb]"
+    },
+    {
+        "name": "observe",
+        "trans": [
+            "vt. 庆祝"
+        ],
+        "usphone": "[əbˈzɜːrv]",
+        "ukphone": "[əbˈzɜːv]"
+    },
+    {
+        "name": "outstanding",
+        "trans": [
+            "adj. 杰出的；显著的；未解决的；未偿付的"
+        ],
+        "usphone": "[aʊtˈstændɪŋ]",
+        "ukphone": "[aʊtˈstændɪŋ]"
+    },
+    {
+        "name": "approve",
+        "trans": [
+            "vi. 批准；赞成；满意"
+        ],
+        "usphone": "[əˈpruːv]",
+        "ukphone": "[əˈpruːv]"
+    },
+    {
+        "name": "artistic",
+        "trans": [
+            "adj. 艺术的；风雅的；有美感的"
+        ],
+        "usphone": "[ɑːrˈtɪstɪk]",
+        "ukphone": "[ɑːˈtɪstɪk]"
+    },
+    {
+        "name": "placement",
+        "trans": [
+            "n. 布置；定位球；人员配置"
+        ],
+        "usphone": "[ˈpleɪsmənt]",
+        "ukphone": "[ˈpleɪsmənt]"
+    },
+    {
+        "name": "insert",
+        "trans": [
+            "n. 插入物；管芯；镶块；[机械]刀片"
+        ],
+        "usphone": "[ɪnˈsɜːrt]",
+        "ukphone": "[ɪnˈsɜːt]"
+    },
+    {
+        "name": "sibling",
+        "trans": [
+            "n. 兄弟姊妹；民族成员"
+        ],
+        "usphone": "[ˈsɪblɪŋ]",
+        "ukphone": "[ˈsɪblɪŋ]"
+    },
+    {
+        "name": "hunting",
+        "trans": [
+            "n. 打猎；追逐；搜索"
+        ],
+        "usphone": "[ˈhʌntɪŋ]",
+        "ukphone": "[ˈhʌntɪŋ]"
+    },
+    {
+        "name": "recognition",
+        "trans": [
+            "n. 识别；承认，认出；重视；赞誉；公认"
+        ],
+        "usphone": "[ˌrekəɡˈnɪʃn]",
+        "ukphone": "[ˌrekəɡˈnɪʃn]"
+    },
+    {
+        "name": "unconscious",
+        "trans": [
+            "adj. 无意识的；失去知觉的；不省人事的；未发觉的"
+        ],
+        "usphone": "[ʌnˈkɑːnʃəs]",
+        "ukphone": "[ʌnˈkɒnʃəs]"
+    },
+    {
+        "name": "genuinely",
+        "trans": [
+            "adv. 真诚地；诚实地"
+        ],
+        "usphone": "[ˈdʒenjuɪnli]",
+        "ukphone": "[ˈdʒenjuɪnli]"
+    },
+    {
+        "name": "reporting",
+        "trans": [
+            "n. 报告；报导"
+        ],
+        "usphone": "",
+        "ukphone": ""
+    },
+    {
+        "name": "efficiently",
+        "trans": [
+            "adv. 有效地；效率高地（efficient的副词形式）"
+        ],
+        "usphone": "[ɪˈfɪʃntli]",
+        "ukphone": "[ɪˈfɪʃ(ə)ntli]"
+    },
+    {
+        "name": "remarkable",
+        "trans": [
+            "adj. 卓越的；非凡的；值得注意的"
+        ],
+        "usphone": "[rɪˈmɑːrkəbl]",
+        "ukphone": "[rɪˈmɑːkəbl]"
+    },
+    {
+        "name": "current",
+        "trans": [
+            "n. （水，气，电）流；趋势；涌流"
+        ],
+        "usphone": "[ˈkɜːrənt]",
+        "ukphone": "[ˈkʌrənt]"
+    },
+    {
+        "name": "surround",
+        "trans": [
+            "n. 围绕物"
+        ],
+        "usphone": "[səˈraʊnd]",
+        "ukphone": "[səˈraʊnd]"
+    },
+    {
+        "name": "mineral",
+        "trans": [
+            "n. 矿物；（英）矿泉水；无机物；苏打水（常用复数表示）"
+        ],
+        "usphone": "[ˈmɪnərəl]",
+        "ukphone": "[ˈmɪnərəl]"
+    },
+    {
+        "name": "cell",
+        "trans": [
+            "n. 细胞；电池；蜂房的巢室；单人小室"
+        ],
+        "usphone": "[sel]",
+        "ukphone": "[sel]"
+    },
+    {
+        "name": "core",
+        "trans": [
+            "n. 核心；要点；果心；[计] 磁心"
+        ],
+        "usphone": "[kɔːr]",
+        "ukphone": "[kɔː(r)]"
+    },
+    {
+        "name": "level",
+        "trans": [
+            "n. 水平；标准；水平面"
+        ],
+        "usphone": "[ˈlevl]",
+        "ukphone": "[ˈlev(ə)l]"
+    },
+    {
+        "name": "sophisticated",
+        "trans": [
+            "adj. 复杂的；精致的；久经世故的；富有经验的"
+        ],
+        "usphone": "[səˈfɪstɪkeɪtɪd]",
+        "ukphone": "[səˈfɪstɪkeɪtɪd]"
+    },
+    {
+        "name": "craft",
+        "trans": [
+            "n. 工艺；手艺；太空船"
+        ],
+        "usphone": "[kræft]",
+        "ukphone": "[krɑːft]"
+    },
+    {
+        "name": "curve",
+        "trans": [
+            "n. 曲线；弯曲；曲线球；曲线图表"
+        ],
+        "usphone": "[kɜːrv]",
+        "ukphone": "[kɜːv]"
+    },
+    {
+        "name": "obligation",
+        "trans": [
+            "n. 义务；职责；债务"
+        ],
+        "usphone": "[ˌɑːblɪˈɡeɪʃn]",
+        "ukphone": "[ˌɒblɪˈɡeɪʃ(ə)n]"
+    },
+    {
         "name": "yet",
         "trans": [
             "conj. 但是；然而"
@@ -11376,11 +6120,5267 @@
         "ukphone": "[jet]"
     },
     {
+        "name": "regional",
+        "trans": [
+            "adj. 地区的；局部的；整个地区的"
+        ],
+        "usphone": "[ˈriːdʒənl]",
+        "ukphone": "[ˈriːdʒənl]"
+    },
+    {
+        "name": "temporarily",
+        "trans": [
+            "adv. 临时地，临时"
+        ],
+        "usphone": "[ˌtempəˈrerəli]",
+        "ukphone": "[ˈtemprərəli]"
+    },
+    {
+        "name": "metaphor",
+        "trans": [
+            "n. 暗喻，隐喻；比喻说法"
+        ],
+        "usphone": "[ˈmetəfərˌˈmetəfɔːr]",
+        "ukphone": "[ˈmetəfə(r); ˈmetəfɔː(r)]"
+    },
+    {
+        "name": "figure",
+        "trans": [
+            "n. 数字；人物；图形；价格；（人的）体形；画像"
+        ],
+        "usphone": "[ˈfɪɡjər]",
+        "ukphone": "[ˈfɪɡə(r)]"
+    },
+    {
+        "name": "institution",
+        "trans": [
+            "n. 制度；建立；（社会或宗教等）公共机构；习俗"
+        ],
+        "usphone": "[ˌɪnstɪˈtuːʃn]",
+        "ukphone": "[ˌɪnstɪˈtjuːʃ(ə)n]"
+    },
+    {
+        "name": "rose",
+        "trans": [
+            "n. 玫瑰；粉红色；蔷薇（花）；粉红色的葡萄酒"
+        ],
+        "usphone": "[roʊz]",
+        "ukphone": "[rəʊz]"
+    },
+    {
+        "name": "analyst",
+        "trans": [
+            "n. 分析者；精神分析医师；分解者"
+        ],
+        "usphone": "[ˈænəlɪst]",
+        "ukphone": "[ˈænəlɪst]"
+    },
+    {
+        "name": "resort",
+        "trans": [
+            "n. 凭借，手段；度假胜地；常去之地"
+        ],
+        "usphone": "[rɪˈzɔːrt]",
+        "ukphone": "[rɪˈzɔːt]"
+    },
+    {
+        "name": "parade",
+        "trans": [
+            "n. 游行；阅兵；炫耀；行进；阅兵场"
+        ],
+        "usphone": "[pəˈreɪd]",
+        "ukphone": "[pəˈreɪd]"
+    },
+    {
+        "name": "perceive",
+        "trans": [
+            "vt. 察觉，感觉；理解；认知"
+        ],
+        "usphone": "[pərˈsiːv]",
+        "ukphone": "[pəˈsiːv]"
+    },
+    {
+        "name": "tone",
+        "trans": [
+            "n. 语气；色调；音调；音色"
+        ],
+        "usphone": "[toʊn]",
+        "ukphone": "[təʊn]"
+    },
+    {
+        "name": "positive",
+        "trans": [
+            "n. 正数；[摄] 正片"
+        ],
+        "usphone": "[ˈpɑːzətɪv]",
+        "ukphone": "[ˈpɒzətɪv]"
+    },
+    {
+        "name": "delivery",
+        "trans": [
+            "n. [贸易] 交付；分娩；递送"
+        ],
+        "usphone": "[dɪˈlɪvəri]",
+        "ukphone": "[dɪˈlɪvəri]"
+    },
+    {
+        "name": "pitch",
+        "trans": [
+            "n. 沥青；音高；程度；树脂；倾斜；投掷；球场"
+        ],
+        "usphone": "[pɪtʃ]",
+        "ukphone": "[pɪtʃ]"
+    },
+    {
+        "name": "instant",
+        "trans": [
+            "n. 瞬间；立即；片刻"
+        ],
+        "usphone": "[ˈɪnstənt]",
+        "ukphone": "[ˈɪnstənt]"
+    },
+    {
+        "name": "panic",
+        "trans": [
+            "n. 恐慌，惊慌；大恐慌"
+        ],
+        "usphone": "[ˈpænɪk]",
+        "ukphone": "[ˈpænɪk]"
+    },
+    {
+        "name": "wander",
+        "trans": [
+            "vi. 徘徊；漫步；迷路；离题"
+        ],
+        "usphone": "[ˈwɑːndər]",
+        "ukphone": "[ˈwɒndə(r)]"
+    },
+    {
+        "name": "aside",
+        "trans": [
+            "prep. 在…旁边"
+        ],
+        "usphone": "[əˈsaɪd]",
+        "ukphone": "[əˈsaɪd]"
+    },
+    {
+        "name": "desire",
+        "trans": [
+            "n. 欲望；要求，心愿；性欲"
+        ],
+        "usphone": "[dɪˈzaɪər]",
+        "ukphone": "[dɪˈzaɪə(r)]"
+    },
+    {
+        "name": "principle",
+        "trans": [
+            "n. 原理，原则；主义，道义；本质，本义；根源，源泉"
+        ],
+        "usphone": "[ˈprɪnsəpl]",
+        "ukphone": "[ˈprɪnsəpl]"
+    },
+    {
+        "name": "plot",
+        "trans": [
+            "n. 情节；图；阴谋"
+        ],
+        "usphone": "[plɑːt]",
+        "ukphone": "[plɒt]"
+    },
+    {
+        "name": "hell",
+        "trans": [
+            "n. 地狱；究竟（作加强语气词）；训斥；黑暗势力"
+        ],
+        "usphone": "[helˌˈheləvə]",
+        "ukphone": "[hel]"
+    },
+    {
+        "name": "timing",
+        "trans": [
+            "n. 定时；调速；时间选择"
+        ],
+        "usphone": "[ˈtaɪmɪŋ]",
+        "ukphone": "[ˈtaɪmɪŋ]"
+    },
+    {
+        "name": "academic",
+        "trans": [
+            "n. 大学生，大学教师；学者"
+        ],
+        "usphone": "[ˌækəˈdemɪk]",
+        "ukphone": "[ˌækəˈdemɪk]"
+    },
+    {
+        "name": "decent",
+        "trans": [
+            "adj. 正派的；得体的；相当好的"
+        ],
+        "usphone": "[ˈdiːsnt]",
+        "ukphone": "[ˈdiːs(ə)nt]"
+    },
+    {
+        "name": "wildlife",
+        "trans": [
+            "n. 野生动植物"
+        ],
+        "usphone": "[ˈwaɪldlaɪf]",
+        "ukphone": "[ˈwaɪldlaɪf]"
+    },
+    {
+        "name": "inquiry",
+        "trans": [
+            "n. 探究；调查；质询"
+        ],
+        "usphone": "[ˈɪnkwəri; ɪnˈkwaɪəri]",
+        "ukphone": "[ɪnˈkwaɪəri]"
+    },
+    {
+        "name": "depression",
+        "trans": [
+            "n. 沮丧；洼地；不景气；忧愁；低气压区"
+        ],
+        "usphone": "[dɪˈpreʃn]",
+        "ukphone": "[dɪˈpreʃn]"
+    },
+    {
+        "name": "shade",
+        "trans": [
+            "n. 树荫；阴影；阴凉处；遮阳物；（照片等的）明暗度；少量、些微；细微的差别"
+        ],
+        "usphone": "[ʃeɪd]",
+        "ukphone": "[ʃeɪd]"
+    },
+    {
+        "name": "associated",
+        "trans": [
+            "v. 联系（associate的过去式和过去分词）"
+        ],
+        "usphone": "[əˈsoʊsieɪtɪdˌəˈsoʊʃieɪtɪd]",
+        "ukphone": "[əˈsəʊsieɪtɪd]"
+    },
+    {
+        "name": "kit",
+        "trans": [
+            "n. 工具箱；成套工具"
+        ],
+        "usphone": "[kɪt]",
+        "ukphone": "[kɪt]"
+    },
+    {
+        "name": "formation",
+        "trans": [
+            "n. 形成；构造；编队"
+        ],
+        "usphone": "[fɔːrˈmeɪʃn]",
+        "ukphone": "[fɔːˈmeɪʃn]"
+    },
+    {
+        "name": "motion",
+        "trans": [
+            "n. 动作；移动；手势；请求；意向；议案"
+        ],
+        "usphone": "[ˈmoʊʃn]",
+        "ukphone": "[ˈməʊʃn]"
+    },
+    {
+        "name": "convert",
+        "trans": [
+            "n. 皈依者；改变宗教信仰者"
+        ],
+        "usphone": "[kənˈvɜːrt]",
+        "ukphone": "[kənˈvɜːt]"
+    },
+    {
+        "name": "delight",
+        "trans": [
+            "n. 高兴"
+        ],
+        "usphone": "[dɪˈlaɪt]",
+        "ukphone": "[dɪˈlaɪt]"
+    },
+    {
+        "name": "psychological",
+        "trans": [
+            "adj. 心理的；心理学的；精神上的"
+        ],
+        "usphone": "[ˌsaɪkəˈlɑːdʒɪkl]",
+        "ukphone": "[ˌsaɪkəˈlɒdʒɪk(ə)l]"
+    },
+    {
+        "name": "characteristic",
+        "trans": [
+            "n. 特征；特性；特色"
+        ],
+        "usphone": "[ˌkærəktəˈrɪstɪk]",
+        "ukphone": "[ˌkærəktəˈrɪstɪk]"
+    },
+    {
+        "name": "creation",
+        "trans": [
+            "n. 创造，创作；创作物，产物"
+        ],
+        "usphone": "[kriˈeɪʃn]",
+        "ukphone": "[kriˈeɪʃ(ə)n]"
+    },
+    {
+        "name": "calculate",
+        "trans": [
+            "vt. 计算；预测；认为；打算"
+        ],
+        "usphone": "[ˈkælkjuleɪt]",
+        "ukphone": "[ˈkælkjuleɪt]"
+    },
+    {
+        "name": "select",
+        "trans": [
+            "n. 被挑选者；精萃"
+        ],
+        "usphone": "[sɪˈlekt]",
+        "ukphone": "[sɪˈlekt]"
+    },
+    {
+        "name": "broadly",
+        "trans": [
+            "adv. 明显地；宽广地；概括地；露骨地；粗鄙地"
+        ],
+        "usphone": "[ˈbrɔːdli]",
+        "ukphone": "[ˈbrɔːdli]"
+    },
+    {
+        "name": "settle",
+        "trans": [
+            "n. 有背长椅"
+        ],
+        "usphone": "[ˈset(ə)l]",
+        "ukphone": "[ˈset(ə)l]"
+    },
+    {
+        "name": "house",
+        "trans": [
+            "n. 住宅；家庭；机构；议会；某种用途的建筑物"
+        ],
+        "usphone": "[haʊs]",
+        "ukphone": "[haʊs]"
+    },
+    {
+        "name": "theft",
+        "trans": [
+            "n. 盗窃；偷；赃物"
+        ],
+        "usphone": "[θeft]",
+        "ukphone": "[θeft]"
+    },
+    {
+        "name": "democratic",
+        "trans": [
+            "adj. 民主的；民主政治的；大众的"
+        ],
+        "usphone": "[ˌdeməˈkrætɪk]",
+        "ukphone": "[ˌdeməˈkrætɪk]"
+    },
+    {
+        "name": "martial",
+        "trans": [
+            "adj. 军事的；战争的；尚武的"
+        ],
+        "usphone": "[ˈmɑːrʃ(ə)l]",
+        "ukphone": "[ˈmɑːʃ(ə)l]"
+    },
+    {
+        "name": "immigration",
+        "trans": [
+            "n. 外来移民；移居"
+        ],
+        "usphone": "[ˌɪmɪˈɡreɪʃn]",
+        "ukphone": "[ˌɪmɪˈɡreɪʃ(ə)n]"
+    },
+    {
+        "name": "satisfaction",
+        "trans": [
+            "n. 满意，满足；赔偿；乐事；赎罪"
+        ],
+        "usphone": "[ˌsætɪsˈfækʃn]",
+        "ukphone": "[ˌsætɪsˈfækʃn]"
+    },
+    {
+        "name": "silk",
+        "trans": [
+            "n. 丝绸；蚕丝；丝织物"
+        ],
+        "usphone": "[sɪlk]",
+        "ukphone": "[sɪlk]"
+    },
+    {
+        "name": "excuse",
+        "trans": [
+            "n. 借口；理由"
+        ],
+        "usphone": "[ɪkˈskjuːs]",
+        "ukphone": "[ɪkˈskjuːs]"
+    },
+    {
+        "name": "satellite",
+        "trans": [
+            "n. 卫星；人造卫星；随从；卫星国家"
+        ],
+        "usphone": "[ˈsætəlaɪt]",
+        "ukphone": "[ˈsætəlaɪt]"
+    },
+    {
+        "name": "component",
+        "trans": [
+            "n. 成分；组件；[电子] 元件"
+        ],
+        "usphone": "[kəmˈpoʊnənt]",
+        "ukphone": "[kəmˈpəʊnənt]"
+    },
+    {
+        "name": "incorporate",
+        "trans": [
+            "vt. 包含，吸收；体现；把……合并"
+        ],
+        "usphone": "[ɪnˈkɔːrpəreɪt]",
+        "ukphone": "[ɪnˈkɔːpəreɪt]"
+    },
+    {
+        "name": "shocked",
+        "trans": [
+            "v. 使震动（shock的过去式）"
+        ],
+        "usphone": "[ʃɑːkt]",
+        "ukphone": "[ʃɒkt]"
+    },
+    {
+        "name": "tissue",
+        "trans": [
+            "n. 组织；纸巾；薄纱；一套"
+        ],
+        "usphone": "[ˈtɪʃuː]",
+        "ukphone": "[ˈtɪʃuː]"
+    },
+    {
+        "name": "format",
+        "trans": [
+            "n. 格式；版式；开本"
+        ],
+        "usphone": "[ˈfɔːrmæt]",
+        "ukphone": "[ˈfɔːmæt]"
+    },
+    {
+        "name": "overnight",
+        "trans": [
+            "adv. 通宵；突然；昨晚"
+        ],
+        "usphone": "[ˌoʊvərˈnaɪt]",
+        "ukphone": "[ˌəʊvəˈnaɪt]"
+    },
+    {
+        "name": "workforce",
+        "trans": [
+            "n. 劳动力；工人总数，职工总数"
+        ],
+        "usphone": "[ˈwɜːrkfɔːrs]",
+        "ukphone": "[ˈwɜːkfɔːs]"
+    },
+    {
+        "name": "mission",
+        "trans": [
+            "n. 使命，任务；代表团；布道"
+        ],
+        "usphone": "[ˈmɪʃn]",
+        "ukphone": "[ˈmɪʃn]"
+    },
+    {
+        "name": "prompt",
+        "trans": [
+            "n. 提示；付款期限；DOS命令：改变DOS系统提示符的风格"
+        ],
+        "usphone": "[prɑːmpt]",
+        "ukphone": "[prɒmpt]"
+    },
+    {
+        "name": "spice",
+        "trans": [
+            "n. 香料；情趣；调味品；少许"
+        ],
+        "usphone": "[spaɪs]",
+        "ukphone": "[spaɪs]"
+    },
+    {
+        "name": "lord",
+        "trans": [
+            "n. 主；上帝"
+        ],
+        "usphone": "[lɔːrd]",
+        "ukphone": "[lɔːd]"
+    },
+    {
+        "name": "headquarters",
+        "trans": [
+            "n. 总部；指挥部；司令部"
+        ],
+        "usphone": "[ˈhedkwɔːrtərz]",
+        "ukphone": "[ˌhedˈkwɔːtəz]"
+    },
+    {
+        "name": "faith",
+        "trans": [
+            "n. 信仰；信念；信任；忠实"
+        ],
+        "usphone": "[feɪθ]",
+        "ukphone": "[feɪθ]"
+    },
+    {
+        "name": "dairy",
+        "trans": [
+            "n. 奶制品；乳牛；制酪场；乳品店；牛奶及乳品业"
+        ],
+        "usphone": "[ˈderi]",
+        "ukphone": "[ˈdeəri]"
+    },
+    {
+        "name": "journalism",
+        "trans": [
+            "n. 新闻业，新闻工作；报章杂志"
+        ],
+        "usphone": "[ˈdʒɜːrnəlɪzəm]",
+        "ukphone": "[ˈdʒɜːnəlɪz(ə)m]"
+    },
+    {
+        "name": "urge",
+        "trans": [
+            "n. 强烈的欲望，迫切要求；推动力"
+        ],
+        "usphone": "[ɜːrdʒ]",
+        "ukphone": "[ɜːdʒ]"
+    },
+    {
+        "name": "trip",
+        "trans": [
+            "n. 旅行；绊倒；差错"
+        ],
+        "usphone": "[trɪp]",
+        "ukphone": "[trɪp]"
+    },
+    {
+        "name": "legend",
+        "trans": [
+            "n. 传奇；说明；图例；刻印文字"
+        ],
+        "usphone": "[ˈledʒənd]",
+        "ukphone": "[ˈledʒənd]"
+    },
+    {
+        "name": "governor",
+        "trans": [
+            "n. 主管人员；统治者，管理者；[自] 调节器；地方长官"
+        ],
+        "usphone": "[ˈɡʌvərnər]",
+        "ukphone": "[ˈɡʌvənə(r)]"
+    },
+    {
+        "name": "therapy",
+        "trans": [
+            "n. 治疗，疗法"
+        ],
+        "usphone": "[ˈθerəpi]",
+        "ukphone": "[ˈθerəpi]"
+    },
+    {
+        "name": "concentration",
+        "trans": [
+            "n. 浓度；集中；浓缩；专心；集合"
+        ],
+        "usphone": "[ˌkɑːnsnˈtreɪʃn]",
+        "ukphone": "[ˌkɒns(ə)nˈtreɪʃ(ə)n]"
+    },
+    {
+        "name": "delete",
+        "trans": [
+            "vt. 删除"
+        ],
+        "usphone": "[dɪˈliːt]",
+        "ukphone": "[dɪˈliːt]"
+    },
+    {
+        "name": "cave",
+        "trans": [
+            "n. 洞穴，窑洞"
+        ],
+        "usphone": "[keɪv]",
+        "ukphone": "[keɪv]"
+    },
+    {
+        "name": "negotiate",
+        "trans": [
+            "vt. 谈判，商议；转让；越过"
+        ],
+        "usphone": "[nɪˈɡoʊʃieɪt]",
+        "ukphone": "[nɪˈɡəʊʃieɪt]"
+    },
+    {
+        "name": "rely",
+        "trans": [
+            "vi. 依靠；信赖"
+        ],
+        "usphone": "[rɪˈlaɪ]",
+        "ukphone": "[rɪˈlaɪ]"
+    },
+    {
+        "name": "ashamed",
+        "trans": [
+            "adj. 惭愧的，感到难为情的；耻于……的"
+        ],
+        "usphone": "[əˈʃeɪmd]",
+        "ukphone": "[əˈʃeɪmd]"
+    },
+    {
+        "name": "breast",
+        "trans": [
+            "n. 乳房，胸部；胸怀；心情"
+        ],
+        "usphone": "[brest]",
+        "ukphone": "[brest]"
+    },
+    {
+        "name": "lifetime",
+        "trans": [
+            "n. 一生；寿命；终生；使用期"
+        ],
+        "usphone": "[ˈlaɪftaɪm]",
+        "ukphone": "[ˈlaɪftaɪm]"
+    },
+    {
+        "name": "spectacular",
+        "trans": [
+            "adj. 壮观的，惊人的；公开展示的"
+        ],
+        "usphone": "[spekˈtækjələr]",
+        "ukphone": "[spekˈtækjələ(r)]"
+    },
+    {
+        "name": "institute",
+        "trans": [
+            "n. 学会，协会；学院"
+        ],
+        "usphone": "[ˈɪnstɪtuːt]",
+        "ukphone": "[ˈɪnstɪtjuːt]"
+    },
+    {
+        "name": "bent",
+        "trans": [
+            "n. 爱好，嗜好"
+        ],
+        "usphone": "[bent]",
+        "ukphone": "[bent]"
+    },
+    {
+        "name": "participation",
+        "trans": [
+            "n. 参与；分享；参股"
+        ],
+        "usphone": "[pɑːrˌtɪsɪˈpeɪʃn]",
+        "ukphone": "[pɑːˌtɪsɪˈpeɪʃn]"
+    },
+    {
+        "name": "grant",
+        "trans": [
+            "n. 拨款；[法] 授予物"
+        ],
+        "usphone": "[ɡrænt]",
+        "ukphone": "[ɡrɑːnt]"
+    },
+    {
+        "name": "investment",
+        "trans": [
+            "n. 投资；投入；封锁"
+        ],
+        "usphone": "[ɪnˈvestmənt]",
+        "ukphone": "[ɪnˈvestmənt]"
+    },
+    {
+        "name": "passionate",
+        "trans": [
+            "adj. 热情的；热烈的，激昂的；易怒的"
+        ],
+        "usphone": "[ˈpæʃənət]",
+        "ukphone": "[ˈpæʃənət]"
+    },
+    {
+        "name": "reveal",
+        "trans": [
+            "n. 揭露；暴露；门侧，窗侧"
+        ],
+        "usphone": "[rɪˈviːl]",
+        "ukphone": "[rɪˈviːl]"
+    },
+    {
+        "name": "priority",
+        "trans": [
+            "n. 优先；优先权；[数] 优先次序；优先考虑的事"
+        ],
+        "usphone": "[praɪˈɔːrəti]",
+        "ukphone": "[praɪˈɒrəti]"
+    },
+    {
+        "name": "contribution",
+        "trans": [
+            "n. 贡献；捐献；投稿"
+        ],
+        "usphone": "[ˌkɑːntrɪˈbjuːʃn]",
+        "ukphone": "[ˌkɒntrɪˈbjuːʃ(ə)n]"
+    },
+    {
+        "name": "bullet",
+        "trans": [
+            "n. 子弹；只选某党全部候选人的投票；豆子"
+        ],
+        "usphone": "[ˈbʊlɪt]",
+        "ukphone": "[ˈbʊlɪt]"
+    },
+    {
+        "name": "self",
+        "trans": [
+            "n. 自己，自我；本质；私心"
+        ],
+        "usphone": "[self]",
+        "ukphone": "[self]"
+    },
+    {
+        "name": "accommodate",
+        "trans": [
+            "vi. 适应；调解"
+        ],
+        "usphone": "[əˈkɑːmədeɪt]",
+        "ukphone": "[əˈkɒmədeɪt]"
+    },
+    {
+        "name": "volume",
+        "trans": [
+            "n. 量；体积；卷；音量；大量；册"
+        ],
+        "usphone": "[ˈvɑːljuːmˌˈvɑːljəm]",
+        "ukphone": "[ˈvɒljuːm]"
+    },
+    {
+        "name": "significant",
+        "trans": [
+            "n. 象征；有意义的事物"
+        ],
+        "usphone": "[sɪɡˈnɪfɪkənt]",
+        "ukphone": "[sɪɡˈnɪfɪkənt]"
+    },
+    {
+        "name": "progressive",
+        "trans": [
+            "n. 改革论者；进步分子"
+        ],
+        "usphone": "[prəˈɡresɪv]",
+        "ukphone": "[prəˈɡresɪv]"
+    },
+    {
+        "name": "tournament",
+        "trans": [
+            "n. 锦标赛，联赛；比赛"
+        ],
+        "usphone": "[ˈtʊrnəmənt; ˈtɜːrnəmənt]",
+        "ukphone": "[ˈtʊənəmənt]"
+    },
+    {
+        "name": "integrate",
+        "trans": [
+            "n. 一体化；集成体"
+        ],
+        "usphone": "[ˈɪntɪɡreɪt]",
+        "ukphone": "[ˈɪntɪɡreɪt]"
+    },
+    {
+        "name": "steam",
+        "trans": [
+            "n. 蒸汽；精力"
+        ],
+        "usphone": "[stiːm]",
+        "ukphone": "[stiːm]"
+    },
+    {
+        "name": "examination",
+        "trans": [
+            "n. 考试；检查；查问"
+        ],
+        "usphone": "[ɪɡˌzæmɪˈneɪʃn]",
+        "ukphone": "[ɪɡˌzæmɪˈneɪʃ(ə)n]"
+    },
+    {
+        "name": "angle",
+        "trans": [
+            "n. 角度，角，方面"
+        ],
+        "usphone": "[ˈæŋɡ(ə)l]",
+        "ukphone": "[ˈæŋɡ(ə)l]"
+    },
+    {
+        "name": "risky",
+        "trans": [
+            "adj. 危险的；冒险的；（作品等）有伤风化的"
+        ],
+        "usphone": "[ˈrɪski]",
+        "ukphone": "[ˈrɪski]"
+    },
+    {
+        "name": "bet",
+        "trans": [
+            "n. 打赌，赌注；被打赌的事物"
+        ],
+        "usphone": "[bet]",
+        "ukphone": "[bet]"
+    },
+    {
+        "name": "tear",
+        "trans": [
+            "vi. 流泪, 撕破"
+        ],
+        "usphone": "[ter]",
+        "ukphone": "[teə(r)]"
+    },
+    {
+        "name": "immune",
+        "trans": [
+            "n. 免疫者；免除者"
+        ],
+        "usphone": "[ɪˈmjuːn]",
+        "ukphone": "[ɪˈmjuːn]"
+    },
+    {
+        "name": "screening",
+        "trans": [
+            "n. 筛选；放映；[物] 屏蔽；审查；防波"
+        ],
+        "usphone": "[ˈskriːnɪŋ]",
+        "ukphone": "[ˈskriːnɪŋ]"
+    },
+    {
+        "name": "victory",
+        "trans": [
+            "n. 胜利；成功；克服"
+        ],
+        "usphone": "[ˈvɪktəri]",
+        "ukphone": "[ˈvɪktəri]"
+    },
+    {
+        "name": "trap",
+        "trans": [
+            "n. 陷阱；圈套；[建] 存水湾"
+        ],
+        "usphone": "[træp]",
+        "ukphone": "[træp]"
+    },
+    {
+        "name": "ethnic",
+        "trans": [
+            "adj. 种族的；人种的"
+        ],
+        "usphone": "[ˈeθnɪk]",
+        "ukphone": "[ˈeθnɪk]"
+    },
+    {
+        "name": "disabled",
+        "trans": [
+            "adj. 残废的，有缺陷的"
+        ],
+        "usphone": "[dɪsˈeɪbld]",
+        "ukphone": "[dɪsˈeɪb(ə)ld]"
+    },
+    {
+        "name": "territory",
+        "trans": [
+            "n. 领土，领域；范围；地域；版图"
+        ],
+        "usphone": "[ˈterətɔːri]",
+        "ukphone": "[ˈterətri]"
+    },
+    {
+        "name": "majority",
+        "trans": [
+            "n. 多数；成年"
+        ],
+        "usphone": "[məˈdʒɔːrəti]",
+        "ukphone": "[məˈdʒɒrəti]"
+    },
+    {
+        "name": "host",
+        "trans": [
+            "n. [计] 主机；主人；主持人；许多"
+        ],
+        "usphone": "[hoʊst]",
+        "ukphone": "[həʊst]"
+    },
+    {
+        "name": "stretch",
+        "trans": [
+            "vt. 伸展,张开；（大量地）使用，消耗（金钱，时间）；使竭尽所能；使全力以赴；"
+        ],
+        "usphone": "[stretʃ]",
+        "ukphone": "[stretʃ]"
+    },
+    {
+        "name": "pointed",
+        "trans": [
+            "v. 指出；瞄准（point的过去式）"
+        ],
+        "usphone": "[ˈpɔɪntɪd]",
+        "ukphone": "[ˈpɔɪntɪd]"
+    },
+    {
+        "name": "curious",
+        "trans": [
+            "adj. 好奇的，有求知欲的；古怪的；爱挑剔的"
+        ],
+        "usphone": "[ˈkjʊriəs]",
+        "ukphone": "[ˈkjʊəriəs]"
+    },
+    {
+        "name": "account",
+        "trans": [
+            "n. 账户；解释；账目，账单；理由；描述"
+        ],
+        "usphone": "[əˈkaʊnt]",
+        "ukphone": "[əˈkaʊnt]"
+    },
+    {
+        "name": "fuel",
+        "trans": [
+            "n. 燃料；刺激因素"
+        ],
+        "usphone": "[ˈfjuːəl]",
+        "ukphone": "[ˈfjuːəl]"
+    },
+    {
+        "name": "democracy",
+        "trans": [
+            "n. 民主，民主主义；民主政治"
+        ],
+        "usphone": "[dɪˈmɑːkrəsi]",
+        "ukphone": "[dɪˈmɒkrəsi]"
+    },
+    {
+        "name": "obstacle",
+        "trans": [
+            "n. 障碍，干扰；妨害物"
+        ],
+        "usphone": "[ˈɑːbstək(ə)l]",
+        "ukphone": "[ˈɒbstəkl]"
+    },
+    {
+        "name": "operator",
+        "trans": [
+            "n. 经营者；操作员；话务员；行家"
+        ],
+        "usphone": "[ˈɑːpəreɪtər]",
+        "ukphone": "[ˈɒpəreɪtə(r)]"
+    },
+    {
+        "name": "firm",
+        "trans": [
+            "n. 公司；商号"
+        ],
+        "usphone": "[fɜːrm]",
+        "ukphone": "[fɜːm]"
+    },
+    {
+        "name": "distant",
+        "trans": [
+            "adj. 遥远的；冷漠的；远隔的；不友好的，冷淡的"
+        ],
+        "usphone": "[ˈdɪstənt]",
+        "ukphone": "[ˈdɪstənt]"
+    },
+    {
+        "name": "workshop",
+        "trans": [
+            "n. 车间；研讨会；工场；讲习班"
+        ],
+        "usphone": "[ˈwɜːrkʃɑːp]",
+        "ukphone": "[ˈwɜːkʃɒp]"
+    },
+    {
+        "name": "survival",
+        "trans": [
+            "n. 幸存，残存；幸存者，残存物"
+        ],
+        "usphone": "[sərˈvaɪvl]",
+        "ukphone": "[səˈvaɪv(ə)l]"
+    },
+    {
+        "name": "confess",
+        "trans": [
+            "vi. 承认；坦白；忏悔；供认"
+        ],
+        "usphone": "[kənˈfes]",
+        "ukphone": "[kənˈfes]"
+    },
+    {
+        "name": "occupy",
+        "trans": [
+            "vt. 占据，占领；居住；使忙碌"
+        ],
+        "usphone": "[ˈɑːkjupaɪ]",
+        "ukphone": "[ˈɒkjupaɪ]"
+    },
+    {
+        "name": "potential",
+        "trans": [
+            "n. 潜能；可能性；[电] 电势"
+        ],
+        "usphone": "[pəˈtenʃl]",
+        "ukphone": "[pəˈtenʃ(ə)l]"
+    },
+    {
+        "name": "defender",
+        "trans": [
+            "n. 防卫者，守卫者；辩护者；拥护者；卫冕者"
+        ],
+        "usphone": "[dɪˈfendər]",
+        "ukphone": "[dɪˈfendə(r)]"
+    },
+    {
+        "name": "aggressive",
+        "trans": [
+            "adj. 侵略性的；好斗的；有进取心的；有闯劲的"
+        ],
+        "usphone": "[əˈɡresɪv]",
+        "ukphone": "[əˈɡresɪv]"
+    },
+    {
+        "name": "consideration",
+        "trans": [
+            "n. 考虑；原因；关心；报酬"
+        ],
+        "usphone": "[kənˌsɪdəˈreɪʃn]",
+        "ukphone": "[kənˌsɪdəˈreɪʃn]"
+    },
+    {
+        "name": "settler",
+        "trans": [
+            "n. 移居者；殖民者"
+        ],
+        "usphone": "[ˈsetlər]",
+        "ukphone": "[ˈsetlə(r)]"
+    },
+    {
+        "name": "document",
+        "trans": [
+            "n. 文件，公文；[计] 文档；证件"
+        ],
+        "usphone": "[ˈdɑːkjumənt]",
+        "ukphone": "[ˈdɒkjumənt]"
+    },
+    {
+        "name": "usage",
+        "trans": [
+            "n. 使用；用法；惯例"
+        ],
+        "usphone": "[ˈjuːsɪdʒˌˈjuːzɪdʒ]",
+        "ukphone": "[ˈjuːsɪdʒ]"
+    },
+    {
+        "name": "visa",
+        "trans": [
+            "n. 签证"
+        ],
+        "usphone": "[ˈviːzə]",
+        "ukphone": "[ˈviːzə]"
+    },
+    {
+        "name": "material",
+        "trans": [
+            "adj. 重要的；物质的，实质性的；肉体的"
+        ],
+        "usphone": "[məˈtɪriəl]",
+        "ukphone": "[məˈtɪəriəl]"
+    },
+    {
+        "name": "line",
+        "trans": [
+            "n. 路线，航线；排；绳"
+        ],
+        "usphone": "[laɪn]",
+        "ukphone": "[laɪn]"
+    },
+    {
+        "name": "county",
+        "trans": [
+            "n. 郡，县"
+        ],
+        "usphone": "[ˈkaʊnti]",
+        "ukphone": "[ˈkaʊnti]"
+    },
+    {
+        "name": "diverse",
+        "trans": [
+            "adj. 不同的；多种多样的；变化多的"
+        ],
+        "usphone": "[daɪˈvɜːrs]",
+        "ukphone": "[daɪˈvɜːs]"
+    },
+    {
+        "name": "agency",
+        "trans": [
+            "n. 代理，中介；代理处，经销处"
+        ],
+        "usphone": "[ˈeɪdʒənsi]",
+        "ukphone": "[ˈeɪdʒənsi]"
+    },
+    {
+        "name": "motivate",
+        "trans": [
+            "vt. 刺激；使有动机；激发…的积极性"
+        ],
+        "usphone": "[ˈmoʊtɪveɪt]",
+        "ukphone": "[ˈməʊtɪveɪt]"
+    },
+    {
+        "name": "temple",
+        "trans": [
+            "n. 庙宇；寺院；神殿；太阳穴"
+        ],
+        "usphone": "[ˈtempl]",
+        "ukphone": "[ˈtemp(ə)l]"
+    },
+    {
+        "name": "trading",
+        "trans": [
+            "n. 交易；贸易；购物"
+        ],
+        "usphone": "",
+        "ukphone": ""
+    },
+    {
+        "name": "auction",
+        "trans": [
+            "n. 拍卖"
+        ],
+        "usphone": "[ˈɔːkʃn]",
+        "ukphone": "[ˈɔːkʃ(ə)n]"
+    },
+    {
+        "name": "estate",
+        "trans": [
+            "n. 房地产；财产；身份"
+        ],
+        "usphone": "[ɪˈsteɪt]",
+        "ukphone": "[ɪˈsteɪt]"
+    },
+    {
+        "name": "destruction",
+        "trans": [
+            "n. 破坏，毁灭；摧毁"
+        ],
+        "usphone": "[dɪˈstrʌkʃn]",
+        "ukphone": "[dɪˈstrʌkʃ(ə)n]"
+    },
+    {
+        "name": "anticipate",
+        "trans": [
+            "vt. 预期，期望；占先，抢先；提前使用"
+        ],
+        "usphone": "[ænˈtɪsɪpeɪt]",
+        "ukphone": "[ænˈtɪsɪpeɪt]"
+    },
+    {
+        "name": "considerably",
+        "trans": [
+            "adv. 相当地；非常地"
+        ],
+        "usphone": "[kənˈsɪdərəbli]",
+        "ukphone": "[kənˈsɪdərəbli]"
+    },
+    {
+        "name": "strictly",
+        "trans": [
+            "adv. 严格地；完全地；确实地"
+        ],
+        "usphone": "[ˈstrɪktli]",
+        "ukphone": "[ˈstrɪktli]"
+    },
+    {
+        "name": "stance",
+        "trans": [
+            "n. 立场；姿态；位置；准备击球姿势"
+        ],
+        "usphone": "[stæns]",
+        "ukphone": "[stæns]"
+    },
+    {
+        "name": "time",
+        "trans": [
+            "n. 时间；时代；次数；节拍；倍数"
+        ],
+        "usphone": "[taɪm]",
+        "ukphone": "[taɪm]"
+    },
+    {
+        "name": "implication",
+        "trans": [
+            "n. 含义；暗示；牵连，卷入；可能的结果，影响"
+        ],
+        "usphone": "[ˌɪmplɪˈkeɪʃn]",
+        "ukphone": "[ˌɪmplɪˈkeɪʃn]"
+    },
+    {
+        "name": "convey",
+        "trans": [
+            "vt. 传达；运输；让与"
+        ],
+        "usphone": "[kənˈveɪ]",
+        "ukphone": "[kənˈveɪ]"
+    },
+    {
+        "name": "whereas",
+        "trans": [
+            "conj. 然而；鉴于；反之"
+        ],
+        "usphone": "[ˌwerˈæz]",
+        "ukphone": "[ˌweərˈæz]"
+    },
+    {
+        "name": "certificate",
+        "trans": [
+            "n. 证书；执照，文凭"
+        ],
+        "usphone": "[sərˈtɪfɪkət]",
+        "ukphone": "[səˈtɪfɪkət]"
+    },
+    {
+        "name": "booking",
+        "trans": [
+            "n. 预订；预约；演出契约"
+        ],
+        "usphone": "[ˈbʊkɪŋ]",
+        "ukphone": "[ˈbʊkɪŋ]"
+    },
+    {
+        "name": "signature",
+        "trans": [
+            "n. 署名；签名；信号"
+        ],
+        "usphone": "[ˈsɪɡnətʃər]",
+        "ukphone": "[ˈsɪɡnətʃə(r)]"
+    },
+    {
+        "name": "attempt",
+        "trans": [
+            "n. 企图，试图；攻击"
+        ],
+        "usphone": "[əˈtempt]",
+        "ukphone": "[əˈtempt]"
+    },
+    {
+        "name": "entrepreneur",
+        "trans": [
+            "n. 企业家；承包人；主办者"
+        ],
+        "usphone": "[ˌɑːntrəprəˈnɜːr]",
+        "ukphone": "[ˌɒntrəprəˈnɜː(r)]"
+    },
+    {
+        "name": "naked",
+        "trans": [
+            "adj. 裸体的；无装饰的；无证据的；直率的"
+        ],
+        "usphone": "[ˈneɪkɪd]",
+        "ukphone": "[ˈneɪkɪd]"
+    },
+    {
+        "name": "spiritual",
+        "trans": [
+            "n. 圣歌（尤指美国南部黑人的）"
+        ],
+        "usphone": "[ˈspɪrɪtʃuəl]",
+        "ukphone": "[ˈspɪrɪtʃuəl]"
+    },
+    {
+        "name": "generate",
+        "trans": [
+            "vt. 使形成；发生；生殖；产生物理反应"
+        ],
+        "usphone": "[ˈdʒenəreɪt]",
+        "ukphone": "[ˈdʒenəreɪt]"
+    },
+    {
+        "name": "back",
+        "trans": [
+            "n. 后面；背部；靠背；足球等的后卫；书报等的末尾"
+        ],
+        "usphone": "[bæk]",
+        "ukphone": "[bæk]"
+    },
+    {
+        "name": "nursing",
+        "trans": [
+            "n. 护理；看护；养育"
+        ],
+        "usphone": "[ˈnɜːrsɪŋ]",
+        "ukphone": "[ˈnɜːsɪŋ]"
+    },
+    {
+        "name": "following",
+        "trans": [
+            "n. 下列事物；一批追随者"
+        ],
+        "usphone": "[ˈfɑːloʊɪŋ]",
+        "ukphone": "[ˈfɒləʊɪŋ]"
+    },
+    {
+        "name": "investor",
+        "trans": [
+            "n. 投资者"
+        ],
+        "usphone": "[ɪnˈvestər]",
+        "ukphone": "[ɪnˈvestə(r)]"
+    },
+    {
+        "name": "aid",
+        "trans": [
+            "n. 援助；帮助；助手；帮助者"
+        ],
+        "usphone": "[eɪd]",
+        "ukphone": "[eɪd]"
+    },
+    {
+        "name": "satisfied",
+        "trans": [
+            "v. 使满意（satisfy的过去式）"
+        ],
+        "usphone": "[ˈsætɪsfaɪd]",
+        "ukphone": "[ˈsætɪsfaɪd]"
+    },
+    {
+        "name": "contract",
+        "trans": [
+            "n. 合同；婚约"
+        ],
+        "usphone": "[ˈkɑːntrækt; kənˈtrækt]",
+        "ukphone": "[ˈkɒntrækt; kənˈtrækt]"
+    },
+    {
+        "name": "try",
+        "trans": [
+            "n. 尝试；努力；试验"
+        ],
+        "usphone": "[traɪ]",
+        "ukphone": "[traɪ]"
+    },
+    {
+        "name": "housing",
+        "trans": [
+            "n. 房屋；住房供给；[机] 外壳；遮盖物；机器等的防护外壳或外罩"
+        ],
+        "usphone": "[ˈhaʊzɪŋ]",
+        "ukphone": "[ˈhaʊzɪŋ]"
+    },
+    {
+        "name": "representative",
+        "trans": [
+            "n. 代表；典型；众议员"
+        ],
+        "usphone": "[ˌreprɪˈzentətɪv]",
+        "ukphone": "[ˌreprɪˈzentətɪv]"
+    },
+    {
+        "name": "critically",
+        "trans": [
+            "adv. 精密地；危急地；严重地；批评性地；用钻研眼光地；很大程度上；极为重要地"
+        ],
+        "usphone": "[ˈkrɪtɪkli]",
+        "ukphone": "[ˈkrɪtɪkli]"
+    },
+    {
+        "name": "undertake",
+        "trans": [
+            "vt. 承担，保证；从事；同意；试图"
+        ],
+        "usphone": "[ˌʌndərˈteɪk]",
+        "ukphone": "[ˌʌndəˈteɪk]"
+    },
+    {
+        "name": "sympathetic",
+        "trans": [
+            "n. 交感神经；容易感受的人"
+        ],
+        "usphone": "[ˌsɪmpəˈθetɪk]",
+        "ukphone": "[ˌsɪmpəˈθetɪk]"
+    },
+    {
+        "name": "healthcare",
+        "trans": [
+            "n. 医疗保健；健康护理，健康服务；卫生保健"
+        ],
+        "usphone": "[ˈhelθˌker]",
+        "ukphone": "[ˈhelθkeə(r)]"
+    },
+    {
+        "name": "chop",
+        "trans": [
+            "n. 砍；排骨；商标；削球"
+        ],
+        "usphone": "[tʃɑːp]",
+        "ukphone": "[tʃɒp]"
+    },
+    {
+        "name": "logo",
+        "trans": [
+            "n. 商标，徽标；标识语"
+        ],
+        "usphone": "[ˈloʊɡoʊ]",
+        "ukphone": "[ˈləʊɡəʊ]"
+    },
+    {
+        "name": "approach",
+        "trans": [
+            "n. 方法；途径；接近"
+        ],
+        "usphone": "[əˈproʊtʃ]",
+        "ukphone": "[əˈprəʊtʃ]"
+    },
+    {
+        "name": "schedule",
+        "trans": [
+            "n. 时间表；计划表；一览表"
+        ],
+        "usphone": "[ˈskedʒuːl]",
+        "ukphone": "[ˈʃedjuːl]"
+    },
+    {
+        "name": "capacity",
+        "trans": [
+            "n. 能力；容量；资格，地位；生产力"
+        ],
+        "usphone": "[kəˈpæsəti]",
+        "ukphone": "[kəˈpæsəti]"
+    },
+    {
+        "name": "origin",
+        "trans": [
+            "n. 起源；原点；出身；开端"
+        ],
+        "usphone": "[ˈɔːrɪdʒɪn]",
+        "ukphone": "[ˈɒrɪdʒɪn]"
+    },
+    {
+        "name": "criticize",
+        "trans": [
+            "vi. 批评；评论；苛求"
+        ],
+        "usphone": "[ˈkrɪtɪsaɪz]",
+        "ukphone": "[ˈkrɪtɪsaɪz]"
+    },
+    {
+        "name": "exit",
+        "trans": [
+            "n. 出口，通道；退场"
+        ],
+        "usphone": "[ˈeksɪt; ˈeɡzɪt]",
+        "ukphone": "[ˈeksɪt]"
+    },
+    {
+        "name": "comprehensive",
+        "trans": [
+            "n. 综合学校；专业综合测验"
+        ],
+        "usphone": "[ˌkɑːmprɪˈhensɪv]",
+        "ukphone": "[ˌkɒmprɪˈhensɪv]"
+    },
+    {
+        "name": "innovation",
+        "trans": [
+            "n. 创新，革新；新方法"
+        ],
+        "usphone": "[ˌɪnəˈveɪʃn]",
+        "ukphone": "[ˌɪnəˈveɪʃ(ə)n]"
+    },
+    {
+        "name": "hearing",
+        "trans": [
+            "n. 听力；审讯，听讯"
+        ],
+        "usphone": "[ˈhɪrɪŋ]",
+        "ukphone": "[ˈhɪərɪŋ]"
+    },
+    {
+        "name": "weekly",
+        "trans": [
+            "n. 周刊"
+        ],
+        "usphone": "[ˈwiːkli]",
+        "ukphone": "[ˈwiːkli]"
+    },
+    {
+        "name": "expansion",
+        "trans": [
+            "n. 膨胀；阐述；扩张物"
+        ],
+        "usphone": "[ɪkˈspænʃn]",
+        "ukphone": "[ɪkˈspænʃ(ə)n]"
+    },
+    {
+        "name": "biological",
+        "trans": [
+            "adj. 生物的；生物学的"
+        ],
+        "usphone": "[ˌbaɪəˈlɑːdʒɪkl]",
+        "ukphone": "[ˌbaɪəˈlɒdʒɪk(ə)l]"
+    },
+    {
+        "name": "ongoing",
+        "trans": [
+            "adj. 不间断的，进行的；前进的"
+        ],
+        "usphone": "[ˈɑːnɡoʊɪŋ]",
+        "ukphone": "[ˈɒnɡəʊɪŋ]"
+    },
+    {
+        "name": "leave",
+        "trans": [
+            "vt. 离开；留下；遗忘；委托"
+        ],
+        "usphone": "[liːv]",
+        "ukphone": "[liːv]"
+    },
+    {
+        "name": "dare",
+        "trans": [
+            "n. 挑战；挑动"
+        ],
+        "usphone": "[der]",
+        "ukphone": "[deə(r)]"
+    },
+    {
+        "name": "unity",
+        "trans": [
+            "n. 团结；一致；联合；个体"
+        ],
+        "usphone": "[ˈjuːnəti]",
+        "ukphone": "[ˈjuːnəti]"
+    },
+    {
+        "name": "widespread",
+        "trans": [
+            "adj. 普遍的，广泛的；分布广的"
+        ],
+        "usphone": "[ˈwaɪdspred]",
+        "ukphone": "[ˈwaɪdspred]"
+    },
+    {
+        "name": "instance",
+        "trans": [
+            "n. 实例；情况；建议"
+        ],
+        "usphone": "[ˈɪnstəns]",
+        "ukphone": "[ˈɪnstəns]"
+    },
+    {
+        "name": "therapist",
+        "trans": [
+            "n. 临床医学家；治疗学家"
+        ],
+        "usphone": "[ˈθerəpɪst]",
+        "ukphone": "[ˈθerəpɪst]"
+    },
+    {
+        "name": "perspective",
+        "trans": [
+            "n. 观点；远景；透视图"
+        ],
+        "usphone": "[pərˈspektɪv]",
+        "ukphone": "[pəˈspektɪv]"
+    },
+    {
+        "name": "spoil",
+        "trans": [
+            "n. 次品；奖品"
+        ],
+        "usphone": "[spɔɪl]",
+        "ukphone": "[spɔɪl]"
+    },
+    {
+        "name": "insist",
+        "trans": [
+            "vi. 坚持，强调"
+        ],
+        "usphone": "[ɪnˈsɪst]",
+        "ukphone": "[ɪnˈsɪst]"
+    },
+    {
+        "name": "blow",
+        "trans": [
+            "n. 吹；打击；殴打"
+        ],
+        "usphone": "[bloʊ]",
+        "ukphone": "[bləʊ]"
+    },
+    {
+        "name": "desperately",
+        "trans": [
+            "adv. 拼命地；绝望地；极度地"
+        ],
+        "usphone": "[ˈdespərətli]",
+        "ukphone": "[ˈdespərətli]"
+    },
+    {
+        "name": "boost",
+        "trans": [
+            "n. 推动；帮助；宣扬"
+        ],
+        "usphone": "[buːst]",
+        "ukphone": "[buːst]"
+    },
+    {
+        "name": "extend",
+        "trans": [
+            "vt. 延伸；扩大；推广；伸出；给予；使竭尽全力；对…估价"
+        ],
+        "usphone": "[ɪkˈstend]",
+        "ukphone": "[ɪkˈstend]"
+    },
+    {
+        "name": "era",
+        "trans": [
+            "n. 时代；年代；纪元"
+        ],
+        "usphone": "[ˈɪrə; ˈerə]",
+        "ukphone": "[ˈɪərə]"
+    },
+    {
+        "name": "imagination",
+        "trans": [
+            "n. [心理] 想象力；空想；幻想物"
+        ],
+        "usphone": "[ɪˌmædʒɪˈneɪʃn]",
+        "ukphone": "[ɪˌmædʒɪˈneɪʃ(ə)n]"
+    },
+    {
+        "name": "output",
+        "trans": [
+            "n. 输出，输出量；产量；出产"
+        ],
+        "usphone": "[ˈaʊtpʊt]",
+        "ukphone": "[ˈaʊtpʊt]"
+    },
+    {
+        "name": "firmly",
+        "trans": [
+            "adv. 坚定地，坚决地；坚固地，稳固地"
+        ],
+        "usphone": "[ˈfɜːrmli]",
+        "ukphone": "[ˈfɜːmli]"
+    },
+    {
+        "name": "stand",
+        "trans": [
+            "n. 站立；立场；看台；停止"
+        ],
+        "usphone": "[stænd]",
+        "ukphone": "[stænd]"
+    },
+    {
+        "name": "parallel",
+        "trans": [
+            "n. 平行线；对比"
+        ],
+        "usphone": "[ˈpærəlel]",
+        "ukphone": "[ˈpærəlel]"
+    },
+    {
+        "name": "manufacturing",
+        "trans": [
+            "adj. 制造的；制造业的"
+        ],
+        "usphone": "[ˌmænjuˈfæktʃərɪŋ]",
+        "ukphone": "[ˌmænjuˈfæktʃərɪŋ]"
+    },
+    {
+        "name": "cheer",
+        "trans": [
+            "n. 欢呼；愉快；心情；令人愉快的事"
+        ],
+        "usphone": "[tʃɪr]",
+        "ukphone": "[tʃɪə(r)]"
+    },
+    {
+        "name": "overseas",
+        "trans": [
+            "adv. 在海外，海外"
+        ],
+        "usphone": "[ˌoʊvərˈsiːz]",
+        "ukphone": "[ˌəʊvəˈsiːz]"
+    },
+    {
+        "name": "terms",
+        "trans": [
+            "n. 地位，关系；[法] 条款；术语；措辞；价钱（term的复数形式）"
+        ],
+        "usphone": "[tɜːrmz]",
+        "ukphone": "[tɜːmz]"
+    },
+    {
+        "name": "display",
+        "trans": [
+            "n. 显示；炫耀"
+        ],
+        "usphone": "[dɪˈspleɪ]",
+        "ukphone": "[dɪˈspleɪ]"
+    },
+    {
+        "name": "logical",
+        "trans": [
+            "adj. 合逻辑的，合理的；逻辑学的"
+        ],
+        "usphone": "[ˈlɑːdʒɪkl]",
+        "ukphone": "[ˈlɒdʒɪk(ə)l]"
+    },
+    {
+        "name": "ambulance",
+        "trans": [
+            "n. [车辆][医] 救护车；战时流动医院"
+        ],
+        "usphone": "[ˈæmbjələns]",
+        "ukphone": "[ˈæmbjələns]"
+    },
+    {
+        "name": "matching",
+        "trans": [
+            "adj. 相配的；一致的；相称的"
+        ],
+        "usphone": "[ˈmætʃɪŋ]",
+        "ukphone": "[ˈmætʃɪŋ]"
+    },
+    {
+        "name": "minister",
+        "trans": [
+            "n. 部长；大臣；牧师"
+        ],
+        "usphone": "[ˈmɪnɪstər]",
+        "ukphone": "[ˈmɪnɪstə(r)]"
+    },
+    {
+        "name": "diversity",
+        "trans": [
+            "n. 多样性；差异"
+        ],
+        "usphone": "[daɪˈvɜːrsəti; dɪˈvɜːsɪti]",
+        "ukphone": "[daɪˈvɜːsəti]"
+    },
+    {
+        "name": "litre",
+        "trans": [
+            "n. [计量] 公升（米制容量单位）"
+        ],
+        "usphone": "[ˈliːtər]",
+        "ukphone": "[ˈliːtə(r)]"
+    },
+    {
+        "name": "tap",
+        "trans": [
+            "n. 水龙头；轻打"
+        ],
+        "usphone": "[tæp]",
+        "ukphone": "[tæp]"
+    },
+    {
+        "name": "spokeswoman",
+        "trans": [
+            "n. 女代言人，女代言人"
+        ],
+        "usphone": "[ˈspoʊkswʊmən]",
+        "ukphone": "[ˈspəʊkswʊmən]"
+    },
+    {
+        "name": "bill",
+        "trans": [
+            "n. [法] 法案；广告；账单；[金融] 票据；钞票；清单"
+        ],
+        "usphone": "[bɪl]",
+        "ukphone": "[bɪl]"
+    },
+    {
+        "name": "entirely",
+        "trans": [
+            "adv. 完全地，彻底地"
+        ],
+        "usphone": "[ɪnˈtaɪərli]",
+        "ukphone": "[ɪnˈtaɪəli]"
+    },
+    {
+        "name": "concrete",
+        "trans": [
+            "n. 具体物；凝结物"
+        ],
+        "usphone": "[ˈkɑːnkriːt]",
+        "ukphone": "[ˈkɒŋkriːt]"
+    },
+    {
+        "name": "cry",
+        "trans": [
+            "n. 叫喊；叫声；口号；呼叫"
+        ],
+        "usphone": "[kraɪ]",
+        "ukphone": "[kraɪ]"
+    },
+    {
+        "name": "crucial",
+        "trans": [
+            "adj. 重要的；决定性的；定局的；决断的"
+        ],
+        "usphone": "[ˈkruːʃl]",
+        "ukphone": "[ˈkruːʃ(ə)l]"
+    },
+    {
+        "name": "automatically",
+        "trans": [
+            "adj. 不经思索的"
+        ],
+        "usphone": "[ˌɔːtəˈmætɪkli]",
+        "ukphone": "[ˌɔːtəˈmætɪkli]"
+    },
+    {
+        "name": "fossil",
+        "trans": [
+            "n. 化石；僵化的事物；顽固不化的人"
+        ],
+        "usphone": "[ˈfɑːsl]",
+        "ukphone": "[ˈfɒsl]"
+    },
+    {
+        "name": "badge",
+        "trans": [
+            "n. 徽章；证章；标记"
+        ],
+        "usphone": "[bædʒ]",
+        "ukphone": "[bædʒ]"
+    },
+    {
+        "name": "assume",
+        "trans": [
+            "vt. 僭取；篡夺；夺取；擅用；侵占"
+        ],
+        "usphone": "[əˈsuːm]",
+        "ukphone": "[əˈsjuːm]"
+    },
+    {
+        "name": "acid",
+        "trans": [
+            "n. 酸；<俚>迷幻药"
+        ],
+        "usphone": "[ˈæsɪd]",
+        "ukphone": "[ˈæsɪd]"
+    },
+    {
+        "name": "flash",
+        "trans": [
+            "n. 闪光，闪现；一瞬间"
+        ],
+        "usphone": "[flæʃ]",
+        "ukphone": "[flæʃ]"
+    },
+    {
+        "name": "contest",
+        "trans": [
+            "n. 竞赛；争夺；争论"
+        ],
+        "usphone": "[ˈkɑːntest]",
+        "ukphone": "[ˈkɒntest]"
+    },
+    {
+        "name": "applicant",
+        "trans": [
+            "n. 申请人，申请者；请求者"
+        ],
+        "usphone": "[ˈæplɪkənt]",
+        "ukphone": "[ˈæplɪkənt]"
+    },
+    {
+        "name": "skull",
+        "trans": [
+            "n. 头盖骨，脑壳"
+        ],
+        "usphone": "[skʌl]",
+        "ukphone": "[skʌl]"
+    },
+    {
+        "name": "resolve",
+        "trans": [
+            "n. 坚决；决定要做的事"
+        ],
+        "usphone": "[rɪˈzɑːlv]",
+        "ukphone": "[rɪˈzɒlv]"
+    },
+    {
+        "name": "anniversary",
+        "trans": [
+            "n. 周年纪念日"
+        ],
+        "usphone": "[ˌænɪˈvɜːrsəri]",
+        "ukphone": "[ˌænɪˈvɜːsəri]"
+    },
+    {
+        "name": "protein",
+        "trans": [
+            "n. 蛋白质；朊"
+        ],
+        "usphone": "[ˈproʊtiːn]",
+        "ukphone": "[ˈprəʊtiːn]"
+    },
+    {
+        "name": "budget",
+        "trans": [
+            "n. 预算，预算费"
+        ],
+        "usphone": "[ˈbʌdʒɪt]",
+        "ukphone": "[ˈbʌdʒɪt]"
+    },
+    {
+        "name": "resident",
+        "trans": [
+            "n. 居民；住院医生"
+        ],
+        "usphone": "[ˈrezɪdənt]",
+        "ukphone": "[ˈrezɪdənt]"
+    },
+    {
+        "name": "industrial",
+        "trans": [
+            "n. 工业股票；工业工人"
+        ],
+        "usphone": "[ɪnˈdʌstriəl]",
+        "ukphone": "[ɪnˈdʌstriəl]"
+    },
+    {
+        "name": "infer",
+        "trans": [
+            "vi. 推断；作出推论"
+        ],
+        "usphone": "[ɪnˈfɜːr]",
+        "ukphone": "[ɪnˈfɜː(r)]"
+    },
+    {
+        "name": "inevitable",
+        "trans": [
+            "adj. 必然的，不可避免的"
+        ],
+        "usphone": "[ɪnˈevɪtəbl]",
+        "ukphone": "[ɪnˈevɪtəbl]"
+    },
+    {
+        "name": "constantly",
+        "trans": [
+            "adv. 不断地；时常地"
+        ],
+        "usphone": "[ˈkɑːnstəntli]",
+        "ukphone": "[ˈkɒnstəntli]"
+    },
+    {
+        "name": "radiation",
+        "trans": [
+            "n. 辐射；发光；放射物"
+        ],
+        "usphone": "[ˌreɪdiˈeɪʃn]",
+        "ukphone": "[ˌreɪdiˈeɪʃn]"
+    },
+    {
+        "name": "deposit",
+        "trans": [
+            "n. 存款；押金；订金；保证金；沉淀物"
+        ],
+        "usphone": "[dɪˈpɑːzɪt]",
+        "ukphone": "[dɪˈpɒzɪt]"
+    },
+    {
+        "name": "inhabitant",
+        "trans": [
+            "n. 居民；居住者"
+        ],
+        "usphone": "[ɪnˈhæbɪtənt]",
+        "ukphone": "[ɪnˈhæbɪtənt]"
+    },
+    {
+        "name": "likewise",
+        "trans": [
+            "adv. 同样地；也"
+        ],
+        "usphone": "[ˈlaɪkwaɪz]",
+        "ukphone": "[ˈlaɪkwaɪz]"
+    },
+    {
+        "name": "transmit",
+        "trans": [
+            "vt. 传输；传播；发射；传达；遗传"
+        ],
+        "usphone": "[trænzˈmɪtˌtrænsˈmɪt]",
+        "ukphone": "[trænzˈmɪt]"
+    },
+    {
+        "name": "courage",
+        "trans": [
+            "n. 勇气；胆量"
+        ],
+        "usphone": "[ˈkɜːrɪdʒ]",
+        "ukphone": "[ˈkʌrɪdʒ]"
+    },
+    {
+        "name": "massive",
+        "trans": [
+            "adj. 大量的；巨大的，厚重的；魁伟的"
+        ],
+        "usphone": "[ˈmæsɪv]",
+        "ukphone": "[ˈmæsɪv]"
+    },
+    {
+        "name": "cute",
+        "trans": [
+            "adj. 可爱的；漂亮的；聪明的，伶俐的"
+        ],
+        "usphone": "[kjuːt]",
+        "ukphone": "[kjuːt]"
+    },
+    {
+        "name": "discipline",
+        "trans": [
+            "n. 学科；纪律；训练；惩罚"
+        ],
+        "usphone": "[ˈdɪsəplɪn]",
+        "ukphone": "[ˈdɪsəplɪn]"
+    },
+    {
+        "name": "judgement",
+        "trans": [
+            "n. 意见；判断力；[法] 审判；评价"
+        ],
+        "usphone": "[ˈdʒʌdʒmənt]",
+        "ukphone": "[ˈdʒʌdʒmənt]"
+    },
+    {
+        "name": "highway",
+        "trans": [
+            "n. 公路，大路；捷径"
+        ],
+        "usphone": "[ˈhaɪweɪ]",
+        "ukphone": "[ˈhaɪweɪ]"
+    },
+    {
+        "name": "tackle",
+        "trans": [
+            "n. 滑车；装备；用具；扭倒"
+        ],
+        "usphone": "[ˈtækl]",
+        "ukphone": "[ˈtæk(ə)l]"
+    },
+    {
+        "name": "additionally",
+        "trans": [
+            "adv. 此外；又，加之"
+        ],
+        "usphone": "[əˈdɪʃənəli]",
+        "ukphone": "[əˈdɪʃənəli]"
+    },
+    {
+        "name": "fame",
+        "trans": [
+            "n. 名声，名望；传闻，传说"
+        ],
+        "usphone": "[feɪm]",
+        "ukphone": "[feɪm]"
+    },
+    {
+        "name": "furious",
+        "trans": [
+            "adj. 激烈的；狂怒的；热烈兴奋的；喧闹的"
+        ],
+        "usphone": "[ˈfjʊriəs]",
+        "ukphone": "[ˈfjʊəriəs]"
+    },
+    {
+        "name": "sustainable",
+        "trans": [
+            "adj. 可以忍受的；足可支撑的；养得起的；可持续的"
+        ],
+        "usphone": "[səˈsteɪnəb(ə)l]",
+        "ukphone": "[səˈsteɪnəb(ə)l]"
+    },
+    {
+        "name": "capture",
+        "trans": [
+            "n. 捕获；战利品，俘虏"
+        ],
+        "usphone": "[ˈkæptʃər]",
+        "ukphone": "[ˈkæptʃə(r)]"
+    },
+    {
+        "name": "revision",
+        "trans": [
+            "n. [印刷] 修正；复习；修订本"
+        ],
+        "usphone": "[rɪˈvɪʒn]",
+        "ukphone": "[rɪˈvɪʒn]"
+    },
+    {
+        "name": "universal",
+        "trans": [
+            "n. 一般概念；普通性"
+        ],
+        "usphone": "[ˌjuːnɪˈvɜːrsl]",
+        "ukphone": "[ˌjuːnɪˈvɜːs(ə)l]"
+    },
+    {
+        "name": "burn",
+        "trans": [
+            "n. 灼伤，烧伤；烙印"
+        ],
+        "usphone": "[bɜːrn]",
+        "ukphone": "[bɜːn]"
+    },
+    {
+        "name": "exclude",
+        "trans": [
+            "vt. 排除；排斥；拒绝接纳；逐出"
+        ],
+        "usphone": "[ɪkˈskluːd]",
+        "ukphone": "[ɪkˈskluːd]"
+    },
+    {
+        "name": "swallow",
+        "trans": [
+            "n. 燕子；一次吞咽的量"
+        ],
+        "usphone": "[ˈswɑːloʊ]",
+        "ukphone": "[ˈswɒləʊ]"
+    },
+    {
+        "name": "joy",
+        "trans": [
+            "n. 欢乐，快乐；乐趣；高兴"
+        ],
+        "usphone": "[dʒɔɪ]",
+        "ukphone": "[dʒɔɪ]"
+    },
+    {
+        "name": "vertical",
+        "trans": [
+            "n. 垂直线，垂直面"
+        ],
+        "usphone": "[ˈvɜːrtɪkl]",
+        "ukphone": "[ˈvɜːtɪk(ə)l]"
+    },
+    {
+        "name": "psychologist",
+        "trans": [
+            "n. 心理学家，心理学者"
+        ],
+        "usphone": "[saɪˈkɑːlədʒɪst]",
+        "ukphone": "[saɪˈkɒlədʒɪst]"
+    },
+    {
+        "name": "sponsorship",
+        "trans": [
+            "n. 赞助；发起；保证人的地位；教父母身份"
+        ],
+        "usphone": "[ˈspɑːnsərʃɪp]",
+        "ukphone": "[ˈspɒnsəʃɪp]"
+    },
+    {
+        "name": "precede",
+        "trans": [
+            "vt. 领先，在…之前；优于，高于"
+        ],
+        "usphone": "[prɪˈsiːd]",
+        "ukphone": "[prɪˈsiːd]"
+    },
+    {
+        "name": "remarkably",
+        "trans": [
+            "adv. 显著地；非常地；引人注目地"
+        ],
+        "usphone": "[rɪˈmɑːrkəbli]",
+        "ukphone": "[rɪˈmɑːkəbli]"
+    },
+    {
+        "name": "oxygen",
+        "trans": [
+            "n. [化学] 氧气，[化学] 氧"
+        ],
+        "usphone": "[ˈɑːksɪdʒən]",
+        "ukphone": "[ˈɒksɪdʒən]"
+    },
+    {
+        "name": "briefly",
+        "trans": [
+            "adv. 短暂地；简略地；暂时地"
+        ],
+        "usphone": "[ˈbriːfli]",
+        "ukphone": "[ˈbriːfli]"
+    },
+    {
+        "name": "recall",
+        "trans": [
+            "n. 召回；回忆；撤消"
+        ],
+        "usphone": "[rɪˈkɔːl]",
+        "ukphone": "[rɪˈkɔːl]"
+    },
+    {
+        "name": "critical",
+        "trans": [
+            "adj. 鉴定的；[核] 临界的；批评的，爱挑剔的；危险的；决定性的；评论的"
+        ],
+        "usphone": "[ˈkrɪtɪkl]",
+        "ukphone": "[ˈkrɪtɪk(ə)l]"
+    },
+    {
+        "name": "significance",
+        "trans": [
+            "n. 意义；重要性；意思"
+        ],
+        "usphone": "[sɪɡˈnɪfɪkəns]",
+        "ukphone": "[sɪɡˈnɪfɪkəns]"
+    },
+    {
+        "name": "ruin",
+        "trans": [
+            "n. 废墟；毁坏；灭亡"
+        ],
+        "usphone": "[ˈruːɪn]",
+        "ukphone": "[ˈruːɪn]"
+    },
+    {
+        "name": "assign",
+        "trans": [
+            "vt. 分配；指派；[计][数] 赋值"
+        ],
+        "usphone": "[əˈsaɪn]",
+        "ukphone": "[əˈsaɪn]"
+    },
+    {
+        "name": "variation",
+        "trans": [
+            "n. 变化；[生物] 变异，变种"
+        ],
+        "usphone": "[ˌveriˈeɪʃn]",
+        "ukphone": "[ˌveəriˈeɪʃn]"
+    },
+    {
+        "name": "worth",
+        "trans": [
+            "n. 价值；财产"
+        ],
+        "usphone": "[wɜːrθ]",
+        "ukphone": "[wɜːθ]"
+    },
+    {
+        "name": "funding",
+        "trans": [
+            "n. 提供资金；用发行长期债券的方法来收回短期债券"
+        ],
+        "usphone": "[ˈfʌndɪŋ]",
+        "ukphone": "[ˈfʌndɪŋ]"
+    },
+    {
+        "name": "disappoint",
+        "trans": [
+            "vt. 使失望"
+        ],
+        "usphone": "[ˌdɪsəˈpɔɪnt]",
+        "ukphone": "[ˌdɪsəˈpɔɪnt]"
+    },
+    {
+        "name": "folding",
+        "trans": [
+            "adj. 可折叠的"
+        ],
+        "usphone": "[ˈfoʊldɪŋ]",
+        "ukphone": "[ˈfəʊldɪŋ]"
+    },
+    {
+        "name": "being",
+        "trans": [
+            "n. 存在；生命；本质；品格"
+        ],
+        "usphone": "[ˈbiːɪŋ]",
+        "ukphone": "[ˈbiːɪŋ]"
+    },
+    {
+        "name": "memorable",
+        "trans": [
+            "adj. 显著的，难忘的；值得纪念的"
+        ],
+        "usphone": "[ˈmemərəbl]",
+        "ukphone": "[ˈmemərəbl]"
+    },
+    {
+        "name": "adequately",
+        "trans": [
+            "adv. 充分地；足够地；适当地"
+        ],
+        "usphone": "[ˈædɪkwətli]",
+        "ukphone": "[ˈædɪkwətli]"
+    },
+    {
+        "name": "concept",
+        "trans": [
+            "n. 观念，概念"
+        ],
+        "usphone": "[ˈkɑːnsept]",
+        "ukphone": "[ˈkɒnsept]"
+    },
+    {
+        "name": "thumb",
+        "trans": [
+            "n. 拇指"
+        ],
+        "usphone": "[θʌm]",
+        "ukphone": "[θʌm]"
+    },
+    {
+        "name": "inflation",
+        "trans": [
+            "n. 膨胀；通货膨胀；夸张；自命不凡"
+        ],
+        "usphone": "[ɪnˈfleɪʃn]",
+        "ukphone": "[ɪnˈfleɪʃn]"
+    },
+    {
+        "name": "survivor",
+        "trans": [
+            "n. 幸存者；生还者；残存物"
+        ],
+        "usphone": "[sərˈvaɪvər]",
+        "ukphone": "[səˈvaɪvə(r)]"
+    },
+    {
+        "name": "electronics",
+        "trans": [
+            "n. 电子学；电子工业"
+        ],
+        "usphone": "[ɪˌlekˈtrɑːnɪks]",
+        "ukphone": "[ɪˌlekˈtrɒnɪks]"
+    },
+    {
+        "name": "textbook",
+        "trans": [
+            "n. 教科书，课本"
+        ],
+        "usphone": "[ˈtekstbʊk]",
+        "ukphone": "[ˈtekstbʊk]"
+    },
+    {
+        "name": "prime",
+        "trans": [
+            "n. 初期；青年；精华；全盛时期"
+        ],
+        "usphone": "[praɪm]",
+        "ukphone": "[praɪm]"
+    },
+    {
+        "name": "council",
+        "trans": [
+            "n. 委员会；会议；理事会；地方议会；顾问班子"
+        ],
+        "usphone": "[ˈkaʊnsl]",
+        "ukphone": "[ˈkaʊns(ə)l]"
+    },
+    {
+        "name": "rat",
+        "trans": [
+            "n. 鼠；卑鄙小人，叛徒"
+        ],
+        "usphone": "[ræt]",
+        "ukphone": "[ræt]"
+    },
+    {
+        "name": "slide",
+        "trans": [
+            "n. 滑动；幻灯片；滑梯；雪崩"
+        ],
+        "usphone": "[slaɪd]",
+        "ukphone": "[slaɪd]"
+    },
+    {
+        "name": "rhythm",
+        "trans": [
+            "n. 节奏；韵律"
+        ],
+        "usphone": "[ˈrɪðəm]",
+        "ukphone": "[ˈrɪðəm]"
+    },
+    {
+        "name": "packet",
+        "trans": [
+            "n. 数据包，信息包；小包，小捆"
+        ],
+        "usphone": "[ˈpækɪt]",
+        "ukphone": "[ˈpækɪt]"
+    },
+    {
+        "name": "accurately",
+        "trans": [
+            "adv. 精确地，准确地"
+        ],
+        "usphone": "[ˈækjərətli]",
+        "ukphone": "[ˈækjərətli]"
+    },
+    {
+        "name": "extreme",
+        "trans": [
+            "n. 极端；末端；最大程度；极端的事物"
+        ],
+        "usphone": "[ɪkˈstriːm]",
+        "ukphone": "[ɪkˈstriːm]"
+    },
+    {
+        "name": "dump",
+        "trans": [
+            "n. 垃圾场；仓库；无秩序地累积"
+        ],
+        "usphone": "[dʌmp]",
+        "ukphone": "[dʌmp]"
+    },
+    {
+        "name": "index",
+        "trans": [
+            "n. 指标；指数；索引；指针"
+        ],
+        "usphone": "[ˈɪndeks]",
+        "ukphone": "[ˈɪndeks]"
+    },
+    {
+        "name": "investigation",
+        "trans": [
+            "n. 调查；调查研究"
+        ],
+        "usphone": "[ɪnˌvestɪˈɡeɪʃn]",
+        "ukphone": "[ɪnˌvestɪˈɡeɪʃn]"
+    },
+    {
+        "name": "exposure",
+        "trans": [
+            "n. 暴露；曝光；揭露；陈列"
+        ],
+        "usphone": "[ɪkˈspoʊʒər]",
+        "ukphone": "[ɪkˈspəʊʒə(r)]"
+    },
+    {
+        "name": "clerk",
+        "trans": [
+            "n. 职员，办事员；店员；书记；记账员；<古>牧师，教士"
+        ],
+        "usphone": "[klɜːrk]",
+        "ukphone": "[klɑːk]"
+    },
+    {
+        "name": "fundamental",
+        "trans": [
+            "n. 基本原理；基本原则"
+        ],
+        "usphone": "[ˌfʌndəˈmentl]",
+        "ukphone": "[ˌfʌndəˈment(ə)l]"
+    },
+    {
+        "name": "distract",
+        "trans": [
+            "vt. 转移；分心"
+        ],
+        "usphone": "[dɪˈstrækt]",
+        "ukphone": "[dɪˈstrækt]"
+    },
+    {
+        "name": "insight",
+        "trans": [
+            "n. 洞察力；洞悉"
+        ],
+        "usphone": "[ˈɪnsaɪt]",
+        "ukphone": "[ˈɪnsaɪt]"
+    },
+    {
+        "name": "medication",
+        "trans": [
+            "n. 药物；药物治疗；药物处理"
+        ],
+        "usphone": "[ˌmedɪˈkeɪʃn]",
+        "ukphone": "[ˌmedɪˈkeɪʃn]"
+    },
+    {
+        "name": "contemporary",
+        "trans": [
+            "n. 同时代的人；同时期的东西"
+        ],
+        "usphone": "[kənˈtempəreri]",
+        "ukphone": "[kənˈtemprəri]"
+    },
+    {
+        "name": "rob",
+        "trans": [
+            "vt. 抢劫；使…丧失；非法剥夺"
+        ],
+        "usphone": "[rɑːb]",
+        "ukphone": "[rɒb]"
+    },
+    {
+        "name": "chair",
+        "trans": [
+            "n. 椅子；讲座；（会议的）主席位；大学教授的职位"
+        ],
+        "usphone": "[tʃer]",
+        "ukphone": "[tʃeə(r)]"
+    },
+    {
+        "name": "controversial",
+        "trans": [
+            "adj. 有争议的；有争论的"
+        ],
+        "usphone": "[ˌkɑːntrəˈvɜːrʃl]",
+        "ukphone": "[ˌkɒntrəˈvɜːʃ(ə)l]"
+    },
+    {
+        "name": "proof",
+        "trans": [
+            "n. 证明；证据；校样；考验；验证；试验"
+        ],
+        "usphone": "[pruːf]",
+        "ukphone": "[pruːf]"
+    },
+    {
+        "name": "cancel",
+        "trans": [
+            "vi. 取消，撤销"
+        ],
+        "usphone": "[ˈkænsl]",
+        "ukphone": "[ˈkæns(ə)l]"
+    },
+    {
+        "name": "barely",
+        "trans": [
+            "adv. 仅仅，勉强；几乎不；公开地；贫乏地"
+        ],
+        "usphone": "[ˈberli]",
+        "ukphone": "[ˈbeəli]"
+    },
+    {
+        "name": "uncertainty",
+        "trans": [
+            "n. 不确定，不可靠"
+        ],
+        "usphone": "[ʌnˈsɜːrtnti]",
+        "ukphone": "[ʌnˈsɜːt(ə)nti]"
+    },
+    {
+        "name": "outer",
+        "trans": [
+            "adj. 外面的，外部的；远离中心的"
+        ],
+        "usphone": "[ˈaʊtər]",
+        "ukphone": "[ˈaʊtə(r)]"
+    },
+    {
+        "name": "adopt",
+        "trans": [
+            "vi. 采取；过继"
+        ],
+        "usphone": "[əˈdɑːpt]",
+        "ukphone": "[əˈdɒpt]"
+    },
+    {
+        "name": "intellectual",
+        "trans": [
+            "n. 知识分子；凭理智做事者"
+        ],
+        "usphone": "[ˌɪntəˈlektʃuəl]",
+        "ukphone": "[ˌɪntəˈlektʃuəl]"
+    },
+    {
+        "name": "landscape",
+        "trans": [
+            "n. 风景；风景画；景色；山水画；乡村风景画；地形；（文件的）横向打印格式"
+        ],
+        "usphone": "[ˈlændskeɪp]",
+        "ukphone": "[ˈlændskeɪp]"
+    },
+    {
+        "name": "file",
+        "trans": [
+            "n. 文件；档案；文件夹；锉刀"
+        ],
+        "usphone": "[faɪl]",
+        "ukphone": "[faɪl]"
+    },
+    {
+        "name": "optimistic",
+        "trans": [
+            "adj. 乐观的；乐观主义的"
+        ],
+        "usphone": "[ˌɑːptɪˈmɪstɪk]",
+        "ukphone": "[ˌɒptɪˈmɪstɪk]"
+    },
+    {
+        "name": "cancer",
+        "trans": [
+            "[天] 巨蟹座"
+        ],
+        "usphone": "[ˈkænsər]",
+        "ukphone": "[ˈkænsə(r)]"
+    },
+    {
+        "name": "household",
+        "trans": [
+            "n. 全家人，一家人；(包括佣工在内的)家庭，户"
+        ],
+        "usphone": "[ˈhaʊshoʊld]",
+        "ukphone": "[ˈhaʊshəʊld]"
+    },
+    {
+        "name": "numerous",
+        "trans": [
+            "adj. 许多的，很多的"
+        ],
+        "usphone": "[ˈnuːmərəs]",
+        "ukphone": "[ˈnjuːmərəs]"
+    },
+    {
+        "name": "evolve",
+        "trans": [
+            "vi. 发展，进展；进化；逐步形成"
+        ],
+        "usphone": "[ɪˈvɑːlv]",
+        "ukphone": "[ɪˈvɒlv]"
+    },
+    {
+        "name": "ultimate",
+        "trans": [
+            "n. 终极；根本；基本原则"
+        ],
+        "usphone": "[ˈʌltɪmət]",
+        "ukphone": "[ˈʌltɪmət]"
+    },
+    {
+        "name": "lyric",
+        "trans": [
+            "adj. 抒情的；吟唱的"
+        ],
+        "usphone": "[ˈlɪrɪk]",
+        "ukphone": "[ˈlɪrɪk]"
+    },
+    {
+        "name": "disk",
+        "trans": [
+            "n. [计] 磁盘，磁碟片；圆盘，盘状物；唱片"
+        ],
+        "usphone": "[dɪsk]",
+        "ukphone": "[dɪsk]"
+    },
+    {
+        "name": "bargain",
+        "trans": [
+            "n. 交易；便宜货；契约"
+        ],
+        "usphone": "[ˈbɑːrɡən]",
+        "ukphone": "[ˈbɑːɡən]"
+    },
+    {
+        "name": "wage",
+        "trans": [
+            "n. 工资；代价；报偿"
+        ],
+        "usphone": "[weɪdʒ]",
+        "ukphone": "[weɪdʒ]"
+    },
+    {
+        "name": "fault",
+        "trans": [
+            "n. 故障；[地质] 断层；错误；缺点；毛病；（网球等）发球失误"
+        ],
+        "usphone": "[fɔːlt]",
+        "ukphone": "[fɔːlt]"
+    },
+    {
+        "name": "starve",
+        "trans": [
+            "vi. 饿死；挨饿；渴望"
+        ],
+        "usphone": "[stɑːrv]",
+        "ukphone": "[stɑːv]"
+    },
+    {
+        "name": "consult",
+        "trans": [
+            "vi. 请教；商议；当顾问"
+        ],
+        "usphone": "[kənˈsʌlt]",
+        "ukphone": "[kənˈsʌlt]"
+    },
+    {
+        "name": "confusion",
+        "trans": [
+            "n. 混淆，混乱；困惑"
+        ],
+        "usphone": "[kənˈfjuːʒn]",
+        "ukphone": "[kənˈfjuːʒn]"
+    },
+    {
+        "name": "precious",
+        "trans": [
+            "adj. 宝贵的；珍贵的；矫揉造作的"
+        ],
+        "usphone": "[ˈpreʃəs]",
+        "ukphone": "[ˈpreʃəs]"
+    },
+    {
+        "name": "upper",
+        "trans": [
+            "adj. 上面的，上部的；较高的"
+        ],
+        "usphone": "[ˈʌpər]",
+        "ukphone": "[ˈʌpə(r)]"
+    },
+    {
+        "name": "editorial",
+        "trans": [
+            "n. 社论"
+        ],
+        "usphone": "[ˌedɪˈtɔːriəl]",
+        "ukphone": "[ˌedɪˈtɔːriəl]"
+    },
+    {
+        "name": "gradually",
+        "trans": [
+            "adv. 逐步地；渐渐地"
+        ],
+        "usphone": "[ˈɡrædʒuəli]",
+        "ukphone": "[ˈɡrædʒuəli]"
+    },
+    {
+        "name": "gay",
+        "trans": [
+            "n. 同性恋者"
+        ],
+        "usphone": "[ɡeɪ]",
+        "ukphone": "[ɡeɪ]"
+    },
+    {
+        "name": "preserve",
+        "trans": [
+            "n. 保护区；禁猎地；加工成的食品"
+        ],
+        "usphone": "[prɪˈzɜːrv]",
+        "ukphone": "[prɪˈzɜːv]"
+    },
+    {
+        "name": "hold",
+        "trans": [
+            "n. 控制；保留"
+        ],
+        "usphone": "[hoʊld]",
+        "ukphone": "[həʊld]"
+    },
+    {
+        "name": "mistake",
+        "trans": [
+            "n. 错误；误会；过失"
+        ],
+        "usphone": "[mɪˈsteɪk]",
+        "ukphone": "[mɪˈsteɪk]"
+    },
+    {
+        "name": "picture",
+        "trans": [
+            "n. 照片，图画；影片；景色；化身"
+        ],
+        "usphone": "[ˈpɪktʃər]",
+        "ukphone": "[ˈpɪktʃə(r)]"
+    },
+    {
+        "name": "actual",
+        "trans": [
+            "adj. 真实的，实际的；现行的，目前的"
+        ],
+        "usphone": "[ˈæktʃuəl]",
+        "ukphone": "[ˈæktʃuəl]"
+    },
+    {
+        "name": "remark",
+        "trans": [
+            "n. 注意；言辞"
+        ],
+        "usphone": "[rɪˈmɑːrk]",
+        "ukphone": "[rɪˈmɑːk]"
+    },
+    {
+        "name": "measurement",
+        "trans": [
+            "n. 测量；[计量] 度量；尺寸；量度制"
+        ],
+        "usphone": "[ˈmeʒərmənt]",
+        "ukphone": "[ˈmeʒəmənt]"
+    },
+    {
+        "name": "gaming",
+        "trans": [
+            "n. 赌博；赌胜负"
+        ],
+        "usphone": "[ˈɡeɪmɪŋ]",
+        "ukphone": "[ˈɡeɪmɪŋ]"
+    },
+    {
+        "name": "chairman",
+        "trans": [
+            "n. 主席，会长；董事长"
+        ],
+        "usphone": "[ˈtʃermən]",
+        "ukphone": "[ˈtʃeəmən]"
+    },
+    {
+        "name": "alongside",
+        "trans": [
+            "prep. 在……旁边"
+        ],
+        "usphone": "[əˌlɔːŋˈsaɪd]",
+        "ukphone": "[əˌlɒŋˈsaɪd]"
+    },
+    {
+        "name": "concerned",
+        "trans": [
+            "v. 关心（concern的过去时和过去分词）；与…有关"
+        ],
+        "usphone": "[kənˈsɜːrnd]",
+        "ukphone": "[kənˈsɜːnd]"
+    },
+    {
+        "name": "debate",
+        "trans": [
+            "n. 辩论；辩论会"
+        ],
+        "usphone": "[dɪˈbeɪt]",
+        "ukphone": "[dɪˈbeɪt]"
+    },
+    {
+        "name": "deck",
+        "trans": [
+            "n. 甲板；行李仓；露天平台"
+        ],
+        "usphone": "[dek]",
+        "ukphone": "[dek]"
+    },
+    {
+        "name": "abstract",
+        "trans": [
+            "n. 摘要；抽象；抽象的概念"
+        ],
+        "usphone": "[ˈæbstrækt]",
+        "ukphone": "[ˈæbstrækt]"
+    },
+    {
+        "name": "shore",
+        "trans": [
+            "n. 海滨；支柱"
+        ],
+        "usphone": "[ʃɔːr]",
+        "ukphone": "[ʃɔː(r)]"
+    },
+    {
+        "name": "permanently",
+        "trans": [
+            "adv. 永久地，长期不变地"
+        ],
+        "usphone": "[ˈpɜːrmənəntli]",
+        "ukphone": "[ˈpɜːmənəntli]"
+    },
+    {
+        "name": "voting",
+        "trans": [
+            "n. 投票；选举"
+        ],
+        "usphone": "[ˈvoʊtɪŋ]",
+        "ukphone": "[ˈvəʊtɪŋ]"
+    },
+    {
+        "name": "retirement",
+        "trans": [
+            "n. 退休，退役"
+        ],
+        "usphone": "[rɪˈtaɪərmənt]",
+        "ukphone": "[rɪˈtaɪəmənt]"
+    },
+    {
+        "name": "fortunate",
+        "trans": [
+            "adj. 幸运的；侥幸的；吉祥的；带来幸运的"
+        ],
+        "usphone": "[ˈfɔːrtʃənət]",
+        "ukphone": "[ˈfɔːtʃənət]"
+    },
+    {
+        "name": "extract",
+        "trans": [
+            "n. 汁；摘录；榨出物；选粹"
+        ],
+        "usphone": "[ˈekstrækt]",
+        "ukphone": "[ˈekstrækt]"
+    },
+    {
+        "name": "circuit",
+        "trans": [
+            "n. [电子] 电路，回路；巡回；一圈；环道"
+        ],
+        "usphone": "[ˈsɜːrkɪt]",
+        "ukphone": "[ˈsɜːkɪt]"
+    },
+    {
+        "name": "survey",
+        "trans": [
+            "n. 调查；测量；审视；纵览"
+        ],
+        "usphone": "[ˈsɜːrveɪ]",
+        "ukphone": "[ˈsɜːveɪ]"
+    },
+    {
+        "name": "jail",
+        "trans": [
+            "n. 监狱；监牢；拘留所"
+        ],
+        "usphone": "[dʒeɪl]",
+        "ukphone": "[dʒeɪl]"
+    },
+    {
+        "name": "popularity",
+        "trans": [
+            "n. 普及，流行；名气；受大众欢迎"
+        ],
+        "usphone": "[ˌpɑːpjuˈlærəti]",
+        "ukphone": "[ˌpɒpjuˈlærəti]"
+    },
+    {
+        "name": "shock",
+        "trans": [
+            "n. 休克；震惊；震动；打击；禾束堆"
+        ],
+        "usphone": "[ʃɑːk]",
+        "ukphone": "[ʃɒk]"
+    },
+    {
+        "name": "greenhouse",
+        "trans": [
+            "n. 温室"
+        ],
+        "usphone": "[ˈɡriːnhaʊs]",
+        "ukphone": "[ˈɡriːnhaʊs]"
+    },
+    {
+        "name": "tropical",
+        "trans": [
+            "adj. 热带的；热情的；酷热的"
+        ],
+        "usphone": "[ˈtrɑːpɪkl]",
+        "ukphone": "[ˈtrɒpɪk(ə)l]"
+    },
+    {
+        "name": "alien",
+        "trans": [
+            "n. 外国人，外侨；外星人"
+        ],
+        "usphone": "[ˈeɪliən]",
+        "ukphone": "[ˈeɪliən]"
+    },
+    {
+        "name": "rubber",
+        "trans": [
+            "n. 橡胶；橡皮；合成橡胶；按摩师"
+        ],
+        "usphone": "[ˈrʌbər]",
+        "ukphone": "[ˈrʌbə(r)]"
+    },
+    {
+        "name": "ensure",
+        "trans": [
+            "vt. 保证，确保；使安全"
+        ],
+        "usphone": "[ɪnˈʃʊr]",
+        "ukphone": "[ɪnˈʃʊə(r)]"
+    },
+    {
+        "name": "praise",
+        "trans": [
+            "n. 赞扬；称赞；荣耀；崇拜"
+        ],
+        "usphone": "[preɪz]",
+        "ukphone": "[preɪz]"
+    },
+    {
+        "name": "beg",
+        "trans": [
+            "vi. 乞讨；请求"
+        ],
+        "usphone": "[beɡ]",
+        "ukphone": "[beɡ]"
+    },
+    {
+        "name": "pursue",
+        "trans": [
+            "vi. 追赶；继续进行"
+        ],
+        "usphone": "[pərˈsuː]",
+        "ukphone": "[pəˈsjuː]"
+    },
+    {
+        "name": "round",
+        "trans": [
+            "n. 圆；循环；一回合；圆形物"
+        ],
+        "usphone": "[raʊnd]",
+        "ukphone": "[raʊnd]"
+    },
+    {
+        "name": "flexible",
+        "trans": [
+            "adj. 灵活的；柔韧的；易弯曲的"
+        ],
+        "usphone": "[ˈfleksəbl]",
+        "ukphone": "[ˈfleksəb(ə)l]"
+    },
+    {
+        "name": "suspend",
+        "trans": [
+            "vt. 延缓，推迟；使暂停；使悬浮"
+        ],
+        "usphone": "[səˈspend]",
+        "ukphone": "[səˈspend]"
+    },
+    {
+        "name": "terribly",
+        "trans": [
+            "adv. 非常；可怕地；极度地"
+        ],
+        "usphone": "[ˈterəbli]",
+        "ukphone": "[ˈterəbli]"
+    },
+    {
+        "name": "interval",
+        "trans": [
+            "n. 间隔；间距；幕间休息"
+        ],
+        "usphone": "[ˈɪntərv(ə)l]",
+        "ukphone": "[ˈɪntəvl]"
+    },
+    {
+        "name": "bear",
+        "trans": [
+            "n. 熊"
+        ],
+        "usphone": "[ber]",
+        "ukphone": "[beə(r)]"
+    },
+    {
+        "name": "licence",
+        "trans": [
+            "n. 许可证，执照；特许"
+        ],
+        "usphone": "[ˈlaɪsns]",
+        "ukphone": "[ˈlaɪsns]"
+    },
+    {
+        "name": "armed",
+        "trans": [
+            "adj. 武装的；有扶手的；有防卫器官的（指动物）"
+        ],
+        "usphone": "[ɑːrmd]",
+        "ukphone": "[ɑːmd]"
+    },
+    {
+        "name": "issue",
+        "trans": [
+            "n. 问题；流出；期号；发行物"
+        ],
+        "usphone": "[ˈɪʃuː]",
+        "ukphone": "[ˈɪʃuː]"
+    },
+    {
+        "name": "drag",
+        "trans": [
+            "n. 拖；拖累"
+        ],
+        "usphone": "[dræɡ]",
+        "ukphone": "[dræɡ]"
+    },
+    {
+        "name": "ideal",
+        "trans": [
+            "n. 理想；典范"
+        ],
+        "usphone": "[aɪˈdiːəl]",
+        "ukphone": "[aɪˈdiːəl]"
+    },
+    {
+        "name": "artificial",
+        "trans": [
+            "adj. 人造的；仿造的；虚伪的；非原产地的；武断的"
+        ],
+        "usphone": "[ˌɑːrtɪˈfɪʃ(ə)l]",
+        "ukphone": "[ˌɑːtɪˈfɪʃl]"
+    },
+    {
+        "name": "instantly",
+        "trans": [
+            "conj. 一…就…"
+        ],
+        "usphone": "[ˈɪnstəntli]",
+        "ukphone": "[ˈɪnstəntli]"
+    },
+    {
+        "name": "lung",
+        "trans": [
+            "n. 肺；呼吸器"
+        ],
+        "usphone": "[lʌŋ]",
+        "ukphone": "[lʌŋ]"
+    },
+    {
+        "name": "satisfy",
+        "trans": [
+            "vi. 令人满意；令人满足"
+        ],
+        "usphone": "[ˈsætɪsfaɪ]",
+        "ukphone": "[ˈsætɪsfaɪ]"
+    },
+    {
+        "name": "honour",
+        "trans": [
+            "n. 荣誉；尊敬；勋章"
+        ],
+        "usphone": "[ˈɑːnər]",
+        "ukphone": "[ˈɒnə(r)]"
+    },
+    {
+        "name": "shaped",
+        "trans": [
+            "adj. 合适的；成某种形状的；有计划的"
+        ],
+        "usphone": "[ʃeɪpt]",
+        "ukphone": "[ʃeɪpt]"
+    },
+    {
+        "name": "grocery",
+        "trans": [
+            "n. 食品杂货店"
+        ],
+        "usphone": "[ˈɡroʊsəri]",
+        "ukphone": "[ˈɡrəʊsəri]"
+    },
+    {
+        "name": "opening",
+        "trans": [
+            "n. 开始；机会；通路；空缺的职位"
+        ],
+        "usphone": "[ˈoʊpənɪŋ]",
+        "ukphone": "[ˈəʊpənɪŋ]"
+    },
+    {
+        "name": "penalty",
+        "trans": [
+            "n. 罚款，罚金；处罚"
+        ],
+        "usphone": "[ˈpenəlti]",
+        "ukphone": "[ˈpenəlti]"
+    },
+    {
+        "name": "rating",
+        "trans": [
+            "n. 等级；等级评定；额定功率"
+        ],
+        "usphone": "[ˈreɪtɪŋ]",
+        "ukphone": "[ˈreɪtɪŋ]"
+    },
+    {
+        "name": "target",
+        "trans": [
+            "n. 目标；靶子"
+        ],
+        "usphone": "[ˈtɑːrɡɪt]",
+        "ukphone": "[ˈtɑːɡɪt]"
+    },
+    {
+        "name": "emerge",
+        "trans": [
+            "vi. 浮现；摆脱；暴露"
+        ],
+        "usphone": "[ɪˈmɜːrdʒ]",
+        "ukphone": "[ɪˈmɜːdʒ]"
+    },
+    {
+        "name": "combination",
+        "trans": [
+            "n. 结合；组合；联合；[化学] 化合"
+        ],
+        "usphone": "[ˌkɑːmbɪˈneɪʃn]",
+        "ukphone": "[ˌkɒmbɪˈneɪʃ(ə)n]"
+    },
+    {
+        "name": "stall",
+        "trans": [
+            "n. 货摊；畜栏；托辞"
+        ],
+        "usphone": "[stɔːl]",
+        "ukphone": "[stɔːl]"
+    },
+    {
+        "name": "jet",
+        "trans": [
+            "n. 喷射，喷嘴；喷气式飞机；黑玉"
+        ],
+        "usphone": "[dʒet]",
+        "ukphone": "[dʒet]"
+    },
+    {
+        "name": "economics",
+        "trans": [
+            "n. 经济学；国家的经济状况"
+        ],
+        "usphone": "[ˌiːkəˈnɑːmɪks; ˌekəˈnɑːmɪks]",
+        "ukphone": "[ˌiːkəˈnɒmɪks]"
+    },
+    {
+        "name": "racial",
+        "trans": [
+            "adj. 种族的；人种的"
+        ],
+        "usphone": "[ˈreɪʃl]",
+        "ukphone": "[ˈreɪʃl]"
+    },
+    {
+        "name": "reasonable",
+        "trans": [
+            "adj. 合理的，公道的；通情达理的"
+        ],
+        "usphone": "[ˈriːz(ə)nəb(ə)l]",
+        "ukphone": "[ˈriːznəbl]"
+    },
+    {
+        "name": "threaten",
+        "trans": [
+            "vt. 威胁；恐吓；预示"
+        ],
+        "usphone": "[ˈθret(ə)n]",
+        "ukphone": "[ˈθret(ə)n]"
+    },
+    {
+        "name": "sometime",
+        "trans": [
+            "adj. 以前的；某一时间的"
+        ],
+        "usphone": "[ˈsʌmtaɪm]",
+        "ukphone": "[ˈsʌmtaɪm]"
+    },
+    {
+        "name": "inner",
+        "trans": [
+            "n. 内部"
+        ],
+        "usphone": "[ˈɪnər]",
+        "ukphone": "[ˈɪnə(r)]"
+    },
+    {
+        "name": "agenda",
+        "trans": [
+            "n. 议程；日常工作事项；日程表"
+        ],
+        "usphone": "[əˈdʒendə]",
+        "ukphone": "[əˈdʒendə]"
+    },
+    {
+        "name": "questionnaire",
+        "trans": [
+            "n. 问卷；调查表"
+        ],
+        "usphone": "[ˌkwestʃəˈner]",
+        "ukphone": "[ˌkwestʃəˈneə(r)]"
+    },
+    {
+        "name": "inspector",
+        "trans": [
+            "n. 检查员；巡视员"
+        ],
+        "usphone": "[ɪnˈspektər]",
+        "ukphone": "[ɪnˈspektə(r)]"
+    },
+    {
+        "name": "finance",
+        "trans": [
+            "n. 财政，财政学；金融"
+        ],
+        "usphone": "[ˈfaɪnæns; faɪˈnæns; fəˈnæns]",
+        "ukphone": "[ˈfaɪnæns]"
+    },
+    {
+        "name": "surgery",
+        "trans": [
+            "n. 外科；外科手术；手术室；诊疗室"
+        ],
+        "usphone": "[ˈsɜːrdʒəri]",
+        "ukphone": "[ˈsɜːdʒəri]"
+    },
+    {
+        "name": "entire",
+        "trans": [
+            "adj. 全部的，整个的；全体的"
+        ],
+        "usphone": "[ɪnˈtaɪər]",
+        "ukphone": "[ɪnˈtaɪə(r)]"
+    },
+    {
+        "name": "accuse",
+        "trans": [
+            "vt. 控告，指控；谴责；归咎于"
+        ],
+        "usphone": "[əˈkjuːz]",
+        "ukphone": "[əˈkjuːz]"
+    },
+    {
+        "name": "gesture",
+        "trans": [
+            "n. 姿态；手势"
+        ],
+        "usphone": "[ˈdʒestʃər]",
+        "ukphone": "[ˈdʒestʃə(r)]"
+    },
+    {
+        "name": "mortgage",
+        "trans": [
+            "vt. 抵押"
+        ],
+        "usphone": "[ˈmɔːrɡɪdʒ]",
+        "ukphone": "[ˈmɔːɡɪdʒ]"
+    },
+    {
+        "name": "comparative",
+        "trans": [
+            "n. 比较级；对手"
+        ],
+        "usphone": "[kəmˈpærətɪv]",
+        "ukphone": "[kəmˈpærətɪv]"
+    },
+    {
+        "name": "shortage",
+        "trans": [
+            "n. 缺乏，缺少；不足"
+        ],
+        "usphone": "[ˈʃɔːrtɪdʒ]",
+        "ukphone": "[ˈʃɔːtɪdʒ]"
+    },
+    {
+        "name": "margin",
+        "trans": [
+            "n. 边缘；利润，余裕；页边的空白"
+        ],
+        "usphone": "[ˈmɑːrdʒɪn]",
+        "ukphone": "[ˈmɑːdʒɪn]"
+    },
+    {
+        "name": "silence",
+        "trans": [
+            "n. 沉默；寂静；缄默；不谈；无声状态"
+        ],
+        "usphone": "[ˈsaɪləns]",
+        "ukphone": "[ˈsaɪləns]"
+    },
+    {
+        "name": "harmful",
+        "trans": [
+            "adj. 有害的；能造成损害的"
+        ],
+        "usphone": "[ˈhɑːrmfl]",
+        "ukphone": "[ˈhɑːmf(ə)l]"
+    },
+    {
+        "name": "transition",
+        "trans": [
+            "n. 过渡；转变；[分子生物] 转换；变调"
+        ],
+        "usphone": "[trænˈzɪʃnˌtrænˈsɪʃn]",
+        "ukphone": "[trænˈzɪʃ(ə)n]"
+    },
+    {
+        "name": "reward",
+        "trans": [
+            "n. [劳经] 报酬；报答；酬谢"
+        ],
+        "usphone": "[rɪˈwɔːrd]",
+        "ukphone": "[rɪˈwɔːd]"
+    },
+    {
+        "name": "equip",
+        "trans": [
+            "vt. 装备，配备"
+        ],
+        "usphone": "[ɪˈkwɪp]",
+        "ukphone": "[ɪˈkwɪp]"
+    },
+    {
+        "name": "pick",
+        "trans": [
+            "n. 选择；鹤嘴锄；挖；掩护"
+        ],
+        "usphone": "[pɪk]",
+        "ukphone": "[pɪk]"
+    },
+    {
+        "name": "date",
+        "trans": [
+            "n. 日期；约会；年代；枣椰子"
+        ],
+        "usphone": "[deɪt]",
+        "ukphone": "[deɪt]"
+    },
+    {
+        "name": "mixed",
+        "trans": [
+            "adj. 混合的；形形色色的；弄糊涂的"
+        ],
+        "usphone": "[mɪkst]",
+        "ukphone": "[mɪkst]"
+    },
+    {
+        "name": "balloon",
+        "trans": [
+            "n. 气球"
+        ],
+        "usphone": "[bəˈluːn]",
+        "ukphone": "[bəˈluːn]"
+    },
+    {
+        "name": "deeply",
+        "trans": [
+            "adv. 深刻地；浓浓地；在深处"
+        ],
+        "usphone": "[ˈdiːpli]",
+        "ukphone": "[ˈdiːpli]"
+    },
+    {
+        "name": "witness",
+        "trans": [
+            "n. 证人；目击者；证据"
+        ],
+        "usphone": "[ˈwɪtnəs]",
+        "ukphone": "[ˈwɪtnəs]"
+    },
+    {
+        "name": "absorb",
+        "trans": [
+            "vt. 吸收；吸引；承受；理解；使…全神贯注"
+        ],
+        "usphone": "[əbˈzɔːrb]",
+        "ukphone": "[əbˈzɔːb]"
+    },
+    {
+        "name": "appeal",
+        "trans": [
+            "n. 呼吁，请求；吸引力，感染力；上诉；诉诸裁判"
+        ],
+        "usphone": "[əˈpiːl]",
+        "ukphone": "[əˈpiːl]"
+    },
+    {
+        "name": "distribute",
+        "trans": [
+            "vt. 分配；散布；分开；把…分类"
+        ],
+        "usphone": "[dɪˈstrɪbjuːt]",
+        "ukphone": "[dɪˈstrɪbjuːt]"
+    },
+    {
+        "name": "composer",
+        "trans": [
+            "n. 作曲家；作家，著作者；设计者"
+        ],
+        "usphone": "[kəmˈpoʊzər]",
+        "ukphone": "[kəmˈpəʊzə(r)]"
+    },
+    {
+        "name": "structure",
+        "trans": [
+            "n. 结构；构造；建筑物"
+        ],
+        "usphone": "[ˈstrʌktʃər]",
+        "ukphone": "[ˈstrʌktʃə(r)]"
+    },
+    {
+        "name": "engage",
+        "trans": [
+            "vi. 从事；答应，保证；交战；啮合"
+        ],
+        "usphone": "[ɪnˈɡeɪdʒ]",
+        "ukphone": "[ɪnˈɡeɪdʒ]"
+    },
+    {
+        "name": "skilled",
+        "trans": [
+            "adj. 熟练的；有技能的；需要技能的"
+        ],
+        "usphone": "[skɪld]",
+        "ukphone": "[skɪld]"
+    },
+    {
+        "name": "choir",
+        "trans": [
+            "n. 唱诗班；合唱队；舞蹈队"
+        ],
+        "usphone": "[ˈkwaɪər]",
+        "ukphone": "[ˈkwaɪə(r)]"
+    },
+    {
+        "name": "marker",
+        "trans": [
+            "n. 记分员；书签；标识物；作记号的人"
+        ],
+        "usphone": "[ˈmɑːrkər]",
+        "ukphone": "[ˈmɑːkə(r)]"
+    },
+    {
+        "name": "affordable",
+        "trans": [
+            "adj. 负担得起的"
+        ],
+        "usphone": "[əˈfɔːrdəbl]",
+        "ukphone": "[əˈfɔːdəb(ə)l]"
+    },
+    {
+        "name": "hesitate",
+        "trans": [
+            "vt. 踌躇，犹豫；有疑虑，不愿意"
+        ],
+        "usphone": "[ˈhezɪteɪt]",
+        "ukphone": "[ˈhezɪteɪt]"
+    },
+    {
+        "name": "way",
+        "trans": [
+            "n. 方法；道路；方向；行业；习惯"
+        ],
+        "usphone": "[weɪ]",
+        "ukphone": "[weɪ]"
+    },
+    {
+        "name": "patient",
+        "trans": [
+            "n. 病人；患者"
+        ],
+        "usphone": "[ˈpeɪʃnt]",
+        "ukphone": "[ˈpeɪʃ(ə)nt]"
+    },
+    {
+        "name": "ultimately",
+        "trans": [
+            "adv. 最后；根本；基本上"
+        ],
+        "usphone": "[ˈʌltɪmətli]",
+        "ukphone": "[ˈʌltɪmətli]"
+    },
+    {
+        "name": "bat",
+        "trans": [
+            "n. 蝙蝠；球棒；球拍；批处理文件的扩展名"
+        ],
+        "usphone": "[bæt]",
+        "ukphone": "[bæt]"
+    },
+    {
+        "name": "navigation",
+        "trans": [
+            "n. 航行；航海"
+        ],
+        "usphone": "[ˌnævɪˈɡeɪʃn]",
+        "ukphone": "[ˌnævɪˈɡeɪʃn]"
+    },
+    {
+        "name": "stream",
+        "trans": [
+            "n. 溪流；流动；潮流；光线"
+        ],
+        "usphone": "[striːm]",
+        "ukphone": "[striːm]"
+    },
+    {
+        "name": "gender",
+        "trans": [
+            "n. 性；性别；性交"
+        ],
+        "usphone": "[ˈdʒendər]",
+        "ukphone": "[ˈdʒendə(r)]"
+    },
+    {
+        "name": "seeker",
+        "trans": [
+            "n. 探求者；搜查人"
+        ],
+        "usphone": "[ˈsiːkər]",
+        "ukphone": "[ˈsiːkə(r)]"
+    },
+    {
+        "name": "classify",
+        "trans": [
+            "vt. 分类；分等"
+        ],
+        "usphone": "[ˈklæsɪfaɪ]",
+        "ukphone": "[ˈklæsɪfaɪ]"
+    },
+    {
+        "name": "wealthy",
+        "trans": [
+            "n. 富人"
+        ],
+        "usphone": "[ˈwelθi]",
+        "ukphone": "[ˈwelθi]"
+    },
+    {
+        "name": "package",
+        "trans": [
+            "n. 包，包裹；套装软件，[计] 程序包"
+        ],
+        "usphone": "[ˈpækɪdʒ]",
+        "ukphone": "[ˈpækɪdʒ]"
+    },
+    {
+        "name": "info",
+        "trans": [
+            "n. 信息；情报"
+        ],
+        "usphone": "[ˈɪnfoʊ]",
+        "ukphone": "[ˈɪnfəʊ]"
+    },
+    {
+        "name": "obey",
+        "trans": [
+            "vt. 服从，听从；按照……行动"
+        ],
+        "usphone": "[əˈbeɪ]",
+        "ukphone": "[əˈbeɪ]"
+    },
+    {
+        "name": "exceed",
+        "trans": [
+            "vt. 超过；胜过"
+        ],
+        "usphone": "[ɪkˈsiːd]",
+        "ukphone": "[ɪkˈsiːd]"
+    },
+    {
+        "name": "truly",
+        "trans": [
+            "adv. 真实地，不假；真诚地"
+        ],
+        "usphone": "[ˈtruːli]",
+        "ukphone": "[ˈtruːli]"
+    },
+    {
+        "name": "depart",
+        "trans": [
+            "adj. 逝世的"
+        ],
+        "usphone": "[dɪˈpɑːrt]",
+        "ukphone": "[dɪˈpɑːt]"
+    },
+    {
+        "name": "gorgeous",
+        "trans": [
+            "adj. 华丽的，灿烂的；极好的"
+        ],
+        "usphone": "[ˈɡɔːrdʒəs]",
+        "ukphone": "[ˈɡɔːdʒəs]"
+    },
+    {
+        "name": "efficient",
+        "trans": [
+            "adj. 有效率的；有能力的；生效的"
+        ],
+        "usphone": "[ɪˈfɪʃnt]",
+        "ukphone": "[ɪˈfɪʃnt]"
+    },
+    {
+        "name": "unacceptable",
+        "trans": [
+            "adj. 不能接受的；不受欢迎的"
+        ],
+        "usphone": "[ˌʌnəkˈseptəbl]",
+        "ukphone": "[ˌʌnəkˈseptəbl]"
+    },
+    {
+        "name": "teens",
+        "trans": [
+            "n. 十多岁，十几岁；青少年"
+        ],
+        "usphone": "[tiːnz]",
+        "ukphone": "[tiːnz]"
+    },
+    {
+        "name": "pace",
+        "trans": [
+            "n. 一步；步速；步伐；速度"
+        ],
+        "usphone": "[peɪs]",
+        "ukphone": "[peɪs]"
+    },
+    {
+        "name": "permanent",
+        "trans": [
+            "n. 烫发（等于permanent wave）"
+        ],
+        "usphone": "[ˈpɜːrmənənt]",
+        "ukphone": "[ˈpɜːmənənt]"
+    },
+    {
+        "name": "registration",
+        "trans": [
+            "n. 登记；注册；挂号"
+        ],
+        "usphone": "[ˌredʒɪˈstreɪʃn]",
+        "ukphone": "[ˌredʒɪˈstreɪʃn]"
+    },
+    {
+        "name": "protester",
+        "trans": [
+            "n. 抗议者；反对者；持异议者"
+        ],
+        "usphone": "[prəˈtestərˌˈproʊtestər]",
+        "ukphone": "[prəˈtestə(r); ˈprəʊtestə(r)]"
+    },
+    {
+        "name": "corporate",
+        "trans": [
+            "adj. 法人的；共同的，全体的；社团的；公司的；企业的"
+        ],
+        "usphone": "[ˈkɔːrpərət]",
+        "ukphone": "[ˈkɔːpərət]"
+    },
+    {
+        "name": "comprise",
+        "trans": [
+            "vt. 包含；由…组成"
+        ],
+        "usphone": "[kəmˈpraɪz]",
+        "ukphone": "[kəmˈpraɪz]"
+    },
+    {
+        "name": "annually",
+        "trans": [
+            "adv. 每年；一年一次"
+        ],
+        "usphone": "[ˈænjuəli]",
+        "ukphone": "[ˈænjuəli]"
+    },
+    {
+        "name": "wherever",
+        "trans": [
+            "conj. 无论在哪里；无论什么情况下"
+        ],
+        "usphone": "[werˈevər]",
+        "ukphone": "[weərˈevə(r)]"
+    },
+    {
+        "name": "coverage",
+        "trans": [
+            "n. 覆盖，覆盖范围；新闻报道"
+        ],
+        "usphone": "[ˈkʌvərɪdʒ]",
+        "ukphone": "[ˈkʌvərɪdʒ]"
+    },
+    {
+        "name": "grab",
+        "trans": [
+            "n. 攫取；霸占；夺取之物"
+        ],
+        "usphone": "[ɡræb]",
+        "ukphone": "[ɡræb]"
+    },
+    {
+        "name": "testing",
+        "trans": [
+            "n. [试验] 测试"
+        ],
+        "usphone": "[ˈtestɪŋ]",
+        "ukphone": "[ˈtestɪŋ]"
+    },
+    {
+        "name": "district",
+        "trans": [
+            "n. 区域；地方；行政区"
+        ],
+        "usphone": "[ˈdɪstrɪkt]",
+        "ukphone": "[ˈdɪstrɪkt]"
+    },
+    {
+        "name": "mayor",
+        "trans": [
+            "n. 市长"
+        ],
+        "usphone": "[ˈmeɪər]",
+        "ukphone": "[meə(r)]"
+    },
+    {
+        "name": "pregnant",
+        "trans": [
+            "adj. 怀孕的；富有意义的"
+        ],
+        "usphone": "[ˈpreɡnənt]",
+        "ukphone": "[ˈpreɡnənt]"
+    },
+    {
+        "name": "hopefully",
+        "trans": [
+            "adv. 有希望地，有前途地"
+        ],
+        "usphone": "[ˈhoʊpfəli]",
+        "ukphone": "[ˈhəʊpfəli]"
+    },
+    {
+        "name": "regard",
+        "trans": [
+            "n. 注意；尊重；问候；凝视"
+        ],
+        "usphone": "[rɪˈɡɑːrd]",
+        "ukphone": "[rɪˈɡɑːd]"
+    },
+    {
+        "name": "encounter",
+        "trans": [
+            "n. 遭遇，偶然碰见"
+        ],
+        "usphone": "[ɪnˈkaʊntər]",
+        "ukphone": "[ɪnˈkaʊntə(r)]"
+    },
+    {
+        "name": "adequate",
+        "trans": [
+            "adj. 充足的；适当的；胜任的"
+        ],
+        "usphone": "[ˈædɪkwət]",
+        "ukphone": "[ˈædɪkwət]"
+    },
+    {
+        "name": "mass",
+        "trans": [
+            "n. 块，团；群众，民众；大量，众多；质量"
+        ],
+        "usphone": "[mæs]",
+        "ukphone": "[mæs]"
+    },
+    {
+        "name": "crop",
+        "trans": [
+            "n. 产量；农作物；庄稼；平头"
+        ],
+        "usphone": "[krɑːp]",
+        "ukphone": "[krɒp]"
+    },
+    {
+        "name": "deliberate",
+        "trans": [
+            "adj. 故意的；深思熟虑的；从容的"
+        ],
+        "usphone": "[dɪˈlɪbərət]",
+        "ukphone": "[dɪˈlɪbərət]"
+    },
+    {
+        "name": "shame",
+        "trans": [
+            "n. 羞耻，羞愧；憾事，带来耻辱的人"
+        ],
+        "usphone": "[ʃeɪm]",
+        "ukphone": "[ʃeɪm]"
+    },
+    {
+        "name": "equivalent",
+        "trans": [
+            "n. 等价物，相等物"
+        ],
+        "usphone": "[ɪˈkwɪvələnt]",
+        "ukphone": "[ɪˈkwɪvələnt]"
+    },
+    {
+        "name": "carbon",
+        "trans": [
+            "n. [化学] 碳；碳棒；复写纸"
+        ],
+        "usphone": "[ˈkɑːrbən]",
+        "ukphone": "[ˈkɑːbən]"
+    },
+    {
+        "name": "attachment",
+        "trans": [
+            "n. 附件；依恋；连接物；扣押财产"
+        ],
+        "usphone": "[əˈtætʃmənt]",
+        "ukphone": "[əˈtætʃmənt]"
+    },
+    {
+        "name": "broad",
+        "trans": [
+            "n. 宽阔部分"
+        ],
+        "usphone": "[brɔːd]",
+        "ukphone": "[brɔːd]"
+    },
+    {
+        "name": "downwards",
+        "trans": [
+            "adv. 向下，往下"
+        ],
+        "usphone": "[ˈdaʊnwərdz]",
+        "ukphone": "[ˈdaʊnwədz]"
+    },
+    {
+        "name": "genetic",
+        "trans": [
+            "adj. 遗传的；基因的；起源的"
+        ],
+        "usphone": "[dʒəˈnetɪk]",
+        "ukphone": "[dʒəˈnetɪk]"
+    },
+    {
+        "name": "deny",
+        "trans": [
+            "vi. 否认；拒绝"
+        ],
+        "usphone": "[dɪˈnaɪ]",
+        "ukphone": "[dɪˈnaɪ]"
+    },
+    {
+        "name": "gain",
+        "trans": [
+            "n. 增加；利润；收获"
+        ],
+        "usphone": "[ɡeɪn]",
+        "ukphone": "[ɡeɪn]"
+    },
+    {
+        "name": "coincidence",
+        "trans": [
+            "n. 巧合；一致；同时发生"
+        ],
+        "usphone": "[koʊˈɪnsɪdəns]",
+        "ukphone": "[kəʊˈɪnsɪdəns]"
+    },
+    {
+        "name": "referee",
+        "trans": [
+            "n. 裁判员；调解人；介绍人"
+        ],
+        "usphone": "[ˌrefəˈriː]",
+        "ukphone": "[ˌrefəˈriː]"
+    },
+    {
+        "name": "undergo",
+        "trans": [
+            "vt. 经历，经受；忍受"
+        ],
+        "usphone": "[ˌʌndərˈɡoʊ]",
+        "ukphone": "[ˌʌndəˈɡəʊ]"
+    },
+    {
+        "name": "creature",
+        "trans": [
+            "n. 动物，生物；人；创造物"
+        ],
+        "usphone": "[ˈkriːtʃər]",
+        "ukphone": "[ˈkriːtʃə(r)]"
+    },
+    {
+        "name": "delighted",
+        "trans": [
+            "adj. 高兴的；欣喜的"
+        ],
+        "usphone": "[dɪˈlaɪtɪd]",
+        "ukphone": "[dɪˈlaɪtɪd]"
+    },
+    {
+        "name": "illusion",
+        "trans": [
+            "n. 幻觉，错觉；错误的观念或信仰"
+        ],
+        "usphone": "[ɪˈluːʒn]",
+        "ukphone": "[ɪˈluːʒ(ə)n]"
+    },
+    {
+        "name": "whoever",
+        "trans": [
+            "pron. 无论谁；任何人"
+        ],
+        "usphone": "[huːˈevər]",
+        "ukphone": "[huːˈevə(r)]"
+    },
+    {
+        "name": "so-called",
+        "trans": [
+            "adj. 所谓的；号称的"
+        ],
+        "usphone": "[ˌsoʊ ˈkɔːld]",
+        "ukphone": "[ˌsəʊ ˈkɔːld]"
+    },
+    {
+        "name": "fund",
+        "trans": [
+            "n. 基金；资金；存款"
+        ],
+        "usphone": "[fʌnd]",
+        "ukphone": "[fʌnd]"
+    },
+    {
+        "name": "civil",
+        "trans": [
+            "adj. 公民的；民间的；文职的；有礼貌的；根据民法的"
+        ],
+        "usphone": "[ˈsɪvl]",
+        "ukphone": "[ˈsɪv(ə)l]"
+    },
+    {
+        "name": "draft",
+        "trans": [
+            "n. 汇票；草稿；选派；（尤指房间、烟囱、炉子等供暖系统中的）（小股）气流"
+        ],
+        "usphone": "[dræft]",
+        "ukphone": "[drɑːft]"
+    },
+    {
+        "name": "astonishing",
+        "trans": [
+            "adj. 惊人的；令人惊讶的"
+        ],
+        "usphone": "[əˈstɑːnɪʃɪŋ]",
+        "ukphone": "[əˈstɒnɪʃɪŋ]"
+    },
+    {
+        "name": "lately",
+        "trans": [
+            "adv. 近来，不久前"
+        ],
+        "usphone": "[ˈleɪtli]",
+        "ukphone": "[ˈleɪtli]"
+    },
+    {
+        "name": "homeless",
+        "trans": [
+            "adj. 无家可归的"
+        ],
+        "usphone": "[ˈhoʊmləs]",
+        "ukphone": "[ˈhəʊmləs]"
+    },
+    {
+        "name": "lens",
+        "trans": [
+            "n. 透镜，镜头；眼睛中的水晶体；晶状体；隐形眼镜；汽车的灯玻璃"
+        ],
+        "usphone": "[lenz]",
+        "ukphone": "[lenz]"
+    },
+    {
+        "name": "downtown",
+        "trans": [
+            "n. 市中心区；三分线以外"
+        ],
+        "usphone": "[ˌdaʊnˈtaʊn]",
+        "ukphone": "[ˌdaʊnˈtaʊn]"
+    },
+    {
+        "name": "position",
+        "trans": [
+            "n. 位置，方位；职位，工作；姿态；站位"
+        ],
+        "usphone": "[pəˈzɪʃn]",
+        "ukphone": "[pəˈzɪʃn]"
+    },
+    {
+        "name": "maximum",
+        "trans": [
+            "n. [数] 极大，最大限度；最大量"
+        ],
+        "usphone": "[ˈmæksɪməm]",
+        "ukphone": "[ˈmæksɪməm]"
+    },
+    {
+        "name": "lane",
+        "trans": [
+            "n. 小巷；[航][水运] 航线；车道；罚球区"
+        ],
+        "usphone": "[leɪn]",
+        "ukphone": "[leɪn]"
+    },
+    {
+        "name": "crew",
+        "trans": [
+            "n. 队，组；全体人员，全体船员"
+        ],
+        "usphone": "[kruː]",
+        "ukphone": "[kruː]"
+    },
+    {
+        "name": "illustrate",
+        "trans": [
+            "vi. 举例"
+        ],
+        "usphone": "[ˈɪləstreɪt]",
+        "ukphone": "[ˈɪləstreɪt]"
+    },
+    {
+        "name": "genius",
+        "trans": [
+            "n. 天才，天赋；精神"
+        ],
+        "usphone": "[ˈdʒiːniəs]",
+        "ukphone": "[ˈdʒiːniəs]"
+    },
+    {
+        "name": "ladder",
+        "trans": [
+            "n. 阶梯；途径；梯状物"
+        ],
+        "usphone": "[ˈlædər]",
+        "ukphone": "[ˈlædə(r)]"
+    },
+    {
+        "name": "fantasy",
+        "trans": [
+            "n. 幻想；白日梦；幻觉"
+        ],
+        "usphone": "[ˈfæntəsi]",
+        "ukphone": "[ˈfæntəsi]"
+    },
+    {
+        "name": "virtual",
+        "trans": [
+            "adj. [计] 虚拟的；实质上的，事实上的（但未在名义上或正式获承认）"
+        ],
+        "usphone": "[ˈvɜːrtʃuəl]",
+        "ukphone": "[ˈvɜːtʃuəl]"
+    },
+    {
+        "name": "historian",
+        "trans": [
+            "n. 历史学家"
+        ],
+        "usphone": "[hɪˈstɔːriən]",
+        "ukphone": "[hɪˈstɔːriən]"
+    },
+    {
+        "name": "reinforce",
+        "trans": [
+            "n. 加强；加固物；加固材料"
+        ],
+        "usphone": "[ˌriːɪnˈfɔːrs]",
+        "ukphone": "[ˌriːɪnˈfɔːs]"
+    },
+    {
+        "name": "receiver",
+        "trans": [
+            "n. 接收器；接受者；收信机；收款员，接待者"
+        ],
+        "usphone": "[rɪˈsiːvər]",
+        "ukphone": "[rɪˈsiːvə(r)]"
+    },
+    {
+        "name": "conflict",
+        "trans": [
+            "n. 冲突，矛盾；斗争；争执"
+        ],
+        "usphone": "[ˈkɑːnflɪkt]",
+        "ukphone": "[ˈkɒnflɪkt]"
+    },
+    {
+        "name": "fold",
+        "trans": [
+            "n. 折痕；信徒；羊栏"
+        ],
+        "usphone": "[foʊld]",
+        "ukphone": "[fəʊld]"
+    },
+    {
+        "name": "spokesman",
+        "trans": [
+            "n. 发言人；代言人"
+        ],
+        "usphone": "[ˈspoʊksmən]",
+        "ukphone": "[ˈspəʊksmən]"
+    },
+    {
+        "name": "somewhat",
+        "trans": [
+            "n. 几分；某物"
+        ],
+        "usphone": "[ˈsʌmwʌt]",
+        "ukphone": "[ˈsʌmwɒt]"
+    },
+    {
+        "name": "deserve",
+        "trans": [
+            "vi. 应受，应得"
+        ],
+        "usphone": "[dɪˈzɜːrv]",
+        "ukphone": "[dɪˈzɜːv]"
+    },
+    {
+        "name": "executive",
+        "trans": [
+            "n. 总经理；执行委员会；执行者；经理主管人员"
+        ],
+        "usphone": "[ɪɡˈzekjətɪv]",
+        "ukphone": "[ɪɡˈzekjətɪv]"
+    },
+    {
+        "name": "obesity",
+        "trans": [
+            "n. 肥大，肥胖"
+        ],
+        "usphone": "[oʊˈbiːsəti]",
+        "ukphone": "[əʊˈbiːsəti]"
+    },
+    {
+        "name": "estimate",
+        "trans": [
+            "n. 估计，估价；判断，看法"
+        ],
+        "usphone": "[ˈestɪmeɪt]",
+        "ukphone": "[ˈestɪmət]"
+    },
+    {
+        "name": "hypothesis",
+        "trans": [
+            "n. 假设"
+        ],
+        "usphone": "[haɪˈpɑːθəsɪs]",
+        "ukphone": "[haɪˈpɒθəsɪs]"
+    },
+    {
+        "name": "tension",
+        "trans": [
+            "n. 张力，拉力；紧张，不安；电压"
+        ],
+        "usphone": "[ˈtenʃn]",
+        "ukphone": "[ˈtenʃ(ə)n]"
+    },
+    {
+        "name": "programming",
+        "trans": [
+            "n. 设计，规划；编制程序，[计] 程序编制"
+        ],
+        "usphone": "[ˈproʊɡræmɪŋ]",
+        "ukphone": "[ˈprəʊɡræmɪŋ]"
+    },
+    {
+        "name": "offence",
+        "trans": [
+            "n. 犯罪；违反；过错；攻击"
+        ],
+        "usphone": "[əˈfens]",
+        "ukphone": "[əˈfens]"
+    },
+    {
+        "name": "possess",
+        "trans": [
+            "vt. 控制；使掌握；持有；迷住；拥有，具备"
+        ],
+        "usphone": "[pəˈzes]",
+        "ukphone": "[pəˈzes]"
+    },
+    {
+        "name": "subsequent",
+        "trans": [
+            "adj. 后来的，随后的"
+        ],
+        "usphone": "[ˈsʌbsɪkwənt]",
+        "ukphone": "[ˈsʌbsɪkwənt]"
+    },
+    {
+        "name": "hook",
+        "trans": [
+            "n. 挂钩，吊钩"
+        ],
+        "usphone": "[hʊk]",
+        "ukphone": "[hʊk]"
+    },
+    {
+        "name": "jury",
+        "trans": [
+            "n. [法] 陪审团；评判委员会"
+        ],
+        "usphone": "[ˈdʒʊri]",
+        "ukphone": "[ˈdʒʊəri]"
+    },
+    {
+        "name": "emphasis",
+        "trans": [
+            "n. 重点；强调；加强语气"
+        ],
+        "usphone": "[ˈemfəsɪs]",
+        "ukphone": "[ˈemfəsɪs]"
+    },
+    {
+        "name": "chief",
+        "trans": [
+            "n. 首领；酋长；主要部分"
+        ],
+        "usphone": "[tʃiːf]",
+        "ukphone": "[tʃiːf]"
+    },
+    {
+        "name": "reduction",
+        "trans": [
+            "n. 减少；下降；缩小；还原反应"
+        ],
+        "usphone": "[rɪˈdʌkʃn]",
+        "ukphone": "[rɪˈdʌkʃn]"
+    },
+    {
+        "name": "whisper",
+        "trans": [
+            "n. 私语；谣传；飒飒的声音"
+        ],
+        "usphone": "[ˈwɪspər]",
+        "ukphone": "[ˈwɪspə(r)]"
+    },
+    {
+        "name": "preference",
+        "trans": [
+            "n. 偏爱，倾向；优先权"
+        ],
+        "usphone": "[ˈprefrəns]",
+        "ukphone": "[ˈprefrəns]"
+    },
+    {
+        "name": "justify",
+        "trans": [
+            "vi. 证明合法；整理版面"
+        ],
+        "usphone": "[ˈdʒʌstɪfaɪ]",
+        "ukphone": "[ˈdʒʌstɪfaɪ]"
+    },
+    {
+        "name": "sponsor",
+        "trans": [
+            "n. 赞助者；主办者；保证人"
+        ],
+        "usphone": "[ˈspɑːnsər]",
+        "ukphone": "[ˈspɒnsə(r)]"
+    },
+    {
+        "name": "distinguish",
+        "trans": [
+            "vi. 区别，区分；辨别"
+        ],
+        "usphone": "[dɪˈstɪŋɡwɪʃ]",
+        "ukphone": "[dɪˈstɪŋɡwɪʃ]"
+    },
+    {
+        "name": "incentive",
+        "trans": [
+            "n. 动机；刺激"
+        ],
+        "usphone": "[ɪnˈsentɪv]",
+        "ukphone": "[ɪnˈsentɪv]"
+    },
+    {
+        "name": "switch",
+        "trans": [
+            "n. 开关；转换；鞭子"
+        ],
+        "usphone": "[swɪtʃ]",
+        "ukphone": "[swɪtʃ]"
+    },
+    {
+        "name": "lottery",
+        "trans": [
+            "n. 彩票；碰运气的事，难算计的事；抽彩给奖法"
+        ],
+        "usphone": "[ˈlɑːtəri]",
+        "ukphone": "[ˈlɒtəri]"
+    },
+    {
+        "name": "ship",
+        "trans": [
+            "n. 船；舰；太空船"
+        ],
+        "usphone": "[ʃɪp]",
+        "ukphone": "[ʃɪp]"
+    },
+    {
+        "name": "terrorism",
+        "trans": [
+            "n. 恐怖主义；恐怖行动；恐怖统治"
+        ],
+        "usphone": "[ˈterərɪzəm]",
+        "ukphone": "[ˈterərɪzəm]"
+    },
+    {
+        "name": "but",
+        "trans": [
+            "conj. 但是；而是；然而"
+        ],
+        "usphone": "[bʌt; bət]",
+        "ukphone": "[bʌt; bət]"
+    },
+    {
+        "name": "hire",
+        "trans": [
+            "n. 雇用，租用；租金，工钱"
+        ],
+        "usphone": "[ˈhaɪər]",
+        "ukphone": "[ˈhaɪə(r)]"
+    },
+    {
+        "name": "alarm",
+        "trans": [
+            "n. 闹钟；警报，警告器；惊慌"
+        ],
+        "usphone": "[əˈlɑːrm]",
+        "ukphone": "[əˈlɑːm]"
+    },
+    {
+        "name": "complex",
+        "trans": [
+            "n. 复合体；综合设施"
+        ],
+        "usphone": "[kəmˈpleks; ˈkɑːmpleks]",
+        "ukphone": "[ˈkɒmpleks]"
+    },
+    {
+        "name": "deadly",
+        "trans": [
+            "adj. 致命的；非常的；死一般的"
+        ],
+        "usphone": "[ˈdedli]",
+        "ukphone": "[ˈdedli]"
+    },
+    {
+        "name": "erupt",
+        "trans": [
+            "vi. 爆发；喷出；发疹；长牙"
+        ],
+        "usphone": "[ɪˈrʌpt]",
+        "ukphone": "[ɪˈrʌpt]"
+    },
+    {
+        "name": "database",
+        "trans": [
+            "n. 数据库，资料库"
+        ],
+        "usphone": "[ˈdeɪtəbeɪs; ˈdætəbeɪs]",
+        "ukphone": "[ˈdeɪtəbeɪs]"
+    },
+    {
+        "name": "unexpected",
+        "trans": [
+            "adj. 意外的，想不到的"
+        ],
+        "usphone": "[ˌʌnɪkˈspektɪd]",
+        "ukphone": "[ˌʌnɪkˈspektɪd]"
+    },
+    {
+        "name": "medal",
+        "trans": [
+            "n. 勋章，奖章；纪念章"
+        ],
+        "usphone": "[ˈmedl]",
+        "ukphone": "[ˈmedl]"
+    },
+    {
+        "name": "float",
+        "trans": [
+            "n. 彩车，花车；漂流物；浮舟；浮萍"
+        ],
+        "usphone": "[floʊt]",
+        "ukphone": "[fləʊt]"
+    },
+    {
+        "name": "oppose",
+        "trans": [
+            "vt. 反对；对抗，抗争"
+        ],
+        "usphone": "[əˈpoʊz]",
+        "ukphone": "[əˈpəʊz]"
+    },
+    {
+        "name": "hunt",
+        "trans": [
+            "n. 狩猎；搜寻"
+        ],
+        "usphone": "[hʌnt]",
+        "ukphone": "[hʌnt]"
+    },
+    {
+        "name": "flame",
+        "trans": [
+            "n. 火焰；热情；光辉"
+        ],
+        "usphone": "[fleɪm]",
+        "ukphone": "[fleɪm]"
+    },
+    {
+        "name": "racism",
+        "trans": [
+            "n. 种族主义，种族歧视；人种偏见"
+        ],
+        "usphone": "[ˈreɪsɪzəm]",
+        "ukphone": "[ˈreɪsɪzəm]"
+    },
+    {
+        "name": "somehow",
+        "trans": [
+            "adv. 以某种方法；莫名其妙地"
+        ],
+        "usphone": "[ˈsʌmhaʊ]",
+        "ukphone": "[ˈsʌmhaʊ]"
+    },
+    {
+        "name": "bold",
+        "trans": [
+            "adj. 大胆的，英勇的；黑体的；厚颜无耻的；险峻的"
+        ],
+        "usphone": "[boʊld]",
+        "ukphone": "[bəʊld]"
+    },
+    {
+        "name": "minimum",
+        "trans": [
+            "n. 最小值；最低限度；最小化；最小量"
+        ],
+        "usphone": "[ˈmɪnɪməm]",
+        "ukphone": "[ˈmɪnɪməm]"
+    },
+    {
+        "name": "disappointment",
+        "trans": [
+            "n. 失望；沮丧"
+        ],
+        "usphone": "[ˌdɪsəˈpɔɪntmənt]",
+        "ukphone": "[ˌdɪsəˈpɔɪntmənt]"
+    },
+    {
+        "name": "dealer",
+        "trans": [
+            "n. 经销商；商人"
+        ],
+        "usphone": "[ˈdiːlər]",
+        "ukphone": "[ˈdiːlə(r)]"
+    },
+    {
+        "name": "basket",
+        "trans": [
+            "n. 篮子；（篮球比赛的）得分；一篮之量；篮筐"
+        ],
+        "usphone": "[ˈbæskɪt]",
+        "ukphone": "[ˈbɑːskɪt]"
+    },
+    {
+        "name": "stiff",
+        "trans": [
+            "adj. 呆板的；坚硬的；严厉的；拘谨的"
+        ],
+        "usphone": "[stɪf]",
+        "ukphone": "[stɪf]"
+    },
+    {
+        "name": "assessment",
+        "trans": [
+            "n. 评定；估价"
+        ],
+        "usphone": "[əˈsesmənt]",
+        "ukphone": "[əˈsesmənt]"
+    },
+    {
+        "name": "critic",
+        "trans": [
+            "n. 批评家，评论家；爱挑剔的人"
+        ],
+        "usphone": "[ˈkrɪtɪk]",
+        "ukphone": "[ˈkrɪtɪk]"
+    },
+    {
+        "name": "enhance",
+        "trans": [
+            "vt. 提高；加强；增加"
+        ],
+        "usphone": "[ɪnˈhæns]",
+        "ukphone": "[ɪnˈhɑːns]"
+    },
+    {
+        "name": "trait",
+        "trans": [
+            "n. 特性，特点；品质；少许"
+        ],
+        "usphone": "[treɪt]",
+        "ukphone": "[treɪt]"
+    },
+    {
+        "name": "broadcaster",
+        "trans": [
+            "n. 广播公司；广播员；播送设备；撒播物"
+        ],
+        "usphone": "[ˈbrɔːdkæstər]",
+        "ukphone": "[ˈbrɔːdkɑːstə(r)]"
+    },
+    {
+        "name": "subject",
+        "trans": [
+            "n. 主题；科目；[语] 主语；国民"
+        ],
+        "usphone": "[ˈsʌbdʒɪkt; ˈsʌbdʒekt]",
+        "ukphone": "[ˈsʌbdʒɪkt; ˈsʌbdʒekt]"
+    },
+    {
+        "name": "assistance",
+        "trans": [
+            "n. 援助，帮助；辅助设备"
+        ],
+        "usphone": "[əˈsɪstəns]",
+        "ukphone": "[əˈsɪstəns]"
+    },
+    {
+        "name": "extraordinary",
+        "trans": [
+            "adj. 非凡的；特别的；离奇的；临时的；特派的"
+        ],
+        "usphone": "[ɪkˈstrɔːrdəneri]",
+        "ukphone": "[ɪkˈstrɔːdnri]"
+    },
+    {
+        "name": "retail",
+        "trans": [
+            "n. 零售"
+        ],
+        "usphone": "[ˈriːteɪl]",
+        "ukphone": "[ˈriːteɪl; rɪˈteɪl]"
+    },
+    {
+        "name": "vary",
+        "trans": [
+            "vi. 变化；变异；违反"
+        ],
+        "usphone": "[ˈveri]",
+        "ukphone": "[ˈveəri]"
+    },
+    {
+        "name": "model",
+        "trans": [
+            "n. 模型；典型；模范；模特儿；样式"
+        ],
+        "usphone": "[ˈmɑːdl]",
+        "ukphone": "[ˈmɒd(ə)l]"
+    },
+    {
+        "name": "economist",
+        "trans": [
+            "n. 经济学者；节俭的人"
+        ],
+        "usphone": "[ɪˈkɑːnəmɪst]",
+        "ukphone": "[ɪˈkɒnəmɪst]"
+    },
+    {
+        "name": "strict",
+        "trans": [
+            "adj. 严格的；绝对的；精确的；详细的"
+        ],
+        "usphone": "[strɪkt]",
+        "ukphone": "[strɪkt]"
+    },
+    {
+        "name": "income",
+        "trans": [
+            "n. 收入，收益；所得"
+        ],
+        "usphone": "[ˈɪnkʌm; ˈɪnkəm]",
+        "ukphone": "[ˈɪnkʌm]"
+    },
+    {
+        "name": "roughly",
+        "trans": [
+            "adv. 粗糙地；概略地"
+        ],
+        "usphone": "[ˈrʌfli]",
+        "ukphone": "[ˈrʌfli]"
+    },
+    {
+        "name": "heaven",
+        "trans": [
+            "n. 天堂；天空；极乐"
+        ],
+        "usphone": "[ˈhevn]",
+        "ukphone": "[ˈhevn]"
+    },
+    {
+        "name": "suspect",
+        "trans": [
+            "n. 嫌疑犯"
+        ],
+        "usphone": "[səˈspekt]",
+        "ukphone": "[səˈspekt]"
+    },
+    {
+        "name": "inevitably",
+        "trans": [
+            "adv. 不可避免地；必然地"
+        ],
+        "usphone": "[ɪnˈevɪtəbli]",
+        "ukphone": "[ɪnˈevɪtəbli]"
+    },
+    {
+        "name": "apparent",
+        "trans": [
+            "adj. 显然的；表面上的"
+        ],
+        "usphone": "[əˈpærənt]",
+        "ukphone": "[əˈpærənt]"
+    },
+    {
+        "name": "unfortunate",
+        "trans": [
+            "adj. 不幸的；令人遗憾的；不成功的"
+        ],
+        "usphone": "[ʌnˈfɔːrtʃənət]",
+        "ukphone": "[ʌnˈfɔːtʃənət]"
+    },
+    {
+        "name": "feather",
+        "trans": [
+            "n. 羽毛"
+        ],
+        "usphone": "[ˈfeðər]",
+        "ukphone": "[ˈfeðə(r)]"
+    },
+    {
+        "name": "incident",
+        "trans": [
+            "n. 事件，事变；插曲"
+        ],
+        "usphone": "[ˈɪnsɪdənt]",
+        "ukphone": "[ˈɪnsɪdənt]"
+    },
+    {
+        "name": "extensively",
+        "trans": [
+            "adv. 广阔地；广大地"
+        ],
+        "usphone": "[ɪkˈstensɪvli]",
+        "ukphone": "[ɪkˈstensɪvli]"
+    },
+    {
+        "name": "steel",
+        "trans": [
+            "n. 钢铁；钢制品；坚固"
+        ],
+        "usphone": "[stiːl]",
+        "ukphone": "[stiːl]"
+    },
+    {
+        "name": "suffering",
+        "trans": [
+            "n. 受难；苦楚"
+        ],
+        "usphone": "[ˈsʌfərɪŋ]",
+        "ukphone": "[ˈsʌfərɪŋ]"
+    },
+    {
+        "name": "civilization",
+        "trans": [
+            "n. 文明；文化"
+        ],
+        "usphone": "[ˌsɪvələˈzeɪʃn]",
+        "ukphone": "[ˌsɪvəlaɪˈzeɪʃ(ə)n]"
+    },
+    {
+        "name": "cheek",
+        "trans": [
+            "n. 面颊，脸颊；臀部"
+        ],
+        "usphone": "[tʃiːk]",
+        "ukphone": "[tʃiːk]"
+    },
+    {
+        "name": "former",
+        "trans": [
+            "n. 模型，样板；起形成作用的人"
+        ],
+        "usphone": "[ˈfɔːrmər]",
+        "ukphone": "[ˈfɔːmə(r)]"
+    },
+    {
+        "name": "distribution",
+        "trans": [
+            "n. 分布；分配"
+        ],
+        "usphone": "[ˌdɪstrɪˈbjuːʃn]",
+        "ukphone": "[ˌdɪstrɪˈbjuːʃn]"
+    },
+    {
+        "name": "spectator",
+        "trans": [
+            "n. 观众；旁观者"
+        ],
+        "usphone": "[ˈspekteɪtər]",
+        "ukphone": "[spekˈteɪtə(r)]"
+    },
+    {
+        "name": "finding",
+        "trans": [
+            "n. 发现；裁决；发现物"
+        ],
+        "usphone": "[ˈfaɪndɪŋ]",
+        "ukphone": "[ˈfaɪndɪŋ]"
+    },
+    {
+        "name": "disagreement",
+        "trans": [
+            "n. 不一致；争论；意见不同"
+        ],
+        "usphone": "[ˌdɪsəˈɡriːmənt]",
+        "ukphone": "[ˌdɪsəˈɡriːmənt]"
+    },
+    {
+        "name": "chart",
+        "trans": [
+            "n. 图表；海图；图纸；排行榜"
+        ],
+        "usphone": "[tʃɑːrt]",
+        "ukphone": "[tʃɑːt]"
+    },
+    {
+        "name": "soul",
+        "trans": [
+            "n. 灵魂；心灵；精神；鬼魂"
+        ],
+        "usphone": "[soʊl]",
+        "ukphone": "[səʊl]"
+    },
+    {
+        "name": "sticky",
+        "trans": [
+            "adj. 粘的；粘性的"
+        ],
+        "usphone": "[ˈstɪki]",
+        "ukphone": "[ˈstɪki]"
+    },
+    {
+        "name": "desert",
+        "trans": [
+            "n. 沙漠；荒原；应得的赏罚"
+        ],
+        "usphone": "[ˈdezərt; dɪˈzɜːrt]",
+        "ukphone": "[ˈdezət]"
+    },
+    {
+        "name": "commitment",
+        "trans": [
+            "n. 承诺，保证；委托；承担义务；献身"
+        ],
+        "usphone": "[kəˈmɪtmənt]",
+        "ukphone": "[kəˈmɪtmənt]"
+    },
+    {
+        "name": "urgent",
+        "trans": [
+            "adj. 紧急的；急迫的"
+        ],
+        "usphone": "[ˈɜːrdʒənt]",
+        "ukphone": "[ˈɜːdʒənt]"
+    },
+    {
+        "name": "opponent",
+        "trans": [
+            "n. 对手；反对者；敌手"
+        ],
+        "usphone": "[əˈpoʊnənt]",
+        "ukphone": "[əˈpəʊnənt]"
+    },
+    {
+        "name": "urban",
+        "trans": [
+            "adj. 城市的；住在都市的"
+        ],
+        "usphone": "[ˈɜːrbən]",
+        "ukphone": "[ˈɜːbən]"
+    },
+    {
+        "name": "dominant",
+        "trans": [
+            "n. 显性"
+        ],
+        "usphone": "[ˈdɑːmɪnənt]",
+        "ukphone": "[ˈdɒmɪnənt]"
+    },
+    {
+        "name": "globalization",
+        "trans": [
+            "n. 全球化"
+        ],
+        "usphone": "[ˌɡloʊbələˈzeɪʃn]",
+        "ukphone": "[ˌɡləʊbəlaɪˈzeɪʃn]"
+    },
+    {
+        "name": "offend",
+        "trans": [
+            "vt. 冒犯；使…不愉快"
+        ],
+        "usphone": "[əˈfend]",
+        "ukphone": "[əˈfend]"
+    },
+    {
+        "name": "enthusiasm",
+        "trans": [
+            "n. 热心，热忱，热情"
+        ],
+        "usphone": "[ɪnˈθuːziæzəm]",
+        "ukphone": "[ɪnˈθjuːziæzəm]"
+    },
+    {
+        "name": "hip",
+        "trans": [
+            "n. 臀部；蔷薇果；忧郁"
+        ],
+        "usphone": "[hɪp]",
+        "ukphone": "[hɪp]"
+    },
+    {
+        "name": "conscious",
+        "trans": [
+            "adj. 意识到的；故意的；神志清醒的"
+        ],
+        "usphone": "[ˈkɑːnʃəs]",
+        "ukphone": "[ˈkɒnʃəs]"
+    },
+    {
+        "name": "invasion",
+        "trans": [
+            "n. 入侵，侵略；侵袭；侵犯"
+        ],
+        "usphone": "[ɪnˈveɪʒn]",
+        "ukphone": "[ɪnˈveɪʒn]"
+    },
+    {
+        "name": "impressed",
+        "trans": [
+            "adj. 印象深刻的；外加的；受感动的；了不起的"
+        ],
+        "usphone": "[ɪmˈprest]",
+        "ukphone": "[ɪmˈprest]"
+    },
+    {
+        "name": "print",
+        "trans": [
+            "n. 印刷业；印花布；印刷字体；印章；印记"
+        ],
+        "usphone": "[prɪnt]",
+        "ukphone": "[prɪnt]"
+    },
+    {
+        "name": "seat",
+        "trans": [
+            "n. 座位；所在地；职位"
+        ],
+        "usphone": "[siːt]",
+        "ukphone": "[siːt]"
+    },
+    {
         "name": "zone",
         "trans": [
             " [地名] 地带、地区（德语）"
         ],
         "usphone": "[zoʊn]",
         "ukphone": "[zəʊn]"
+    },
+    {
+        "name": "firework",
+        "trans": [
+            "n. 烟火；激烈情绪"
+        ],
+        "usphone": "[ˈfaɪərwɜːrk]",
+        "ukphone": "[ˈfaɪəwɜːk]"
+    },
+    {
+        "name": "power",
+        "trans": [
+            "n. 力量，能力；电力，功率；政权，势力；[数] 幂"
+        ],
+        "usphone": "[ˈpaʊər]",
+        "ukphone": "[ˈpaʊə(r)]"
+    },
+    {
+        "name": "resist",
+        "trans": [
+            "n. [助剂] 抗蚀剂；防染剂"
+        ],
+        "usphone": "[rɪˈzɪst]",
+        "ukphone": "[rɪˈzɪst]"
+    },
+    {
+        "name": "magnificent",
+        "trans": [
+            "adj. 高尚的；壮丽的；华丽的；宏伟的"
+        ],
+        "usphone": "[mæɡˈnɪfɪsnt]",
+        "ukphone": "[mæɡˈnɪfɪs(ə)nt]"
+    },
+    {
+        "name": "revolution",
+        "trans": [
+            "n. 革命；旋转；运行；循环"
+        ],
+        "usphone": "[ˌrevəˈluːʃn]",
+        "ukphone": "[ˌrevəˈluːʃn]"
+    },
+    {
+        "name": "decrease",
+        "trans": [
+            "n. 减少，减小；减少量"
+        ],
+        "usphone": "[dɪˈkriːs; ˈdiːkriːs]",
+        "ukphone": "[dɪˈkriːs]"
+    },
+    {
+        "name": "outfit",
+        "trans": [
+            "n. 机构；用具；全套装备"
+        ],
+        "usphone": "[ˈaʊtfɪt]",
+        "ukphone": "[ˈaʊtfɪt]"
+    },
+    {
+        "name": "shot",
+        "trans": [
+            "n. 发射；炮弹；射手；镜头"
+        ],
+        "usphone": "[ʃɑːt]",
+        "ukphone": "[ʃɒt]"
+    },
+    {
+        "name": "equal",
+        "trans": [
+            "n. 对手；匹敌；同辈；相等的事物"
+        ],
+        "usphone": "[ˈiːkwəl]",
+        "ukphone": "[ˈiːkwəl]"
+    },
+    {
+        "name": "cite",
+        "trans": [
+            "vt. 引用；传讯；想起；表彰"
+        ],
+        "usphone": "[saɪt]",
+        "ukphone": "[saɪt]"
+    },
+    {
+        "name": "gang",
+        "trans": [
+            "n. 群；一伙；一组"
+        ],
+        "usphone": "[ɡæŋ]",
+        "ukphone": "[ɡæŋ]"
+    },
+    {
+        "name": "speculate",
+        "trans": [
+            "vi. 推测；投机；思索"
+        ],
+        "usphone": "[ˈspekjuleɪt]",
+        "ukphone": "[ˈspekjuleɪt]"
+    },
+    {
+        "name": "rival",
+        "trans": [
+            "n. 对手；竞争者"
+        ],
+        "usphone": "[ˈraɪvl]",
+        "ukphone": "[ˈraɪv(ə)l]"
+    },
+    {
+        "name": "reach",
+        "trans": [
+            "n. 范围；延伸；河段；横风行驶"
+        ],
+        "usphone": "[riːtʃ]",
+        "ukphone": "[riːtʃ]"
+    },
+    {
+        "name": "compound",
+        "trans": [
+            "n. [化学] 化合物；混合物；复合词"
+        ],
+        "usphone": "[ˈkɑːmpaʊnd]",
+        "ukphone": "[ˈkɒmpaʊnd]"
+    },
+    {
+        "name": "norm",
+        "trans": [
+            "n. 标准，规范"
+        ],
+        "usphone": "[nɔːrm]",
+        "ukphone": "[nɔːm]"
+    },
+    {
+        "name": "pursuit",
+        "trans": [
+            "n. 追赶，追求；职业，工作"
+        ],
+        "usphone": "[pərˈsuːt]",
+        "ukphone": "[pəˈsjuːt]"
+    },
+    {
+        "name": "indication",
+        "trans": [
+            "n. 指示，指出；迹象；象征"
+        ],
+        "usphone": "[ˌɪndɪˈkeɪʃn]",
+        "ukphone": "[ˌɪndɪˈkeɪʃn]"
+    },
+    {
+        "name": "creativity",
+        "trans": [
+            "n. 创造力；创造性"
+        ],
+        "usphone": "[ˌkriːeɪˈtɪvəti]",
+        "ukphone": "[ˌkriːeɪˈtɪvəti]"
+    },
+    {
+        "name": "ancestor",
+        "trans": [
+            "n. 始祖，祖先；被继承人"
+        ],
+        "usphone": "[ˈænsestər]",
+        "ukphone": "[ˈænsestə(r)]"
+    },
+    {
+        "name": "elderly",
+        "trans": [
+            "adj. 上了年纪的；过了中年的；稍老的"
+        ],
+        "usphone": "[ˈeldərli]",
+        "ukphone": "[ˈeldəli]"
+    },
+    {
+        "name": "spot",
+        "trans": [
+            "n. 地点；斑点"
+        ],
+        "usphone": "[spɑːt]",
+        "ukphone": "[spɒt]"
+    },
+    {
+        "name": "guarantee",
+        "trans": [
+            "n. 保证；担保；保证人；保证书；抵押品"
+        ],
+        "usphone": "[ˌɡærənˈtiː]",
+        "ukphone": "[ˌɡærənˈtiː]"
+    },
+    {
+        "name": "arms",
+        "trans": [
+            "n. 臂（arm的复数）；[军] 武器；纹章"
+        ],
+        "usphone": "[ɑːrmz]",
+        "ukphone": "[ɑːmz]"
+    },
+    {
+        "name": "anxiety",
+        "trans": [
+            "n. 焦虑；渴望；挂念；令人焦虑的事"
+        ],
+        "usphone": "[æŋˈzaɪəti]",
+        "ukphone": "[æŋˈzaɪəti]"
+    },
+    {
+        "name": "scratch",
+        "trans": [
+            "n. 擦伤；抓痕；刮擦声；乱写"
+        ],
+        "usphone": "[skrætʃ]",
+        "ukphone": "[skrætʃ]"
+    },
+    {
+        "name": "stimulate",
+        "trans": [
+            "vi. 起刺激作用；起促进作用"
+        ],
+        "usphone": "[ˈstɪmjuleɪt]",
+        "ukphone": "[ˈstɪmjuleɪt]"
+    },
+    {
+        "name": "vital",
+        "trans": [
+            "adj. 至关重要的；生死攸关的；有活力的"
+        ],
+        "usphone": "[ˈvaɪtl]",
+        "ukphone": "[ˈvaɪt(ə)l]"
+    },
+    {
+        "name": "basically",
+        "trans": [
+            "adv. 主要地，基本上"
+        ],
+        "usphone": "[ˈbeɪsɪkli]",
+        "ukphone": "[ˈbeɪsɪkli]"
+    },
+    {
+        "name": "portion",
+        "trans": [
+            "n. 部分；一份；命运"
+        ],
+        "usphone": "[ˈpɔːrʃn]",
+        "ukphone": "[ˈpɔːʃ(ə)n]"
+    },
+    {
+        "name": "forum",
+        "trans": [
+            "n. 论坛，讨论会；法庭；公开讨论的广场"
+        ],
+        "usphone": "[ˈfɔːrəm]",
+        "ukphone": "[ˈfɔːrəm]"
+    },
+    {
+        "name": "narrow",
+        "trans": [
+            "adj. 狭窄的，有限的；勉强的；精密的；度量小的"
+        ],
+        "usphone": "[ˈnæroʊ]",
+        "ukphone": "[ˈnærəʊ]"
+    },
+    {
+        "name": "acquire",
+        "trans": [
+            "vt. 获得；取得；学到；捕获"
+        ],
+        "usphone": "[əˈkwaɪər]",
+        "ukphone": "[əˈkwaɪə(r)]"
+    },
+    {
+        "name": "ballet",
+        "trans": [
+            "n. 芭蕾舞剧；芭蕾舞乐曲"
+        ],
+        "usphone": "[bæˈleɪ]",
+        "ukphone": "[ˈbæleɪ]"
+    },
+    {
+        "name": "panel",
+        "trans": [
+            "n. 仪表板；嵌板；座谈小组，全体陪审员"
+        ],
+        "usphone": "[ˈpænl]",
+        "ukphone": "[ˈpæn(ə)l]"
+    },
+    {
+        "name": "establish",
+        "trans": [
+            "vi. 植物定植"
+        ],
+        "usphone": "[ɪˈstæblɪʃ]",
+        "ukphone": "[ɪˈstæblɪʃ]"
+    },
+    {
+        "name": "term",
+        "trans": [
+            "n. 术语；学期；期限；条款；(代数式等的)项"
+        ],
+        "usphone": "[tɜːrm]",
+        "ukphone": "[tɜːm]"
     }
 ]

--- a/public/dicts/Duolingo_Vocabulary_C1.json
+++ b/public/dicts/Duolingo_Vocabulary_C1.json
@@ -1,891 +1,11 @@
 [
     {
-        "name": "abortion",
+        "name": "predator",
         "trans": [
-            "n. 流产，堕胎，小产；流产的胎儿；（计划等）失败，夭折"
+            "n. [动] 捕食者；[动] 食肉动物；掠夺者"
         ],
-        "usphone": "[əˈbɔːrʃn]",
-        "ukphone": "[əˈbɔːʃn]"
-    },
-    {
-        "name": "absence",
-        "trans": [
-            "n. 没有；缺乏；缺席；不注意"
-        ],
-        "usphone": "[ˈæbsəns]",
-        "ukphone": "[ˈæbsəns]"
-    },
-    {
-        "name": "absent",
-        "trans": [
-            "adj. 缺席的；缺少的；心不在焉的；茫然的"
-        ],
-        "usphone": "[ˈæbsənt]",
-        "ukphone": "[ˈæbsənt]"
-    },
-    {
-        "name": "absurd",
-        "trans": [
-            "n. 荒诞；荒诞作品"
-        ],
-        "usphone": "[əbˈsɜːrd]",
-        "ukphone": "[əbˈsɜːd]"
-    },
-    {
-        "name": "abundance",
-        "trans": [
-            "n. 充裕，丰富"
-        ],
-        "usphone": "[əˈbʌndəns]",
-        "ukphone": "[əˈbʌndəns]"
-    },
-    {
-        "name": "abuse",
-        "trans": [
-            "n. 滥用；虐待；辱骂；弊端；恶习，陋习"
-        ],
-        "usphone": "[əˈbjuːs]",
-        "ukphone": "[əˈbjuːs]"
-    },
-    {
-        "name": "academy",
-        "trans": [
-            "n. 学院；研究院；学会；专科院校"
-        ],
-        "usphone": "[əˈkædəmi]",
-        "ukphone": "[əˈkædəmi]"
-    },
-    {
-        "name": "accelerate",
-        "trans": [
-            "vt. 使……加快；使……增速"
-        ],
-        "usphone": "[əkˈseləreɪt]",
-        "ukphone": "[əkˈseləreɪt]"
-    },
-    {
-        "name": "acceptance",
-        "trans": [
-            "n. 接纳；赞同；容忍"
-        ],
-        "usphone": "[əkˈseptəns]",
-        "ukphone": "[əkˈseptəns]"
-    },
-    {
-        "name": "accessible",
-        "trans": [
-            "adj. 易接近的；可进入的；可理解的"
-        ],
-        "usphone": "[əkˈsesəbl]",
-        "ukphone": "[əkˈsesəb(ə)l]"
-    },
-    {
-        "name": "accomplishment",
-        "trans": [
-            "n. 成就；完成；技艺，技能"
-        ],
-        "usphone": "[əˈkɑːmplɪʃmənt]",
-        "ukphone": "[əˈkʌmplɪʃmənt]"
-    },
-    {
-        "name": "accordance",
-        "trans": [
-            "n. 一致；和谐"
-        ],
-        "usphone": "[əˈkɔːrdns]",
-        "ukphone": "[əˈkɔːd(ə)ns]"
-    },
-    {
-        "name": "accordingly",
-        "trans": [
-            "adv. 因此，于是；相应地；照著"
-        ],
-        "usphone": "[əˈkɔːrdɪŋli]",
-        "ukphone": "[əˈkɔːdɪŋli]"
-    },
-    {
-        "name": "accountability",
-        "trans": [
-            "n. 有义务；有责任；可说明性"
-        ],
-        "usphone": "[əˌkaʊntəˈbɪləti]",
-        "ukphone": "[əˌkaʊntəˈbɪləti]"
-    },
-    {
-        "name": "accountable",
-        "trans": [
-            "adj. 有责任的；有解释义务的；可解释的"
-        ],
-        "usphone": "[əˈkaʊntəbl]",
-        "ukphone": "[əˈkaʊntəbl]"
-    },
-    {
-        "name": "accumulate",
-        "trans": [
-            "vt. 积攒"
-        ],
-        "usphone": "[əˈkjuːmjəleɪt]",
-        "ukphone": "[əˈkjuːmjəleɪt]"
-    },
-    {
-        "name": "accumulation",
-        "trans": [
-            "n. 积聚，累积；堆积物"
-        ],
-        "usphone": "[əˌkjuːmjəˈleɪʃn]",
-        "ukphone": "[əˌkjuːmjəˈleɪʃn]"
-    },
-    {
-        "name": "accusation",
-        "trans": [
-            "n. 控告，指控；谴责"
-        ],
-        "usphone": "[ˌækjuˈzeɪʃn]",
-        "ukphone": "[ˌækjuˈzeɪʃn]"
-    },
-    {
-        "name": "accused",
-        "trans": [
-            "n. 被告"
-        ],
-        "usphone": "[əˈkjuːzd]",
-        "ukphone": "[əˈkjuːzd]"
-    },
-    {
-        "name": "acid",
-        "trans": [
-            "n. 酸；<俚>迷幻药"
-        ],
-        "usphone": "[ˈæsɪd]",
-        "ukphone": "[ˈæsɪd]"
-    },
-    {
-        "name": "acquisition",
-        "trans": [
-            "n. 获得物，获得；收购"
-        ],
-        "usphone": "[ˌækwɪˈzɪʃn]",
-        "ukphone": "[ˌækwɪˈzɪʃ(ə)n]"
-    },
-    {
-        "name": "acre",
-        "trans": [
-            "n. 土地，地产；英亩"
-        ],
-        "usphone": "[ˈeɪkər]",
-        "ukphone": "[ˈeɪkə(r)]"
-    },
-    {
-        "name": "activation",
-        "trans": [
-            "n. [电子][物] 激活；活化作用"
-        ],
-        "usphone": "[ˌæktɪˈveɪʃn]",
-        "ukphone": "[ˌæktɪˈveɪʃn]"
-    },
-    {
-        "name": "activist",
-        "trans": [
-            "n. 积极分子；激进主义分子"
-        ],
-        "usphone": "[ˈæktɪvɪst]",
-        "ukphone": "[ˈæktɪvɪst]"
-    },
-    {
-        "name": "acute",
-        "trans": [
-            "adj. 严重的，[医] 急性的；敏锐的；激烈的；尖声的"
-        ],
-        "usphone": "[əˈkjuːt]",
-        "ukphone": "[əˈkjuːt]"
-    },
-    {
-        "name": "adaptation",
-        "trans": [
-            "n. 适应；改编；改编本，改写本"
-        ],
-        "usphone": "[ˌædæpˈteɪʃn]",
-        "ukphone": "[ˌædæpˈteɪʃn]"
-    },
-    {
-        "name": "adhere",
-        "trans": [
-            "vi. 坚持；依附；粘着；追随"
-        ],
-        "usphone": "[ədˈhɪr]",
-        "ukphone": "[ədˈhɪə(r)]"
-    },
-    {
-        "name": "adjacent",
-        "trans": [
-            "adj. 邻近的，毗连的"
-        ],
-        "usphone": "[əˈdʒeɪs(ə)nt]",
-        "ukphone": "[əˈdʒeɪs(ə)nt]"
-    },
-    {
-        "name": "adjustment",
-        "trans": [
-            "n. 调整，调节；调节器"
-        ],
-        "usphone": "[əˈdʒʌstmənt]",
-        "ukphone": "[əˈdʒʌstmənt]"
-    },
-    {
-        "name": "administer",
-        "trans": [
-            "vt. 管理；执行；给予"
-        ],
-        "usphone": "[ədˈmɪnɪstər]",
-        "ukphone": "[ədˈmɪnɪstə(r)]"
-    },
-    {
-        "name": "administrative",
-        "trans": [
-            "adj. 管理的，行政的"
-        ],
-        "usphone": "[ədˈmɪnɪstreɪtɪv]",
-        "ukphone": "[ədˈmɪnɪstrətɪv]"
-    },
-    {
-        "name": "administrator",
-        "trans": [
-            "n. 管理人；行政官"
-        ],
-        "usphone": "[ədˈmɪnɪstreɪtər]",
-        "ukphone": "[ədˈmɪnɪstreɪtə(r)]"
-    },
-    {
-        "name": "admission",
-        "trans": [
-            "n. 承认；入场费；进入许可；坦白；录用"
-        ],
-        "usphone": "[ədˈmɪʃn]",
-        "ukphone": "[ədˈmɪʃ(ə)n]"
-    },
-    {
-        "name": "adolescent",
-        "trans": [
-            "n. 青少年"
-        ],
-        "usphone": "[ˌædəˈles(ə)nt]",
-        "ukphone": "[ˌædəˈles(ə)nt]"
-    },
-    {
-        "name": "adoption",
-        "trans": [
-            "n. 采用；收养；接受"
-        ],
-        "usphone": "[əˈdɑːpʃn]",
-        "ukphone": "[əˈdɒpʃn]"
-    },
-    {
-        "name": "adverse",
-        "trans": [
-            "adj. 不利的；相反的；敌对的（名词adverseness，副词adversely）"
-        ],
-        "usphone": "[ədˈvɜːrsˌˈædvɜːrs]",
-        "ukphone": "[ˈædvɜːs]"
-    },
-    {
-        "name": "advocate",
-        "trans": [
-            "n. 提倡者；支持者；律师"
-        ],
-        "usphone": "[ˈædvəkeɪt]",
-        "ukphone": "[ˈædvəkeɪt]"
-    },
-    {
-        "name": "aesthetic",
-        "trans": [
-            "adj. 美的；美学的；审美的，具有审美趣味的"
-        ],
-        "usphone": "[esˈθetɪk]",
-        "ukphone": "[iːsˈθetɪk]"
-    },
-    {
-        "name": "affection",
-        "trans": [
-            "n. 喜爱，感情；影响；感染"
-        ],
-        "usphone": "[əˈfekʃn]",
-        "ukphone": "[əˈfekʃn]"
-    },
-    {
-        "name": "aftermath",
-        "trans": [
-            "n. 后果；余波"
-        ],
-        "usphone": "[ˈæftərmæθ]",
-        "ukphone": "[ˈɑːftəmæθ; ˈɑːftəmɑːθ]"
-    },
-    {
-        "name": "aggression",
-        "trans": [
-            "n. 侵略；进攻；侵犯；侵害"
-        ],
-        "usphone": "[əˈɡreʃn]",
-        "ukphone": "[əˈɡreʃ(ə)n]"
-    },
-    {
-        "name": "agricultural",
-        "trans": [
-            "adj. 农业的；农艺的"
-        ],
-        "usphone": "[ˌæɡrɪˈkʌltʃərəl]",
-        "ukphone": "[ˌæɡrɪˈkʌltʃərəl]"
-    },
-    {
-        "name": "aide",
-        "trans": [
-            "n. 助手；副官；侍从武官"
-        ],
-        "usphone": "[eɪd]",
-        "ukphone": "[eɪd]"
-    },
-    {
-        "name": "albeit",
-        "trans": [
-            "conj. 虽然；即使"
-        ],
-        "usphone": "[ˌɔːlˈbiːɪt]",
-        "ukphone": "[ˌɔːlˈbiːɪt]"
-    },
-    {
-        "name": "alert",
-        "trans": [
-            "n. 警戒，警惕；警报"
-        ],
-        "usphone": "[əˈlɜːrt]",
-        "ukphone": "[əˈlɜːt]"
-    },
-    {
-        "name": "alien",
-        "trans": [
-            "n. 外国人，外侨；外星人"
-        ],
-        "usphone": "[ˈeɪliən]",
-        "ukphone": "[ˈeɪliən]"
-    },
-    {
-        "name": "align",
-        "trans": [
-            "vt. 使结盟；使成一行；匹配"
-        ],
-        "usphone": "[əˈlaɪn]",
-        "ukphone": "[əˈlaɪn]"
-    },
-    {
-        "name": "alignment",
-        "trans": [
-            "n. 队列，成直线；校准；结盟"
-        ],
-        "usphone": "[əˈlaɪnmənt]",
-        "ukphone": "[əˈlaɪnmənt]"
-    },
-    {
-        "name": "alike",
-        "trans": [
-            "adj. 相似的；相同的"
-        ],
-        "usphone": "[əˈlaɪk]",
-        "ukphone": "[əˈlaɪk]"
-    },
-    {
-        "name": "allegation",
-        "trans": [
-            "n. 指控; 陈述，主张; 宣称; 陈词，陈述;"
-        ],
-        "usphone": "[ˌæləˈɡeɪʃn]",
-        "ukphone": "[ˌæləˈɡeɪʃn]"
-    },
-    {
-        "name": "allege",
-        "trans": [
-            "vt. 宣称，断言；提出…作为理由"
-        ],
-        "usphone": "[əˈledʒ]",
-        "ukphone": "[əˈledʒ]"
-    },
-    {
-        "name": "allegedly",
-        "trans": [
-            "adv. 依其申述；据说，据称"
-        ],
-        "usphone": "[əˈledʒɪdli]",
-        "ukphone": "[əˈledʒɪdli]"
-    },
-    {
-        "name": "alliance",
-        "trans": [
-            "n. 联盟，联合；联姻"
-        ],
-        "usphone": "[əˈlaɪəns]",
-        "ukphone": "[əˈlaɪəns]"
-    },
-    {
-        "name": "allocate",
-        "trans": [
-            "vt. 分配；拨出；使坐落于"
-        ],
-        "usphone": "[ˈæləkeɪt]",
-        "ukphone": "[ˈæləkeɪt]"
-    },
-    {
-        "name": "allocation",
-        "trans": [
-            "n. 分配，配置；安置"
-        ],
-        "usphone": "[ˌæləˈkeɪʃ(ə)n]",
-        "ukphone": "[ˌæləˈkeɪʃ(ə)n]"
-    },
-    {
-        "name": "allowance",
-        "trans": [
-            "n. 津贴，零用钱；允许；限额"
-        ],
-        "usphone": "[əˈlaʊəns]",
-        "ukphone": "[əˈlaʊəns]"
-    },
-    {
-        "name": "ally",
-        "trans": [
-            "n. 同盟国；伙伴；同盟者；助手"
-        ],
-        "usphone": "[ˈælaɪ]",
-        "ukphone": "[ˈælaɪ]"
-    },
-    {
-        "name": "aluminium",
-        "trans": [
-            "n. 铝"
-        ],
-        "usphone": "[ˌæljəˈmɪniəm; ˌæləˈmɪniəm]",
-        "ukphone": "[ˌæljəˈmɪniəm; ˌæləˈmɪniəm]"
-    },
-    {
-        "name": "amateur",
-        "trans": [
-            "n. 爱好者；业余爱好者；外行"
-        ],
-        "usphone": "[ˈæmətər; ˈæmətʃər]",
-        "ukphone": "[ˈæmətə(r)]"
-    },
-    {
-        "name": "ambassador",
-        "trans": [
-            "n. 大使；代表；使节"
-        ],
-        "usphone": "[æmˈbæsədər]",
-        "ukphone": "[æmˈbæsədə(r)]"
-    },
-    {
-        "name": "amend",
-        "trans": [
-            "vt. 修改；改善，改进"
-        ],
-        "usphone": "[əˈmend]",
-        "ukphone": "[əˈmend]"
-    },
-    {
-        "name": "amendment",
-        "trans": [
-            "n. 修正案；改善；改正"
-        ],
-        "usphone": "[əˈmendmənt]",
-        "ukphone": "[əˈmendmənt]"
-    },
-    {
-        "name": "amid",
-        "trans": [
-            "prep. 在其中，在其间"
-        ],
-        "usphone": "[əˈmɪd]",
-        "ukphone": "[əˈmɪd]"
-    },
-    {
-        "name": "analogy",
-        "trans": [
-            "n. 类比；类推；类似"
-        ],
-        "usphone": "[əˈnælədʒi]",
-        "ukphone": "[əˈnælədʒi]"
-    },
-    {
-        "name": "anchor",
-        "trans": [
-            "n. 锚；抛锚停泊；靠山；新闻节目主播"
-        ],
-        "usphone": "[ˈæŋkər]",
-        "ukphone": "[ˈæŋkə(r)]"
-    },
-    {
-        "name": "angel",
-        "trans": [
-            "n. 天使；守护神；善人"
-        ],
-        "usphone": "[ˈeɪndʒl]",
-        "ukphone": "[ˈeɪndʒl]"
-    },
-    {
-        "name": "anonymous",
-        "trans": [
-            "adj. 匿名的，无名的；无个性特征的"
-        ],
-        "usphone": "[əˈnɑːnɪməs]",
-        "ukphone": "[əˈnɒnɪməs]"
-    },
-    {
-        "name": "apparatus",
-        "trans": [
-            "n. 装置，设备；仪器；器官"
-        ],
-        "usphone": "[ˌæpəˈrætəs]",
-        "ukphone": "[ˌæpəˈreɪtəs]"
-    },
-    {
-        "name": "appealing",
-        "trans": [
-            "v. 恳求（appeal的ing形式）；将…上诉"
-        ],
-        "usphone": "[əˈpiːlɪŋ]",
-        "ukphone": "[əˈpiːlɪŋ]"
-    },
-    {
-        "name": "appetite",
-        "trans": [
-            "n. 食欲；嗜好"
-        ],
-        "usphone": "[ˈæpɪtaɪt]",
-        "ukphone": "[ˈæpɪtaɪt]"
-    },
-    {
-        "name": "applaud",
-        "trans": [
-            "vt. 赞同；称赞；向…喝彩"
-        ],
-        "usphone": "[əˈplɔːd]",
-        "ukphone": "[əˈplɔːd]"
-    },
-    {
-        "name": "applicable",
-        "trans": [
-            "adj. 可适用的；可应用的；合适的"
-        ],
-        "usphone": "[ˈæplɪkəblˌəˈplɪkəbl]",
-        "ukphone": "[əˈplɪkəb(ə)l]"
-    },
-    {
-        "name": "appoint",
-        "trans": [
-            "vt. 任命；指定；约定"
-        ],
-        "usphone": "[əˈpɔɪnt]",
-        "ukphone": "[əˈpɔɪnt]"
-    },
-    {
-        "name": "appreciation",
-        "trans": [
-            "n. 欣赏，鉴别；增值；感谢"
-        ],
-        "usphone": "[əˌpriːʃiˈeɪʃn]",
-        "ukphone": "[əˌpriːʃiˈeɪʃn]"
-    },
-    {
-        "name": "arbitrary",
-        "trans": [
-            "adj. [数] 任意的；武断的；专制的"
-        ],
-        "usphone": "[ˈɑːrbɪtreri]",
-        "ukphone": "[ˈɑːbɪtrəri]"
-    },
-    {
-        "name": "architectural",
-        "trans": [
-            "adj. 建筑学的；建筑上的；符合建筑法的"
-        ],
-        "usphone": "[ˌɑːrkɪˈtektʃərəl]",
-        "ukphone": "[ˌɑːkɪˈtektʃərəl]"
-    },
-    {
-        "name": "archive",
-        "trans": [
-            "n. 档案馆；档案文件"
-        ],
-        "usphone": "[ˈɑːrkaɪv]",
-        "ukphone": "[ˈɑːkaɪv]"
-    },
-    {
-        "name": "arena",
-        "trans": [
-            "n. 舞台；竞技场"
-        ],
-        "usphone": "[əˈriːnə]",
-        "ukphone": "[əˈriːnə]"
-    },
-    {
-        "name": "arguably",
-        "trans": [
-            "adv. 可论证地；可争辩地；正如可提出证据加以证明的那样地"
-        ],
-        "usphone": "[ˈɑːrɡjuəbli]",
-        "ukphone": "[ˈɑːɡjuəbli]"
-    },
-    {
-        "name": "arm",
-        "trans": [
-            "n. 手臂；武器；袖子；装备；部门"
-        ],
-        "usphone": "[ɑːrm]",
-        "ukphone": "[ɑːm]"
-    },
-    {
-        "name": "array",
-        "trans": [
-            "n. 数组，阵列；排列，列阵；大批，一系列；衣服"
-        ],
-        "usphone": "[əˈreɪ]",
-        "ukphone": "[əˈreɪ]"
-    },
-    {
-        "name": "articulate",
-        "trans": [
-            "adj. 发音清晰的；口才好的；有关节的"
-        ],
-        "usphone": "[ɑːrˈtɪkjuleɪt]",
-        "ukphone": "[ɑːˈtɪkjuleɪt]"
-    },
-    {
-        "name": "ash",
-        "trans": [
-            "n. 灰；灰烬"
-        ],
-        "usphone": "[æʃ]",
-        "ukphone": "[æʃ]"
-    },
-    {
-        "name": "aspiration",
-        "trans": [
-            "n. 渴望；抱负；送气；吸气；吸引术"
-        ],
-        "usphone": "[ˌæspəˈreɪʃn]",
-        "ukphone": "[ˌæspəˈreɪʃ(ə)n]"
-    },
-    {
-        "name": "aspire",
-        "trans": [
-            "vi. 渴望；立志；追求"
-        ],
-        "usphone": "[əˈspaɪər]",
-        "ukphone": "[əˈspaɪə(r)]"
-    },
-    {
-        "name": "assassination",
-        "trans": [
-            "n. 暗杀，行刺"
-        ],
-        "usphone": "[əˌsæsɪˈneɪʃn]",
-        "ukphone": "[əˌsæsɪˈneɪʃ(ə)n]"
-    },
-    {
-        "name": "assault",
-        "trans": [
-            "n. 攻击；袭击"
-        ],
-        "usphone": "[əˈsɔːlt]",
-        "ukphone": "[əˈsɔːlt]"
-    },
-    {
-        "name": "assemble",
-        "trans": [
-            "vt. 集合，聚集；装配；收集"
-        ],
-        "usphone": "[əˈsembl]",
-        "ukphone": "[əˈsemb(ə)l]"
-    },
-    {
-        "name": "assembly",
-        "trans": [
-            "n. 装配；集会，集合"
-        ],
-        "usphone": "[əˈsembli]",
-        "ukphone": "[əˈsembli]"
-    },
-    {
-        "name": "assert",
-        "trans": [
-            "vt. 维护，坚持；断言；主张；声称"
-        ],
-        "usphone": "[əˈsɜːrt]",
-        "ukphone": "[əˈsɜːt]"
-    },
-    {
-        "name": "assertion",
-        "trans": [
-            "n. 断言，声明；主张，要求；坚持；认定"
-        ],
-        "usphone": "[əˈsɜːrʃn]",
-        "ukphone": "[əˈsɜːʃ(ə)n]"
-    },
-    {
-        "name": "assurance",
-        "trans": [
-            "n. 保证，担保；（人寿）保险；确信；断言；厚脸皮，无耻"
-        ],
-        "usphone": "[əˈʃʊrəns]",
-        "ukphone": "[əˈʃʊərəns]"
-    },
-    {
-        "name": "asylum",
-        "trans": [
-            "n. 庇护；收容所，救济院"
-        ],
-        "usphone": "[əˈsaɪləm]",
-        "ukphone": "[əˈsaɪləm]"
-    },
-    {
-        "name": "atrocity",
-        "trans": [
-            "n. 暴行；凶恶，残暴"
-        ],
-        "usphone": "[əˈtrɑːsəti]",
-        "ukphone": "[əˈtrɒsəti]"
-    },
-    {
-        "name": "attain",
-        "trans": [
-            "n. 成就"
-        ],
-        "usphone": "[əˈteɪn]",
-        "ukphone": "[əˈteɪn]"
-    },
-    {
-        "name": "attendance",
-        "trans": [
-            "n. 出席；到场；出席人数；考勤"
-        ],
-        "usphone": "[əˈtendəns]",
-        "ukphone": "[əˈtendəns]"
-    },
-    {
-        "name": "attorney",
-        "trans": [
-            "n. 律师；代理人；检查官"
-        ],
-        "usphone": "[əˈtɜːrni]",
-        "ukphone": "[əˈtɜːni]"
-    },
-    {
-        "name": "attribute",
-        "trans": [
-            "n. 属性；特质"
-        ],
-        "usphone": "[əˈtrɪbjuːt]",
-        "ukphone": "[əˈtrɪbjuːt]"
-    },
-    {
-        "name": "audit",
-        "trans": [
-            "n. 审计；[审计] 查账"
-        ],
-        "usphone": "[ˈɔːdɪt]",
-        "ukphone": "[ˈɔːdɪt]"
-    },
-    {
-        "name": "authentic",
-        "trans": [
-            "adj. 真正的，真实的；可信的"
-        ],
-        "usphone": "[ɔːˈθentɪk]",
-        "ukphone": "[ɔːˈθentɪk]"
-    },
-    {
-        "name": "authorize",
-        "trans": [
-            "vt. 批准，认可；授权给；委托代替"
-        ],
-        "usphone": "[ˈɔːθəraɪz]",
-        "ukphone": "[ˈɔːθəraɪz]"
-    },
-    {
-        "name": "auto",
-        "trans": [
-            "n. 汽车（等于automobile）；自动"
-        ],
-        "usphone": "[ˈɔːtoʊ]",
-        "ukphone": "[ˈɔːtəʊ]"
-    },
-    {
-        "name": "autonomy",
-        "trans": [
-            "n. 自治，自治权"
-        ],
-        "usphone": "[ɔːˈtɑːnəmi]",
-        "ukphone": "[ɔːˈtɒnəmi]"
-    },
-    {
-        "name": "availability",
-        "trans": [
-            "n. 可用性；有效性；实用性"
-        ],
-        "usphone": "[əˌveɪləˈbɪləti]",
-        "ukphone": "[əˌveɪləˈbɪləti]"
-    },
-    {
-        "name": "await",
-        "trans": [
-            "vt. 等候，等待；期待"
-        ],
-        "usphone": "[əˈweɪt]",
-        "ukphone": "[əˈweɪt]"
-    },
-    {
-        "name": "backdrop",
-        "trans": [
-            "n. 背景；背景幕；交流声"
-        ],
-        "usphone": "[ˈbækdrɑːp]",
-        "ukphone": "[ˈbækdrɒp]"
-    },
-    {
-        "name": "backing",
-        "trans": [
-            "n. 支持；后退；支持者；衬背"
-        ],
-        "usphone": "[ˈbækɪŋ]",
-        "ukphone": "[ˈbækɪŋ]"
-    },
-    {
-        "name": "backup",
-        "trans": [
-            "n. 支持；后援；阻塞"
-        ],
-        "usphone": "[ˈbækʌp]",
-        "ukphone": "[ˈbækʌp]"
-    },
-    {
-        "name": "bail",
-        "trans": [
-            "n. 保释，保释人；保释金；杓"
-        ],
-        "usphone": "[beɪl]",
-        "ukphone": "[beɪl]"
-    },
-    {
-        "name": "ballot",
-        "trans": [
-            "n. 投票；投票用纸；投票总数"
-        ],
-        "usphone": "[ˈbælət]",
-        "ukphone": "[ˈbælət]"
-    },
-    {
-        "name": "banner",
-        "trans": [
-            "n. 横幅图片的广告模式"
-        ],
-        "usphone": "[ˈbænər]",
-        "ukphone": "[ˈbænə(r)]"
+        "usphone": "[ˈpredətər]",
+        "ukphone": "[ˈpredətə(r)]"
     },
     {
         "name": "bare",
@@ -896,3556 +16,20 @@
         "ukphone": "[beə(r)]"
     },
     {
-        "name": "barrel",
+        "name": "scattered",
         "trans": [
-            "n. 桶；枪管，炮管"
+            "adj. 分散的；散乱的"
         ],
-        "usphone": "[ˈbærəl]",
-        "ukphone": "[ˈbærəl]"
+        "usphone": "[ˈskætərd]",
+        "ukphone": "[ˈskætəd]"
     },
     {
-        "name": "bass",
+        "name": "revolutionary",
         "trans": [
-            "n. 鲈鱼；男低音；低音部；椴树"
+            "n. 革命者"
         ],
-        "usphone": "[beɪs; bæs]",
-        "ukphone": "[beɪs]"
-    },
-    {
-        "name": "bat",
-        "trans": [
-            "n. 蝙蝠；球棒；球拍；批处理文件的扩展名"
-        ],
-        "usphone": "[bæt]",
-        "ukphone": "[bæt]"
-    },
-    {
-        "name": "battlefield",
-        "trans": [
-            "n. 战场；沙场"
-        ],
-        "usphone": "[ˈbætlfiːld]",
-        "ukphone": "[ˈbætlfiːld]"
-    },
-    {
-        "name": "bay",
-        "trans": [
-            "n. 海湾；狗吠声"
-        ],
-        "usphone": "[beɪ]",
-        "ukphone": "[beɪ]"
-    },
-    {
-        "name": "beam",
-        "trans": [
-            "n. 横梁；光线；电波；船宽；[计量] 秤杆"
-        ],
-        "usphone": "[biːm]",
-        "ukphone": "[biːm]"
-    },
-    {
-        "name": "beast",
-        "trans": [
-            "n. 野兽；畜生，人面兽心的人"
-        ],
-        "usphone": "[biːst]",
-        "ukphone": "[biːst]"
-    },
-    {
-        "name": "behalf",
-        "trans": [
-            "n. 代表；利益"
-        ],
-        "usphone": "[bɪˈhæf]",
-        "ukphone": "[bɪˈhɑːf]"
-    },
-    {
-        "name": "beloved",
-        "trans": [
-            "n. 心爱的人；亲爱的教友"
-        ],
-        "usphone": "[bɪˈlʌvɪd]",
-        "ukphone": "[bɪˈlʌvɪd]"
-    },
-    {
-        "name": "bench",
-        "trans": [
-            "n. 长凳；工作台；替补队员"
-        ],
-        "usphone": "[bentʃ]",
-        "ukphone": "[bentʃ]"
-    },
-    {
-        "name": "benchmark",
-        "trans": [
-            "n. 基准；标准检查程序"
-        ],
-        "usphone": "[ˈbentʃmɑːrk]",
-        "ukphone": "[ˈbentʃmɑːk]"
-    },
-    {
-        "name": "beneath",
-        "trans": [
-            "prep. 在…之下"
-        ],
-        "usphone": "[bɪˈniːθ]",
-        "ukphone": "[bɪˈniːθ]"
-    },
-    {
-        "name": "beneficiary",
-        "trans": [
-            "n. [金融] 受益人，受惠者；封臣"
-        ],
-        "usphone": "[ˌbenɪˈfɪʃieri]",
-        "ukphone": "[ˌbenɪˈfɪʃəri]"
-    },
-    {
-        "name": "betray",
-        "trans": [
-            "vt. 背叛；出卖；泄露（秘密）；露出…迹象"
-        ],
-        "usphone": "[bɪˈtreɪ]",
-        "ukphone": "[bɪˈtreɪ]"
-    },
-    {
-        "name": "bind",
-        "trans": [
-            "n. 捆绑；困境；讨厌的事情；植物的藤蔓"
-        ],
-        "usphone": "[baɪnd]",
-        "ukphone": "[baɪnd]"
-    },
-    {
-        "name": "biography",
-        "trans": [
-            "n. 传记；档案；个人简介"
-        ],
-        "usphone": "[baɪˈɑːɡrəfi]",
-        "ukphone": "[baɪˈɒɡrəfi]"
-    },
-    {
-        "name": "bishop",
-        "trans": [
-            "n. （基督教的）主教；（国际象棋的）象"
-        ],
-        "usphone": "[ˈbɪʃəp]",
-        "ukphone": "[ˈbɪʃəp]"
-    },
-    {
-        "name": "bizarre",
-        "trans": [
-            "adj. 奇异的（指态度，容貌，款式等）"
-        ],
-        "usphone": "[bɪˈzɑːr]",
-        "ukphone": "[bɪˈzɑː(r)]"
-    },
-    {
-        "name": "blade",
-        "trans": [
-            "n. 叶片；刀片，刀锋；剑"
-        ],
-        "usphone": "[bleɪd]",
-        "ukphone": "[bleɪd]"
-    },
-    {
-        "name": "blast",
-        "trans": [
-            "n. 爆炸；冲击波；一阵"
-        ],
-        "usphone": "[blæst]",
-        "ukphone": "[blɑːst]"
-    },
-    {
-        "name": "bleed",
-        "trans": [
-            "vt. 使出血；榨取"
-        ],
-        "usphone": "[bliːd]",
-        "ukphone": "[bliːd]"
-    },
-    {
-        "name": "blend",
-        "trans": [
-            "n. 混合；掺合物"
-        ],
-        "usphone": "[blend]",
-        "ukphone": "[blend]"
-    },
-    {
-        "name": "bless",
-        "trans": [
-            "vt. 祝福；保佑；赞美"
-        ],
-        "usphone": "[bles]",
-        "ukphone": "[bles]"
-    },
-    {
-        "name": "blessing",
-        "trans": [
-            "n. 祝福；赐福；祷告"
-        ],
-        "usphone": "[ˈblesɪŋ]",
-        "ukphone": "[ˈblesɪŋ]"
-    },
-    {
-        "name": "boast",
-        "trans": [
-            "n. 自夸；值得夸耀的事物，引以为荣的事物"
-        ],
-        "usphone": "[boʊst]",
-        "ukphone": "[bəʊst]"
-    },
-    {
-        "name": "bonus",
-        "trans": [
-            "n. 奖金；红利；额外津贴"
-        ],
-        "usphone": "[ˈboʊnəs]",
-        "ukphone": "[ˈbəʊnəs]"
-    },
-    {
-        "name": "boom",
-        "trans": [
-            "n. 繁荣；吊杆；隆隆声"
-        ],
-        "usphone": "[buːm]",
-        "ukphone": "[buːm]"
-    },
-    {
-        "name": "bounce",
-        "trans": [
-            "n. 跳；弹力；活力"
-        ],
-        "usphone": "[baʊns]",
-        "ukphone": "[baʊns]"
-    },
-    {
-        "name": "boundary",
-        "trans": [
-            "n. 边界；范围；分界线"
-        ],
-        "usphone": "[ˈbaʊndri]",
-        "ukphone": "[ˈbaʊndri]"
-    },
-    {
-        "name": "bow",
-        "trans": [
-            "n. 弓；鞠躬；船首"
-        ],
-        "usphone": "[baʊ; boʊ]",
-        "ukphone": "[bəʊ]"
-    },
-    {
-        "name": "breach",
-        "trans": [
-            "n. 违背，违反；缺口"
-        ],
-        "usphone": "[briːtʃ]",
-        "ukphone": "[briːtʃ]"
-    },
-    {
-        "name": "breakdown",
-        "trans": [
-            "n. 故障；崩溃；分解；分类；衰弱；跺脚曳步舞"
-        ],
-        "usphone": "[ˈbreɪkdaʊn]",
-        "ukphone": "[ˈbreɪkdaʊn]"
-    },
-    {
-        "name": "breakthrough",
-        "trans": [
-            "n. 突破；突破性进展"
-        ],
-        "usphone": "[ˈbreɪkθruː]",
-        "ukphone": "[ˈbreɪkθruː]"
-    },
-    {
-        "name": "breed",
-        "trans": [
-            "n. [生物] 品种；种类，类型"
-        ],
-        "usphone": "[briːd]",
-        "ukphone": "[briːd]"
-    },
-    {
-        "name": "broadband",
-        "trans": [
-            "n. 宽频；宽波段"
-        ],
-        "usphone": "[ˈbrɔːdbænd]",
-        "ukphone": "[ˈbrɔːdbænd]"
-    },
-    {
-        "name": "browser",
-        "trans": [
-            "n. [计] 浏览器；吃嫩叶的动物；浏览书本的人"
-        ],
-        "usphone": "[ˈbraʊzər]",
-        "ukphone": "[ˈbraʊzə(r)]"
-    },
-    {
-        "name": "brutal",
-        "trans": [
-            "adj. 残忍的；野蛮的，不讲理的"
-        ],
-        "usphone": "[ˈbruːt(ə)l]",
-        "ukphone": "[ˈbruːt(ə)l]"
-    },
-    {
-        "name": "buck",
-        "trans": [
-            "n. （美）钱，元；雄鹿；纨绔子弟；年轻的印第安人或黑人"
-        ],
-        "usphone": "[bʌk]",
-        "ukphone": "[bʌk]"
-    },
-    {
-        "name": "buddy",
-        "trans": [
-            "n. 伙伴，好朋友；密友；小男孩"
-        ],
-        "usphone": "[ˈbʌdi]",
-        "ukphone": "[ˈbʌdi]"
-    },
-    {
-        "name": "buffer",
-        "trans": [
-            "n. [计] 缓冲区；缓冲器，[车辆] 减震器"
-        ],
-        "usphone": "[ˈbʌfər]",
-        "ukphone": "[ˈbʌfə(r)]"
-    },
-    {
-        "name": "bulk",
-        "trans": [
-            "n. 体积，容量；大多数，大部分；大块"
-        ],
-        "usphone": "[bʌlk]",
-        "ukphone": "[bʌlk]"
-    },
-    {
-        "name": "burden",
-        "trans": [
-            "n. 负担；责任；船的载货量"
-        ],
-        "usphone": "[ˈbɜːrdn]",
-        "ukphone": "[ˈbɜːdn]"
-    },
-    {
-        "name": "bureaucracy",
-        "trans": [
-            "n. 官僚主义；官僚机构；官僚政治"
-        ],
-        "usphone": "[bjʊˈrɑːkrəsi]",
-        "ukphone": "[bjʊəˈrɒkrəsi]"
-    },
-    {
-        "name": "burial",
-        "trans": [
-            "n. 埋葬；葬礼；弃绝"
-        ],
-        "usphone": "[ˈberiəl]",
-        "ukphone": "[ˈberiəl]"
-    },
-    {
-        "name": "burst",
-        "trans": [
-            "n. 爆发，突发；爆炸"
-        ],
-        "usphone": "[bɜːrst]",
-        "ukphone": "[bɜːst]"
-    },
-    {
-        "name": "cabinet",
-        "trans": [
-            "n. 内阁；橱柜；展览艺术品的小陈列室"
-        ],
-        "usphone": "[ˈkæbɪnət]",
-        "ukphone": "[ˈkæbɪnət]"
-    },
-    {
-        "name": "calculation",
-        "trans": [
-            "n. 计算；估计；计算的结果；深思熟虑"
-        ],
-        "usphone": "[ˌkælkjuˈleɪʃn]",
-        "ukphone": "[ˌkælkjuˈleɪʃn]"
-    },
-    {
-        "name": "canvas",
-        "trans": [
-            "n. 帆布"
-        ],
-        "usphone": "[ˈkænvəs]",
-        "ukphone": "[ˈkænvəs]"
-    },
-    {
-        "name": "capability",
-        "trans": [
-            "n. 才能，能力；性能，容量"
-        ],
-        "usphone": "[ˌkeɪpəˈbɪləti]",
-        "ukphone": "[ˌkeɪpəˈbɪləti]"
-    },
-    {
-        "name": "capitalism",
-        "trans": [
-            "n. 资本主义"
-        ],
-        "usphone": "[ˈkæpɪtəlɪzəm]",
-        "ukphone": "[ˈkæpɪtəlɪzəm]"
-    },
-    {
-        "name": "capitalist",
-        "trans": [
-            "n. 资本家；资本主义者"
-        ],
-        "usphone": "[ˈkæpɪtəlɪst]",
-        "ukphone": "[ˈkæpɪtəlɪst]"
-    },
-    {
-        "name": "cargo",
-        "trans": [
-            "n. 货物，船货"
-        ],
-        "usphone": "[ˈkɑːrɡoʊ]",
-        "ukphone": "[ˈkɑːɡəʊ]"
-    },
-    {
-        "name": "carriage",
-        "trans": [
-            "n. 运输；运费；四轮马车；举止；客车厢"
-        ],
-        "usphone": "[ˈkærɪdʒ]",
-        "ukphone": "[ˈkærɪdʒ]"
-    },
-    {
-        "name": "carve",
-        "trans": [
-            "vt. 雕刻；切开；开创"
-        ],
-        "usphone": "[kɑːrv]",
-        "ukphone": "[kɑːv]"
-    },
-    {
-        "name": "casino",
-        "trans": [
-            "n. 俱乐部，赌场；娱乐场"
-        ],
-        "usphone": "[kəˈsiːnoʊ]",
-        "ukphone": "[kəˈsiːnəʊ]"
-    },
-    {
-        "name": "casualty",
-        "trans": [
-            "n. 意外事故；伤亡人员；急诊室"
-        ],
-        "usphone": "[ˈkæʒuəlti]",
-        "ukphone": "[ˈkæʒuəlti]"
-    },
-    {
-        "name": "catalogue",
-        "trans": [
-            "n. 目录；（美）大学情况一览"
-        ],
-        "usphone": "[ˈkætəlɔːɡ]",
-        "ukphone": "[ˈkætəlɒɡ]"
-    },
-    {
-        "name": "cater",
-        "trans": [
-            "vt. 投合，迎合；满足需要；提供饮食及服务"
-        ],
-        "usphone": "[ˈkeɪtər]",
-        "ukphone": "[ˈkeɪtə(r)]"
-    },
-    {
-        "name": "cattle",
-        "trans": [
-            "n. 牛；牲畜（骂人的话）；家畜；无价值的人"
-        ],
-        "usphone": "[ˈkæt(ə)l]",
-        "ukphone": "[ˈkæt(ə)l]"
-    },
-    {
-        "name": "caution",
-        "trans": [
-            "n. 小心，谨慎；警告，警示"
-        ],
-        "usphone": "[ˈkɔːʃn]",
-        "ukphone": "[ˈkɔːʃn]"
-    },
-    {
-        "name": "cautious",
-        "trans": [
-            "adj. 谨慎的；十分小心的"
-        ],
-        "usphone": "[ˈkɔːʃəs]",
-        "ukphone": "[ˈkɔːʃəs]"
-    },
-    {
-        "name": "cease",
-        "trans": [
-            "n. 停止"
-        ],
-        "usphone": "[siːs]",
-        "ukphone": "[siːs]"
-    },
-    {
-        "name": "cemetery",
-        "trans": [
-            "n. 墓地；公墓"
-        ],
-        "usphone": "[ˈseməteri]",
-        "ukphone": "[ˈsemətri]"
-    },
-    {
-        "name": "chamber",
-        "trans": [
-            "n. （身体或器官内的）室，膛；房间；会所"
-        ],
-        "usphone": "[ˈtʃeɪmbər]",
-        "ukphone": "[ˈtʃeɪmbə(r)]"
-    },
-    {
-        "name": "chaos",
-        "trans": [
-            "n. 混沌，混乱"
-        ],
-        "usphone": "[ˈkeɪɑːs]",
-        "ukphone": "[ˈkeɪɒs]"
-    },
-    {
-        "name": "characterize",
-        "trans": [
-            "vt. 描绘…的特性；具有…的特征"
-        ],
-        "usphone": "[ˈkærəktəraɪz]",
-        "ukphone": "[ˈkærəktəraɪz]"
-    },
-    {
-        "name": "charm",
-        "trans": [
-            "n. 魅力，吸引力；魔力"
-        ],
-        "usphone": "[tʃɑːrm]",
-        "ukphone": "[tʃɑːm]"
-    },
-    {
-        "name": "charter",
-        "trans": [
-            "n. 宪章；执照；特许状"
-        ],
-        "usphone": "[ˈtʃɑːrtər]",
-        "ukphone": "[ˈtʃɑːtə(r)]"
-    },
-    {
-        "name": "chronic",
-        "trans": [
-            "adj. 慢性的；长期的；习惯性的"
-        ],
-        "usphone": "[ˈkrɑːnɪk]",
-        "ukphone": "[ˈkrɒnɪk]"
-    },
-    {
-        "name": "chunk",
-        "trans": [
-            "n. 大块；矮胖的人或物"
-        ],
-        "usphone": "[tʃʌŋk]",
-        "ukphone": "[tʃʌŋk]"
-    },
-    {
-        "name": "circulate",
-        "trans": [
-            "vt. 使循环；使流通；使传播"
-        ],
-        "usphone": "[ˈsɜːrkjəleɪt]",
-        "ukphone": "[ˈsɜːkjəleɪt]"
-    },
-    {
-        "name": "circulation",
-        "trans": [
-            "n. 流通，传播；循环；发行量"
-        ],
-        "usphone": "[ˌsɜːrkjəˈleɪʃn]",
-        "ukphone": "[ˌsɜːkjəˈleɪʃn]"
-    },
-    {
-        "name": "citizenship",
-        "trans": [
-            "n. [法] 公民身份，公民资格；国籍；公民权"
-        ],
-        "usphone": "[ˈsɪtɪzənʃɪp]",
-        "ukphone": "[ˈsɪtɪzənʃɪp]"
-    },
-    {
-        "name": "civic",
-        "trans": [
-            "adj. 市的；公民的，市民的"
-        ],
-        "usphone": "[ˈsɪvɪk]",
-        "ukphone": "[ˈsɪvɪk]"
-    },
-    {
-        "name": "civilian",
-        "trans": [
-            "n. 平民，百姓"
-        ],
-        "usphone": "[səˈvɪliən]",
-        "ukphone": "[səˈvɪliən]"
-    },
-    {
-        "name": "clarity",
-        "trans": [
-            "n. 清楚，明晰；透明"
-        ],
-        "usphone": "[ˈklærəti]",
-        "ukphone": "[ˈklærəti]"
-    },
-    {
-        "name": "clash",
-        "trans": [
-            "n. 冲突，不协调；碰撞声，铿锵声"
-        ],
-        "usphone": "[klæʃ]",
-        "ukphone": "[klæʃ]"
-    },
-    {
-        "name": "classification",
-        "trans": [
-            "n. 分类；类别，等级"
-        ],
-        "usphone": "[ˌklæsɪfɪˈkeɪʃn]",
-        "ukphone": "[ˌklæsɪfɪˈkeɪʃ(ə)n]"
-    },
-    {
-        "name": "cling",
-        "trans": [
-            "vi. 坚持，墨守；紧贴；附着"
-        ],
-        "usphone": "[klɪŋ]",
-        "ukphone": "[klɪŋ]"
-    },
-    {
-        "name": "clinical",
-        "trans": [
-            "adj. 临床的；诊所的"
-        ],
-        "usphone": "[ˈklɪnɪkl]",
-        "ukphone": "[ˈklɪnɪk(ə)l]"
-    },
-    {
-        "name": "closure",
-        "trans": [
-            "n. 关闭；终止，结束"
-        ],
-        "usphone": "[ˈkloʊʒər]",
-        "ukphone": "[ˈkləʊʒə(r)]"
-    },
-    {
-        "name": "cluster",
-        "trans": [
-            "n. 群；簇；丛；串"
-        ],
-        "usphone": "[ˈklʌstər]",
-        "ukphone": "[ˈklʌstə(r)]"
-    },
-    {
-        "name": "coalition",
-        "trans": [
-            "n. 联合；结合，合并"
-        ],
-        "usphone": "[ˌkoʊəˈlɪʃ(ə)n]",
-        "ukphone": "[ˌkəʊəˈlɪʃ(ə)n]"
-    },
-    {
-        "name": "coastal",
-        "trans": [
-            "adj. 沿海的；海岸的"
-        ],
-        "usphone": "[ˈkoʊstl]",
-        "ukphone": "[ˈkəʊst(ə)l]"
-    },
-    {
-        "name": "cocktail",
-        "trans": [
-            "n. 鸡尾酒；开胃食品"
-        ],
-        "usphone": "[ˈkɑːkteɪl]",
-        "ukphone": "[ˈkɒkteɪl]"
-    },
-    {
-        "name": "cognitive",
-        "trans": [
-            "adj. 认知的，认识的"
-        ],
-        "usphone": "[ˈkɑːɡnətɪv]",
-        "ukphone": "[ˈkɒɡnətɪv]"
-    },
-    {
-        "name": "coincide",
-        "trans": [
-            "vi. 一致，符合；同时发生"
-        ],
-        "usphone": "[ˌkoʊɪnˈsaɪd]",
-        "ukphone": "[ˌkəʊɪnˈsaɪd]"
-    },
-    {
-        "name": "collaborate",
-        "trans": [
-            "vi. 合作；勾结，通敌"
-        ],
-        "usphone": "[kəˈlæbəreɪt]",
-        "ukphone": "[kəˈlæbəreɪt]"
-    },
-    {
-        "name": "collaboration",
-        "trans": [
-            "n. 合作；勾结；通敌"
-        ],
-        "usphone": "[kəˌlæbəˈreɪʃn]",
-        "ukphone": "[kəˌlæbəˈreɪʃ(ə)n]"
-    },
-    {
-        "name": "collective",
-        "trans": [
-            "n. 集团；集合体；集合名词"
-        ],
-        "usphone": "[kəˈlektɪv]",
-        "ukphone": "[kəˈlektɪv]"
-    },
-    {
-        "name": "collision",
-        "trans": [
-            "n. 碰撞；冲突；（意见，看法）的抵触；（政党等的）倾轧"
-        ],
-        "usphone": "[kəˈlɪʒn]",
-        "ukphone": "[kəˈlɪʒ(ə)n]"
-    },
-    {
-        "name": "colonial",
-        "trans": [
-            "n. 殖民地居民"
-        ],
-        "usphone": "[kəˈloʊniəl]",
-        "ukphone": "[kəˈləʊniəl]"
-    },
-    {
-        "name": "columnist",
-        "trans": [
-            "n. 专栏作家"
-        ],
-        "usphone": "[ˈkɑːləmnɪst]",
-        "ukphone": "[ˈkɒləmnɪst]"
-    },
-    {
-        "name": "combat",
-        "trans": [
-            "n. 战斗；争论"
-        ],
-        "usphone": "[ˈkɑːmbæt]",
-        "ukphone": "[ˈkɒmbæt]"
-    },
-    {
-        "name": "commence",
-        "trans": [
-            "v. 开始；着手；<英>获得学位"
-        ],
-        "usphone": "[kəˈmens]",
-        "ukphone": "[kəˈmens]"
-    },
-    {
-        "name": "commentary",
-        "trans": [
-            "n. 评论；注释；评注；说明"
-        ],
-        "usphone": "[ˈkɑːmənteri]",
-        "ukphone": "[ˈkɒmənt(ə)ri]"
-    },
-    {
-        "name": "commentator",
-        "trans": [
-            "n. 评论员，解说员；实况播音员；时事评论者"
-        ],
-        "usphone": "[ˈkɑːmənteɪtər]",
-        "ukphone": "[ˈkɒmənteɪtə(r)]"
-    },
-    {
-        "name": "commerce",
-        "trans": [
-            "n. 贸易；商业；商务"
-        ],
-        "usphone": "[ˈkɑːmɜːrs]",
-        "ukphone": "[ˈkɒmɜːs]"
-    },
-    {
-        "name": "commissioner",
-        "trans": [
-            "n. 理事；委员；行政长官；总裁"
-        ],
-        "usphone": "[kəˈmɪʃənər]",
-        "ukphone": "[kəˈmɪʃənə(r)]"
-    },
-    {
-        "name": "commodity",
-        "trans": [
-            "n. 商品，货物；日用品"
-        ],
-        "usphone": "[kəˈmɑːdəti]",
-        "ukphone": "[kəˈmɒdəti]"
-    },
-    {
-        "name": "communist",
-        "trans": [
-            "n. 共产党员；共产主义者"
-        ],
-        "usphone": "[ˈkɑːmjənɪst]",
-        "ukphone": "[ˈkɒmjənɪst]"
-    },
-    {
-        "name": "companion",
-        "trans": [
-            "n. 同伴；朋友；指南；手册"
-        ],
-        "usphone": "[kəmˈpænjən]",
-        "ukphone": "[kəmˈpænjən]"
-    },
-    {
-        "name": "comparable",
-        "trans": [
-            "adj. 可比较的；比得上的"
-        ],
-        "usphone": "[ˈkɑːmpərəbl]",
-        "ukphone": "[ˈkɒmpərəb(ə)l]"
-    },
-    {
-        "name": "compassion",
-        "trans": [
-            "n. 同情；怜悯"
-        ],
-        "usphone": "[kəmˈpæʃn]",
-        "ukphone": "[kəmˈpæʃn]"
-    },
-    {
-        "name": "compel",
-        "trans": [
-            "vt. 强迫，迫使；强使发生"
-        ],
-        "usphone": "[kəmˈpel]",
-        "ukphone": "[kəmˈpel]"
-    },
-    {
-        "name": "compelling",
-        "trans": [
-            "adj. 引人注目的；强制的；激发兴趣的"
-        ],
-        "usphone": "[kəmˈpelɪŋ]",
-        "ukphone": "[kəmˈpelɪŋ]"
-    },
-    {
-        "name": "compensate",
-        "trans": [
-            "vt. 补偿，赔偿；付报酬"
-        ],
-        "usphone": "[ˈkɑːmpenseɪt]",
-        "ukphone": "[ˈkɒmpenseɪt]"
-    },
-    {
-        "name": "compensation",
-        "trans": [
-            "n. 补偿；报酬；赔偿金"
-        ],
-        "usphone": "[ˌkɑːmpenˈseɪʃn]",
-        "ukphone": "[ˌkɒmpenˈseɪʃ(ə)n]"
-    },
-    {
-        "name": "competence",
-        "trans": [
-            "n. 能力，胜任；权限；作证能力；足以过舒适生活的收入"
-        ],
-        "usphone": "[ˈkɑːmpɪtəns]",
-        "ukphone": "[ˈkɒmpɪtəns]"
-    },
-    {
-        "name": "competent",
-        "trans": [
-            "adj. 胜任的；有能力的；能干的；足够的"
-        ],
-        "usphone": "[ˈkɑːmpɪtənt]",
-        "ukphone": "[ˈkɒmpɪtənt]"
-    },
-    {
-        "name": "compile",
-        "trans": [
-            "vt. 编译；编制；编辑；[图情] 汇编"
-        ],
-        "usphone": "[kəmˈpaɪl]",
-        "ukphone": "[kəmˈpaɪl]"
-    },
-    {
-        "name": "complement",
-        "trans": [
-            "n. 补语；余角；补足物"
-        ],
-        "usphone": "[ˈkɑːmplɪment; ˈkɑːmplɪmənt]",
-        "ukphone": "[ˈkɒmplɪment]"
-    },
-    {
-        "name": "complexity",
-        "trans": [
-            "n. 复杂，复杂性；复杂错综的事物"
-        ],
-        "usphone": "[kəmˈpleksəti]",
-        "ukphone": "[kəmˈpleksəti]"
-    },
-    {
-        "name": "compliance",
-        "trans": [
-            "n. 顺从，服从；承诺"
-        ],
-        "usphone": "[kəmˈplaɪəns]",
-        "ukphone": "[kəmˈplaɪəns]"
-    },
-    {
-        "name": "complication",
-        "trans": [
-            "n. 并发症；复杂；复杂化；混乱"
-        ],
-        "usphone": "[ˌkɑːmplɪˈkeɪʃn]",
-        "ukphone": "[ˌkɒmplɪˈkeɪʃn]"
-    },
-    {
-        "name": "comply",
-        "trans": [
-            "vi. 遵守；顺从，遵从；答应"
-        ],
-        "usphone": "[kəmˈplaɪ]",
-        "ukphone": "[kəmˈplaɪ]"
-    },
-    {
-        "name": "composition",
-        "trans": [
-            "n. 作文，作曲，作品；[材] 构成；合成物；成分"
-        ],
-        "usphone": "[ˌkɑːmpəˈzɪʃn]",
-        "ukphone": "[ˌkɒmpəˈzɪʃ(ə)n]"
-    },
-    {
-        "name": "compromise",
-        "trans": [
-            "n. 妥协，和解；折衷"
-        ],
-        "usphone": "[ˈkɑːmprəmaɪz]",
-        "ukphone": "[ˈkɒmprəmaɪz]"
-    },
-    {
-        "name": "compute",
-        "trans": [
-            "n. 计算；估计；推断"
-        ],
-        "usphone": "[kəmˈpjuːt]",
-        "ukphone": "[kəmˈpjuːt]"
-    },
-    {
-        "name": "conceal",
-        "trans": [
-            "vt. 隐藏；隐瞒"
-        ],
-        "usphone": "[kənˈsiːl]",
-        "ukphone": "[kənˈsiːl]"
-    },
-    {
-        "name": "concede",
-        "trans": [
-            "vi. 让步"
-        ],
-        "usphone": "[kənˈsiːd]",
-        "ukphone": "[kənˈsiːd]"
-    },
-    {
-        "name": "conceive",
-        "trans": [
-            "vi. 怀孕；设想；考虑"
-        ],
-        "usphone": "[kənˈsiːv]",
-        "ukphone": "[kənˈsiːv]"
-    },
-    {
-        "name": "conception",
-        "trans": [
-            "n. 怀孕；概念；设想；开始"
-        ],
-        "usphone": "[kənˈsepʃn]",
-        "ukphone": "[kənˈsepʃn]"
-    },
-    {
-        "name": "concession",
-        "trans": [
-            "n. 让步；特许（权）；承认；退位"
-        ],
-        "usphone": "[kənˈseʃn]",
-        "ukphone": "[kənˈseʃn]"
-    },
-    {
-        "name": "condemn",
-        "trans": [
-            "vt. 谴责；判刑，定罪；声讨"
-        ],
-        "usphone": "[kənˈdem]",
-        "ukphone": "[kənˈdem]"
-    },
-    {
-        "name": "confer",
-        "trans": [
-            "vt. 授予；给予"
-        ],
-        "usphone": "[kənˈfɜːr]",
-        "ukphone": "[kənˈfɜː(r)]"
-    },
-    {
-        "name": "confession",
-        "trans": [
-            "n. 忏悔，告解；供认；表白"
-        ],
-        "usphone": "[kənˈfeʃn]",
-        "ukphone": "[kənˈfeʃn]"
-    },
-    {
-        "name": "configuration",
-        "trans": [
-            "n. 配置；结构；外形"
-        ],
-        "usphone": "[kənˌfɪɡjəˈreɪʃn]",
-        "ukphone": "[kənˌfɪɡəˈreɪʃn]"
-    },
-    {
-        "name": "confine",
-        "trans": [
-            "n. 界限，边界;约束；限制"
-        ],
-        "usphone": "[kənˈfaɪn]",
-        "ukphone": "[kənˈfaɪn]"
-    },
-    {
-        "name": "confirmation",
-        "trans": [
-            "n. 确认；证实；证明；批准"
-        ],
-        "usphone": "[ˌkɑːnfərˈmeɪʃn]",
-        "ukphone": "[ˌkɒnfəˈmeɪʃ(ə)n]"
-    },
-    {
-        "name": "confront",
-        "trans": [
-            "vt. 面对；遭遇；比较"
-        ],
-        "usphone": "[kənˈfrʌnt]",
-        "ukphone": "[kənˈfrʌnt]"
-    },
-    {
-        "name": "confrontation",
-        "trans": [
-            "n. 对抗；面对；对质"
-        ],
-        "usphone": "[ˌkɑːnfrənˈteɪʃn]",
-        "ukphone": "[ˌkɒnfrʌnˈteɪʃn]"
-    },
-    {
-        "name": "congratulate",
-        "trans": [
-            "vt. 祝贺；恭喜；庆贺"
-        ],
-        "usphone": "[kənˈɡrætʃuleɪt]",
-        "ukphone": "[kənˈɡrætʃuleɪt]"
-    },
-    {
-        "name": "congregation",
-        "trans": [
-            "n. 集会；集合；圣会"
-        ],
-        "usphone": "[ˌkɑːŋɡrɪˈɡeɪʃn]",
-        "ukphone": "[ˌkɒŋɡrɪˈɡeɪʃ(ə)n]"
-    },
-    {
-        "name": "congressional",
-        "trans": [
-            "adj. 国会的；会议的；议会的"
-        ],
-        "usphone": "[kənˈɡreʃənl]",
-        "ukphone": "[kənˈɡreʃənl]"
-    },
-    {
-        "name": "conquer",
-        "trans": [
-            "vt. 战胜，征服；攻克，攻取"
-        ],
-        "usphone": "[ˈkɑːŋkər]",
-        "ukphone": "[ˈkɒŋkə(r)]"
-    },
-    {
-        "name": "conscience",
-        "trans": [
-            "n. 道德心，良心"
-        ],
-        "usphone": "[ˈkɑːnʃəns]",
-        "ukphone": "[ˈkɒnʃəns]"
-    },
-    {
-        "name": "consciousness",
-        "trans": [
-            "n. 意识；知觉；觉悟；感觉"
-        ],
-        "usphone": "[ˈkɑːnʃəsnəs]",
-        "ukphone": "[ˈkɒnʃəsnəs]"
-    },
-    {
-        "name": "consecutive",
-        "trans": [
-            "adj. 连贯的；连续不断的"
-        ],
-        "usphone": "[kənˈsekjətɪv]",
-        "ukphone": "[kənˈsekjətɪv]"
-    },
-    {
-        "name": "consensus",
-        "trans": [
-            "n. 一致；舆论；合意"
-        ],
-        "usphone": "[kənˈsensəs]",
-        "ukphone": "[kənˈsensəs]"
-    },
-    {
-        "name": "consent",
-        "trans": [
-            "n. 同意；（意见等的）一致；赞成"
-        ],
-        "usphone": "[kənˈsent]",
-        "ukphone": "[kənˈsent]"
-    },
-    {
-        "name": "conserve",
-        "trans": [
-            "n. 果酱；蜜饯"
-        ],
-        "usphone": "[kənˈsɜːrv]",
-        "ukphone": "[kənˈsɜːv]"
-    },
-    {
-        "name": "consistency",
-        "trans": [
-            "n. [计] 一致性；稠度；相容性"
-        ],
-        "usphone": "[kənˈsɪstənsi]",
-        "ukphone": "[kənˈsɪstənsi]"
-    },
-    {
-        "name": "consolidate",
-        "trans": [
-            "vt. 巩固，使固定；联合"
-        ],
-        "usphone": "[kənˈsɑːlɪdeɪt]",
-        "ukphone": "[kənˈsɒlɪdeɪt]"
-    },
-    {
-        "name": "constituency",
-        "trans": [
-            "n. （选区的）选民；支持者；（一批）顾客"
-        ],
-        "usphone": "[kənˈstɪtʃuənsi]",
-        "ukphone": "[kənˈstɪtʃuənsi]"
-    },
-    {
-        "name": "constitute",
-        "trans": [
-            "vt. 组成，构成；建立；任命"
-        ],
-        "usphone": "[ˈkɑːnstɪtuːt]",
-        "ukphone": "[ˈkɒnstɪtjuːt]"
-    },
-    {
-        "name": "constitution",
-        "trans": [
-            "n. 宪法；体制；章程；构造；建立，组成；体格"
-        ],
-        "usphone": "[ˌkɑːnstɪˈtuːʃn]",
-        "ukphone": "[ˌkɒnstɪˈtjuːʃ(ə)n]"
-    },
-    {
-        "name": "constitutional",
-        "trans": [
-            "n. 保健散步；保健运动"
-        ],
-        "usphone": "[ˌkɑːnstɪˈtuːʃənl]",
-        "ukphone": "[ˌkɒnstɪˈtjuːʃənl]"
-    },
-    {
-        "name": "constraint",
-        "trans": [
-            "n. [数] 约束；局促，态度不自然；强制"
-        ],
-        "usphone": "[kənˈstreɪnt]",
-        "ukphone": "[kənˈstreɪnt]"
-    },
-    {
-        "name": "consultation",
-        "trans": [
-            "n. 咨询；磋商；[临床] 会诊；讨论会"
-        ],
-        "usphone": "[ˌkɑːnslˈteɪʃn]",
-        "ukphone": "[ˌkɒns(ə)lˈteɪʃ(ə)n]"
-    },
-    {
-        "name": "contemplate",
-        "trans": [
-            "vt. 沉思；注视；思忖；预期"
-        ],
-        "usphone": "[ˈkɑːntəmpleɪt]",
-        "ukphone": "[ˈkɒntəmpleɪt]"
-    },
-    {
-        "name": "contempt",
-        "trans": [
-            "n. 轻视，蔑视；耻辱"
-        ],
-        "usphone": "[kənˈtempt]",
-        "ukphone": "[kənˈtempt]"
-    },
-    {
-        "name": "contend",
-        "trans": [
-            "vi. 竞争；奋斗；斗争；争论"
-        ],
-        "usphone": "[kənˈtend]",
-        "ukphone": "[kənˈtend]"
-    },
-    {
-        "name": "contender",
-        "trans": [
-            "n. 竞争者；争夺者"
-        ],
-        "usphone": "[kənˈtendər]",
-        "ukphone": "[kənˈtendə(r)]"
-    },
-    {
-        "name": "content",
-        "trans": [
-            "n. 内容，目录；满足；容量"
-        ],
-        "usphone": "[ˈkɑːntent; kənˈtent]",
-        "ukphone": "[ˈkɒntent]"
-    },
-    {
-        "name": "contention",
-        "trans": [
-            "n. 争论，争辩；争夺；论点"
-        ],
-        "usphone": "[kənˈtenʃn]",
-        "ukphone": "[kənˈtenʃn]"
-    },
-    {
-        "name": "continually",
-        "trans": [
-            "adv. 不断地；频繁地"
-        ],
-        "usphone": "[kənˈtɪnjuəli]",
-        "ukphone": "[kənˈtɪnjuəli]"
-    },
-    {
-        "name": "contractor",
-        "trans": [
-            "n. 承包人；立契约者"
-        ],
-        "usphone": "[ˈkɑːntræktər]",
-        "ukphone": "[kənˈtræktə(r); ˈkɒntræktə(r)]"
-    },
-    {
-        "name": "contradiction",
-        "trans": [
-            "n. 矛盾；否认；反驳"
-        ],
-        "usphone": "[ˌkɑːntrəˈdɪkʃn]",
-        "ukphone": "[ˌkɒntrəˈdɪkʃn]"
-    },
-    {
-        "name": "contrary",
-        "trans": [
-            "n. 相反；反面"
-        ],
-        "usphone": "[ˈkɑːntreri]",
-        "ukphone": "[ˈkɒntrəri]"
-    },
-    {
-        "name": "contributor",
-        "trans": [
-            "n. 贡献者；投稿者；捐助者"
-        ],
-        "usphone": "[kənˈtrɪbjətər]",
-        "ukphone": "[kənˈtrɪbjətə(r)]"
-    },
-    {
-        "name": "conversion",
-        "trans": [
-            "n. 转换；变换；[金融] 兑换；改变信仰"
-        ],
-        "usphone": "[kənˈvɜːrʒn]",
-        "ukphone": "[kənˈvɜːʃn]"
-    },
-    {
-        "name": "convict",
-        "trans": [
-            "n. 罪犯"
-        ],
-        "usphone": "[kənˈvɪkt; ˈkɑnvɪkt]",
-        "ukphone": "[kənˈvɪkt]"
-    },
-    {
-        "name": "conviction",
-        "trans": [
-            "n. 定罪；确信；证明有罪；确信，坚定的信仰"
-        ],
-        "usphone": "[kənˈvɪkʃn]",
-        "ukphone": "[kənˈvɪkʃn]"
-    },
-    {
-        "name": "cooperate",
-        "trans": [
-            "vi. 合作，配合；协力"
-        ],
-        "usphone": "[koʊˈɑːpəreɪt]",
-        "ukphone": "[kəʊˈɒpəreɪt]"
-    },
-    {
-        "name": "cooperative",
-        "trans": [
-            "n. 合作社"
-        ],
-        "usphone": "[koʊˈɑːpərətɪv]",
-        "ukphone": "[kəʊˈɒpərətɪv]"
-    },
-    {
-        "name": "coordinate",
-        "trans": [
-            "n. 坐标；同等的人或物"
-        ],
-        "usphone": "[koʊˈɔːrdɪneɪt]",
-        "ukphone": "[kəʊˈɔːdɪneɪt]"
-    },
-    {
-        "name": "coordination",
-        "trans": [
-            "n. 协调，调和；对等，同等"
-        ],
-        "usphone": "[koʊˌɔːrdɪˈneɪʃn]",
-        "ukphone": "[kəʊˌɔːdɪˈneɪʃn]"
-    },
-    {
-        "name": "coordinator",
-        "trans": [
-            "n. 协调者；[自] 协调器；同等的人或物"
-        ],
-        "usphone": "[koʊˈɔːrdɪneɪtər]",
-        "ukphone": "[kəʊˈɔːdɪneɪtə(r)]"
-    },
-    {
-        "name": "cop",
-        "trans": [
-            "n. 巡警，警官"
-        ],
-        "usphone": "[kɑːp]",
-        "ukphone": "[kɒp]"
-    },
-    {
-        "name": "copper",
-        "trans": [
-            "n. 铜；铜币；警察"
-        ],
-        "usphone": "[ˈkɑːpər]",
-        "ukphone": "[ˈkɒpə(r)]"
-    },
-    {
-        "name": "copyright",
-        "trans": [
-            "n. 版权，著作权"
-        ],
-        "usphone": "[ˈkɑːpiraɪt]",
-        "ukphone": "[ˈkɒpiraɪt]"
-    },
-    {
-        "name": "correction",
-        "trans": [
-            "n. 改正，修正"
-        ],
-        "usphone": "[kəˈrekʃn]",
-        "ukphone": "[kəˈrekʃn]"
-    },
-    {
-        "name": "correlate",
-        "trans": [
-            "n. 相关物；相关联的人"
-        ],
-        "usphone": "[ˈkɔːrəleɪt]",
-        "ukphone": "[ˈkɒrələt]"
-    },
-    {
-        "name": "correlation",
-        "trans": [
-            "n. [数] 相关，关联；相互关系"
-        ],
-        "usphone": "[ˌkɔːrəˈleɪʃ(ə)n]",
-        "ukphone": "[ˌkɒrəˈleɪʃ(ə)n]"
-    },
-    {
-        "name": "correspond",
-        "trans": [
-            "vi. 符合，一致；相应；通信"
-        ],
-        "usphone": "[ˌkɔːrəˈspɑːnd]",
-        "ukphone": "[ˌkɒrəˈspɒnd]"
-    },
-    {
-        "name": "correspondence",
-        "trans": [
-            "n. 通信；一致；相当"
-        ],
-        "usphone": "[ˌkɔːrəˈspɑːndəns]",
-        "ukphone": "[ˌkɒrəˈspɒndəns]"
-    },
-    {
-        "name": "correspondent",
-        "trans": [
-            "n. 通讯记者；客户；通信者；代理商行"
-        ],
-        "usphone": "[ˌkɔːrəˈspɑːndənt]",
-        "ukphone": "[ˌkɒrəˈspɒndənt]"
-    },
-    {
-        "name": "corresponding",
-        "trans": [
-            "adj. 相当的，相应的；一致的；通信的"
-        ],
-        "usphone": "[ˌkɔːrəˈspɑːndɪŋ]",
-        "ukphone": "[ˌkɒrəˈspɒndɪŋ]"
-    },
-    {
-        "name": "corrupt",
-        "trans": [
-            "adj. 腐败的，贪污的；堕落的"
-        ],
-        "usphone": "[kəˈrʌpt]",
-        "ukphone": "[kəˈrʌpt]"
-    },
-    {
-        "name": "corruption",
-        "trans": [
-            "n. 贪污，腐败；堕落"
-        ],
-        "usphone": "[kəˈrʌpʃn]",
-        "ukphone": "[kəˈrʌpʃ(ə)n]"
-    },
-    {
-        "name": "costly",
-        "trans": [
-            "adj. 昂贵的；代价高的"
-        ],
-        "usphone": "[ˈkɔːstli]",
-        "ukphone": "[ˈkɒstli]"
-    },
-    {
-        "name": "councillor",
-        "trans": [
-            "n. 议员；顾问；参赞（等于councilor）"
-        ],
-        "usphone": "[ˈkaʊnsələr]",
-        "ukphone": "[ˈkaʊnsələ(r)]"
-    },
-    {
-        "name": "counselling",
-        "trans": [
-            "n. 辅导；建议"
-        ],
-        "usphone": "[ˈkaʊnsəlɪŋ]",
-        "ukphone": "[ˈkaʊnsəlɪŋ]"
-    },
-    {
-        "name": "counsellor",
-        "trans": [
-            "n. 顾问；参赞；辅导员（等于counselor）；律师；法律顾问"
-        ],
-        "usphone": "[ˈkaʊnsələr]",
-        "ukphone": "[ˈkaʊnsələ(r)]"
-    },
-    {
-        "name": "counter",
-        "trans": [
-            "n. 柜台；对立面；计数器；（某些棋盘游戏的）筹码"
-        ],
-        "usphone": "[ˈkaʊntər]",
-        "ukphone": "[ˈkaʊntə(r)]"
-    },
-    {
-        "name": "counterpart",
-        "trans": [
-            "n. 副本；配对物；极相似的人或物"
-        ],
-        "usphone": "[ˈkaʊntərpɑːrt]",
-        "ukphone": "[ˈkaʊntəpɑːt]"
-    },
-    {
-        "name": "countless",
-        "trans": [
-            "adj. 无数的；数不尽的"
-        ],
-        "usphone": "[ˈkaʊntləs]",
-        "ukphone": "[ˈkaʊntləs]"
-    },
-    {
-        "name": "coup",
-        "trans": [
-            "n. 政变；妙计；出乎意料的行动；砰然的一击"
-        ],
-        "usphone": "[kuː]",
-        "ukphone": "[kuː]"
-    },
-    {
-        "name": "courtesy",
-        "trans": [
-            "n. 礼貌；好意；恩惠"
-        ],
-        "usphone": "[ˈkɜːrtəsi]",
-        "ukphone": "[ˈkɜːtəsi]"
-    },
-    {
-        "name": "craft",
-        "trans": [
-            "n. 工艺；手艺；太空船"
-        ],
-        "usphone": "[kræft]",
-        "ukphone": "[krɑːft]"
-    },
-    {
-        "name": "crawl",
-        "trans": [
-            "n. 爬行；养鱼池；匍匐而行"
-        ],
-        "usphone": "[krɔːl]",
-        "ukphone": "[krɔːl]"
-    },
-    {
-        "name": "creator",
-        "trans": [
-            "n. 创造者；创建者"
-        ],
-        "usphone": "[kriˈeɪtər]",
-        "ukphone": "[kriˈeɪtə(r)]"
-    },
-    {
-        "name": "credibility",
-        "trans": [
-            "n. 可信性；确实性"
-        ],
-        "usphone": "[ˌkredəˈbɪləti]",
-        "ukphone": "[ˌkredəˈbɪləti]"
-    },
-    {
-        "name": "credible",
-        "trans": [
-            "adj. 可靠的，可信的"
-        ],
-        "usphone": "[ˈkredəbl]",
-        "ukphone": "[ˈkredəb(ə)l]"
-    },
-    {
-        "name": "creep",
-        "trans": [
-            "n. 爬行；毛骨悚然的感觉；谄媚者"
-        ],
-        "usphone": "[kriːp]",
-        "ukphone": "[kriːp]"
-    },
-    {
-        "name": "critique",
-        "trans": [
-            "n. 批评；评论文章"
-        ],
-        "usphone": "[krɪˈtiːk]",
-        "ukphone": "[krɪˈtiːk]"
-    },
-    {
-        "name": "crown",
-        "trans": [
-            "n. 王冠；花冠；王权；顶点"
-        ],
-        "usphone": "[kraʊn]",
-        "ukphone": "[kraʊn]"
-    },
-    {
-        "name": "crude",
-        "trans": [
-            "n. 原油；天然的物质"
-        ],
-        "usphone": "[kruːd]",
-        "ukphone": "[kruːd]"
-    },
-    {
-        "name": "crush",
-        "trans": [
-            "n. 粉碎；迷恋；压榨；拥挤的人群"
-        ],
-        "usphone": "[krʌʃ]",
-        "ukphone": "[krʌʃ]"
-    },
-    {
-        "name": "crystal",
-        "trans": [
-            "n. 结晶，晶体；水晶；水晶饰品"
-        ],
-        "usphone": "[ˈkrɪstl]",
-        "ukphone": "[ˈkrɪst(ə)l]"
-    },
-    {
-        "name": "cult",
-        "trans": [
-            "n. 祭仪（尤其指宗教上的）；礼拜；狂热信徒"
-        ],
-        "usphone": "[kʌlt]",
-        "ukphone": "[kʌlt]"
-    },
-    {
-        "name": "cultivate",
-        "trans": [
-            "vt. 培养；陶冶；耕作"
-        ],
-        "usphone": "[ˈkʌltɪveɪt]",
-        "ukphone": "[ˈkʌltɪveɪt]"
-    },
-    {
-        "name": "curiosity",
-        "trans": [
-            "n. 好奇，好奇心；珍品，古董，古玩"
-        ],
-        "usphone": "[ˌkjʊriˈɑːsəti]",
-        "ukphone": "[ˌkjʊəriˈɒsəti]"
-    },
-    {
-        "name": "custody",
-        "trans": [
-            "n. 保管；监护；拘留；抚养权"
-        ],
-        "usphone": "[ˈkʌstədi]",
-        "ukphone": "[ˈkʌstədi]"
-    },
-    {
-        "name": "cutting",
-        "trans": [
-            "n. [机] 切断；剪辑；开凿"
-        ],
-        "usphone": "[ˈkʌtɪŋ]",
-        "ukphone": "[ˈkʌtɪŋ]"
-    },
-    {
-        "name": "cynical",
-        "trans": [
-            "adj. 愤世嫉俗的；冷嘲的"
-        ],
-        "usphone": "[ˈsɪnɪkl]",
-        "ukphone": "[ˈsɪnɪk(ə)l]"
-    },
-    {
-        "name": "dam",
-        "trans": [
-            "n. [水利] 水坝；障碍"
-        ],
-        "usphone": "[dæm]",
-        "ukphone": "[dæm]"
-    },
-    {
-        "name": "damaging",
-        "trans": [
-            "v. 破坏（damage的现在分词形式）；损害"
-        ],
-        "usphone": "[ˈdæmɪdʒɪŋ]",
-        "ukphone": "[ˈdæmɪdʒɪŋ]"
-    },
-    {
-        "name": "dawn",
-        "trans": [
-            "n. 黎明；开端"
-        ],
-        "usphone": "[dɔːn]",
-        "ukphone": "[dɔːn]"
-    },
-    {
-        "name": "debris",
-        "trans": [
-            "n. 碎片，残骸"
-        ],
-        "usphone": "[dəˈbriː]",
-        "ukphone": "[ˈdebriː]"
-    },
-    {
-        "name": "debut",
-        "trans": [
-            "n. 初次登台；开张"
-        ],
-        "usphone": "[deɪˈbjuː]",
-        "ukphone": "[ˈdeɪbjuː]"
-    },
-    {
-        "name": "decision-making",
-        "trans": [
-            "n. 决策"
-        ],
-        "usphone": "[dɪˈsɪʒn meɪkɪŋ]",
-        "ukphone": "[dɪˈsɪʒn meɪkɪŋ]"
-    },
-    {
-        "name": "decisive",
-        "trans": [
-            "adj. 决定性的；果断的，坚定的"
-        ],
-        "usphone": "[dɪˈsaɪsɪv]",
-        "ukphone": "[dɪˈsaɪsɪv]"
-    },
-    {
-        "name": "declaration",
-        "trans": [
-            "n. （纳税品等的）申报；宣布；公告；申诉书"
-        ],
-        "usphone": "[ˌdekləˈreɪʃn]",
-        "ukphone": "[ˌdekləˈreɪʃn]"
-    },
-    {
-        "name": "dedicated",
-        "trans": [
-            "adj. 专用的；专注的；献身的"
-        ],
-        "usphone": "[ˈdedɪkeɪtɪd]",
-        "ukphone": "[ˈdedɪkeɪtɪd]"
-    },
-    {
-        "name": "dedication",
-        "trans": [
-            "n. 奉献；献身；赠言"
-        ],
-        "usphone": "[ˌdedɪˈkeɪʃn]",
-        "ukphone": "[ˌdedɪˈkeɪʃ(ə)n]"
-    },
-    {
-        "name": "deed",
-        "trans": [
-            "n. 行动；功绩；证书；[法] 契据"
-        ],
-        "usphone": "[diːd]",
-        "ukphone": "[diːd]"
-    },
-    {
-        "name": "deem",
-        "trans": [
-            "vt. 认为，视作；相信"
-        ],
-        "usphone": "[diːm]",
-        "ukphone": "[diːm]"
-    },
-    {
-        "name": "default",
-        "trans": [
-            "n. 违约；缺席；缺乏；系统默认值"
-        ],
-        "usphone": "[dɪˈfɔːltˌˈdiːfɔːlt]",
-        "ukphone": "[dɪˈfɔːlt]"
-    },
-    {
-        "name": "defect",
-        "trans": [
-            "n. 缺点，缺陷；不足之处"
-        ],
-        "usphone": "[ˈdiːfekt; dɪˈfekt]",
-        "ukphone": "[ˈdiːfekt]"
-    },
-    {
-        "name": "defensive",
-        "trans": [
-            "n. 防御；守势"
-        ],
-        "usphone": "[dɪˈfensɪv]",
-        "ukphone": "[dɪˈfensɪv]"
-    },
-    {
-        "name": "deficiency",
-        "trans": [
-            "n. 缺陷，缺点；缺乏；不足的数额"
-        ],
-        "usphone": "[dɪˈfɪʃnsi]",
-        "ukphone": "[dɪˈfɪʃ(ə)nsi]"
-    },
-    {
-        "name": "deficit",
-        "trans": [
-            "n. 赤字；不足额"
-        ],
-        "usphone": "[ˈdefɪsɪt]",
-        "ukphone": "[ˈdefɪsɪt]"
-    },
-    {
-        "name": "defy",
-        "trans": [
-            "n. 挑战；对抗"
-        ],
-        "usphone": "[dɪˈfaɪ]",
-        "ukphone": "[dɪˈfaɪ]"
-    },
-    {
-        "name": "delegate",
-        "trans": [
-            "n. 代表"
-        ],
-        "usphone": "[ˈdelɪɡət, ˈdelɪɡeɪt]",
-        "ukphone": "[ˈdelɪɡət]"
-    },
-    {
-        "name": "delegation",
-        "trans": [
-            "n. 代表团；授权；委托"
-        ],
-        "usphone": "[ˌdelɪˈɡeɪʃn]",
-        "ukphone": "[ˌdelɪˈɡeɪʃn]"
-    },
-    {
-        "name": "delicate",
-        "trans": [
-            "adj. 微妙的；精美的，雅致的；柔和的；易碎的；纤弱的；清淡可口的"
-        ],
-        "usphone": "[ˈdelɪkət]",
-        "ukphone": "[ˈdelɪkət]"
-    },
-    {
-        "name": "demon",
-        "trans": [
-            "n. 恶魔；魔鬼；精力充沛的人；邪恶的事物"
-        ],
-        "usphone": "[ˈdiːmən]",
-        "ukphone": "[ˈdiːmən]"
-    },
-    {
-        "name": "denial",
-        "trans": [
-            "n. 否认；拒绝；节制；背弃"
-        ],
-        "usphone": "[dɪˈnaɪəl]",
-        "ukphone": "[dɪˈnaɪəl]"
-    },
-    {
-        "name": "denounce",
-        "trans": [
-            "vt. 谴责；告发；公然抨击；通告废除"
-        ],
-        "usphone": "[dɪˈnaʊns]",
-        "ukphone": "[dɪˈnaʊns]"
-    },
-    {
-        "name": "dense",
-        "trans": [
-            "adj. 稠密的；浓厚的；愚钝的"
-        ],
-        "usphone": "[dens]",
-        "ukphone": "[dens]"
-    },
-    {
-        "name": "density",
-        "trans": [
-            "n. 密度"
-        ],
-        "usphone": "[ˈdensəti]",
-        "ukphone": "[ˈdensəti]"
-    },
-    {
-        "name": "dependence",
-        "trans": [
-            "n. 依赖；依靠；信任；信赖"
-        ],
-        "usphone": "[dɪˈpendəns]",
-        "ukphone": "[dɪˈpendəns]"
-    },
-    {
-        "name": "depict",
-        "trans": [
-            "vt. 描述；描画"
-        ],
-        "usphone": "[dɪˈpɪkt]",
-        "ukphone": "[dɪˈpɪkt]"
-    },
-    {
-        "name": "deploy",
-        "trans": [
-            "n. 部署"
-        ],
-        "usphone": "[dɪˈplɔɪ]",
-        "ukphone": "[dɪˈplɔɪ]"
-    },
-    {
-        "name": "deployment",
-        "trans": [
-            "n. 调度，部署"
-        ],
-        "usphone": "[dɪˈplɔɪmənt]",
-        "ukphone": "[dɪˈplɔɪmənt]"
-    },
-    {
-        "name": "deposit",
-        "trans": [
-            "n. 存款；押金；订金；保证金；沉淀物"
-        ],
-        "usphone": "[dɪˈpɑːzɪt]",
-        "ukphone": "[dɪˈpɒzɪt]"
-    },
-    {
-        "name": "deprive",
-        "trans": [
-            "vt. 使丧失，剥夺"
-        ],
-        "usphone": "[dɪˈpraɪv]",
-        "ukphone": "[dɪˈpraɪv]"
-    },
-    {
-        "name": "deputy",
-        "trans": [
-            "n. 代理人，代表"
-        ],
-        "usphone": "[ˈdepjuti]",
-        "ukphone": "[ˈdepjuti]"
-    },
-    {
-        "name": "descend",
-        "trans": [
-            "vi. 下降；下去；下来；遗传；屈尊"
-        ],
-        "usphone": "[dɪˈsend]",
-        "ukphone": "[dɪˈsend]"
-    },
-    {
-        "name": "descent",
-        "trans": [
-            "n. 下降；血统；袭击"
-        ],
-        "usphone": "[dɪˈsent]",
-        "ukphone": "[dɪˈsent]"
-    },
-    {
-        "name": "designate",
-        "trans": [
-            "vt. 指定；指派；标出；把…定名为"
-        ],
-        "usphone": "[ˈdezɪɡneɪt]",
-        "ukphone": "[ˈdezɪɡneɪt]"
-    },
-    {
-        "name": "desirable",
-        "trans": [
-            "n. 合意的人或事物"
-        ],
-        "usphone": "[dɪˈzaɪərəbl]",
-        "ukphone": "[dɪˈzaɪərəb(ə)l]"
-    },
-    {
-        "name": "desktop",
-        "trans": [
-            "n. 桌面；台式机"
-        ],
-        "usphone": "[ˈdesktɑːp]",
-        "ukphone": "[ˈdesktɒp]"
-    },
-    {
-        "name": "destructive",
-        "trans": [
-            "adj. 破坏的；毁灭性的；有害的，消极的"
-        ],
-        "usphone": "[dɪˈstrʌktɪv]",
-        "ukphone": "[dɪˈstrʌktɪv]"
-    },
-    {
-        "name": "detain",
-        "trans": [
-            "vt. 拘留；留住；耽搁"
-        ],
-        "usphone": "[dɪˈteɪn]",
-        "ukphone": "[dɪˈteɪn]"
-    },
-    {
-        "name": "detection",
-        "trans": [
-            "n. 侦查，探测；发觉，发现；察觉"
-        ],
-        "usphone": "[dɪˈtekʃn]",
-        "ukphone": "[dɪˈtekʃ(ə)n]"
-    },
-    {
-        "name": "detention",
-        "trans": [
-            "n. 拘留；延迟；挽留"
-        ],
-        "usphone": "[dɪˈtenʃn]",
-        "ukphone": "[dɪˈtenʃn]"
-    },
-    {
-        "name": "deteriorate",
-        "trans": [
-            "vi. 恶化，变坏"
-        ],
-        "usphone": "[dɪˈtɪriəreɪt]",
-        "ukphone": "[dɪˈtɪəriəreɪt]"
-    },
-    {
-        "name": "devastate",
-        "trans": [
-            "vt. 毁灭；毁坏"
-        ],
-        "usphone": "[ˈdevəsteɪt]",
-        "ukphone": "[ˈdevəsteɪt]"
-    },
-    {
-        "name": "devil",
-        "trans": [
-            "n. 魔鬼；撒旦；家伙；恶棍；淘气鬼；冒失鬼"
-        ],
-        "usphone": "[ˈdevl]",
-        "ukphone": "[ˈdev(ə)l]"
-    },
-    {
-        "name": "devise",
-        "trans": [
-            "n. 遗赠"
-        ],
-        "usphone": "[dɪˈvaɪz]",
-        "ukphone": "[dɪˈvaɪz]"
-    },
-    {
-        "name": "diagnose",
-        "trans": [
-            "vt. 诊断；断定"
-        ],
-        "usphone": "[ˌdaɪəɡˈnoʊs]",
-        "ukphone": "[ˈdaɪəɡnəʊz; ˌdaɪəɡˈnəʊz]"
-    },
-    {
-        "name": "diagnosis",
-        "trans": [
-            "n. 诊断"
-        ],
-        "usphone": "[ˌdaɪəɡˈnoʊsɪs]",
-        "ukphone": "[ˌdaɪəɡˈnəʊsɪs]"
-    },
-    {
-        "name": "dictate",
-        "trans": [
-            "n. 命令；指示"
-        ],
-        "usphone": "[ˈdɪkteɪt]",
-        "ukphone": "[dɪkˈteɪt]"
-    },
-    {
-        "name": "dictator",
-        "trans": [
-            "n. 独裁者；命令者"
-        ],
-        "usphone": "[ˈdɪkteɪtər]",
-        "ukphone": "[dɪkˈteɪtə(r)]"
-    },
-    {
-        "name": "differentiate",
-        "trans": [
-            "vt. 区分，区别"
-        ],
-        "usphone": "[ˌdɪfəˈrenʃieɪt]",
-        "ukphone": "[ˌdɪfəˈrenʃieɪt]"
-    },
-    {
-        "name": "dignity",
-        "trans": [
-            "n. 尊严；高贵"
-        ],
-        "usphone": "[ˈdɪɡnəti]",
-        "ukphone": "[ˈdɪɡnəti]"
-    },
-    {
-        "name": "dilemma",
-        "trans": [
-            "n. 困境；进退两难；两刀论法"
-        ],
-        "usphone": "[dɪˈlemə; daɪˈlemə]",
-        "ukphone": "[dɪˈlemə]"
-    },
-    {
-        "name": "dimension",
-        "trans": [
-            "n. 方面;[数] 维；尺寸；次元；容积 vt. 标出尺寸"
-        ],
-        "usphone": "[daɪˈmenʃn; dɪˈmenʃn]",
-        "ukphone": "[daɪˈmenʃn; dɪˈmenʃn]"
-    },
-    {
-        "name": "diminish",
-        "trans": [
-            "vt. 使减少；使变小"
-        ],
-        "usphone": "[dɪˈmɪnɪʃ]",
-        "ukphone": "[dɪˈmɪnɪʃ]"
-    },
-    {
-        "name": "dip",
-        "trans": [
-            "n. 下沉，下降；倾斜；浸渍，蘸湿"
-        ],
-        "usphone": "[dɪp]",
-        "ukphone": "[dɪp]"
-    },
-    {
-        "name": "diplomat",
-        "trans": [
-            "n. 外交家，外交官；有外交手腕的人；处事圆滑机敏的人"
-        ],
-        "usphone": "[ˈdɪpləmæt]",
-        "ukphone": "[ˈdɪpləmæt]"
-    },
-    {
-        "name": "diplomatic",
-        "trans": [
-            "adj. 外交的；外交上的；老练的"
-        ],
-        "usphone": "[ˌdɪpləˈmætɪk]",
-        "ukphone": "[ˌdɪpləˈmætɪk]"
-    },
-    {
-        "name": "directory",
-        "trans": [
-            "n. [计] 目录；工商名录；姓名地址录"
-        ],
-        "usphone": "[dəˈrektəri; daɪˈrektəri]",
-        "ukphone": "[dəˈrektəri; daɪˈrektəri]"
-    },
-    {
-        "name": "disastrous",
-        "trans": [
-            "adj. 灾难性的；损失惨重的；悲伤的"
-        ],
-        "usphone": "[dɪˈzæstrəs]",
-        "ukphone": "[dɪˈzɑːstrəs]"
-    },
-    {
-        "name": "discard",
-        "trans": [
-            "n. 抛弃；被丢弃的东西或人"
-        ],
-        "usphone": "[dɪˈskɑːrd]",
-        "ukphone": "[dɪˈskɑːd]"
-    },
-    {
-        "name": "discharge",
-        "trans": [
-            "n. 排放；卸货；解雇"
-        ],
-        "usphone": "[dɪsˈtʃɑːrdʒ]",
-        "ukphone": "[dɪsˈtʃɑːdʒ]"
-    },
-    {
-        "name": "disclose",
-        "trans": [
-            "vt. 公开；揭露"
-        ],
-        "usphone": "[dɪsˈkloʊz]",
-        "ukphone": "[dɪsˈkləʊz]"
-    },
-    {
-        "name": "disclosure",
-        "trans": [
-            "n. [审计] 披露；揭发；被揭发出来的事情"
-        ],
-        "usphone": "[dɪsˈkloʊʒər]",
-        "ukphone": "[dɪsˈkləʊʒə(r)]"
-    },
-    {
-        "name": "discourse",
-        "trans": [
-            "n. 论述；谈话；演讲"
-        ],
-        "usphone": "[ˈdɪskɔːrs]",
-        "ukphone": "[ˈdɪskɔːs]"
-    },
-    {
-        "name": "discretion",
-        "trans": [
-            "n. 自由裁量权；谨慎；判断力；判定；考虑周到"
-        ],
-        "usphone": "[dɪˈskreʃn]",
-        "ukphone": "[dɪˈskreʃn]"
-    },
-    {
-        "name": "discrimination",
-        "trans": [
-            "n. 歧视；区别，辨别；识别力"
-        ],
-        "usphone": "[dɪˌskrɪmɪˈneɪʃn]",
-        "ukphone": "[dɪˌskrɪmɪˈneɪʃn]"
-    },
-    {
-        "name": "dismissal",
-        "trans": [
-            "n. 解雇；免职"
-        ],
-        "usphone": "[dɪsˈmɪsl]",
-        "ukphone": "[dɪsˈmɪs(ə)l]"
-    },
-    {
-        "name": "displace",
-        "trans": [
-            "vt. 取代；置换；转移；把…免职；排水"
-        ],
-        "usphone": "[dɪsˈpleɪs]",
-        "ukphone": "[dɪsˈpleɪs]"
-    },
-    {
-        "name": "disposal",
-        "trans": [
-            "n. 处理；支配；清理；安排"
-        ],
-        "usphone": "[dɪˈspoʊzl]",
-        "ukphone": "[dɪˈspəʊzl]"
-    },
-    {
-        "name": "dispose",
-        "trans": [
-            "n. 处置；性情"
-        ],
-        "usphone": "[dɪˈspoʊz]",
-        "ukphone": "[dɪˈspəʊz]"
-    },
-    {
-        "name": "dispute",
-        "trans": [
-            "n. 辩论；争吵"
-        ],
-        "usphone": "[dɪˈspjuːt; ˈdɪspjuːt]",
-        "ukphone": "[dɪˈspjuːt]"
-    },
-    {
-        "name": "disrupt",
-        "trans": [
-            "vt. 破坏；使瓦解；使分裂；使中断；使陷于混乱"
-        ],
-        "usphone": "[dɪsˈrʌpt]",
-        "ukphone": "[dɪsˈrʌpt]"
-    },
-    {
-        "name": "disruption",
-        "trans": [
-            "n. 破坏，毁坏；分裂，瓦解"
-        ],
-        "usphone": "[dɪsˈrʌpʃn]",
-        "ukphone": "[dɪsˈrʌpʃn]"
-    },
-    {
-        "name": "dissolve",
-        "trans": [
-            "n. 叠化画面；画面的溶暗"
-        ],
-        "usphone": "[dɪˈzɑːlv]",
-        "ukphone": "[dɪˈzɒlv]"
-    },
-    {
-        "name": "distinction",
-        "trans": [
-            "n. 区别；差别；特性；荣誉、勋章"
-        ],
-        "usphone": "[dɪˈstɪŋkʃn]",
-        "ukphone": "[dɪˈstɪŋkʃn]"
-    },
-    {
-        "name": "distinctive",
-        "trans": [
-            "adj. 有特色的，与众不同的"
-        ],
-        "usphone": "[dɪˈstɪŋktɪv]",
-        "ukphone": "[dɪˈstɪŋktɪv]"
-    },
-    {
-        "name": "distort",
-        "trans": [
-            "vt. 扭曲；使失真；曲解"
-        ],
-        "usphone": "[dɪˈstɔːrt]",
-        "ukphone": "[dɪˈstɔːt]"
-    },
-    {
-        "name": "distress",
-        "trans": [
-            "n. 危难，不幸；贫困；悲痛"
-        ],
-        "usphone": "[dɪˈstres]",
-        "ukphone": "[dɪˈstres]"
-    },
-    {
-        "name": "disturbing",
-        "trans": [
-            "v. 干扰；打断（disturb的ing形式）"
-        ],
-        "usphone": "[dɪˈstɜːrbɪŋ]",
-        "ukphone": "[dɪˈstɜːbɪŋ]"
-    },
-    {
-        "name": "divert",
-        "trans": [
-            "vt. 转移；使…欢娱；使…转向"
-        ],
-        "usphone": "[daɪˈvɜːrt]",
-        "ukphone": "[daɪˈvɜːt]"
-    },
-    {
-        "name": "divine",
-        "trans": [
-            "n. 牧师；神学家"
-        ],
-        "usphone": "[dɪˈvaɪn]",
-        "ukphone": "[dɪˈvaɪn]"
-    },
-    {
-        "name": "doctrine",
-        "trans": [
-            "n. 主义；学说；教义；信条"
-        ],
-        "usphone": "[ˈdɑːktrɪn]",
-        "ukphone": "[ˈdɒktrɪn]"
-    },
-    {
-        "name": "documentation",
-        "trans": [
-            "n. 文件, 证明文件, 史实, 文件编制"
-        ],
-        "usphone": "[ˌdɑːkjumenˈteɪʃn]",
-        "ukphone": "[ˌdɒkjumenˈteɪʃn]"
-    },
-    {
-        "name": "domain",
-        "trans": [
-            "n. 领域；域名；产业；地产"
-        ],
-        "usphone": "[doʊˈmeɪn]",
-        "ukphone": "[dəˈmeɪn; dəʊˈmeɪn]"
-    },
-    {
-        "name": "dominance",
-        "trans": [
-            "n. 优势；统治；支配"
-        ],
-        "usphone": "[ˈdɑːmɪnəns]",
-        "ukphone": "[ˈdɒmɪnəns]"
-    },
-    {
-        "name": "donor",
-        "trans": [
-            "n. 捐赠者；供者；赠送人"
-        ],
-        "usphone": "[ˈdoʊnər]",
-        "ukphone": "[ˈdəʊnə(r)]"
-    },
-    {
-        "name": "dose",
-        "trans": [
-            "n. 剂量；一剂，一服"
-        ],
-        "usphone": "[doʊs]",
-        "ukphone": "[dəʊs]"
-    },
-    {
-        "name": "drain",
-        "trans": [
-            "n. 排水；下水道，排水管；消耗"
-        ],
-        "usphone": "[dreɪn]",
-        "ukphone": "[dreɪn]"
-    },
-    {
-        "name": "drift",
-        "trans": [
-            "n. 漂流，漂移；趋势；漂流物"
-        ],
-        "usphone": "[drɪft]",
-        "ukphone": "[drɪft]"
-    },
-    {
-        "name": "driving",
-        "trans": [
-            "n. 驾驶；操纵"
-        ],
-        "usphone": "[ˈdraɪvɪŋ]",
-        "ukphone": "[ˈdraɪvɪŋ]"
-    },
-    {
-        "name": "drown",
-        "trans": [
-            "vt. 淹没；把…淹死"
-        ],
-        "usphone": "[draʊn]",
-        "ukphone": "[draʊn]"
-    },
-    {
-        "name": "dual",
-        "trans": [
-            "n. 双数；双数词"
-        ],
-        "usphone": "[ˈduːəl]",
-        "ukphone": "[ˈdjuːəl]"
-    },
-    {
-        "name": "dub",
-        "trans": [
-            "n. 笨蛋；鼓声"
-        ],
-        "usphone": "[dʌb]",
-        "ukphone": "[dʌb]"
-    },
-    {
-        "name": "dumb",
-        "trans": [
-            "adj. 哑的，无说话能力的；不说话的，无声音的"
-        ],
-        "usphone": "[dʌm]",
-        "ukphone": "[dʌm]"
-    },
-    {
-        "name": "duo",
-        "trans": [
-            "n. 二重奏；二重唱；二人组"
-        ],
-        "usphone": "[ˈduːoʊ]",
-        "ukphone": "[ˈdjuːəʊ]"
-    },
-    {
-        "name": "dynamic",
-        "trans": [
-            "n. 动态；动力"
-        ],
-        "usphone": "[daɪˈnæmɪk]",
-        "ukphone": "[daɪˈnæmɪk]"
-    },
-    {
-        "name": "eager",
-        "trans": [
-            "adj. 渴望的；热切的；热心的"
-        ],
-        "usphone": "[ˈiːɡər]",
-        "ukphone": "[ˈiːɡə(r)]"
-    },
-    {
-        "name": "earnings",
-        "trans": [
-            "n. 收入"
-        ],
-        "usphone": "[ˈɜːrnɪŋz]",
-        "ukphone": "[ˈɜːnɪŋz]"
-    },
-    {
-        "name": "ease",
-        "trans": [
-            "n. 轻松，舒适；安逸，悠闲"
-        ],
-        "usphone": "[iːz]",
-        "ukphone": "[iːz]"
-    },
-    {
-        "name": "echo",
-        "trans": [
-            "n. 回音；效仿"
-        ],
-        "usphone": "[ˈekoʊ]",
-        "ukphone": "[ˈekəʊ]"
-    },
-    {
-        "name": "ecological",
-        "trans": [
-            "adj. 生态的，生态学的"
-        ],
-        "usphone": "[ˌiːkəˈlɑːdʒɪkl]",
-        "ukphone": "[ˌiːkəˈlɒdʒɪkl]"
-    },
-    {
-        "name": "educator",
-        "trans": [
-            "n. 教育家；教育工作者；教师"
-        ],
-        "usphone": "[ˈedʒukeɪtər]",
-        "ukphone": "[ˈedʒukeɪtə(r)]"
-    },
-    {
-        "name": "effectiveness",
-        "trans": [
-            "n. 效力"
-        ],
-        "usphone": "[ɪˈfektɪvnəs]",
-        "ukphone": "[ɪˈfektɪvnəs]"
-    },
-    {
-        "name": "efficiency",
-        "trans": [
-            "n. 效率；效能；功效"
-        ],
-        "usphone": "[ɪˈfɪʃnsi]",
-        "ukphone": "[ɪˈfɪʃ(ə)nsi]"
-    },
-    {
-        "name": "ego",
-        "trans": [
-            "n. 自我；自负；自我意识"
-        ],
-        "usphone": "[ˈiːɡoʊ]",
-        "ukphone": "[ˈiːɡəʊ]"
-    },
-    {
-        "name": "elaborate",
-        "trans": [
-            "adj. 精心制作的；详尽的；煞费苦心的"
-        ],
-        "usphone": "[ɪˈlæbərət; ɪˈlæbəreɪt; ɪˈlæbərɪt]",
-        "ukphone": "[ɪˈlæbərət]"
-    },
-    {
-        "name": "electoral",
-        "trans": [
-            "adj. 选举的；选举人的"
-        ],
-        "usphone": "[ɪˈlektərəl]",
-        "ukphone": "[ɪˈlektərəl]"
-    },
-    {
-        "name": "elevate",
-        "trans": [
-            "vt. 提升；举起；振奋情绪等；提升…的职位"
-        ],
-        "usphone": "[ˈelɪveɪt]",
-        "ukphone": "[ˈelɪveɪt]"
-    },
-    {
-        "name": "eligible",
-        "trans": [
-            "n. 合格者；适任者；有资格者"
-        ],
-        "usphone": "[ˈelɪdʒəbl]",
-        "ukphone": "[ˈelɪdʒəb(ə)l]"
-    },
-    {
-        "name": "elite",
-        "trans": [
-            "n. 精英；精华；中坚分子"
-        ],
-        "usphone": "[eɪˈliːt; ɪˈliːt]",
-        "ukphone": "[eɪˈliːt]"
-    },
-    {
-        "name": "embark",
-        "trans": [
-            "vi. 从事，着手；上船或飞机"
-        ],
-        "usphone": "[ɪmˈbɑːrk]",
-        "ukphone": "[ɪmˈbɑːk]"
-    },
-    {
-        "name": "embarrassment",
-        "trans": [
-            "n. 窘迫，难堪；使人为难的人或事物；拮据"
-        ],
-        "usphone": "[ɪmˈbærəsmənt]",
-        "ukphone": "[ɪmˈbærəsmənt]"
-    },
-    {
-        "name": "embassy",
-        "trans": [
-            "n. 大使馆；大使馆全体人员"
-        ],
-        "usphone": "[ˈembəsi]",
-        "ukphone": "[ˈembəsi]"
-    },
-    {
-        "name": "embed",
-        "trans": [
-            "vt. 栽种；使嵌入，使插入；使深留脑中"
-        ],
-        "usphone": "[ɪmˈbed]",
-        "ukphone": "[ɪmˈbed]"
-    },
-    {
-        "name": "embody",
-        "trans": [
-            "vt. 体现，使具体化；具体表达"
-        ],
-        "usphone": "[ɪmˈbɑːdi]",
-        "ukphone": "[ɪmˈbɒdi]"
-    },
-    {
-        "name": "emergence",
-        "trans": [
-            "n. 出现，浮现；发生；露头"
-        ],
-        "usphone": "[ɪˈmɜːrdʒəns]",
-        "ukphone": "[ɪˈmɜːdʒəns]"
-    },
-    {
-        "name": "empirical",
-        "trans": [
-            "adj. 经验主义的，完全根据经验的；实证的"
-        ],
-        "usphone": "[ɪmˈpɪrɪkl]",
-        "ukphone": "[ɪmˈpɪrɪk(ə)l]"
-    },
-    {
-        "name": "empower",
-        "trans": [
-            "vt. 授权，允许；使能够"
-        ],
-        "usphone": "[ɪmˈpaʊər]",
-        "ukphone": "[ɪmˈpaʊə(r)]"
-    },
-    {
-        "name": "enact",
-        "trans": [
-            "vt. 颁布；制定法律；扮演；发生"
-        ],
-        "usphone": "[ɪˈnækt]",
-        "ukphone": "[ɪˈnækt]"
-    },
-    {
-        "name": "encompass",
-        "trans": [
-            "vt. 包含；包围，环绕；完成"
-        ],
-        "usphone": "[ɪnˈkʌmpəs]",
-        "ukphone": "[ɪnˈkʌmpəs]"
-    },
-    {
-        "name": "encouragement",
-        "trans": [
-            "n. 鼓励"
-        ],
-        "usphone": "[ɪnˈkɜːrɪdʒmənt]",
-        "ukphone": "[ɪnˈkʌrɪdʒmənt]"
-    },
-    {
-        "name": "encouraging",
-        "trans": [
-            "v. 鼓励，支持（encourage的ing形式）"
-        ],
-        "usphone": "[ɪnˈkɜːrɪdʒɪŋ]",
-        "ukphone": "[ɪnˈkʌrɪdʒɪŋ]"
-    },
-    {
-        "name": "endeavour",
-        "trans": [
-            "n. 尽力，竭力"
-        ],
-        "usphone": "[ɪnˈdevər]",
-        "ukphone": "[ɪnˈdevə(r)]"
-    },
-    {
-        "name": "endless",
-        "trans": [
-            "adj. 无止境的；连续的；环状的；漫无目的的"
-        ],
-        "usphone": "[ˈendləs]",
-        "ukphone": "[ˈendləs]"
-    },
-    {
-        "name": "endorse",
-        "trans": [
-            "vt. 背书；认可；签署；赞同；在背面签名"
-        ],
-        "usphone": "[ɪnˈdɔːrs]",
-        "ukphone": "[ɪnˈdɔːs]"
-    },
-    {
-        "name": "endorsement",
-        "trans": [
-            "n. 认可，支持；背书；签注（文件）"
-        ],
-        "usphone": "[ɪnˈdɔːrsmənt]",
-        "ukphone": "[ɪnˈdɔːsmənt]"
-    },
-    {
-        "name": "endure",
-        "trans": [
-            "vt. 忍耐；容忍"
-        ],
-        "usphone": "[ɪnˈdʊr]",
-        "ukphone": "[ɪnˈdjʊə(r)]"
-    },
-    {
-        "name": "enforce",
-        "trans": [
-            "vt. 实施，执行；强迫，强制"
-        ],
-        "usphone": "[ɪnˈfɔːrs]",
-        "ukphone": "[ɪnˈfɔːs]"
-    },
-    {
-        "name": "enforcement",
-        "trans": [
-            "n. 执行，实施；强制"
-        ],
-        "usphone": "[ɪnˈfɔːrsmənt]",
-        "ukphone": "[ɪnˈfɔːsmənt]"
-    },
-    {
-        "name": "engagement",
-        "trans": [
-            "n. 婚约；约会；交战；诺言"
-        ],
-        "usphone": "[ɪnˈɡeɪdʒmənt]",
-        "ukphone": "[ɪnˈɡeɪdʒmənt]"
-    },
-    {
-        "name": "engaging",
-        "trans": [
-            "v. 参加（engage的ing形式）；保证；雇用"
-        ],
-        "usphone": "[ɪnˈɡeɪdʒɪŋ]",
-        "ukphone": "[ɪnˈɡeɪdʒɪŋ]"
-    },
-    {
-        "name": "enquire",
-        "trans": [
-            "vi. 询问；调查；问候（等于inquire）"
-        ],
-        "usphone": "[ɪnˈkwaɪər]",
-        "ukphone": "[ɪnˈkwaɪə(r)]"
-    },
-    {
-        "name": "enrich",
-        "trans": [
-            "vt. 使充实；使肥沃；使富足"
-        ],
-        "usphone": "[ɪnˈrɪtʃ]",
-        "ukphone": "[ɪnˈrɪtʃ]"
-    },
-    {
-        "name": "enrol",
-        "trans": [
-            "vi. 注册；参军"
-        ],
-        "usphone": "[ɪnˈroʊl]",
-        "ukphone": "[ɪnˈrəʊl]"
-    },
-    {
-        "name": "ensue",
-        "trans": [
-            "vi. 跟着发生，接着发生；继起"
-        ],
-        "usphone": "[ɪnˈsuː]",
-        "ukphone": "[ɪnˈsjuː]"
-    },
-    {
-        "name": "enterprise",
-        "trans": [
-            "n. 企业；事业；进取心；事业心"
-        ],
-        "usphone": "[ˈentərpraɪz]",
-        "ukphone": "[ˈentəpraɪz]"
-    },
-    {
-        "name": "enthusiast",
-        "trans": [
-            "n. 狂热者，热心家"
-        ],
-        "usphone": "[ɪnˈθuːziæst]",
-        "ukphone": "[ɪnˈθjuːziæst]"
-    },
-    {
-        "name": "entitle",
-        "trans": [
-            "vt. 称做…；定名为…；给…称号；使…有权利"
-        ],
-        "usphone": "[ɪnˈtaɪtl]",
-        "ukphone": "[ɪnˈtaɪt(ə)l]"
-    },
-    {
-        "name": "entity",
-        "trans": [
-            "n. 实体；存在；本质"
-        ],
-        "usphone": "[ˈentəti]",
-        "ukphone": "[ˈentəti]"
-    },
-    {
-        "name": "epidemic",
-        "trans": [
-            "n. 传染病；流行病；风尚等的流行"
-        ],
-        "usphone": "[ˌepɪˈdemɪk]",
-        "ukphone": "[ˌepɪˈdemɪk]"
-    },
-    {
-        "name": "equality",
-        "trans": [
-            "n. 平等；相等；[数] 等式"
-        ],
-        "usphone": "[iˈkwɑːləti]",
-        "ukphone": "[iˈkwɒləti]"
-    },
-    {
-        "name": "equation",
-        "trans": [
-            "n. 方程式，等式；相等；[化学] 反应式"
-        ],
-        "usphone": "[ɪˈkweɪʒn]",
-        "ukphone": "[ɪˈkweɪʒ(ə)n]"
-    },
-    {
-        "name": "erect",
-        "trans": [
-            "vt. 使竖立；建造；安装"
-        ],
-        "usphone": "[ɪˈrekt]",
-        "ukphone": "[ɪˈrekt]"
-    },
-    {
-        "name": "escalate",
-        "trans": [
-            "vt. 使逐步上升"
-        ],
-        "usphone": "[ˈeskəleɪt]",
-        "ukphone": "[ˈeskəleɪt]"
-    },
-    {
-        "name": "essence",
-        "trans": [
-            "n. 本质，实质；精华；香精"
-        ],
-        "usphone": "[ˈesns]",
-        "ukphone": "[ˈes(ə)ns]"
-    },
-    {
-        "name": "establishment",
-        "trans": [
-            "n. 确立，制定；公司；设施"
-        ],
-        "usphone": "[ɪˈstæblɪʃmənt]",
-        "ukphone": "[ɪˈstæblɪʃmənt]"
-    },
-    {
-        "name": "eternal",
-        "trans": [
-            "adj. 永恒的；不朽的"
-        ],
-        "usphone": "[ɪˈtɜːrnl]",
-        "ukphone": "[ɪˈtɜːn(ə)l]"
-    },
-    {
-        "name": "evacuate",
-        "trans": [
-            "vt. 疏散，撤退；排泄"
-        ],
-        "usphone": "[ɪˈvækjueɪt]",
-        "ukphone": "[ɪˈvækjueɪt]"
-    },
-    {
-        "name": "evoke",
-        "trans": [
-            "vt. 引起，唤起；博得"
-        ],
-        "usphone": "[ɪˈvoʊk]",
-        "ukphone": "[ɪˈvəʊk]"
-    },
-    {
-        "name": "evolutionary",
-        "trans": [
-            "adj. 进化的；发展的；渐进的"
-        ],
-        "usphone": "[ˌevəˈluːʃəneri]",
-        "ukphone": "[ˌiːvəˈluːʃən(ə)ri]"
-    },
-    {
-        "name": "exaggerate",
-        "trans": [
-            "vt. 使扩大；使增大"
-        ],
-        "usphone": "[ɪɡˈzædʒəreɪt]",
-        "ukphone": "[ɪɡˈzædʒəreɪt]"
-    },
-    {
-        "name": "excellence",
-        "trans": [
-            "n. 优秀；美德；长处"
-        ],
-        "usphone": "[ˈeksələns]",
-        "ukphone": "[ˈeksələns]"
-    },
-    {
-        "name": "exceptional",
-        "trans": [
-            "n. 超常的学生"
-        ],
-        "usphone": "[ɪkˈsepʃənl]",
-        "ukphone": "[ɪkˈsepʃən(ə)l]"
-    },
-    {
-        "name": "excess",
-        "trans": [
-            "n. 超过，超额；过度，过量；无节制"
-        ],
-        "usphone": "[ɪkˈses]",
-        "ukphone": "[ɪkˈses]"
-    },
-    {
-        "name": "exclusion",
-        "trans": [
-            "n. 排除；排斥；驱逐；被排除在外的事物"
-        ],
-        "usphone": "[ɪkˈskluːʒn]",
-        "ukphone": "[ɪkˈskluːʒ(ə)n]"
-    },
-    {
-        "name": "exclusive",
-        "trans": [
-            "n. 独家新闻；独家经营的项目；排外者"
-        ],
-        "usphone": "[ɪkˈskluːsɪv]",
-        "ukphone": "[ɪkˈskluːsɪv]"
-    },
-    {
-        "name": "exclusively",
-        "trans": [
-            "adv. 唯一地；专有地；排外地"
-        ],
-        "usphone": "[ɪkˈskluːsɪvli]",
-        "ukphone": "[ɪkˈskluːsɪvli]"
-    },
-    {
-        "name": "execute",
-        "trans": [
-            "vt. 实行；执行；处死"
-        ],
-        "usphone": "[ˈeksɪkjuːt]",
-        "ukphone": "[ˈeksɪkjuːt]"
-    },
-    {
-        "name": "execution",
-        "trans": [
-            "n. 执行，实行；完成；死刑"
-        ],
-        "usphone": "[ˌeksɪˈkjuːʃn]",
-        "ukphone": "[ˌeksɪˈkjuːʃ(ə)n]"
-    },
-    {
-        "name": "exert",
-        "trans": [
-            "vt. 运用，发挥；施以影响"
-        ],
-        "usphone": "[ɪɡˈzɜːrt]",
-        "ukphone": "[ɪɡˈzɜːt]"
-    },
-    {
-        "name": "exile",
-        "trans": [
-            "n. 流放，充军；放逐，被放逐者；流犯"
-        ],
-        "usphone": "[ˈeksaɪlˌˈeɡzaɪl]",
-        "ukphone": "[ˈeksaɪl]"
-    },
-    {
-        "name": "exit",
-        "trans": [
-            "n. 出口，通道；退场"
-        ],
-        "usphone": "[ˈeksɪt; ˈeɡzɪt]",
-        "ukphone": "[ˈeksɪt]"
-    },
-    {
-        "name": "expenditure",
-        "trans": [
-            "n. 支出，花费；经费，消费额"
-        ],
-        "usphone": "[ɪkˈspendɪtʃər]",
-        "ukphone": "[ɪkˈspendɪtʃə(r)]"
-    },
-    {
-        "name": "experimental",
-        "trans": [
-            "adj. 实验的；根据实验的；试验性的"
-        ],
-        "usphone": "[ɪkˌsperɪˈmentl]",
-        "ukphone": "[ɪkˌsperɪˈment(ə)l]"
-    },
-    {
-        "name": "expire",
-        "trans": [
-            "vi. 期满；终止；死亡；呼气"
-        ],
-        "usphone": "[ɪkˈspaɪər]",
-        "ukphone": "[ɪkˈspaɪə(r)]"
-    },
-    {
-        "name": "explicit",
-        "trans": [
-            "adj. 明确的；清楚的；直率的；详述的"
-        ],
-        "usphone": "[ɪkˈsplɪsɪt]",
-        "ukphone": "[ɪkˈsplɪsɪt]"
-    },
-    {
-        "name": "explicitly",
-        "trans": [
-            "adv. 明确地；明白地"
-        ],
-        "usphone": "[ɪkˈsplɪsɪtli]",
-        "ukphone": "[ɪkˈsplɪsɪtli]"
-    },
-    {
-        "name": "exploitation",
-        "trans": [
-            "n. 开发，开采；利用；广告推销；剥削"
-        ],
-        "usphone": "[ˌeksplɔɪˈteɪʃn]",
-        "ukphone": "[ˌeksplɔɪˈteɪʃ(ə)n]"
-    },
-    {
-        "name": "explosive",
-        "trans": [
-            "n. 炸药；爆炸物"
-        ],
-        "usphone": "[ɪkˈsploʊsɪvˌɪkˈsploʊzɪv]",
-        "ukphone": "[ɪkˈspləʊsɪv]"
-    },
-    {
-        "name": "extract",
-        "trans": [
-            "n. 汁；摘录；榨出物；选粹"
-        ],
-        "usphone": "[ˈekstrækt]",
-        "ukphone": "[ˈekstrækt]"
-    },
-    {
-        "name": "extremist",
-        "trans": [
-            "n. 极端主义者，过激分子"
-        ],
-        "usphone": "[ɪkˈstriːmɪst]",
-        "ukphone": "[ɪkˈstriːmɪst]"
-    },
-    {
-        "name": "facilitate",
-        "trans": [
-            "vt. 促进；帮助；使容易"
-        ],
-        "usphone": "[fəˈsɪlɪteɪt]",
-        "ukphone": "[fəˈsɪlɪteɪt]"
-    },
-    {
-        "name": "faction",
-        "trans": [
-            "n. 派别；内讧；小集团；纪实小说"
-        ],
-        "usphone": "[ˈfækʃn]",
-        "ukphone": "[ˈfækʃ(ə)n]"
-    },
-    {
-        "name": "faculty",
-        "trans": [
-            "n. 科，系；能力；全体教员"
-        ],
-        "usphone": "[ˈfæklti]",
-        "ukphone": "[ˈfæk(ə)lti]"
-    },
-    {
-        "name": "fade",
-        "trans": [
-            "n. [电影][电视] 淡出；[电影][电视] 淡入"
-        ],
-        "usphone": "[feɪd]",
-        "ukphone": "[feɪd]"
-    },
-    {
-        "name": "fairness",
-        "trans": [
-            "n. 公平；美好；清晰；顺利性"
-        ],
-        "usphone": "[ˈfernəs]",
-        "ukphone": "[ˈfeənəs]"
-    },
-    {
-        "name": "fatal",
-        "trans": [
-            "adj. 致命的；重大的；毁灭性的；命中注定的"
-        ],
-        "usphone": "[ˈfeɪtl]",
-        "ukphone": "[ˈfeɪt(ə)l]"
-    },
-    {
-        "name": "fate",
-        "trans": [
-            "n. 命运"
-        ],
-        "usphone": "[feɪt]",
-        "ukphone": "[feɪt]"
-    },
-    {
-        "name": "favourable",
-        "trans": [
-            "n. 有利"
-        ],
-        "usphone": "[ˈfeɪvərəbl]",
-        "ukphone": "[ˈfeɪvərəb(ə)l]"
-    },
-    {
-        "name": "feat",
-        "trans": [
-            "n. 功绩，壮举；技艺表演"
-        ],
-        "usphone": "[fiːt]",
-        "ukphone": "[fiːt]"
-    },
-    {
-        "name": "feminist",
-        "trans": [
-            "n. 女权主义者"
-        ],
-        "usphone": "[ˈfemənɪst]",
-        "ukphone": "[ˈfemənɪst]"
-    },
-    {
-        "name": "fibre",
-        "trans": [
-            "n. 纤维；纤维制品"
-        ],
-        "usphone": "[ˈfaɪbər]",
-        "ukphone": "[ˈfaɪbə(r)]"
-    },
-    {
-        "name": "fierce",
-        "trans": [
-            "adj. 凶猛的；猛烈的；暴躁的"
-        ],
-        "usphone": "[fɪrs]",
-        "ukphone": "[fɪəs]"
-    },
-    {
-        "name": "film-maker",
-        "trans": [
-            "n. 电影制作人"
-        ],
-        "usphone": "[ˈfɪlm meɪkər]",
-        "ukphone": "[ˈfɪlm meɪkə(r)]"
-    },
-    {
-        "name": "filter",
-        "trans": [
-            "n. 滤波器；[化工] 过滤器；筛选；滤光器"
-        ],
-        "usphone": "[ˈfɪltər]",
-        "ukphone": "[ˈfɪltə(r)]"
-    },
-    {
-        "name": "fine",
-        "trans": [
-            "n. 罚款"
-        ],
-        "usphone": "[faɪn]",
-        "ukphone": "[faɪn]"
-    },
-    {
-        "name": "firearm",
-        "trans": [
-            "n. 火器；枪炮"
-        ],
-        "usphone": "[ˈfaɪərɑːrm]",
-        "ukphone": "[ˈfaɪərɑːm]"
-    },
-    {
-        "name": "fit",
-        "trans": [
-            "n. 合身；发作；痉挛"
-        ],
-        "usphone": "[fɪt]",
-        "ukphone": "[fɪt]"
-    },
-    {
-        "name": "fixture",
-        "trans": [
-            "n. 设备；固定装置；固定于某处不大可能移动之物"
-        ],
-        "usphone": "[ˈfɪkstʃər]",
-        "ukphone": "[ˈfɪkstʃə(r)]"
-    },
-    {
-        "name": "flaw",
-        "trans": [
-            "n. 瑕疵，缺点；一阵狂风；短暂的风暴；裂缝，裂纹"
-        ],
-        "usphone": "[flɔː]",
-        "ukphone": "[flɔː]"
-    },
-    {
-        "name": "flawed",
-        "trans": [
-            "adj. 有缺陷的；有瑕疵的；有裂纹的"
-        ],
-        "usphone": "[flɔːd]",
-        "ukphone": "[flɔːd]"
-    },
-    {
-        "name": "flee",
-        "trans": [
-            "vt. 逃跑，逃走；逃避"
-        ],
-        "usphone": "[fliː]",
-        "ukphone": "[fliː]"
-    },
-    {
-        "name": "fleet",
-        "trans": [
-            "n. 舰队；港湾；小河"
-        ],
-        "usphone": "[fliːt]",
-        "ukphone": "[fliːt]"
-    },
-    {
-        "name": "flesh",
-        "trans": [
-            "n. 肉；肉体"
-        ],
-        "usphone": "[fleʃ]",
-        "ukphone": "[fleʃ]"
-    },
-    {
-        "name": "flexibility",
-        "trans": [
-            "n. 灵活性；弹性；适应性"
-        ],
-        "usphone": "[ˌfleksəˈbɪləti]",
-        "ukphone": "[ˌfleksəˈbɪləti]"
-    },
-    {
-        "name": "flourish",
-        "trans": [
-            "n. 兴旺；茂盛；挥舞；炫耀；华饰"
-        ],
-        "usphone": "[ˈflɜːrɪʃ]",
-        "ukphone": "[ˈflʌrɪʃ]"
-    },
-    {
-        "name": "fluid",
-        "trans": [
-            "n. 流体；液体"
-        ],
-        "usphone": "[ˈfluːɪd]",
-        "ukphone": "[ˈfluːɪd]"
-    },
-    {
-        "name": "footage",
-        "trans": [
-            "n. 英尺长度；连续镜头；以尺计算长度"
-        ],
-        "usphone": "[ˈfʊtɪdʒ]",
-        "ukphone": "[ˈfʊtɪdʒ]"
-    },
-    {
-        "name": "foreigner",
-        "trans": [
-            "n. 外地人，外国人"
-        ],
-        "usphone": "[ˈfɔːrənər]",
-        "ukphone": "[ˈfɒrənə(r)]"
-    },
-    {
-        "name": "forge",
-        "trans": [
-            "n. 熔炉，锻铁炉；铁工厂"
-        ],
-        "usphone": "[fɔːrdʒ]",
-        "ukphone": "[fɔːdʒ]"
-    },
-    {
-        "name": "formula",
-        "trans": [
-            "n. [数] 公式，准则；配方；婴儿食品"
-        ],
-        "usphone": "[ˈfɔːrmjələ]",
-        "ukphone": "[ˈfɔːmjələ]"
-    },
-    {
-        "name": "formulate",
-        "trans": [
-            "vt. 规划；用公式表示；明确地表达"
-        ],
-        "usphone": "[ˈfɔːrmjuleɪt]",
-        "ukphone": "[ˈfɔːmjuleɪt]"
-    },
-    {
-        "name": "forth",
-        "trans": [
-            "adv. 向前，向外；自…以后"
-        ],
-        "usphone": "[fɔːrθ]",
-        "ukphone": "[fɔːθ]"
-    },
-    {
-        "name": "forthcoming",
-        "trans": [
-            "n. 来临"
-        ],
-        "usphone": "[ˌfɔːrθˈkʌmɪŋ]",
-        "ukphone": "[ˌfɔːθˈkʌmɪŋ]"
-    },
-    {
-        "name": "foster",
-        "trans": [
-            "vt. 培养；养育，抚育；抱（希望等）"
-        ],
-        "usphone": "[ˈfɑːstər]",
-        "ukphone": "[ˈfɒstə(r)]"
-    },
-    {
-        "name": "fragile",
-        "trans": [
-            "adj. 脆的；易碎的"
-        ],
-        "usphone": "[ˈfrædʒl]",
-        "ukphone": "[ˈfrædʒaɪl]"
-    },
-    {
-        "name": "franchise",
-        "trans": [
-            "n. 特权；公民权；经销权；管辖权"
-        ],
-        "usphone": "[ˈfræntʃaɪz]",
-        "ukphone": "[ˈfræntʃaɪz]"
-    },
-    {
-        "name": "frankly",
-        "trans": [
-            "adv. 真诚地，坦白地"
-        ],
-        "usphone": "[ˈfræŋkli]",
-        "ukphone": "[ˈfræŋkli]"
-    },
-    {
-        "name": "frustrated",
-        "trans": [
-            "v. 挫败；阻挠（frustrate的过去式和过去分词形式）"
-        ],
-        "usphone": "[ˈfrʌstreɪtɪd]",
-        "ukphone": "[frʌˈstreɪtɪd]"
-    },
-    {
-        "name": "frustrating",
-        "trans": [
-            "v. 使沮丧（frustrate的ing形式）"
-        ],
-        "usphone": "[ˈfrʌstreɪtɪŋ]",
-        "ukphone": "[frʌˈstreɪtɪŋ]"
-    },
-    {
-        "name": "frustration",
-        "trans": [
-            "n. 挫折"
-        ],
-        "usphone": "[frʌˈstreɪʃn]",
-        "ukphone": "[frʌˈstreɪʃ(ə)n]"
-    },
-    {
-        "name": "functional",
-        "trans": [
-            "adj. 功能的"
-        ],
-        "usphone": "[ˈfʌŋkʃənl]",
-        "ukphone": "[ˈfʌŋkʃən(ə)l]"
-    },
-    {
-        "name": "fundraising",
-        "trans": [
-            "n. 筹款；资金募集"
-        ],
-        "usphone": "[ˈfʌndreɪzɪŋ]",
-        "ukphone": "[ˈfʌndreɪzɪŋ]"
-    },
-    {
-        "name": "funeral",
-        "trans": [
-            "n. 葬礼；麻烦事"
-        ],
-        "usphone": "[ˈfjuːnərəl]",
-        "ukphone": "[ˈfjuːnərəl]"
-    },
-    {
-        "name": "gallon",
-        "trans": [
-            "n. 加仑（容量单位）"
-        ],
-        "usphone": "[ˈɡælən]",
-        "ukphone": "[ˈɡælən]"
-    },
-    {
-        "name": "gambling",
-        "trans": [
-            "n. 赌博；投机"
-        ],
-        "usphone": "[ˈɡæmblɪŋ]",
-        "ukphone": "[ˈɡæmblɪŋ]"
-    },
-    {
-        "name": "gathering",
-        "trans": [
-            "n. 聚集；集会；收款"
-        ],
-        "usphone": "[ˈɡæðərɪŋ]",
-        "ukphone": "[ˈɡæðərɪŋ]"
-    },
-    {
-        "name": "gaze",
-        "trans": [
-            "n. 凝视；注视"
-        ],
-        "usphone": "[ɡeɪz]",
-        "ukphone": "[ɡeɪz]"
-    },
-    {
-        "name": "gear",
-        "trans": [
-            "n. 齿轮；装置，工具；传动装置"
-        ],
-        "usphone": "[ɡɪr]",
-        "ukphone": "[ɡɪə(r)]"
-    },
-    {
-        "name": "generic",
-        "trans": [
-            "adj. 类的；一般的；属的；非商标的"
-        ],
-        "usphone": "[dʒəˈnerɪk]",
-        "ukphone": "[dʒəˈnerɪk]"
-    },
-    {
-        "name": "genocide",
-        "trans": [
-            "n. 种族灭绝；灭绝整个种族的大屠杀"
-        ],
-        "usphone": "[ˈdʒenəsaɪd]",
-        "ukphone": "[ˈdʒenəsaɪd]"
-    },
-    {
-        "name": "glance",
-        "trans": [
-            "n. 一瞥；一滑；闪光"
-        ],
-        "usphone": "[ɡlæns]",
-        "ukphone": "[ɡlɑːns]"
-    },
-    {
-        "name": "glimpse",
-        "trans": [
-            "n. 一瞥，一看"
-        ],
-        "usphone": "[ɡlɪmps]",
-        "ukphone": "[ɡlɪmps]"
-    },
-    {
-        "name": "glorious",
-        "trans": [
-            "adj. 光荣的；辉煌的；极好的"
-        ],
-        "usphone": "[ˈɡlɔːriəs]",
-        "ukphone": "[ˈɡlɔːriəs]"
-    },
-    {
-        "name": "glory",
-        "trans": [
-            "n. 光荣，荣誉；赞颂"
-        ],
-        "usphone": "[ˈɡlɔːri]",
-        "ukphone": "[ˈɡlɔːri]"
-    },
-    {
-        "name": "governance",
-        "trans": [
-            "n. 管理；统治；支配"
-        ],
-        "usphone": "[ˈɡʌvərnəns]",
-        "ukphone": "[ˈɡʌvənəns]"
-    },
-    {
-        "name": "grace",
-        "trans": [
-            "n. 优雅；恩惠；魅力；慈悲"
-        ],
-        "usphone": "[ɡreɪs]",
-        "ukphone": "[ɡreɪs]"
-    },
-    {
-        "name": "grasp",
-        "trans": [
-            "n. 抓住；理解；控制"
-        ],
-        "usphone": "[ɡræsp]",
-        "ukphone": "[ɡrɑːsp]"
-    },
-    {
-        "name": "grave",
-        "trans": [
-            "n. 墓穴，坟墓；死亡"
-        ],
-        "usphone": "[ɡreɪv; ɡrɑːv]",
-        "ukphone": "[ɡreɪv]"
-    },
-    {
-        "name": "gravity",
-        "trans": [
-            "n. 重力，地心引力；严重性；庄严"
-        ],
-        "usphone": "[ˈɡrævəti]",
-        "ukphone": "[ˈɡrævəti]"
-    },
-    {
-        "name": "grid",
-        "trans": [
-            "n. 网格；格子，栅格；输电网"
-        ],
-        "usphone": "[ɡrɪd]",
-        "ukphone": "[ɡrɪd]"
-    },
-    {
-        "name": "grief",
-        "trans": [
-            "n. 悲痛；忧伤；不幸"
-        ],
-        "usphone": "[ɡriːf]",
-        "ukphone": "[ɡriːf]"
-    },
-    {
-        "name": "grin",
-        "trans": [
-            "n. 露齿笑"
-        ],
-        "usphone": "[ɡrɪn]",
-        "ukphone": "[ɡrɪn]"
-    },
-    {
-        "name": "grind",
-        "trans": [
-            "n. 磨；苦工作"
-        ],
-        "usphone": "[ɡraɪnd]",
-        "ukphone": "[ɡraɪnd]"
-    },
-    {
-        "name": "grip",
-        "trans": [
-            "n. 紧握；柄；支配；握拍方式；拍柄绷带"
-        ],
-        "usphone": "[ɡrɪp]",
-        "ukphone": "[ɡrɪp]"
-    },
-    {
-        "name": "gross",
-        "trans": [
-            "n. 总额，总数"
-        ],
-        "usphone": "[ɡroʊs]",
-        "ukphone": "[ɡrəʊs]"
+        "usphone": "[ˌrevəˈluːʃəneri]",
+        "ukphone": "[ˌrevəˈluːʃənəri]"
     },
     {
         "name": "guerrilla",
@@ -4456,124 +40,308 @@
         "ukphone": "[ɡəˈrɪlə]"
     },
     {
-        "name": "guidance",
+        "name": "regulator",
         "trans": [
-            "n. 指导，引导；领导"
+            "n. 调整者；监管者；校准器"
         ],
-        "usphone": "[ˈɡaɪdns]",
-        "ukphone": "[ˈɡaɪdns]"
+        "usphone": "[ˈreɡjuleɪtər]",
+        "ukphone": "[ˈreɡjuleɪtə(r)]"
     },
     {
-        "name": "guilt",
+        "name": "sack",
         "trans": [
-            "n. 犯罪，过失；内疚"
+            "n. 麻布袋；洗劫"
         ],
-        "usphone": "[ɡɪlt]",
-        "ukphone": "[ɡɪlt]"
+        "usphone": "[sæk]",
+        "ukphone": "[sæk]"
     },
     {
-        "name": "gut",
+        "name": "biography",
         "trans": [
-            "n. 内脏；肠子；剧情；胆量；海峡；勇气；直觉；肠"
+            "n. 传记；档案；个人简介"
         ],
-        "usphone": "[ɡʌt]",
-        "ukphone": "[ɡʌt]"
+        "usphone": "[baɪˈɑːɡrəfi]",
+        "ukphone": "[baɪˈɒɡrəfi]"
     },
     {
-        "name": "hail",
+        "name": "foreigner",
         "trans": [
-            "n. 冰雹；致敬；招呼；一阵"
+            "n. 外地人，外国人"
         ],
-        "usphone": "[heɪl]",
-        "ukphone": "[heɪl]"
+        "usphone": "[ˈfɔːrənər]",
+        "ukphone": "[ˈfɒrənə(r)]"
     },
     {
-        "name": "halfway",
+        "name": "postpone",
         "trans": [
-            "adj. 中途的；不彻底的"
+            "vt. 使…延期；把…放在次要地位；把…放在后面"
         ],
-        "usphone": "[ˌhæfˈweɪ]",
-        "ukphone": "[ˌhɑːfˈweɪ]"
+        "usphone": "[poʊˈspoʊn]",
+        "ukphone": "[pəˈspəʊn]"
     },
     {
-        "name": "halt",
+        "name": "inherent",
         "trans": [
-            "n. 停止；立定；休息"
+            "adj. 固有的；内在的；与生俱来的，遗传的"
         ],
-        "usphone": "[hɔːlt]",
-        "ukphone": "[hɔːlt]"
+        "usphone": "[ɪnˈherəntˌɪnˈhɪrənt]",
+        "ukphone": "[ɪnˈherənt]"
     },
     {
-        "name": "handful",
+        "name": "optical",
         "trans": [
-            "n. 少数；一把；棘手事"
+            "adj. 光学的；眼睛的，视觉的"
         ],
-        "usphone": "[ˈhændfʊl]",
-        "ukphone": "[ˈhændfʊl]"
+        "usphone": "[ˈɑːptɪk(ə)l]",
+        "ukphone": "[ˈɒptɪk(ə)l]"
     },
     {
-        "name": "handling",
+        "name": "counterpart",
         "trans": [
-            "n. 处理"
+            "n. 副本；配对物；极相似的人或物"
         ],
-        "usphone": "[ˈhændlɪŋ]",
-        "ukphone": "[ˈhændlɪŋ]"
+        "usphone": "[ˈkaʊntərpɑːrt]",
+        "ukphone": "[ˈkaʊntəpɑːt]"
     },
     {
-        "name": "handy",
+        "name": "problematic",
         "trans": [
-            "adj. 便利的；手边的，就近的；容易取得的；敏捷的"
+            "adj. 问题的；有疑问的；不确定的"
         ],
-        "usphone": "[ˈhændi]",
-        "ukphone": "[ˈhændi]"
+        "usphone": "[ˌprɑːbləˈmætɪk]",
+        "ukphone": "[ˌprɒbləˈmætɪk]"
     },
     {
-        "name": "harassment",
+        "name": "terrific",
         "trans": [
-            "n. 骚扰；烦恼"
+            "adj. 极好的；极其的，非常的；可怕的"
         ],
-        "usphone": "[həˈræsməntˌˈhærəsmənt]",
-        "ukphone": "[ˈhærəsmənt]"
+        "usphone": "[təˈrɪfɪk]",
+        "ukphone": "[təˈrɪfɪk]"
     },
     {
-        "name": "hardware",
+        "name": "pump",
         "trans": [
-            "n. 计算机硬件；五金器具"
+            "n. 泵，抽水机；打气筒"
         ],
-        "usphone": "[ˈhɑːrdwer]",
-        "ukphone": "[ˈhɑːdweə(r)]"
+        "usphone": "[pʌmp]",
+        "ukphone": "[pʌmp]"
     },
     {
-        "name": "harmony",
+        "name": "amid",
         "trans": [
-            "n. 协调；和睦；融洽；调和"
+            "prep. 在其中，在其间"
         ],
-        "usphone": "[ˈhɑːrməni]",
-        "ukphone": "[ˈhɑːməni]"
+        "usphone": "[əˈmɪd]",
+        "ukphone": "[əˈmɪd]"
     },
     {
-        "name": "harsh",
+        "name": "trophy",
         "trans": [
-            "adj. 严厉的；严酷的；刺耳的；粗糙的；刺目的"
+            "n. 奖品；战利品；纪念品"
         ],
-        "usphone": "[hɑːrʃ]",
-        "ukphone": "[hɑːʃ]"
+        "usphone": "[ˈtroʊfi]",
+        "ukphone": "[ˈtrəʊfi]"
     },
     {
-        "name": "harvest",
+        "name": "renew",
         "trans": [
-            "n. 收获；产量；结果"
+            "vt. 使更新；续借；续费；复兴；重申"
         ],
-        "usphone": "[ˈhɑːrvɪst]",
-        "ukphone": "[ˈhɑːvɪst]"
+        "usphone": "[rɪˈnuː]",
+        "ukphone": "[rɪˈnjuː]"
     },
     {
-        "name": "hatred",
+        "name": "devise",
         "trans": [
-            "n. 憎恨；怨恨；敌意"
+            "n. 遗赠"
         ],
-        "usphone": "[ˈheɪtrɪd]",
-        "ukphone": "[ˈheɪtrɪd]"
+        "usphone": "[dɪˈvaɪz]",
+        "ukphone": "[dɪˈvaɪz]"
+    },
+    {
+        "name": "parish",
+        "trans": [
+            "n. 教区"
+        ],
+        "usphone": "[ˈpærɪʃ]",
+        "ukphone": "[ˈpærɪʃ]"
+    },
+    {
+        "name": "refuge",
+        "trans": [
+            "n. 避难；避难所；庇护"
+        ],
+        "usphone": "[ˈrefjuːdʒ]",
+        "ukphone": "[ˈrefjuːdʒ]"
+    },
+    {
+        "name": "compromise",
+        "trans": [
+            "n. 妥协，和解；折衷"
+        ],
+        "usphone": "[ˈkɑːmprəmaɪz]",
+        "ukphone": "[ˈkɒmprəmaɪz]"
+    },
+    {
+        "name": "acceptance",
+        "trans": [
+            "n. 接纳；赞同；容忍"
+        ],
+        "usphone": "[əkˈseptəns]",
+        "ukphone": "[əkˈseptəns]"
+    },
+    {
+        "name": "commentator",
+        "trans": [
+            "n. 评论员，解说员；实况播音员；时事评论者"
+        ],
+        "usphone": "[ˈkɑːmənteɪtər]",
+        "ukphone": "[ˈkɒmənteɪtə(r)]"
+    },
+    {
+        "name": "counter",
+        "trans": [
+            "n. 柜台；对立面；计数器；（某些棋盘游戏的）筹码"
+        ],
+        "usphone": "[ˈkaʊntər]",
+        "ukphone": "[ˈkaʊntə(r)]"
+    },
+    {
+        "name": "concede",
+        "trans": [
+            "vi. 让步"
+        ],
+        "usphone": "[kənˈsiːd]",
+        "ukphone": "[kənˈsiːd]"
+    },
+    {
+        "name": "integral",
+        "trans": [
+            "n. 积分；部分；完整"
+        ],
+        "usphone": "[ˈɪntɪɡrəl]",
+        "ukphone": "[ˈɪntɪɡrəl]"
+    },
+    {
+        "name": "socialist",
+        "trans": [
+            "n. 社会主义者；社会党党员"
+        ],
+        "usphone": "[ˈsoʊʃəlɪst]",
+        "ukphone": "[ˈsəʊʃəlɪst]"
+    },
+    {
+        "name": "mainstream",
+        "trans": [
+            "n. 主流"
+        ],
+        "usphone": "[ˈmeɪnstriːm]",
+        "ukphone": "[ˈmeɪnstriːm]"
+    },
+    {
+        "name": "statistical",
+        "trans": [
+            "adj. 统计的；统计学的"
+        ],
+        "usphone": "[stəˈtɪstɪkl]",
+        "ukphone": "[stəˈtɪstɪk(ə)l]"
+    },
+    {
+        "name": "differentiate",
+        "trans": [
+            "vt. 区分，区别"
+        ],
+        "usphone": "[ˌdɪfəˈrenʃieɪt]",
+        "ukphone": "[ˌdɪfəˈrenʃieɪt]"
+    },
+    {
+        "name": "stimulus",
+        "trans": [
+            "n. 刺激；激励；刺激物"
+        ],
+        "usphone": "[ˈstɪmjələs]",
+        "ukphone": "[ˈstɪmjələs]"
+    },
+    {
+        "name": "presidency",
+        "trans": [
+            "n. 总统（或董事长、会长、大学校长等）的职位（任期）；管辖；支配"
+        ],
+        "usphone": "[ˈprezɪdənsi]",
+        "ukphone": "[ˈprezɪdənsi]"
+    },
+    {
+        "name": "bounce",
+        "trans": [
+            "n. 跳；弹力；活力"
+        ],
+        "usphone": "[baʊns]",
+        "ukphone": "[baʊns]"
+    },
+    {
+        "name": "utility",
+        "trans": [
+            "n. 实用；效用；公共设施；功用"
+        ],
+        "usphone": "[juːˈtɪləti]",
+        "ukphone": "[juːˈtɪləti]"
+    },
+    {
+        "name": "entitle",
+        "trans": [
+            "vt. 称做…；定名为…；给…称号；使…有权利"
+        ],
+        "usphone": "[ɪnˈtaɪtl]",
+        "ukphone": "[ɪnˈtaɪt(ə)l]"
+    },
+    {
+        "name": "provision",
+        "trans": [
+            "n. 规定；条款；准备；[经] 供应品"
+        ],
+        "usphone": "[prəˈvɪʒn]",
+        "ukphone": "[prəˈvɪʒn]"
+    },
+    {
+        "name": "migration",
+        "trans": [
+            "n. 迁移；移民；移动"
+        ],
+        "usphone": "[maɪˈɡreɪʃn]",
+        "ukphone": "[maɪˈɡreɪʃn]"
+    },
+    {
+        "name": "maintenance",
+        "trans": [
+            "n. 维护，维修；保持；生活费用"
+        ],
+        "usphone": "[ˈmeɪntənəns]",
+        "ukphone": "[ˈmeɪntənəns]"
+    },
+    {
+        "name": "residential",
+        "trans": [
+            "adj. 住宅的；与居住有关的"
+        ],
+        "usphone": "[ˌrezɪˈdenʃ(ə)l]",
+        "ukphone": "[ˌrezɪˈdenʃ(ə)l]"
+    },
+    {
+        "name": "emergence",
+        "trans": [
+            "n. 出现，浮现；发生；露头"
+        ],
+        "usphone": "[ɪˈmɜːrdʒəns]",
+        "ukphone": "[ɪˈmɜːdʒəns]"
+    },
+    {
+        "name": "net",
+        "trans": [
+            "n. 网；网络；净利；实价"
+        ],
+        "usphone": "[net]",
+        "ukphone": "[net]"
     },
     {
         "name": "haunt",
@@ -4592,1340 +360,20 @@
         "ukphone": "[ˈhæzəd]"
     },
     {
-        "name": "heighten",
+        "name": "coincide",
         "trans": [
-            "vt. 提高；增高；加强；使更显著"
+            "vi. 一致，符合；同时发生"
         ],
-        "usphone": "[ˈhaɪtn]",
-        "ukphone": "[ˈhaɪtn]"
+        "usphone": "[ˌkoʊɪnˈsaɪd]",
+        "ukphone": "[ˌkəʊɪnˈsaɪd]"
     },
     {
-        "name": "heritage",
+        "name": "coup",
         "trans": [
-            "n. 遗产；传统；继承物；继承权"
+            "n. 政变；妙计；出乎意料的行动；砰然的一击"
         ],
-        "usphone": "[ˈherɪtɪdʒ]",
-        "ukphone": "[ˈherɪtɪdʒ]"
-    },
-    {
-        "name": "hierarchy",
-        "trans": [
-            "n. 层级；等级制度"
-        ],
-        "usphone": "[ˈhaɪərɑːrki]",
-        "ukphone": "[ˈhaɪərɑːki]"
-    },
-    {
-        "name": "high-profile",
-        "trans": [
-            "adj. 高调的；备受瞩目的；知名度高的"
-        ],
-        "usphone": "[ˌhaɪ ˈproʊfaɪl]",
-        "ukphone": "[ˌhaɪ ˈprəʊfaɪl]"
-    },
-    {
-        "name": "hint",
-        "trans": [
-            "n. 暗示；线索"
-        ],
-        "usphone": "[hɪnt]",
-        "ukphone": "[hɪnt]"
-    },
-    {
-        "name": "homeland",
-        "trans": [
-            "n. 祖国；故乡"
-        ],
-        "usphone": "[ˈhoʊmlænd]",
-        "ukphone": "[ˈhəʊmlænd]"
-    },
-    {
-        "name": "hook",
-        "trans": [
-            "n. 挂钩，吊钩"
-        ],
-        "usphone": "[hʊk]",
-        "ukphone": "[hʊk]"
-    },
-    {
-        "name": "hopeful",
-        "trans": [
-            "n. 有希望成功的人"
-        ],
-        "usphone": "[ˈhoʊpfl]",
-        "ukphone": "[ˈhəʊpf(ə)l]"
-    },
-    {
-        "name": "horizon",
-        "trans": [
-            "n. [天] 地平线；视野；眼界；范围"
-        ],
-        "usphone": "[həˈraɪzn]",
-        "ukphone": "[həˈraɪz(ə)n]"
-    },
-    {
-        "name": "horn",
-        "trans": [
-            "n. 喇叭，号角；角"
-        ],
-        "usphone": "[hɔːrn]",
-        "ukphone": "[hɔːn]"
-    },
-    {
-        "name": "hostage",
-        "trans": [
-            "n. 人质；抵押品"
-        ],
-        "usphone": "[ˈhɑːstɪdʒ]",
-        "ukphone": "[ˈhɒstɪdʒ]"
-    },
-    {
-        "name": "hostile",
-        "trans": [
-            "n. 敌对"
-        ],
-        "usphone": "[ˈhɑːstlˌˈhɑːstaɪl]",
-        "ukphone": "[ˈhɒstaɪl]"
-    },
-    {
-        "name": "hostility",
-        "trans": [
-            "n. 敌意；战争行动"
-        ],
-        "usphone": "[hɑːˈstɪləti]",
-        "ukphone": "[hɒˈstɪləti]"
-    },
-    {
-        "name": "humanitarian",
-        "trans": [
-            "n. 人道主义者；慈善家；博爱主义者；基督凡人论者"
-        ],
-        "usphone": "[hjuːˌmænɪˈteriən]",
-        "ukphone": "[hjuːˌmænɪˈteəriən]"
-    },
-    {
-        "name": "humanity",
-        "trans": [
-            "n. 人类；人道；仁慈；人文学科"
-        ],
-        "usphone": "[hjuːˈmænəti]",
-        "ukphone": "[hjuːˈmænəti]"
-    },
-    {
-        "name": "humble",
-        "trans": [
-            "adj. 谦逊的；简陋的；（级别或地位）低下的；不大的"
-        ],
-        "usphone": "[ˈhʌmbl]",
-        "ukphone": "[ˈhʌmb(ə)l]"
-    },
-    {
-        "name": "hydrogen",
-        "trans": [
-            "n. [化学] 氢"
-        ],
-        "usphone": "[ˈhaɪdrədʒən]",
-        "ukphone": "[ˈhaɪdrədʒən]"
-    },
-    {
-        "name": "identification",
-        "trans": [
-            "n. 鉴定，识别；认同；身份证明"
-        ],
-        "usphone": "[aɪˌdentɪfɪˈkeɪʃn]",
-        "ukphone": "[aɪˌdentɪfɪˈkeɪʃn]"
-    },
-    {
-        "name": "ideological",
-        "trans": [
-            "adj. 思想的；意识形态的"
-        ],
-        "usphone": "[ˌaɪdiəˈlɑːdʒɪklˌˌɪdiəˈlɑːdʒɪkl]",
-        "ukphone": "[ˌaɪdiəˈlɒdʒɪk(ə)l]"
-    },
-    {
-        "name": "ideology",
-        "trans": [
-            "n. 意识形态；思想意识；观念学"
-        ],
-        "usphone": "[ˌaɪdiˈɑːlədʒi]",
-        "ukphone": "[ˌaɪdiˈɒlədʒi]"
-    },
-    {
-        "name": "idiot",
-        "trans": [
-            "n. 笨蛋，傻瓜；白痴"
-        ],
-        "usphone": "[ˈɪdiət]",
-        "ukphone": "[ˈɪdiət]"
-    },
-    {
-        "name": "ignorance",
-        "trans": [
-            "n. 无知，愚昧；不知，不懂"
-        ],
-        "usphone": "[ˈɪɡnərəns]",
-        "ukphone": "[ˈɪɡnərəns]"
-    },
-    {
-        "name": "imagery",
-        "trans": [
-            "n. 像；意象；比喻；形象化"
-        ],
-        "usphone": "[ˈɪmɪdʒəri]",
-        "ukphone": "[ˈɪmɪdʒəri]"
-    },
-    {
-        "name": "immense",
-        "trans": [
-            "adj. 巨大的，广大的；无边无际的；非常好的"
-        ],
-        "usphone": "[ɪˈmens]",
-        "ukphone": "[ɪˈmens]"
-    },
-    {
-        "name": "imminent",
-        "trans": [
-            "adj. 即将来临的；迫近的"
-        ],
-        "usphone": "[ˈɪmɪnənt]",
-        "ukphone": "[ˈɪmɪnənt]"
-    },
-    {
-        "name": "implementation",
-        "trans": [
-            "n. [计] 实现；履行；安装启用"
-        ],
-        "usphone": "[ˌɪmplɪmenˈteɪʃn]",
-        "ukphone": "[ˌɪmplɪmenˈteɪʃ(ə)n]"
-    },
-    {
-        "name": "imprison",
-        "trans": [
-            "vt. 监禁；关押；使…下狱"
-        ],
-        "usphone": "[ɪmˈprɪzn]",
-        "ukphone": "[ɪmˈprɪzn]"
-    },
-    {
-        "name": "imprisonment",
-        "trans": [
-            "n. 监禁，关押；坐牢；下狱"
-        ],
-        "usphone": "[ɪmˈprɪznmənt]",
-        "ukphone": "[ɪmˈprɪznmənt]"
-    },
-    {
-        "name": "inability",
-        "trans": [
-            "n. 无能力；无才能"
-        ],
-        "usphone": "[ˌɪnəˈbɪləti]",
-        "ukphone": "[ˌɪnəˈbɪləti]"
-    },
-    {
-        "name": "inadequate",
-        "trans": [
-            "adj. 不充分的，不适当的"
-        ],
-        "usphone": "[ɪnˈædɪkwət]",
-        "ukphone": "[ɪnˈædɪkwət]"
-    },
-    {
-        "name": "inappropriate",
-        "trans": [
-            "adj. 不适当的；不相称的"
-        ],
-        "usphone": "[ˌɪnəˈproʊpriət]",
-        "ukphone": "[ˌɪnəˈprəʊpriət]"
-    },
-    {
-        "name": "incidence",
-        "trans": [
-            "n. 发生率；影响；[光] 入射；影响范围"
-        ],
-        "usphone": "[ˈɪnsɪdəns]",
-        "ukphone": "[ˈɪnsɪdəns]"
-    },
-    {
-        "name": "inclined",
-        "trans": [
-            "v. 使…倾向（incline的过去分词）"
-        ],
-        "usphone": "[ɪnˈklaɪnd]",
-        "ukphone": "[ɪnˈklaɪnd]"
-    },
-    {
-        "name": "inclusion",
-        "trans": [
-            "n. 包含；内含物"
-        ],
-        "usphone": "[ɪnˈkluːʒn]",
-        "ukphone": "[ɪnˈkluːʒn]"
-    },
-    {
-        "name": "incur",
-        "trans": [
-            "vt. 招致，引发；蒙受"
-        ],
-        "usphone": "[ɪnˈkɜːr]",
-        "ukphone": "[ɪnˈkɜː(r)]"
-    },
-    {
-        "name": "indicator",
-        "trans": [
-            "n. 指示器；[试剂] 指示剂；[计] 指示符；压力计"
-        ],
-        "usphone": "[ˈɪndɪkeɪtər]",
-        "ukphone": "[ˈɪndɪkeɪtə(r)]"
-    },
-    {
-        "name": "indictment",
-        "trans": [
-            "n. 起诉书；控告"
-        ],
-        "usphone": "[ɪnˈdaɪtmənt]",
-        "ukphone": "[ɪnˈdaɪtmənt]"
-    },
-    {
-        "name": "indigenous",
-        "trans": [
-            "adj. 本土的；土著的；国产的；固有的"
-        ],
-        "usphone": "[ɪnˈdɪdʒənəs]",
-        "ukphone": "[ɪnˈdɪdʒənəs]"
-    },
-    {
-        "name": "induce",
-        "trans": [
-            "vt. 诱导；引起；引诱；感应"
-        ],
-        "usphone": "[ɪnˈduːs]",
-        "ukphone": "[ɪnˈdjuːs]"
-    },
-    {
-        "name": "indulge",
-        "trans": [
-            "vi. 沉溺；满足；放任"
-        ],
-        "usphone": "[ɪnˈdʌldʒ]",
-        "ukphone": "[ɪnˈdʌldʒ]"
-    },
-    {
-        "name": "inequality",
-        "trans": [
-            "n. 不平等；不同；不平均"
-        ],
-        "usphone": "[ˌɪnɪˈkwɑːləti]",
-        "ukphone": "[ˌɪnɪˈkwɒləti]"
-    },
-    {
-        "name": "infamous",
-        "trans": [
-            "adj. 声名狼藉的；无耻的；邪恶的；不名誉的"
-        ],
-        "usphone": "[ˈɪnfəməs]",
-        "ukphone": "[ˈɪnfəməs]"
-    },
-    {
-        "name": "infant",
-        "trans": [
-            "n. 婴儿；幼儿；未成年人"
-        ],
-        "usphone": "[ˈɪnfənt]",
-        "ukphone": "[ˈɪnfənt]"
-    },
-    {
-        "name": "infect",
-        "trans": [
-            "vt. 感染，传染"
-        ],
-        "usphone": "[ɪnˈfekt]",
-        "ukphone": "[ɪnˈfekt]"
-    },
-    {
-        "name": "inflict",
-        "trans": [
-            "vt. 造成；使遭受（损伤、痛苦等）；给予（打击等）"
-        ],
-        "usphone": "[ɪnˈflɪkt]",
-        "ukphone": "[ɪnˈflɪkt]"
-    },
-    {
-        "name": "influential",
-        "trans": [
-            "adj. 有影响的；有势力的"
-        ],
-        "usphone": "[ˌɪnfluˈenʃl]",
-        "ukphone": "[ˌɪnfluˈenʃl]"
-    },
-    {
-        "name": "inherent",
-        "trans": [
-            "adj. 固有的；内在的；与生俱来的，遗传的"
-        ],
-        "usphone": "[ɪnˈherəntˌɪnˈhɪrənt]",
-        "ukphone": "[ɪnˈherənt]"
-    },
-    {
-        "name": "inhibit",
-        "trans": [
-            "vt. 抑制；禁止"
-        ],
-        "usphone": "[ɪnˈhɪbɪt]",
-        "ukphone": "[ɪnˈhɪbɪt]"
-    },
-    {
-        "name": "initiate",
-        "trans": [
-            "n. 开始；新加入者，接受初步知识者"
-        ],
-        "usphone": "[ɪˈnɪʃieɪt]",
-        "ukphone": "[ɪˈnɪʃieɪt]"
-    },
-    {
-        "name": "inject",
-        "trans": [
-            "vt. 注入；注射"
-        ],
-        "usphone": "[ɪnˈdʒekt]",
-        "ukphone": "[ɪnˈdʒekt]"
-    },
-    {
-        "name": "injection",
-        "trans": [
-            "n. 注射；注射剂；充血；射入轨道"
-        ],
-        "usphone": "[ɪnˈdʒekʃn]",
-        "ukphone": "[ɪnˈdʒekʃn]"
-    },
-    {
-        "name": "injustice",
-        "trans": [
-            "n. 不公正；不讲道义"
-        ],
-        "usphone": "[ɪnˈdʒʌstɪs]",
-        "ukphone": "[ɪnˈdʒʌstɪs]"
-    },
-    {
-        "name": "inmate",
-        "trans": [
-            "n. (尤指)同院病人；同狱犯人；同被(收容所)收容者"
-        ],
-        "usphone": "[ˈɪnmeɪt]",
-        "ukphone": "[ˈɪnmeɪt]"
-    },
-    {
-        "name": "insertion",
-        "trans": [
-            "n. 插入；嵌入；插入物"
-        ],
-        "usphone": "[ɪnˈsɜːrʃn]",
-        "ukphone": "[ɪnˈsɜːʃn]"
-    },
-    {
-        "name": "insider",
-        "trans": [
-            "n. 内部的人，会员；熟悉内情者"
-        ],
-        "usphone": "[ɪnˈsaɪdər]",
-        "ukphone": "[ɪnˈsaɪdə(r)]"
-    },
-    {
-        "name": "inspect",
-        "trans": [
-            "vt. 检查；视察；检阅"
-        ],
-        "usphone": "[ɪnˈspekt]",
-        "ukphone": "[ɪnˈspekt]"
-    },
-    {
-        "name": "inspection",
-        "trans": [
-            "n. 视察，检查"
-        ],
-        "usphone": "[ɪnˈspekʃn]",
-        "ukphone": "[ɪnˈspekʃ(ə)n]"
-    },
-    {
-        "name": "inspiration",
-        "trans": [
-            "n. 灵感；鼓舞；吸气；妙计"
-        ],
-        "usphone": "[ˌɪnspəˈreɪʃn]",
-        "ukphone": "[ˌɪnspəˈreɪʃ(ə)n]"
-    },
-    {
-        "name": "instinct",
-        "trans": [
-            "n. 本能，直觉；天性"
-        ],
-        "usphone": "[ˈɪnstɪŋkt]",
-        "ukphone": "[ˈɪnstɪŋkt]"
-    },
-    {
-        "name": "institutional",
-        "trans": [
-            "adj. 制度的；制度上的"
-        ],
-        "usphone": "[ˌɪnstɪˈtuːʃənl]",
-        "ukphone": "[ˌɪnstɪˈtjuːʃənl]"
-    },
-    {
-        "name": "instruct",
-        "trans": [
-            "vt. 指导；通知；命令；教授"
-        ],
-        "usphone": "[ɪnˈstrʌkt]",
-        "ukphone": "[ɪnˈstrʌkt]"
-    },
-    {
-        "name": "instrumental",
-        "trans": [
-            "n. 器乐曲；工具字，工具格"
-        ],
-        "usphone": "[ˌɪnstrəˈmentl]",
-        "ukphone": "[ˌɪnstrəˈment(ə)l]"
-    },
-    {
-        "name": "insufficient",
-        "trans": [
-            "adj. 不足的，不充足的；不胜任的；缺乏能力的"
-        ],
-        "usphone": "[ˌɪnsəˈfɪʃ(ə)nt]",
-        "ukphone": "[ˌɪnsəˈfɪʃ(ə)nt]"
-    },
-    {
-        "name": "insult",
-        "trans": [
-            "n. 侮辱；凌辱；无礼"
-        ],
-        "usphone": "[ɪnˈsʌlt; ˈɪnsʌlt]",
-        "ukphone": "[ɪnˈsʌlt]"
-    },
-    {
-        "name": "intact",
-        "trans": [
-            "adj. 完整的；原封不动的；未受损伤的"
-        ],
-        "usphone": "[ɪnˈtækt]",
-        "ukphone": "[ɪnˈtækt]"
-    },
-    {
-        "name": "intake",
-        "trans": [
-            "n. 摄取量；通风口；引入口；引入的量"
-        ],
-        "usphone": "[ˈɪnteɪk]",
-        "ukphone": "[ˈɪnteɪk]"
-    },
-    {
-        "name": "integral",
-        "trans": [
-            "n. 积分；部分；完整"
-        ],
-        "usphone": "[ˈɪntɪɡrəl]",
-        "ukphone": "[ˈɪntɪɡrəl]"
-    },
-    {
-        "name": "integrated",
-        "trans": [
-            "adj. 综合的；完整的；互相协调的"
-        ],
-        "usphone": "[ˈɪntɪɡreɪtɪd]",
-        "ukphone": "[ˈɪntɪɡreɪtɪd]"
-    },
-    {
-        "name": "integration",
-        "trans": [
-            "n. 集成；综合"
-        ],
-        "usphone": "[ˌɪntɪˈɡreɪʃn]",
-        "ukphone": "[ˌɪntɪˈɡreɪʃ(ə)n]"
-    },
-    {
-        "name": "integrity",
-        "trans": [
-            "n. 完整；正直；诚实；廉正"
-        ],
-        "usphone": "[ɪnˈteɡrəti]",
-        "ukphone": "[ɪnˈteɡrəti]"
-    },
-    {
-        "name": "intellectual",
-        "trans": [
-            "n. 知识分子；凭理智做事者"
-        ],
-        "usphone": "[ˌɪntəˈlektʃuəl]",
-        "ukphone": "[ˌɪntəˈlektʃuəl]"
-    },
-    {
-        "name": "intensify",
-        "trans": [
-            "vt. 使加强，使强化；使变激烈"
-        ],
-        "usphone": "[ɪnˈtensɪfaɪ]",
-        "ukphone": "[ɪnˈtensɪfaɪ]"
-    },
-    {
-        "name": "intensity",
-        "trans": [
-            "n. 强度；强烈；[电子] 亮度；紧张"
-        ],
-        "usphone": "[ɪnˈtensəti]",
-        "ukphone": "[ɪnˈtensəti]"
-    },
-    {
-        "name": "intensive",
-        "trans": [
-            "n. 加强器"
-        ],
-        "usphone": "[ɪnˈtensɪv]",
-        "ukphone": "[ɪnˈtensɪv]"
-    },
-    {
-        "name": "intent",
-        "trans": [
-            "n. 意图；目的；含义"
-        ],
-        "usphone": "[ɪnˈtent]",
-        "ukphone": "[ɪnˈtent]"
-    },
-    {
-        "name": "interactive",
-        "trans": [
-            "adj. 交互式的；相互作用的"
-        ],
-        "usphone": "[ˌɪntərˈæktɪv]",
-        "ukphone": "[ˌɪntərˈæktɪv]"
-    },
-    {
-        "name": "interface",
-        "trans": [
-            "n. 界面；<计>接口；交界面"
-        ],
-        "usphone": "[ˈɪntərfeɪs]",
-        "ukphone": "[ˈɪntəfeɪs]"
-    },
-    {
-        "name": "interfere",
-        "trans": [
-            "vi. 干涉；妨碍；打扰"
-        ],
-        "usphone": "[ˌɪntərˈfɪr]",
-        "ukphone": "[ˌɪntəˈfɪə(r)]"
-    },
-    {
-        "name": "interference",
-        "trans": [
-            "n. 干扰，冲突；干涉"
-        ],
-        "usphone": "[ˌɪntərˈfɪrəns]",
-        "ukphone": "[ˌɪntəˈfɪərəns]"
-    },
-    {
-        "name": "interim",
-        "trans": [
-            "n. 过渡时期，中间时期；暂定"
-        ],
-        "usphone": "[ˈɪntərɪm]",
-        "ukphone": "[ˈɪntərɪm]"
-    },
-    {
-        "name": "interior",
-        "trans": [
-            "n. 内部；本质"
-        ],
-        "usphone": "[ɪnˈtɪriər]",
-        "ukphone": "[ɪnˈtɪəriə(r)]"
-    },
-    {
-        "name": "intermediate",
-        "trans": [
-            "n. [化学] 中间物；媒介"
-        ],
-        "usphone": "[ˌɪntərˈmiːdiət]",
-        "ukphone": "[ˌɪntəˈmiːdiət]"
-    },
-    {
-        "name": "intervene",
-        "trans": [
-            "vi. 干涉；调停；插入"
-        ],
-        "usphone": "[ˌɪntərˈviːn]",
-        "ukphone": "[ˌɪntəˈviːn]"
-    },
-    {
-        "name": "intervention",
-        "trans": [
-            "n. 介入；调停；妨碍"
-        ],
-        "usphone": "[ˌɪntərˈvenʃn]",
-        "ukphone": "[ˌɪntəˈvenʃ(ə)n]"
-    },
-    {
-        "name": "intimate",
-        "trans": [
-            "n. 知己；至交"
-        ],
-        "usphone": "[ˈɪntɪmət; ˈɪntəmət; ˈɪntɪmeɪt]",
-        "ukphone": "[ˈɪntɪmət]"
-    },
-    {
-        "name": "intriguing",
-        "trans": [
-            "adj. 有趣的；迷人的"
-        ],
-        "usphone": "[ɪnˈtriːɡɪŋ]",
-        "ukphone": "[ɪnˈtriːɡɪŋ]"
-    },
-    {
-        "name": "investigator",
-        "trans": [
-            "n. 研究者；调查者；侦查员"
-        ],
-        "usphone": "[ɪnˈvestɪɡeɪtər]",
-        "ukphone": "[ɪnˈvestɪɡeɪtə(r)]"
-    },
-    {
-        "name": "invisible",
-        "trans": [
-            "adj. 无形的，看不见的；无形的；不显眼的，暗藏的"
-        ],
-        "usphone": "[ɪnˈvɪzəbl]",
-        "ukphone": "[ɪnˈvɪzəb(ə)l]"
-    },
-    {
-        "name": "invoke",
-        "trans": [
-            "vt. 调用；祈求；引起；恳求"
-        ],
-        "usphone": "[ɪnˈvoʊk]",
-        "ukphone": "[ɪnˈvəʊk]"
-    },
-    {
-        "name": "involvement",
-        "trans": [
-            "n. 牵连；包含；混乱；财政困难"
-        ],
-        "usphone": "[ɪnˈvɑːlvmənt]",
-        "ukphone": "[ɪnˈvɒlvmənt]"
-    },
-    {
-        "name": "ironic",
-        "trans": [
-            "adj. 讽刺的；反话的"
-        ],
-        "usphone": "[aɪˈrɑːnɪk]",
-        "ukphone": "[aɪˈrɒnɪk]"
-    },
-    {
-        "name": "ironically",
-        "trans": [
-            "adv. 讽刺地；说反话地"
-        ],
-        "usphone": "[aɪˈrɑːnɪkli]",
-        "ukphone": "[aɪˈrɒnɪkli]"
-    },
-    {
-        "name": "irony",
-        "trans": [
-            "n. 讽刺；反语；具有讽刺意味的事"
-        ],
-        "usphone": "[ˈaɪrəni]",
-        "ukphone": "[ˈaɪrəni]"
-    },
-    {
-        "name": "irrelevant",
-        "trans": [
-            "adj. 不相干的；不切题的"
-        ],
-        "usphone": "[ɪˈreləvənt]",
-        "ukphone": "[ɪˈreləvənt]"
-    },
-    {
-        "name": "isolation",
-        "trans": [
-            "n. 隔离；孤立；[电] 绝缘；[化学] 离析"
-        ],
-        "usphone": "[ˌaɪsəˈleɪʃn]",
-        "ukphone": "[ˌaɪsəˈleɪʃn]"
-    },
-    {
-        "name": "judicial",
-        "trans": [
-            "adj. 公正的，明断的；法庭的；审判上的"
-        ],
-        "usphone": "[dʒuːˈdɪʃəl]",
-        "ukphone": "[dʒuˈdɪʃl]"
-    },
-    {
-        "name": "junction",
-        "trans": [
-            "n. 连接，接合；交叉点；接合点"
-        ],
-        "usphone": "[ˈdʒʌŋkʃn]",
-        "ukphone": "[ˈdʒʌŋkʃn]"
-    },
-    {
-        "name": "jurisdiction",
-        "trans": [
-            "n. 司法权，审判权，管辖权；权限，权力"
-        ],
-        "usphone": "[ˌdʒʊrɪsˈdɪkʃn]",
-        "ukphone": "[ˌdʒʊərɪsˈdɪkʃn]"
-    },
-    {
-        "name": "just",
-        "trans": [
-            "adv. 只是，仅仅；刚才，刚刚；正好，恰好；实在；刚要"
-        ],
-        "usphone": "[dʒʌst]",
-        "ukphone": "[dʒʌst]"
-    },
-    {
-        "name": "justification",
-        "trans": [
-            "n. 理由；辩护；认为有理，认为正当；释罪"
-        ],
-        "usphone": "[ˌdʒʌstɪfɪˈkeɪʃn]",
-        "ukphone": "[ˌdʒʌstɪfɪˈkeɪʃn]"
-    },
-    {
-        "name": "kidnap",
-        "trans": [
-            "vt. 绑架；诱拐；拐骗"
-        ],
-        "usphone": "[ˈkɪdnæp]",
-        "ukphone": "[ˈkɪdnæp]"
-    },
-    {
-        "name": "kidney",
-        "trans": [
-            "n. [解剖] 肾脏；腰子；个性"
-        ],
-        "usphone": "[ˈkɪdni]",
-        "ukphone": "[ˈkɪdni]"
-    },
-    {
-        "name": "kingdom",
-        "trans": [
-            "n. 王国；界；领域"
-        ],
-        "usphone": "[ˈkɪŋdəm]",
-        "ukphone": "[ˈkɪŋdəm]"
-    },
-    {
-        "name": "lad",
-        "trans": [
-            "n. 少年，小伙子；家伙"
-        ],
-        "usphone": "[læd]",
-        "ukphone": "[læd]"
-    },
-    {
-        "name": "landlord",
-        "trans": [
-            "n. 房东，老板；地主"
-        ],
-        "usphone": "[ˈlændlɔːrd]",
-        "ukphone": "[ˈlændlɔːd]"
-    },
-    {
-        "name": "landmark",
-        "trans": [
-            "n. [航]陆标；地标；界标；里程碑；纪念碑；地界标；划时代的事"
-        ],
-        "usphone": "[ˈlændmɑːrk]",
-        "ukphone": "[ˈlændmɑːk]"
-    },
-    {
-        "name": "lap",
-        "trans": [
-            "n. 一圈；膝盖；下摆；山坳"
-        ],
-        "usphone": "[læp]",
-        "ukphone": "[læp]"
-    },
-    {
-        "name": "large-scale",
-        "trans": [
-            "adj. 大规模的，大范围的；大比例尺的"
-        ],
-        "usphone": "[ˌlɑːrdʒ ˈskeɪl]",
-        "ukphone": "[ˌlɑːdʒ ˈskeɪl]"
-    },
-    {
-        "name": "laser",
-        "trans": [
-            "n. 激光"
-        ],
-        "usphone": "[ˈleɪzər]",
-        "ukphone": "[ˈleɪzə(r)]"
-    },
-    {
-        "name": "latter",
-        "trans": [
-            "adj. 后者的；近来的；后面的；较后的"
-        ],
-        "usphone": "[ˈlætər]",
-        "ukphone": "[ˈlætə(r)]"
-    },
-    {
-        "name": "lawn",
-        "trans": [
-            "n. 草地；草坪"
-        ],
-        "usphone": "[lɔːn]",
-        "ukphone": "[lɔːn]"
-    },
-    {
-        "name": "lawsuit",
-        "trans": [
-            "n. 诉讼（尤指非刑事案件）；诉讼案件"
-        ],
-        "usphone": "[ˈlɔːsuːt]",
-        "ukphone": "[ˈlɔːsuːt]"
-    },
-    {
-        "name": "layout",
-        "trans": [
-            "n. 布局；设计；安排；陈列"
-        ],
-        "usphone": "[ˈleɪaʊt]",
-        "ukphone": "[ˈleɪaʊt]"
-    },
-    {
-        "name": "leak",
-        "trans": [
-            "n. 泄漏；漏洞，裂缝"
-        ],
-        "usphone": "[liːk]",
-        "ukphone": "[liːk]"
-    },
-    {
-        "name": "leap",
-        "trans": [
-            "vi. 跳，跳跃"
-        ],
-        "usphone": "[liːp]",
-        "ukphone": "[liːp]"
-    },
-    {
-        "name": "legacy",
-        "trans": [
-            "n. 遗赠，遗产"
-        ],
-        "usphone": "[ˈleɡəsi]",
-        "ukphone": "[ˈleɡəsi]"
-    },
-    {
-        "name": "legendary",
-        "trans": [
-            "adj. 传说的，传奇的"
-        ],
-        "usphone": "[ˈledʒənderi]",
-        "ukphone": "[ˈledʒəndri]"
-    },
-    {
-        "name": "legislation",
-        "trans": [
-            "n. 立法；法律"
-        ],
-        "usphone": "[ˌledʒɪsˈleɪʃn]",
-        "ukphone": "[ˌledʒɪsˈleɪʃn]"
-    },
-    {
-        "name": "legislative",
-        "trans": [
-            "adj. 立法的；有立法权的"
-        ],
-        "usphone": "[ˈledʒɪsleɪtɪv]",
-        "ukphone": "[ˈledʒɪslətɪv]"
-    },
-    {
-        "name": "legislature",
-        "trans": [
-            "n. 立法机关；立法机构"
-        ],
-        "usphone": "[ˈledʒɪsleɪtʃər]",
-        "ukphone": "[ˈledʒɪslətʃə(r)]"
-    },
-    {
-        "name": "legitimate",
-        "trans": [
-            "adj. 合法的；正当的；合理的；正统的"
-        ],
-        "usphone": "[lɪˈdʒɪtɪmət]",
-        "ukphone": "[lɪˈdʒɪtɪmət]"
-    },
-    {
-        "name": "lengthy",
-        "trans": [
-            "adj. 漫长的，冗长的；啰唆的"
-        ],
-        "usphone": "[ˈleŋθi]",
-        "ukphone": "[ˈleŋθi]"
-    },
-    {
-        "name": "lesbian",
-        "trans": [
-            "adj. [心理] 女同性恋的"
-        ],
-        "usphone": "[ˈlezbiən]",
-        "ukphone": "[ˈlezbiən]"
-    },
-    {
-        "name": "lesser",
-        "trans": [
-            "adj. 较少的；次要的；更小的"
-        ],
-        "usphone": "[ˈlesər]",
-        "ukphone": "[ˈlesə(r)]"
-    },
-    {
-        "name": "lethal",
-        "trans": [
-            "adj. 致命的，致死的"
-        ],
-        "usphone": "[ˈliːθl]",
-        "ukphone": "[ˈliːθ(ə)l]"
-    },
-    {
-        "name": "liable",
-        "trans": [
-            "adj. 有责任的，有义务的；应受罚的；有…倾向的；易…的"
-        ],
-        "usphone": "[ˈlaɪəbl]",
-        "ukphone": "[ˈlaɪəb(ə)l]"
-    },
-    {
-        "name": "liberal",
-        "trans": [
-            "adj. 自由主义的；慷慨的；不拘泥的；宽大的"
-        ],
-        "usphone": "[ˈlɪbərəl]",
-        "ukphone": "[ˈlɪbərəl]"
-    },
-    {
-        "name": "liberation",
-        "trans": [
-            "n. 释放，解放"
-        ],
-        "usphone": "[ˌlɪbəˈreɪʃn]",
-        "ukphone": "[ˌlɪbəˈreɪʃ(ə)n]"
-    },
-    {
-        "name": "liberty",
-        "trans": [
-            "n. 自由；许可；冒失"
-        ],
-        "usphone": "[ˈlɪbərti]",
-        "ukphone": "[ˈlɪbəti]"
-    },
-    {
-        "name": "license",
-        "trans": [
-            "n. 执照，许可证；特许"
-        ],
-        "usphone": "[ˈlaɪsns]",
-        "ukphone": "[ˈlaɪsns]"
-    },
-    {
-        "name": "lifelong",
-        "trans": [
-            "adj. 终身的"
-        ],
-        "usphone": "[ˈlaɪflɔːŋ]",
-        "ukphone": "[ˈlaɪflɒŋ]"
-    },
-    {
-        "name": "likelihood",
-        "trans": [
-            "n. 可能性，可能"
-        ],
-        "usphone": "[ˈlaɪklihʊd]",
-        "ukphone": "[ˈlaɪklihʊd]"
-    },
-    {
-        "name": "limb",
-        "trans": [
-            "n. 肢，臂；分支；枝干"
-        ],
-        "usphone": "[lɪm]",
-        "ukphone": "[lɪm]"
-    },
-    {
-        "name": "linear",
-        "trans": [
-            "adj. 线的，线型的；直线的，线状的；长度的"
-        ],
-        "usphone": "[ˈlɪniər]",
-        "ukphone": "[ˈlɪniə(r)]"
-    },
-    {
-        "name": "line-up",
-        "trans": [
-            "vt. 排成直线；排成行"
-        ],
-        "usphone": "[ˈlaɪn ʌp]",
-        "ukphone": "[ˈlaɪn ʌp]"
-    },
-    {
-        "name": "linger",
-        "trans": [
-            "vi. 徘徊；苟延残喘；磨蹭"
-        ],
-        "usphone": "[ˈlɪŋɡər]",
-        "ukphone": "[ˈlɪŋɡə(r)]"
-    },
-    {
-        "name": "listing",
-        "trans": [
-            "n. 列表，清单"
-        ],
-        "usphone": "[ˈlɪstɪŋ]",
-        "ukphone": "[ˈlɪstɪŋ]"
-    },
-    {
-        "name": "literacy",
-        "trans": [
-            "n. 读写能力；精通文学"
-        ],
-        "usphone": "[ˈlɪtərəsi]",
-        "ukphone": "[ˈlɪtərəsi]"
-    },
-    {
-        "name": "liver",
-        "trans": [
-            "n. 肝脏；生活者，居民"
-        ],
-        "usphone": "[ˈlɪvər]",
-        "ukphone": "[ˈlɪvə(r)]"
-    },
-    {
-        "name": "lobby",
-        "trans": [
-            "n. 大厅；休息室；会客室；游说议员的团体"
-        ],
-        "usphone": "[ˈlɑːbi]",
-        "ukphone": "[ˈlɒbi]"
-    },
-    {
-        "name": "log",
-        "trans": [
-            "vi. 伐木"
-        ],
-        "usphone": "[lɔːɡ]",
-        "ukphone": "[lɒɡ]"
-    },
-    {
-        "name": "logic",
-        "trans": [
-            "n. 逻辑；逻辑学；逻辑性"
-        ],
-        "usphone": "[ˈlɑːdʒɪk]",
-        "ukphone": "[ˈlɒdʒɪk]"
-    },
-    {
-        "name": "long-standing",
-        "trans": [
-            "adj. 长期存在的；存在已久的"
-        ],
-        "usphone": "[ˌlɔːŋ ˈstændɪŋ]",
-        "ukphone": "[ˌlɒŋ ˈstændɪŋ]"
-    },
-    {
-        "name": "long-time",
-        "trans": [
-            "adj. 长期；长期载荷"
-        ],
-        "usphone": "[ˈlɔːŋ taɪm]",
-        "ukphone": "[ˈlɒŋ taɪm]"
-    },
-    {
-        "name": "loom",
-        "trans": [
-            "n. 织布机；若隐若现的景象"
-        ],
-        "usphone": "[luːm]",
-        "ukphone": "[luːm]"
-    },
-    {
-        "name": "loop",
-        "trans": [
-            "vi. 打环；翻筋斗"
-        ],
-        "usphone": "[luːp]",
-        "ukphone": "[luːp]"
-    },
-    {
-        "name": "loyalty",
-        "trans": [
-            "n. 忠诚；忠心；忠实；忠于…感情"
-        ],
-        "usphone": "[ˈlɔɪəlti]",
-        "ukphone": "[ˈlɔɪəlti]"
-    },
-    {
-        "name": "machinery",
-        "trans": [
-            "n. 机械；机器；机构；机械装置"
-        ],
-        "usphone": "[məˈʃiːnəri]",
-        "ukphone": "[məˈʃiːnəri]"
-    },
-    {
-        "name": "magical",
-        "trans": [
-            "adj. 魔术的；有魔力的"
-        ],
-        "usphone": "[ˈmædʒɪkl]",
-        "ukphone": "[ˈmædʒɪkl]"
-    },
-    {
-        "name": "magistrate",
-        "trans": [
-            "n. 地方法官；文职官员；治安推事"
-        ],
-        "usphone": "[ˈmædʒɪstreɪt]",
-        "ukphone": "[ˈmædʒɪstreɪt]"
-    },
-    {
-        "name": "magnetic",
-        "trans": [
-            "adj. 地磁的；有磁性的；有吸引力的"
-        ],
-        "usphone": "[mæɡˈnetɪk]",
-        "ukphone": "[mæɡˈnetɪk]"
-    },
-    {
-        "name": "magnitude",
-        "trans": [
-            "n. 大小；量级；[地震] 震级；重要；光度"
-        ],
-        "usphone": "[ˈmæɡnɪtuːd]",
-        "ukphone": "[ˈmæɡnɪtjuːd]"
-    },
-    {
-        "name": "mainland",
-        "trans": [
-            "n. 大陆；本土"
-        ],
-        "usphone": "[ˈmeɪnlənd; ˈmeɪnlænd]",
-        "ukphone": "[ˈmeɪnlənd; ˈmeɪnlænd]"
-    },
-    {
-        "name": "mainstream",
-        "trans": [
-            "n. 主流"
-        ],
-        "usphone": "[ˈmeɪnstriːm]",
-        "ukphone": "[ˈmeɪnstriːm]"
-    },
-    {
-        "name": "maintenance",
-        "trans": [
-            "n. 维护，维修；保持；生活费用"
-        ],
-        "usphone": "[ˈmeɪntənəns]",
-        "ukphone": "[ˈmeɪntənəns]"
-    },
-    {
-        "name": "mandate",
-        "trans": [
-            "n. 授权；命令，指令；委托管理；受命进行的工作"
-        ],
-        "usphone": "[ˈmændeɪt]",
-        "ukphone": "[ˈmændeɪt]"
-    },
-    {
-        "name": "mandatory",
-        "trans": [
-            "adj. 强制的；托管的；命令的"
-        ],
-        "usphone": "[ˈmændətɔːri]",
-        "ukphone": "[ˈmændətəri]"
-    },
-    {
-        "name": "manifest",
-        "trans": [
-            "vt. 证明，表明；显示"
-        ],
-        "usphone": "[ˈmænɪfest]",
-        "ukphone": "[ˈmænɪfest]"
-    },
-    {
-        "name": "manipulate",
-        "trans": [
-            "vt. 操纵；操作；巧妙地处理；篡改"
-        ],
-        "usphone": "[məˈnɪpjuleɪt]",
-        "ukphone": "[məˈnɪpjuleɪt]"
-    },
-    {
-        "name": "manipulation",
-        "trans": [
-            "n. 操纵；操作；处理；篡改"
-        ],
-        "usphone": "[məˌnɪpjuˈleɪʃn]",
-        "ukphone": "[məˌnɪpjuˈleɪʃn]"
-    },
-    {
-        "name": "manuscript",
-        "trans": [
-            "n. [图情] 手稿；原稿"
-        ],
-        "usphone": "[ˈmænjuskrɪpt]",
-        "ukphone": "[ˈmænjuskrɪpt]"
-    },
-    {
-        "name": "March",
-        "trans": [
-            "n. 三月"
-        ],
-        "usphone": "[mɑːrtʃ]",
-        "ukphone": "[mɑːtʃ]"
-    },
-    {
-        "name": "march",
-        "trans": [
-            "n. 三月"
-        ],
-        "usphone": "[mɑːrtʃ]",
-        "ukphone": "[mɑːtʃ]"
-    },
-    {
-        "name": "marginal",
-        "trans": [
-            "adj. 边缘的；临界的；末端的"
-        ],
-        "usphone": "[ˈmɑːrdʒɪnl]",
-        "ukphone": "[ˈmɑːdʒɪn(ə)l]"
-    },
-    {
-        "name": "marine",
-        "trans": [
-            "adj. 船舶的；海生的；海产的；航海的，海运的"
-        ],
-        "usphone": "[məˈriːn]",
-        "ukphone": "[məˈriːn]"
-    },
-    {
-        "name": "marketplace",
-        "trans": [
-            "n. 市场；商场；市集"
-        ],
-        "usphone": "[ˈmɑːrkɪtpleɪs]",
-        "ukphone": "[ˈmɑːkɪtpleɪs]"
-    },
-    {
-        "name": "mask",
-        "trans": [
-            "n. 面具；口罩；掩饰"
-        ],
-        "usphone": "[mæsk]",
-        "ukphone": "[mɑːsk]"
+        "usphone": "[kuː]",
+        "ukphone": "[kuː]"
     },
     {
         "name": "massacre",
@@ -5936,324 +384,84 @@
         "ukphone": "[ˈmæsəkə(r)]"
     },
     {
-        "name": "mathematical",
+        "name": "epidemic",
         "trans": [
-            "adj. 数学的，数学上的；精确的"
+            "n. 传染病；流行病；风尚等的流行"
         ],
-        "usphone": "[ˌmæθəˈmætɪkl]",
-        "ukphone": "[ˌmæθəˈmætɪk(ə)l]"
+        "usphone": "[ˌepɪˈdemɪk]",
+        "ukphone": "[ˌepɪˈdemɪk]"
     },
     {
-        "name": "mature",
+        "name": "weave",
         "trans": [
-            "adj. 成熟的；充分考虑的；到期的；成年人的"
+            "vi. 纺织；编成；迂回行进"
         ],
-        "usphone": "[məˈtʃʊr; məˈtʊr]",
-        "ukphone": "[məˈtʃʊə(r)]"
+        "usphone": "[wiːv]",
+        "ukphone": "[wiːv]"
     },
     {
-        "name": "maximize",
+        "name": "inadequate",
         "trans": [
-            "vt. 取…最大值；对…极为重视"
+            "adj. 不充分的，不适当的"
         ],
-        "usphone": "[ˈmæksɪmaɪz]",
-        "ukphone": "[ˈmæksɪmaɪz]"
+        "usphone": "[ɪnˈædɪkwət]",
+        "ukphone": "[ɪnˈædɪkwət]"
     },
     {
-        "name": "meaningful",
+        "name": "evoke",
         "trans": [
-            "adj. 有意义的；意味深长的"
+            "vt. 引起，唤起；博得"
         ],
-        "usphone": "[ˈmiːnɪŋfl]",
-        "ukphone": "[ˈmiːnɪŋfl]"
+        "usphone": "[ɪˈvoʊk]",
+        "ukphone": "[ɪˈvəʊk]"
     },
     {
-        "name": "meantime",
+        "name": "strand",
         "trans": [
-            "n. 其时，其间"
+            "n. 线；串；海滨"
         ],
-        "usphone": "[ˈmiːntaɪm]",
-        "ukphone": "[ˈmiːntaɪm]"
+        "usphone": "[strænd]",
+        "ukphone": "[strænd]"
     },
     {
-        "name": "medieval",
+        "name": "favourable",
         "trans": [
-            "adj. 中世纪的；原始的；仿中世纪的；老式的"
+            "n. 有利"
         ],
-        "usphone": "[ˌmediˈiːvlˌˌmiːdˈiːvl]",
-        "ukphone": "[ˌmediˈiːvl]"
+        "usphone": "[ˈfeɪvərəbl]",
+        "ukphone": "[ˈfeɪvərəb(ə)l]"
     },
     {
-        "name": "meditation",
+        "name": "explosive",
         "trans": [
-            "n. 冥想；沉思，深思"
+            "n. 炸药；爆炸物"
         ],
-        "usphone": "[ˌmedɪˈteɪʃn]",
-        "ukphone": "[ˌmedɪˈteɪʃn]"
+        "usphone": "[ɪkˈsploʊsɪvˌɪkˈsploʊzɪv]",
+        "ukphone": "[ɪkˈspləʊsɪv]"
     },
     {
-        "name": "melody",
+        "name": "gross",
         "trans": [
-            "n. 旋律；歌曲；美妙的音乐"
+            "n. 总额，总数"
         ],
-        "usphone": "[ˈmelədi]",
-        "ukphone": "[ˈmelədi]"
+        "usphone": "[ɡroʊs]",
+        "ukphone": "[ɡrəʊs]"
     },
     {
-        "name": "memo",
+        "name": "unify",
         "trans": [
-            "n. 备忘录"
+            "vt. 统一；使相同，使一致"
         ],
-        "usphone": "[ˈmemoʊ]",
-        "ukphone": "[ˈmeməʊ]"
+        "usphone": "[ˈjuːnɪfaɪ]",
+        "ukphone": "[ˈjuːnɪfaɪ]"
     },
     {
-        "name": "memoir",
+        "name": "bleed",
         "trans": [
-            "n. 回忆录；研究报告；自传；实录"
+            "vt. 使出血；榨取"
         ],
-        "usphone": "[ˈmemwɑːr]",
-        "ukphone": "[ˈmemwɑː(r)]"
-    },
-    {
-        "name": "memorial",
-        "trans": [
-            "n. 纪念碑，纪念馆；纪念仪式；纪念物"
-        ],
-        "usphone": "[məˈmɔːriəl]",
-        "ukphone": "[məˈmɔːriəl]"
-    },
-    {
-        "name": "mentor",
-        "trans": [
-            "n. 指导者，良师益友"
-        ],
-        "usphone": "[ˈmentɔːr]",
-        "ukphone": "[ˈmentɔː(r)]"
-    },
-    {
-        "name": "merchant",
-        "trans": [
-            "n. 商人，批发商；店主"
-        ],
-        "usphone": "[ˈmɜːrtʃənt]",
-        "ukphone": "[ˈmɜːtʃənt]"
-    },
-    {
-        "name": "mercy",
-        "trans": [
-            "n. 仁慈，宽容；怜悯；幸运；善行"
-        ],
-        "usphone": "[ˈmɜːrsi]",
-        "ukphone": "[ˈmɜːsi]"
-    },
-    {
-        "name": "mere",
-        "trans": [
-            "adj. 仅仅的；只不过的"
-        ],
-        "usphone": "[mɪr]",
-        "ukphone": "[mɪə(r)]"
-    },
-    {
-        "name": "merely",
-        "trans": [
-            "adv. 仅仅，只不过；只是"
-        ],
-        "usphone": "[ˈmɪrli]",
-        "ukphone": "[ˈmɪəli]"
-    },
-    {
-        "name": "merge",
-        "trans": [
-            "vt. 合并；使合并；吞没"
-        ],
-        "usphone": "[mɜːrdʒ]",
-        "ukphone": "[mɜːdʒ]"
-    },
-    {
-        "name": "merger",
-        "trans": [
-            "n. （企业等的）合并；并购；吸收（如刑法中重罪吸收轻罪）"
-        ],
-        "usphone": "[ˈmɜːrdʒər]",
-        "ukphone": "[ˈmɜːdʒə(r)]"
-    },
-    {
-        "name": "merit",
-        "trans": [
-            "n. 优点，价值；功绩；功过"
-        ],
-        "usphone": "[ˈmerɪt]",
-        "ukphone": "[ˈmerɪt]"
-    },
-    {
-        "name": "methodology",
-        "trans": [
-            "n. 方法学，方法论"
-        ],
-        "usphone": "[ˌmeθəˈdɑːlədʒi]",
-        "ukphone": "[ˌmeθəˈdɒlədʒi]"
-    },
-    {
-        "name": "midst",
-        "trans": [
-            "n. 当中，中间"
-        ],
-        "usphone": "[mɪdst]",
-        "ukphone": "[mɪdst]"
-    },
-    {
-        "name": "migration",
-        "trans": [
-            "n. 迁移；移民；移动"
-        ],
-        "usphone": "[maɪˈɡreɪʃn]",
-        "ukphone": "[maɪˈɡreɪʃn]"
-    },
-    {
-        "name": "militant",
-        "trans": [
-            "adj. 好战的"
-        ],
-        "usphone": "[ˈmɪlɪtənt]",
-        "ukphone": "[ˈmɪlɪtənt]"
-    },
-    {
-        "name": "militia",
-        "trans": [
-            "n. 民兵组织；自卫队；义勇军；国民军"
-        ],
-        "usphone": "[məˈlɪʃə]",
-        "ukphone": "[məˈlɪʃə]"
-    },
-    {
-        "name": "mill",
-        "trans": [
-            "vi. 乱转；被碾磨"
-        ],
-        "usphone": "[mɪl]",
-        "ukphone": "[mɪl]"
-    },
-    {
-        "name": "minimal",
-        "trans": [
-            "adj. 最低的；最小限度的"
-        ],
-        "usphone": "[ˈmɪnɪml]",
-        "ukphone": "[ˈmɪnɪml]"
-    },
-    {
-        "name": "minimize",
-        "trans": [
-            "vt. 使减到最少；小看，极度轻视"
-        ],
-        "usphone": "[ˈmɪnɪmaɪz]",
-        "ukphone": "[ˈmɪnɪmaɪz]"
-    },
-    {
-        "name": "mining",
-        "trans": [
-            "n. 矿业；采矿"
-        ],
-        "usphone": "[ˈmaɪnɪŋ]",
-        "ukphone": "[ˈmaɪnɪŋ]"
-    },
-    {
-        "name": "ministry",
-        "trans": [
-            "n. （政府的）部门"
-        ],
-        "usphone": "[ˈmɪnɪstri]",
-        "ukphone": "[ˈmɪnɪstri]"
-    },
-    {
-        "name": "minute",
-        "trans": [
-            "n. 分，分钟；片刻，一会儿；备忘录，笔记；会议记录"
-        ],
-        "usphone": "[ˈmɪnɪt]",
-        "ukphone": "[ˈmɪnɪt]"
-    },
-    {
-        "name": "miracle",
-        "trans": [
-            "n. 奇迹，奇迹般的人或物；惊人的事例"
-        ],
-        "usphone": "[ˈmɪrəkl]",
-        "ukphone": "[ˈmɪrəkl]"
-    },
-    {
-        "name": "misery",
-        "trans": [
-            "n. 痛苦，悲惨；不幸；苦恼；穷困"
-        ],
-        "usphone": "[ˈmɪzəri]",
-        "ukphone": "[ˈmɪzəri]"
-    },
-    {
-        "name": "misleading",
-        "trans": [
-            "adj. 令人误解的；引入歧途的"
-        ],
-        "usphone": "[ˌmɪsˈliːdɪŋ]",
-        "ukphone": "[ˌmɪsˈliːdɪŋ]"
-    },
-    {
-        "name": "missile",
-        "trans": [
-            "n. 导弹；投射物"
-        ],
-        "usphone": "[ˈmɪsl]",
-        "ukphone": "[ˈmɪsaɪl]"
-    },
-    {
-        "name": "mob",
-        "trans": [
-            "n. 暴民，暴徒；民众；乌合之众"
-        ],
-        "usphone": "[mɑːb]",
-        "ukphone": "[mɒb]"
-    },
-    {
-        "name": "mobility",
-        "trans": [
-            "n. 移动性；机动性；[电子] 迁移率"
-        ],
-        "usphone": "[moʊˈbɪləti]",
-        "ukphone": "[məʊˈbɪləti]"
-    },
-    {
-        "name": "mobilize",
-        "trans": [
-            "vt. 动员，调动；集合，组织；使…流通；使…松动"
-        ],
-        "usphone": "[ˈmoʊbəlaɪz]",
-        "ukphone": "[ˈməʊbəlaɪz]"
-    },
-    {
-        "name": "moderate",
-        "trans": [
-            "adj. 稳健的，温和的；适度的，中等的；有节制的"
-        ],
-        "usphone": "[ˈmɑːdərət]",
-        "ukphone": "[ˈmɒdərət]"
-    },
-    {
-        "name": "modification",
-        "trans": [
-            "n. 修改，修正；改变"
-        ],
-        "usphone": "[ˌmɑːdɪfɪˈkeɪʃn]",
-        "ukphone": "[ˌmɒdɪfɪˈkeɪʃn]"
-    },
-    {
-        "name": "momentum",
-        "trans": [
-            "n. 势头；[物] 动量；动力；冲力"
-        ],
-        "usphone": "[moʊˈmentəm]",
-        "ukphone": "[məˈmentəm]"
+        "usphone": "[bliːd]",
+        "ukphone": "[bliːd]"
     },
     {
         "name": "monk",
@@ -6264,1372 +472,28 @@
         "ukphone": "[mʌŋk]"
     },
     {
-        "name": "monopoly",
+        "name": "legislative",
         "trans": [
-            "n. 垄断；垄断者；专卖权"
+            "adj. 立法的；有立法权的"
         ],
-        "usphone": "[məˈnɑːpəli]",
-        "ukphone": "[məˈnɒpəli]"
+        "usphone": "[ˈledʒɪsleɪtɪv]",
+        "ukphone": "[ˈledʒɪslətɪv]"
     },
     {
-        "name": "morality",
+        "name": "tobacco",
         "trans": [
-            "n. 道德；品行，美德"
+            "n. 烟草，烟叶；烟草制品；抽烟"
         ],
-        "usphone": "[məˈræləti]",
-        "ukphone": "[məˈræləti]"
+        "usphone": "[təˈbækoʊ]",
+        "ukphone": "[təˈbækəʊ]"
     },
     {
-        "name": "motive",
+        "name": "fluid",
         "trans": [
-            "n. 动机，目的；主题"
+            "n. 流体；液体"
         ],
-        "usphone": "[ˈməʊtɪv]",
-        "ukphone": "[ˈməʊtɪv]"
-    },
-    {
-        "name": "motorist",
-        "trans": [
-            "n. 驾车旅行的人，开汽车的人"
-        ],
-        "usphone": "[ˈmoʊtərɪst]",
-        "ukphone": "[ˈməʊtərɪst]"
-    },
-    {
-        "name": "municipal",
-        "trans": [
-            "adj. 市政的，市的；地方自治的"
-        ],
-        "usphone": "[mjuːˈnɪsɪpl]",
-        "ukphone": "[mjuːˈnɪsɪpl]"
-    },
-    {
-        "name": "mutual",
-        "trans": [
-            "adj. 共同的；相互的，彼此的"
-        ],
-        "usphone": "[ˈmjuːtʃuəl]",
-        "ukphone": "[ˈmjuːtʃuəl]"
-    },
-    {
-        "name": "namely",
-        "trans": [
-            "adv. 也就是；即是；换句话说"
-        ],
-        "usphone": "[ˈneɪmli]",
-        "ukphone": "[ˈneɪmli]"
-    },
-    {
-        "name": "nationwide",
-        "trans": [
-            "adj. 全国范围的；全国性的"
-        ],
-        "usphone": "[ˌneɪʃnˈwaɪd]",
-        "ukphone": "[ˌneɪʃnˈwaɪd]"
-    },
-    {
-        "name": "naval",
-        "trans": [
-            "adj. 海军的；军舰的"
-        ],
-        "usphone": "[ˈneɪvl]",
-        "ukphone": "[ˈneɪv(ə)l]"
-    },
-    {
-        "name": "neglect",
-        "trans": [
-            "vt. 疏忽，忽视；忽略"
-        ],
-        "usphone": "[nɪˈɡlekt]",
-        "ukphone": "[nɪˈɡlekt]"
-    },
-    {
-        "name": "neighbouring",
-        "trans": [
-            "adj. 邻近的；附近的；接壤的"
-        ],
-        "usphone": "[ˈneɪbərɪŋ]",
-        "ukphone": "[ˈneɪbərɪŋ]"
-    },
-    {
-        "name": "nest",
-        "trans": [
-            "n. 巢，窝；安乐窝；温床"
-        ],
-        "usphone": "[nest]",
-        "ukphone": "[nest]"
-    },
-    {
-        "name": "net",
-        "trans": [
-            "n. 网；网络；净利；实价"
-        ],
-        "usphone": "[net]",
-        "ukphone": "[net]"
-    },
-    {
-        "name": "newsletter",
-        "trans": [
-            "n. 时事通讯"
-        ],
-        "usphone": "[ˈnuːzletər]",
-        "ukphone": "[ˈnjuːzletə(r)]"
-    },
-    {
-        "name": "niche",
-        "trans": [
-            "n. 壁龛；合适的职业；[亦称作 niche market]【商业】有利可图的市场(或形势等)"
-        ],
-        "usphone": "[niːʃˌnɪtʃ]",
-        "ukphone": "[niːʃ; nɪtʃ]"
-    },
-    {
-        "name": "noble",
-        "trans": [
-            "adj. 高尚的；贵族的；惰性的；宏伟的"
-        ],
-        "usphone": "[ˈnoʊbl]",
-        "ukphone": "[ˈnəʊbl]"
-    },
-    {
-        "name": "nod",
-        "trans": [
-            "n. 点头；打盹；摆动"
-        ],
-        "usphone": "[nɑːd]",
-        "ukphone": "[nɒd]"
-    },
-    {
-        "name": "nominate",
-        "trans": [
-            "vt. 推荐；提名；任命；指定"
-        ],
-        "usphone": "[ˈnɑːmɪneɪt]",
-        "ukphone": "[ˈnɒmɪneɪt]"
-    },
-    {
-        "name": "nomination",
-        "trans": [
-            "n. 任命，提名；提名权"
-        ],
-        "usphone": "[ˌnɑːmɪˈneɪʃn]",
-        "ukphone": "[ˌnɒmɪˈneɪʃn]"
-    },
-    {
-        "name": "nominee",
-        "trans": [
-            "n. 被任命者；被提名的人；代名人"
-        ],
-        "usphone": "[ˌnɑːmɪˈniː]",
-        "ukphone": "[ˌnɒmɪˈniː]"
-    },
-    {
-        "name": "nonetheless",
-        "trans": [
-            "adv. 尽管如此，但是"
-        ],
-        "usphone": "[ˌnʌnðəˈles]",
-        "ukphone": "[ˌnʌnðəˈles]"
-    },
-    {
-        "name": "non-profit",
-        "trans": [
-            "adj. 非营利的"
-        ],
-        "usphone": "[ˌnɑːn ˈprɑːfɪt]",
-        "ukphone": "[ˌnɒn ˈprɒfɪt]"
-    },
-    {
-        "name": "nonsense",
-        "trans": [
-            "n. 胡说；废话"
-        ],
-        "usphone": "[ˈnɑːnsens; ˈnɑːnsns]",
-        "ukphone": "[ˈnɒns(ə)ns]"
-    },
-    {
-        "name": "noon",
-        "trans": [
-            "n. 中午；正午；全盛期"
-        ],
-        "usphone": "[nuːn]",
-        "ukphone": "[nuːn]"
-    },
-    {
-        "name": "notable",
-        "trans": [
-            "adj. 值得注意的，显著的；著名的"
-        ],
-        "usphone": "[ˈnoʊtəbl]",
-        "ukphone": "[ˈnəʊtəbl]"
-    },
-    {
-        "name": "notably",
-        "trans": [
-            "adv. 显著地；尤其"
-        ],
-        "usphone": "[ˈnoʊtəbli]",
-        "ukphone": "[ˈnəʊtəbli]"
-    },
-    {
-        "name": "notify",
-        "trans": [
-            "vt. 通告，通知；公布"
-        ],
-        "usphone": "[ˈnoʊtɪfaɪ]",
-        "ukphone": "[ˈnəʊtɪfaɪ]"
-    },
-    {
-        "name": "notorious",
-        "trans": [
-            "adj. 声名狼藉的，臭名昭著的"
-        ],
-        "usphone": "[noʊˈtɔːriəs]",
-        "ukphone": "[nəʊˈtɔːriəs]"
-    },
-    {
-        "name": "novel",
-        "trans": [
-            "adj. 新奇的；异常的"
-        ],
-        "usphone": "[ˈnɑːv(ə)l]",
-        "ukphone": "[ˈnɒv(ə)l]"
-    },
-    {
-        "name": "nursery",
-        "trans": [
-            "n. 苗圃；托儿所；温床"
-        ],
-        "usphone": "[ˈnɜːrsəri]",
-        "ukphone": "[ˈnɜːsəri]"
-    },
-    {
-        "name": "objection",
-        "trans": [
-            "n. 异议，反对；缺陷，缺点；妨碍；拒绝的理由"
-        ],
-        "usphone": "[əbˈdʒekʃn]",
-        "ukphone": "[əbˈdʒekʃn]"
-    },
-    {
-        "name": "oblige",
-        "trans": [
-            "vt. 迫使；强制；赐，施恩惠；责成；义务"
-        ],
-        "usphone": "[əˈblaɪdʒ]",
-        "ukphone": "[əˈblaɪdʒ]"
-    },
-    {
-        "name": "obsess",
-        "trans": [
-            "vt. 迷住，缠住；使…着迷；使…困扰"
-        ],
-        "usphone": "[əbˈses]",
-        "ukphone": "[əbˈses]"
-    },
-    {
-        "name": "obsession",
-        "trans": [
-            "n. 痴迷；困扰；[内科][心理] 强迫观念"
-        ],
-        "usphone": "[əbˈseʃn]",
-        "ukphone": "[əbˈseʃn]"
-    },
-    {
-        "name": "occasional",
-        "trans": [
-            "adj. 偶然的；临时的；特殊场合的"
-        ],
-        "usphone": "[əˈkeɪʒənl]",
-        "ukphone": "[əˈkeɪʒən(ə)l]"
-    },
-    {
-        "name": "occurrence",
-        "trans": [
-            "n. 发生；出现；事件；发现"
-        ],
-        "usphone": "[əˈkɜːrəns]",
-        "ukphone": "[əˈkʌrəns]"
-    },
-    {
-        "name": "odds",
-        "trans": [
-            "n. 几率；胜算；不平等；差别"
-        ],
-        "usphone": "[ɑːdz]",
-        "ukphone": "[ɒdz]"
-    },
-    {
-        "name": "offering",
-        "trans": [
-            "n. 提供；祭品；奉献物；牲礼"
-        ],
-        "usphone": "[ˈɔːfərɪŋ]",
-        "ukphone": "[ˈɒfərɪŋ]"
-    },
-    {
-        "name": "offspring",
-        "trans": [
-            "n. 后代，子孙；产物"
-        ],
-        "usphone": "[ˈɔːfsprɪŋ]",
-        "ukphone": "[ˈɒfsprɪŋ]"
-    },
-    {
-        "name": "operational",
-        "trans": [
-            "adj. 操作的；运作的"
-        ],
-        "usphone": "[ˌɑːpəˈreɪʃən(ə)l]",
-        "ukphone": "[ˌɒpəˈreɪʃən(ə)l]"
-    },
-    {
-        "name": "opt",
-        "trans": [
-            "vi. 选择"
-        ],
-        "usphone": "[ɑːpt]",
-        "ukphone": "[ɒpt]"
-    },
-    {
-        "name": "optical",
-        "trans": [
-            "adj. 光学的；眼睛的，视觉的"
-        ],
-        "usphone": "[ˈɑːptɪk(ə)l]",
-        "ukphone": "[ˈɒptɪk(ə)l]"
-    },
-    {
-        "name": "optimism",
-        "trans": [
-            "n. 乐观；乐观主义"
-        ],
-        "usphone": "[ˈɑːptɪmɪzəm]",
-        "ukphone": "[ˈɒptɪmɪzəm]"
-    },
-    {
-        "name": "oral",
-        "trans": [
-            "n. 口试"
-        ],
-        "usphone": "[ˈɔːrəl]",
-        "ukphone": "[ˈɔːrəl]"
-    },
-    {
-        "name": "organizational",
-        "trans": [
-            "adj. 组织的；编制的"
-        ],
-        "usphone": "[ˌɔːrɡənəˈzeɪʃənl]",
-        "ukphone": "[ˌɔːɡənaɪˈzeɪʃənl]"
-    },
-    {
-        "name": "orientation",
-        "trans": [
-            "n. 方向；定向；适应；情况介绍；向东方"
-        ],
-        "usphone": "[ˌɔːriənˈteɪʃn]",
-        "ukphone": "[ˌɔːriənˈteɪʃ(ə)n]"
-    },
-    {
-        "name": "originate",
-        "trans": [
-            "vt. 引起；创作"
-        ],
-        "usphone": "[əˈrɪdʒɪneɪt]",
-        "ukphone": "[əˈrɪdʒɪneɪt]"
-    },
-    {
-        "name": "outbreak",
-        "trans": [
-            "n. （战争的）爆发；（疾病的）发作"
-        ],
-        "usphone": "[ˈaʊtbreɪk]",
-        "ukphone": "[ˈaʊtbreɪk]"
-    },
-    {
-        "name": "outing",
-        "trans": [
-            "n. 远足；短途旅游；体育比赛"
-        ],
-        "usphone": "[ˈaʊtɪŋ]",
-        "ukphone": "[ˈaʊtɪŋ]"
-    },
-    {
-        "name": "outlet",
-        "trans": [
-            "n. 出口，排放孔；[电] 电源插座；销路；发泄的方法；批发商店"
-        ],
-        "usphone": "[ˈaʊtlet]",
-        "ukphone": "[ˈaʊtlet]"
-    },
-    {
-        "name": "outlook",
-        "trans": [
-            "n. 展望；观点；景色"
-        ],
-        "usphone": "[ˈaʊtlʊk]",
-        "ukphone": "[ˈaʊtlʊk]"
-    },
-    {
-        "name": "outrage",
-        "trans": [
-            "n. 愤怒，愤慨；暴行；侮辱"
-        ],
-        "usphone": "[ˈaʊtreɪdʒ]",
-        "ukphone": "[ˈaʊtreɪdʒ]"
-    },
-    {
-        "name": "outsider",
-        "trans": [
-            "n. 外人；无取胜希望者"
-        ],
-        "usphone": "[ˌaʊtˈsaɪdər]",
-        "ukphone": "[ˌaʊtˈsaɪdə(r)]"
-    },
-    {
-        "name": "overlook",
-        "trans": [
-            "vt. 忽略；俯瞰；远眺；检查；高耸于…之上"
-        ],
-        "usphone": "[ˌoʊvərˈlʊk]",
-        "ukphone": "[ˌəʊvəˈlʊk]"
-    },
-    {
-        "name": "overly",
-        "trans": [
-            "adv. 过度地；极度地"
-        ],
-        "usphone": "[ˈoʊvərli]",
-        "ukphone": "[ˈəʊvəli]"
-    },
-    {
-        "name": "oversee",
-        "trans": [
-            "vt. 监督；审查；俯瞰；偷看到，无意中看到"
-        ],
-        "usphone": "[ˌoʊvərˈsiː]",
-        "ukphone": "[ˌəʊvəˈsiː]"
-    },
-    {
-        "name": "overturn",
-        "trans": [
-            "vt. 推翻；倾覆；破坏"
-        ],
-        "usphone": "[ˌoʊvərˈtɜːrn]",
-        "ukphone": "[ˌəʊvəˈtɜːn]"
-    },
-    {
-        "name": "overwhelm",
-        "trans": [
-            "vt. 淹没；压倒；受打击；覆盖；压垮"
-        ],
-        "usphone": "[ˌoʊvərˈwelm]",
-        "ukphone": "[ˌəʊvəˈwelm]"
-    },
-    {
-        "name": "overwhelming",
-        "trans": [
-            "adj. 压倒性的；势不可挡的"
-        ],
-        "usphone": "[ˌoʊvərˈwelmɪŋ]",
-        "ukphone": "[ˌəʊvəˈwelmɪŋ]"
-    },
-    {
-        "name": "pad",
-        "trans": [
-            "n. 衬垫；护具；便笺簿；填补"
-        ],
-        "usphone": "[pæd]",
-        "ukphone": "[pæd]"
-    },
-    {
-        "name": "parameter",
-        "trans": [
-            "n. 参数；系数；参量"
-        ],
-        "usphone": "[pəˈræmɪtər]",
-        "ukphone": "[pəˈræmɪtə(r)]"
-    },
-    {
-        "name": "parental",
-        "trans": [
-            "adj. 父母亲的，父母的；亲代的，亲本的"
-        ],
-        "usphone": "[pəˈrentl]",
-        "ukphone": "[pəˈrent(ə)l]"
-    },
-    {
-        "name": "parish",
-        "trans": [
-            "n. 教区"
-        ],
-        "usphone": "[ˈpærɪʃ]",
-        "ukphone": "[ˈpærɪʃ]"
-    },
-    {
-        "name": "parliamentary",
-        "trans": [
-            "adj. 议会的；国会的；议会制度的"
-        ],
-        "usphone": "[ˌpɑːrləˈmentri]",
-        "ukphone": "[ˌpɑːləˈmentri]"
-    },
-    {
-        "name": "partial",
-        "trans": [
-            "adj. 局部的；偏爱的；不公平的"
-        ],
-        "usphone": "[ˈpɑːrʃl]",
-        "ukphone": "[ˈpɑːʃ(ə)l]"
-    },
-    {
-        "name": "partially",
-        "trans": [
-            "adv. 部分地；偏袒地"
-        ],
-        "usphone": "[ˈpɑːrʃəli]",
-        "ukphone": "[ˈpɑːʃəli]"
-    },
-    {
-        "name": "passing",
-        "trans": [
-            "n. 经过；及格；流逝；去世"
-        ],
-        "usphone": "[ˈpæsɪŋ]",
-        "ukphone": "[ˈpɑːsɪŋ]"
-    },
-    {
-        "name": "passive",
-        "trans": [
-            "n. 被动语态"
-        ],
-        "usphone": "[ˈpæsɪv]",
-        "ukphone": "[ˈpæsɪv]"
-    },
-    {
-        "name": "pastor",
-        "trans": [
-            "n. 牧师"
-        ],
-        "usphone": "[ˈpæstər]",
-        "ukphone": "[ˈpɑːstə(r)]"
-    },
-    {
-        "name": "patch",
-        "trans": [
-            "n. 眼罩；斑点；碎片；小块土地"
-        ],
-        "usphone": "[pætʃ]",
-        "ukphone": "[pætʃ]"
-    },
-    {
-        "name": "patent",
-        "trans": [
-            "n. 专利权；执照；专利品"
-        ],
-        "usphone": "[ˈpætnt; ˈpeɪtnt]",
-        "ukphone": "[ˈpæt(ə)nt]"
-    },
-    {
-        "name": "pathway",
-        "trans": [
-            "n. 路，道；途径，路径"
-        ],
-        "usphone": "[ˈpæθweɪ]",
-        "ukphone": "[ˈpɑːθweɪ]"
-    },
-    {
-        "name": "patrol",
-        "trans": [
-            "n. 巡逻；巡逻队；侦察队"
-        ],
-        "usphone": "[pəˈtroʊl]",
-        "ukphone": "[pəˈtrəʊl]"
-    },
-    {
-        "name": "patron",
-        "trans": [
-            "n. 赞助人；保护人；主顾"
-        ],
-        "usphone": "[ˈpeɪtrən]",
-        "ukphone": "[ˈpeɪtrən]"
-    },
-    {
-        "name": "peak",
-        "trans": [
-            "n. 山峰；最高点；顶点；帽舌"
-        ],
-        "usphone": "[piːk]",
-        "ukphone": "[piːk]"
-    },
-    {
-        "name": "peasant",
-        "trans": [
-            "n. 农民；乡下人"
-        ],
-        "usphone": "[ˈpeznt]",
-        "ukphone": "[ˈpez(ə)nt]"
-    },
-    {
-        "name": "peculiar",
-        "trans": [
-            "n. 特权；特有财产"
-        ],
-        "usphone": "[pɪˈkjuːliər]",
-        "ukphone": "[pɪˈkjuːliə(r)]"
-    },
-    {
-        "name": "persist",
-        "trans": [
-            "vi. 存留，坚持；持续，固执"
-        ],
-        "usphone": "[pərˈsɪst]",
-        "ukphone": "[pəˈsɪst]"
-    },
-    {
-        "name": "persistent",
-        "trans": [
-            "adj. 固执的，坚持的；持久稳固的"
-        ],
-        "usphone": "[pərˈsɪstənt]",
-        "ukphone": "[pəˈsɪstənt]"
-    },
-    {
-        "name": "personnel",
-        "trans": [
-            "n. 人事部门；全体人员"
-        ],
-        "usphone": "[ˌpɜːrsəˈnel]",
-        "ukphone": "[ˌpɜːsəˈnel]"
-    },
-    {
-        "name": "petition",
-        "trans": [
-            "n. 请愿；请愿书；祈求；[法] 诉状"
-        ],
-        "usphone": "[pəˈtɪʃn]",
-        "ukphone": "[pəˈtɪʃn]"
-    },
-    {
-        "name": "philosopher",
-        "trans": [
-            "n. 哲学家；哲人"
-        ],
-        "usphone": "[fəˈlɑːsəfər]",
-        "ukphone": "[fəˈlɒsəfə(r)]"
-    },
-    {
-        "name": "philosophical",
-        "trans": [
-            "adj. 哲学的（等于philosophic）；冷静的"
-        ],
-        "usphone": "[ˌfɪləˈsɑːfɪkl]",
-        "ukphone": "[ˌfɪləˈsɒfɪk(ə)l]"
-    },
-    {
-        "name": "physician",
-        "trans": [
-            "n. [医] 医师；内科医师"
-        ],
-        "usphone": "[fɪˈzɪʃn]",
-        "ukphone": "[fɪˈzɪʃn]"
-    },
-    {
-        "name": "pioneer",
-        "trans": [
-            "n. 先锋；拓荒者"
-        ],
-        "usphone": "[ˌpaɪəˈnɪr]",
-        "ukphone": "[ˌpaɪəˈnɪə(r)]"
-    },
-    {
-        "name": "pipeline",
-        "trans": [
-            "n. 管道；输油管；传递途径"
-        ],
-        "usphone": "[ˈpaɪplaɪn]",
-        "ukphone": "[ˈpaɪplaɪn]"
-    },
-    {
-        "name": "pirate",
-        "trans": [
-            "n. 海盗；盗版；侵犯专利权者"
-        ],
-        "usphone": "[ˈpaɪrət]",
-        "ukphone": "[ˈpaɪrət]"
-    },
-    {
-        "name": "pit",
-        "trans": [
-            "n. 矿井；深坑；陷阱；（物体或人体表面上的）凹陷；（英国剧场的）正厅后排；正厅后排的观众"
-        ],
-        "usphone": "[pɪt]",
-        "ukphone": "[pɪt]"
-    },
-    {
-        "name": "plea",
-        "trans": [
-            "n. 恳求，请求；辩解，辩护；借口，托辞"
-        ],
-        "usphone": "[pliː]",
-        "ukphone": "[pliː]"
-    },
-    {
-        "name": "plead",
-        "trans": [
-            "vt. 借口；为...辩护；托称"
-        ],
-        "usphone": "[pliːd]",
-        "ukphone": "[pliːd]"
-    },
-    {
-        "name": "pledge",
-        "trans": [
-            "n. 保证，誓言；抵押；抵押品，典当物"
-        ],
-        "usphone": "[pledʒ]",
-        "ukphone": "[pledʒ]"
-    },
-    {
-        "name": "plug",
-        "trans": [
-            "n. 插头；塞子；栓"
-        ],
-        "usphone": "[plʌɡ]",
-        "ukphone": "[plʌɡ]"
-    },
-    {
-        "name": "plunge",
-        "trans": [
-            "n. 投入；跳进"
-        ],
-        "usphone": "[plʌndʒ]",
-        "ukphone": "[plʌndʒ]"
-    },
-    {
-        "name": "pole",
-        "trans": [
-            "n. 杆；极点；电极"
-        ],
-        "usphone": "[poʊl]",
-        "ukphone": "[pəʊl]"
-    },
-    {
-        "name": "poll",
-        "trans": [
-            "n. 投票；民意测验；投票数；投票所"
-        ],
-        "usphone": "[poʊl]",
-        "ukphone": "[pəʊl]"
-    },
-    {
-        "name": "pond",
-        "trans": [
-            "n. 池塘"
-        ],
-        "usphone": "[pɑːnd]",
-        "ukphone": "[pɒnd]"
-    },
-    {
-        "name": "pop",
-        "trans": [
-            "abbr. 卖点广告（Point of Purchase）"
-        ],
-        "usphone": "[pɑːp]",
-        "ukphone": "[pɒp]"
-    },
-    {
-        "name": "portfolio",
-        "trans": [
-            "n. 公文包；文件夹；证券投资组合；部长职务"
-        ],
-        "usphone": "[pɔːrtˈfoʊlioʊ]",
-        "ukphone": "[pɔːtˈfəʊliəʊ]"
-    },
-    {
-        "name": "portray",
-        "trans": [
-            "vt. 描绘；扮演"
-        ],
-        "usphone": "[pɔːrˈtreɪ]",
-        "ukphone": "[pɔːˈtreɪ]"
-    },
-    {
-        "name": "postpone",
-        "trans": [
-            "vt. 使…延期；把…放在次要地位；把…放在后面"
-        ],
-        "usphone": "[poʊˈspoʊn]",
-        "ukphone": "[pəˈspəʊn]"
-    },
-    {
-        "name": "post-war",
-        "trans": [
-            "adj. 战后的"
-        ],
-        "usphone": "[ˌpoʊst ˈwɔːr]",
-        "ukphone": "[ˌpəʊst ˈwɔː(r)]"
-    },
-    {
-        "name": "practitioner",
-        "trans": [
-            "n. 开业者，从业者，执业医生"
-        ],
-        "usphone": "[prækˈtɪʃənər]",
-        "ukphone": "[prækˈtɪʃənə(r)]"
-    },
-    {
-        "name": "preach",
-        "trans": [
-            "n. 说教"
-        ],
-        "usphone": "[priːtʃ]",
-        "ukphone": "[priːtʃ]"
-    },
-    {
-        "name": "precedent",
-        "trans": [
-            "n. 先例；前例"
-        ],
-        "usphone": "[ˈpresɪdənt]",
-        "ukphone": "[ˈpresɪdənt]"
-    },
-    {
-        "name": "precision",
-        "trans": [
-            "n. 精度，[数] 精密度；精确"
-        ],
-        "usphone": "[prɪˈsɪʒn]",
-        "ukphone": "[prɪˈsɪʒn]"
-    },
-    {
-        "name": "predator",
-        "trans": [
-            "n. [动] 捕食者；[动] 食肉动物；掠夺者"
-        ],
-        "usphone": "[ˈpredətər]",
-        "ukphone": "[ˈpredətə(r)]"
-    },
-    {
-        "name": "predecessor",
-        "trans": [
-            "n. 前任，前辈"
-        ],
-        "usphone": "[ˈpredəsesər]",
-        "ukphone": "[ˈpriːdəsesə(r)]"
-    },
-    {
-        "name": "predominantly",
-        "trans": [
-            "adv. 主要地；显著地"
-        ],
-        "usphone": "[prɪˈdɑːmɪnəntli]",
-        "ukphone": "[prɪˈdɒmɪnəntli]"
-    },
-    {
-        "name": "pregnancy",
-        "trans": [
-            "n. 怀孕；丰富，多产；意义深长"
-        ],
-        "usphone": "[ˈpreɡnənsi]",
-        "ukphone": "[ˈpreɡnənsi]"
-    },
-    {
-        "name": "prejudice",
-        "trans": [
-            "n. 偏见；侵害"
-        ],
-        "usphone": "[ˈpredʒudɪs]",
-        "ukphone": "[ˈpredʒədɪs]"
-    },
-    {
-        "name": "preliminary",
-        "trans": [
-            "n. 准备；预赛；初步措施"
-        ],
-        "usphone": "[prɪˈlɪmɪneri]",
-        "ukphone": "[prɪˈlɪmɪnəri]"
-    },
-    {
-        "name": "premier",
-        "trans": [
-            "n. 总理，首相"
-        ],
-        "usphone": "[prɪˈmɪrˌprɪˈmjɪr]",
-        "ukphone": "[ˈpremiə(r)]"
-    },
-    {
-        "name": "premise",
-        "trans": [
-            "n. 前提；上述各项；房屋连地基"
-        ],
-        "usphone": "[ˈpremɪs]",
-        "ukphone": "[ˈpremɪs]"
-    },
-    {
-        "name": "premium",
-        "trans": [
-            "n. 额外费用；奖金；保险费;(商)溢价"
-        ],
-        "usphone": "[ˈpriːmiəm]",
-        "ukphone": "[ˈpriːmiəm]"
-    },
-    {
-        "name": "prescribe",
-        "trans": [
-            "vt. 规定；开处方"
-        ],
-        "usphone": "[prɪˈskraɪb]",
-        "ukphone": "[prɪˈskraɪb]"
-    },
-    {
-        "name": "prescription",
-        "trans": [
-            "n. 药方；指示；惯例"
-        ],
-        "usphone": "[prɪˈskrɪpʃn]",
-        "ukphone": "[prɪˈskrɪpʃn]"
-    },
-    {
-        "name": "presently",
-        "trans": [
-            "adv. （美）目前；不久"
-        ],
-        "usphone": "[ˈprezntli]",
-        "ukphone": "[ˈprezntli]"
-    },
-    {
-        "name": "preservation",
-        "trans": [
-            "n. 保存，保留"
-        ],
-        "usphone": "[ˌprezərˈveɪʃn]",
-        "ukphone": "[ˌprezəˈveɪʃ(ə)n]"
-    },
-    {
-        "name": "preside",
-        "trans": [
-            "vi. 主持，担任会议主席"
-        ],
-        "usphone": "[prɪˈzaɪd]",
-        "ukphone": "[prɪˈzaɪd]"
-    },
-    {
-        "name": "presidency",
-        "trans": [
-            "n. 总统（或董事长、会长、大学校长等）的职位（任期）；管辖；支配"
-        ],
-        "usphone": "[ˈprezɪdənsi]",
-        "ukphone": "[ˈprezɪdənsi]"
-    },
-    {
-        "name": "presidential",
-        "trans": [
-            "adj. 总统的；首长的；统辖的"
-        ],
-        "usphone": "[ˌprezɪˈdenʃl]",
-        "ukphone": "[ˌprezɪˈdenʃl]"
-    },
-    {
-        "name": "prestigious",
-        "trans": [
-            "adj. 有名望的；享有声望的"
-        ],
-        "usphone": "[preˈstiːdʒəs]",
-        "ukphone": "[preˈstɪdʒəs]"
-    },
-    {
-        "name": "presumably",
-        "trans": [
-            "adv. 大概；推测起来；可假定"
-        ],
-        "usphone": "[prɪˈzuːməbli]",
-        "ukphone": "[prɪˈzjuːməbli]"
-    },
-    {
-        "name": "presume",
-        "trans": [
-            "vi. 相信；擅自行为"
-        ],
-        "usphone": "[prɪˈzuːm]",
-        "ukphone": "[prɪˈzjuːm]"
-    },
-    {
-        "name": "prevail",
-        "trans": [
-            "vi. 盛行，流行；战胜，获胜"
-        ],
-        "usphone": "[prɪˈveɪl]",
-        "ukphone": "[prɪˈveɪl]"
-    },
-    {
-        "name": "prevalence",
-        "trans": [
-            "n. 流行；普遍；广泛"
-        ],
-        "usphone": "[ˈprevələns]",
-        "ukphone": "[ˈprevələns]"
-    },
-    {
-        "name": "prevention",
-        "trans": [
-            "n. 预防；阻止；妨碍"
-        ],
-        "usphone": "[prɪˈvenʃn]",
-        "ukphone": "[prɪˈvenʃn]"
-    },
-    {
-        "name": "prey",
-        "trans": [
-            "n. 捕食；牺牲者；被捕食的动物"
-        ],
-        "usphone": "[preɪ]",
-        "ukphone": "[preɪ]"
-    },
-    {
-        "name": "principal",
-        "trans": [
-            "adj. 主要的；资本的"
-        ],
-        "usphone": "[ˈprɪnsəpl]",
-        "ukphone": "[ˈprɪnsəpl]"
-    },
-    {
-        "name": "privatization",
-        "trans": [
-            "n. 私有化"
-        ],
-        "usphone": "[ˌpraɪvətəˈzeɪʃn]",
-        "ukphone": "[ˌpraɪvətaɪˈzeɪʃn]"
-    },
-    {
-        "name": "privilege",
-        "trans": [
-            "n. 特权；优待"
-        ],
-        "usphone": "[ˈprɪvəlɪdʒ]",
-        "ukphone": "[ˈprɪvəlɪdʒ]"
-    },
-    {
-        "name": "probe",
-        "trans": [
-            "n. 探针；调查"
-        ],
-        "usphone": "[proʊb]",
-        "ukphone": "[prəʊb]"
-    },
-    {
-        "name": "problematic",
-        "trans": [
-            "adj. 问题的；有疑问的；不确定的"
-        ],
-        "usphone": "[ˌprɑːbləˈmætɪk]",
-        "ukphone": "[ˌprɒbləˈmætɪk]"
-    },
-    {
-        "name": "proceeding",
-        "trans": [
-            "n. 进行；程序；诉讼；事项"
-        ],
-        "usphone": "[prəˈsiːdɪŋ]",
-        "ukphone": "[prəˈsiːdɪŋ]"
-    },
-    {
-        "name": "proceeds",
-        "trans": [
-            "n. 收入，收益；实收款项"
-        ],
-        "usphone": "[ˈproʊsiːdz]",
-        "ukphone": "[ˈprəʊsiːdz]"
-    },
-    {
-        "name": "processing",
-        "trans": [
-            "v. 加工；[自] 处理；对…起诉（process的ing形式）"
-        ],
-        "usphone": "[ˈprɑːsesɪŋ]",
-        "ukphone": "[ˈprəʊsesɪŋ]"
-    },
-    {
-        "name": "processor",
-        "trans": [
-            "n. [计] 处理器；处理程序；加工者"
-        ],
-        "usphone": "[ˈprɑːsesər]",
-        "ukphone": "[ˈprəʊsesə(r)]"
-    },
-    {
-        "name": "proclaim",
-        "trans": [
-            "vt. 宣告，公布；声明；表明；赞扬"
-        ],
-        "usphone": "[prəˈkleɪm]",
-        "ukphone": "[prəˈkleɪm]"
-    },
-    {
-        "name": "productive",
-        "trans": [
-            "adj. 能生产的；生产的，生产性的；多产的；富有成效的"
-        ],
-        "usphone": "[prəˈdʌktɪv]",
-        "ukphone": "[prəˈdʌktɪv]"
-    },
-    {
-        "name": "productivity",
-        "trans": [
-            "n. 生产力；生产率；生产能力"
-        ],
-        "usphone": "[ˌproʊdʌkˈtɪvətiˌˌprɑːdʌkˈtɪvəti]",
-        "ukphone": "[ˌprɒdʌkˈtɪvəti]"
-    },
-    {
-        "name": "profitable",
-        "trans": [
-            "adj. 有利可图的；赚钱的；有益的"
-        ],
-        "usphone": "[ˈprɑːfɪtəbl]",
-        "ukphone": "[ˈprɒfɪtəb(ə)l]"
-    },
-    {
-        "name": "profound",
-        "trans": [
-            "adj. 深厚的；意义深远的；渊博的"
-        ],
-        "usphone": "[prəˈfaʊnd]",
-        "ukphone": "[prəˈfaʊnd]"
-    },
-    {
-        "name": "projection",
-        "trans": [
-            "n. 投射；规划；突出；发射；推测"
-        ],
-        "usphone": "[prəˈdʒekʃn]",
-        "ukphone": "[prəˈdʒekʃn]"
-    },
-    {
-        "name": "prominent",
-        "trans": [
-            "adj. 突出的，显著的；杰出的；卓越的"
-        ],
-        "usphone": "[ˈprɑːmɪnənt]",
-        "ukphone": "[ˈprɒmɪnənt]"
-    },
-    {
-        "name": "pronounced",
-        "trans": [
-            "v. 发音；宣告；断言（pronounce的过去分词）"
-        ],
-        "usphone": "[prəˈnaʊnst]",
-        "ukphone": "[prəˈnaʊnst]"
-    },
-    {
-        "name": "propaganda",
-        "trans": [
-            "n. 宣传；传道总会"
-        ],
-        "usphone": "[ˌprɑːpəˈɡændə]",
-        "ukphone": "[ˌprɒpəˈɡændə]"
-    },
-    {
-        "name": "proposition",
-        "trans": [
-            "n. [数] 命题；提议；主题；议题"
-        ],
-        "usphone": "[ˌprɑːpəˈzɪʃn]",
-        "ukphone": "[ˌprɒpəˈzɪʃ(ə)n]"
-    },
-    {
-        "name": "prosecute",
-        "trans": [
-            "vt. 检举；贯彻；从事；依法进行"
-        ],
-        "usphone": "[ˈprɑːsɪkjuːt]",
-        "ukphone": "[ˈprɒsɪkjuːt]"
-    },
-    {
-        "name": "prosecution",
-        "trans": [
-            "n. 起诉，检举；进行；经营"
-        ],
-        "usphone": "[ˌprɑːsɪˈkjuːʃn]",
-        "ukphone": "[ˌprɒsɪˈkjuːʃn]"
-    },
-    {
-        "name": "prosecutor",
-        "trans": [
-            "n. 检察官；公诉人；[法] 起诉人；实行者"
-        ],
-        "usphone": "[ˈprɑːsɪkjuːtər]",
-        "ukphone": "[ˈprɒsɪkjuːtə(r)]"
-    },
-    {
-        "name": "prospective",
-        "trans": [
-            "n. 预期；展望"
-        ],
-        "usphone": "[prəˈspektɪv]",
-        "ukphone": "[prəˈspektɪv]"
-    },
-    {
-        "name": "prosperity",
-        "trans": [
-            "n. 繁荣，成功"
-        ],
-        "usphone": "[prɑːˈsperəti]",
-        "ukphone": "[prɒˈsperəti]"
-    },
-    {
-        "name": "protective",
-        "trans": [
-            "adj. 防护的；关切保护的；保护贸易的"
-        ],
-        "usphone": "[prəˈtektɪv]",
-        "ukphone": "[prəˈtektɪv]"
-    },
-    {
-        "name": "protocol",
-        "trans": [
-            "n. 协议；草案；礼仪"
-        ],
-        "usphone": "[ˈproʊtəkɑːl]",
-        "ukphone": "[ˈprəʊtəkɒl]"
-    },
-    {
-        "name": "province",
-        "trans": [
-            "n. 省；领域；职权"
-        ],
-        "usphone": "[ˈprɑːvɪns]",
-        "ukphone": "[ˈprɒvɪns]"
-    },
-    {
-        "name": "provincial",
-        "trans": [
-            "n. 粗野的人；乡下人；外地人"
-        ],
-        "usphone": "[prəˈvɪnʃl]",
-        "ukphone": "[prəˈvɪnʃl]"
-    },
-    {
-        "name": "provision",
-        "trans": [
-            "n. 规定；条款；准备；[经] 供应品"
-        ],
-        "usphone": "[prəˈvɪʒn]",
-        "ukphone": "[prəˈvɪʒn]"
-    },
-    {
-        "name": "provoke",
-        "trans": [
-            "vt. 驱使；激怒；煽动；惹起"
-        ],
-        "usphone": "[prəˈvoʊk]",
-        "ukphone": "[prəˈvəʊk]"
-    },
-    {
-        "name": "psychiatric",
-        "trans": [
-            "adj. 精神病学的；精神病治疗的"
-        ],
-        "usphone": "[ˌsaɪkiˈætrɪk]",
-        "ukphone": "[ˌsaɪkiˈætrɪk]"
-    },
-    {
-        "name": "pulse",
-        "trans": [
-            "n. [电子] 脉冲；脉搏"
-        ],
-        "usphone": "[pʌls]",
-        "ukphone": "[pʌls]"
-    },
-    {
-        "name": "pump",
-        "trans": [
-            "n. 泵，抽水机；打气筒"
-        ],
-        "usphone": "[pʌmp]",
-        "ukphone": "[pʌmp]"
-    },
-    {
-        "name": "punch",
-        "trans": [
-            "n. 冲压机；打洞器；钻孔机"
-        ],
-        "usphone": "[pʌntʃ]",
-        "ukphone": "[pʌntʃ]"
-    },
-    {
-        "name": "query",
-        "trans": [
-            "n. 疑问，质问；疑问号 ；[计] 查询"
-        ],
-        "usphone": "[ˈkwɪri]",
-        "ukphone": "[ˈkwɪəri]"
-    },
-    {
-        "name": "quest",
-        "trans": [
-            "n. 追求；寻找"
-        ],
-        "usphone": "[kwest]",
-        "ukphone": "[kwest]"
-    },
-    {
-        "name": "quota",
-        "trans": [
-            "n. 配额；定额；限额"
-        ],
-        "usphone": "[ˈkwoʊtə]",
-        "ukphone": "[ˈkwəʊtə]"
-    },
-    {
-        "name": "radar",
-        "trans": [
-            "n. [雷达] 雷达，无线电探测器"
-        ],
-        "usphone": "[ˈreɪdɑːr]",
-        "ukphone": "[ˈreɪdɑː(r)]"
-    },
-    {
-        "name": "radical",
-        "trans": [
-            "n. 基础；激进分子；[物化] 原子团；[数] 根数"
-        ],
-        "usphone": "[ˈrædɪkl]",
-        "ukphone": "[ˈrædɪk(ə)l]"
-    },
-    {
-        "name": "rage",
-        "trans": [
-            "n. 愤怒；狂暴，肆虐；情绪激动"
-        ],
-        "usphone": "[reɪdʒ]",
-        "ukphone": "[reɪdʒ]"
-    },
-    {
-        "name": "raid",
-        "trans": [
-            "n. 袭击；突袭；搜捕；抢劫"
-        ],
-        "usphone": "[reɪd]",
-        "ukphone": "[reɪd]"
-    },
-    {
-        "name": "rally",
-        "trans": [
-            "n. 集会；回复；公路赛车会"
-        ],
-        "usphone": "[ˈræli]",
-        "ukphone": "[ˈræli]"
-    },
-    {
-        "name": "ranking",
-        "trans": [
-            "n. 等级；地位"
-        ],
-        "usphone": "[ˈræŋkɪŋ]",
-        "ukphone": "[ˈræŋkɪŋ]"
+        "usphone": "[ˈfluːɪd]",
+        "ukphone": "[ˈfluːɪd]"
     },
     {
         "name": "rape",
@@ -7640,84 +504,68 @@
         "ukphone": "[reɪp]"
     },
     {
-        "name": "ratio",
+        "name": "compel",
         "trans": [
-            "n. 比率，比例"
+            "vt. 强迫，迫使；强使发生"
         ],
-        "usphone": "[ˈreɪʃioʊ]",
-        "ukphone": "[ˈreɪʃiəʊ]"
+        "usphone": "[kəmˈpel]",
+        "ukphone": "[kəmˈpel]"
     },
     {
-        "name": "rational",
+        "name": "funeral",
         "trans": [
-            "n. 有理数"
+            "n. 葬礼；麻烦事"
         ],
-        "usphone": "[ˈræʃ(ə)nəl]",
-        "ukphone": "[ˈræʃnəl]"
+        "usphone": "[ˈfjuːnərəl]",
+        "ukphone": "[ˈfjuːnərəl]"
     },
     {
-        "name": "ray",
+        "name": "leak",
         "trans": [
-            "n. 射线；光线；【鱼类】鳐形目(Rajiformes)鱼"
+            "n. 泄漏；漏洞，裂缝"
         ],
-        "usphone": "[reɪ]",
-        "ukphone": "[reɪ]"
+        "usphone": "[liːk]",
+        "ukphone": "[liːk]"
     },
     {
-        "name": "readily",
+        "name": "marine",
         "trans": [
-            "adv. 容易地；乐意地；无困难地"
+            "adj. 船舶的；海生的；海产的；航海的，海运的"
         ],
-        "usphone": "[ˈredɪli]",
-        "ukphone": "[ˈredɪli]"
+        "usphone": "[məˈriːn]",
+        "ukphone": "[məˈriːn]"
     },
     {
-        "name": "realization",
+        "name": "appoint",
         "trans": [
-            "n. 实现；领悟"
+            "vt. 任命；指定；约定"
         ],
-        "usphone": "[ˌriːələˈzeɪʃn]",
-        "ukphone": "[ˌriːəlaɪˈzeɪʃn; ˌrɪəlaɪˈzeɪʃn]"
+        "usphone": "[əˈpɔɪnt]",
+        "ukphone": "[əˈpɔɪnt]"
     },
     {
-        "name": "realm",
+        "name": "enforce",
         "trans": [
-            "n. 领域，范围；王国"
+            "vt. 实施，执行；强迫，强制"
         ],
-        "usphone": "[relm]",
-        "ukphone": "[relm]"
+        "usphone": "[ɪnˈfɔːrs]",
+        "ukphone": "[ɪnˈfɔːs]"
     },
     {
-        "name": "rear",
+        "name": "correspondent",
         "trans": [
-            "n. 后面；屁股；后方部队"
+            "n. 通讯记者；客户；通信者；代理商行"
         ],
-        "usphone": "[rɪr]",
-        "ukphone": "[rɪə(r)]"
+        "usphone": "[ˌkɔːrəˈspɑːndənt]",
+        "ukphone": "[ˌkɒrəˈspɒndənt]"
     },
     {
-        "name": "reasoning",
+        "name": "toll",
         "trans": [
-            "n. 推理；论证；评理"
+            "vt. 征收；敲钟"
         ],
-        "usphone": "[ˈriːzənɪŋ]",
-        "ukphone": "[ˈriːzənɪŋ]"
-    },
-    {
-        "name": "reassure",
-        "trans": [
-            "vt. 使…安心，使消除疑虑"
-        ],
-        "usphone": "[ˌriːəˈʃʊr]",
-        "ukphone": "[ˌriːəˈʃʊə(r)]"
-    },
-    {
-        "name": "rebel",
-        "trans": [
-            "n. 反叛者；叛徒"
-        ],
-        "usphone": "[ˈrebl]",
-        "ukphone": "[ˈrebl]"
+        "usphone": "[toʊl]",
+        "ukphone": "[təʊl]"
     },
     {
         "name": "rebellion",
@@ -7728,60 +576,556 @@
         "ukphone": "[rɪˈbeljən]"
     },
     {
-        "name": "recipient",
+        "name": "align",
         "trans": [
-            "n. 容器，接受者；容纳者"
+            "vt. 使结盟；使成一行；匹配"
         ],
-        "usphone": "[rɪˈsɪpiənt]",
-        "ukphone": "[rɪˈsɪpiənt]"
+        "usphone": "[əˈlaɪn]",
+        "ukphone": "[əˈlaɪn]"
     },
     {
-        "name": "reconstruction",
+        "name": "trio",
         "trans": [
-            "n. 再建，重建；改造；复兴"
+            "n. 三重唱；三件一套；三个一组"
         ],
-        "usphone": "[ˌriːkənˈstrʌkʃn]",
-        "ukphone": "[ˌriːkənˈstrʌkʃn]"
+        "usphone": "[ˈtriːoʊ]",
+        "ukphone": "[ˈtriːəʊ]"
     },
     {
-        "name": "recount",
+        "name": "dispose",
         "trans": [
-            "n. 重算"
+            "n. 处置；性情"
         ],
-        "usphone": "[rɪˈkaʊnt]",
-        "ukphone": "[rɪˈkaʊnt; ˈriːkaʊnt; ˌriːˈkaʊnt]"
+        "usphone": "[dɪˈspoʊz]",
+        "ukphone": "[dɪˈspəʊz]"
     },
     {
-        "name": "referendum",
+        "name": "inmate",
         "trans": [
-            "n. 公民投票权；外交官请示书"
+            "n. (尤指)同院病人；同狱犯人；同被(收容所)收容者"
         ],
-        "usphone": "[ˌrefəˈrendəm]",
-        "ukphone": "[ˌrefəˈrendəm]"
+        "usphone": "[ˈɪnmeɪt]",
+        "ukphone": "[ˈɪnmeɪt]"
     },
     {
-        "name": "reflection",
+        "name": "bishop",
         "trans": [
-            "n. 反射；沉思；映象"
+            "n. （基督教的）主教；（国际象棋的）象"
         ],
-        "usphone": "[rɪˈflekʃn]",
-        "ukphone": "[rɪˈflekʃn]"
+        "usphone": "[ˈbɪʃəp]",
+        "ukphone": "[ˈbɪʃəp]"
     },
     {
-        "name": "reform",
+        "name": "enact",
         "trans": [
-            "n. 改革，改良；改正"
+            "vt. 颁布；制定法律；扮演；发生"
         ],
-        "usphone": "[rɪˈfɔːrm]",
-        "ukphone": "[rɪˈfɔːm]"
+        "usphone": "[ɪˈnækt]",
+        "ukphone": "[ɪˈnækt]"
     },
     {
-        "name": "refuge",
+        "name": "stir",
         "trans": [
-            "n. 避难；避难所；庇护"
+            "n. 搅拌；轰动"
         ],
-        "usphone": "[ˈrefjuːdʒ]",
-        "ukphone": "[ˈrefjuːdʒ]"
+        "usphone": "[stɜːr]",
+        "ukphone": "[stɜː(r)]"
+    },
+    {
+        "name": "flaw",
+        "trans": [
+            "n. 瑕疵，缺点；一阵狂风；短暂的风暴；裂缝，裂纹"
+        ],
+        "usphone": "[flɔː]",
+        "ukphone": "[flɔː]"
+    },
+    {
+        "name": "horizon",
+        "trans": [
+            "n. [天] 地平线；视野；眼界；范围"
+        ],
+        "usphone": "[həˈraɪzn]",
+        "ukphone": "[həˈraɪz(ə)n]"
+    },
+    {
+        "name": "consecutive",
+        "trans": [
+            "adj. 连贯的；连续不断的"
+        ],
+        "usphone": "[kənˈsekjətɪv]",
+        "ukphone": "[kənˈsekjətɪv]"
+    },
+    {
+        "name": "partially",
+        "trans": [
+            "adv. 部分地；偏袒地"
+        ],
+        "usphone": "[ˈpɑːrʃəli]",
+        "ukphone": "[ˈpɑːʃəli]"
+    },
+    {
+        "name": "riot",
+        "trans": [
+            "n. 暴乱；放纵；蔓延"
+        ],
+        "usphone": "[ˈraɪət]",
+        "ukphone": "[ˈraɪət]"
+    },
+    {
+        "name": "accordingly",
+        "trans": [
+            "adv. 因此，于是；相应地；照著"
+        ],
+        "usphone": "[əˈkɔːrdɪŋli]",
+        "ukphone": "[əˈkɔːdɪŋli]"
+    },
+    {
+        "name": "bureaucracy",
+        "trans": [
+            "n. 官僚主义；官僚机构；官僚政治"
+        ],
+        "usphone": "[bjʊˈrɑːkrəsi]",
+        "ukphone": "[bjʊəˈrɒkrəsi]"
+    },
+    {
+        "name": "conception",
+        "trans": [
+            "n. 怀孕；概念；设想；开始"
+        ],
+        "usphone": "[kənˈsepʃn]",
+        "ukphone": "[kənˈsepʃn]"
+    },
+    {
+        "name": "flesh",
+        "trans": [
+            "n. 肉；肉体"
+        ],
+        "usphone": "[fleʃ]",
+        "ukphone": "[fleʃ]"
+    },
+    {
+        "name": "tenant",
+        "trans": [
+            "n. 承租人；房客；佃户；居住者"
+        ],
+        "usphone": "[ˈtenənt]",
+        "ukphone": "[ˈtenənt]"
+    },
+    {
+        "name": "adaptation",
+        "trans": [
+            "n. 适应；改编；改编本，改写本"
+        ],
+        "usphone": "[ˌædæpˈteɪʃn]",
+        "ukphone": "[ˌædæpˈteɪʃn]"
+    },
+    {
+        "name": "interference",
+        "trans": [
+            "n. 干扰，冲突；干涉"
+        ],
+        "usphone": "[ˌɪntərˈfɪrəns]",
+        "ukphone": "[ˌɪntəˈfɪərəns]"
+    },
+    {
+        "name": "taxpayer",
+        "trans": [
+            "n. 纳税人；所收租金只够支付地产税的建筑物"
+        ],
+        "usphone": "[ˈtækspeɪər]",
+        "ukphone": "[ˈtækspeɪə(r)]"
+    },
+    {
+        "name": "span",
+        "trans": [
+            "n. 跨度，跨距；范围"
+        ],
+        "usphone": "[spæn]",
+        "ukphone": "[spæn]"
+    },
+    {
+        "name": "disclose",
+        "trans": [
+            "vt. 公开；揭露"
+        ],
+        "usphone": "[dɪsˈkloʊz]",
+        "ukphone": "[dɪsˈkləʊz]"
+    },
+    {
+        "name": "brutal",
+        "trans": [
+            "adj. 残忍的；野蛮的，不讲理的"
+        ],
+        "usphone": "[ˈbruːt(ə)l]",
+        "ukphone": "[ˈbruːt(ə)l]"
+    },
+    {
+        "name": "ignorance",
+        "trans": [
+            "n. 无知，愚昧；不知，不懂"
+        ],
+        "usphone": "[ˈɪɡnərəns]",
+        "ukphone": "[ˈɪɡnərəns]"
+    },
+    {
+        "name": "dissolve",
+        "trans": [
+            "n. 叠化画面；画面的溶暗"
+        ],
+        "usphone": "[dɪˈzɑːlv]",
+        "ukphone": "[dɪˈzɒlv]"
+    },
+    {
+        "name": "acute",
+        "trans": [
+            "adj. 严重的，[医] 急性的；敏锐的；激烈的；尖声的"
+        ],
+        "usphone": "[əˈkjuːt]",
+        "ukphone": "[əˈkjuːt]"
+    },
+    {
+        "name": "slot",
+        "trans": [
+            "n. 位置；狭槽；水沟；硬币投币口"
+        ],
+        "usphone": "[slɑːt]",
+        "ukphone": "[slɒt]"
+    },
+    {
+        "name": "accordance",
+        "trans": [
+            "n. 一致；和谐"
+        ],
+        "usphone": "[əˈkɔːrdns]",
+        "ukphone": "[əˈkɔːd(ə)ns]"
+    },
+    {
+        "name": "embark",
+        "trans": [
+            "vi. 从事，着手；上船或飞机"
+        ],
+        "usphone": "[ɪmˈbɑːrk]",
+        "ukphone": "[ɪmˈbɑːk]"
+    },
+    {
+        "name": "overlook",
+        "trans": [
+            "vt. 忽略；俯瞰；远眺；检查；高耸于…之上"
+        ],
+        "usphone": "[ˌoʊvərˈlʊk]",
+        "ukphone": "[ˌəʊvəˈlʊk]"
+    },
+    {
+        "name": "cooperative",
+        "trans": [
+            "n. 合作社"
+        ],
+        "usphone": "[koʊˈɑːpərətɪv]",
+        "ukphone": "[kəʊˈɒpərətɪv]"
+    },
+    {
+        "name": "barrel",
+        "trans": [
+            "n. 桶；枪管，炮管"
+        ],
+        "usphone": "[ˈbærəl]",
+        "ukphone": "[ˈbærəl]"
+    },
+    {
+        "name": "demon",
+        "trans": [
+            "n. 恶魔；魔鬼；精力充沛的人；邪恶的事物"
+        ],
+        "usphone": "[ˈdiːmən]",
+        "ukphone": "[ˈdiːmən]"
+    },
+    {
+        "name": "chronic",
+        "trans": [
+            "adj. 慢性的；长期的；习惯性的"
+        ],
+        "usphone": "[ˈkrɑːnɪk]",
+        "ukphone": "[ˈkrɒnɪk]"
+    },
+    {
+        "name": "desktop",
+        "trans": [
+            "n. 桌面；台式机"
+        ],
+        "usphone": "[ˈdesktɑːp]",
+        "ukphone": "[ˈdesktɒp]"
+    },
+    {
+        "name": "diminish",
+        "trans": [
+            "vt. 使减少；使变小"
+        ],
+        "usphone": "[dɪˈmɪnɪʃ]",
+        "ukphone": "[dɪˈmɪnɪʃ]"
+    },
+    {
+        "name": "premium",
+        "trans": [
+            "n. 额外费用；奖金；保险费;(商)溢价"
+        ],
+        "usphone": "[ˈpriːmiəm]",
+        "ukphone": "[ˈpriːmiəm]"
+    },
+    {
+        "name": "mentor",
+        "trans": [
+            "n. 指导者，良师益友"
+        ],
+        "usphone": "[ˈmentɔːr]",
+        "ukphone": "[ˈmentɔː(r)]"
+    },
+    {
+        "name": "domain",
+        "trans": [
+            "n. 领域；域名；产业；地产"
+        ],
+        "usphone": "[doʊˈmeɪn]",
+        "ukphone": "[dəˈmeɪn; dəʊˈmeɪn]"
+    },
+    {
+        "name": "transparent",
+        "trans": [
+            "adj. 透明的；显然的；坦率的；易懂的"
+        ],
+        "usphone": "[trænsˈpærənt]",
+        "ukphone": "[trænsˈpærənt]"
+    },
+    {
+        "name": "fibre",
+        "trans": [
+            "n. 纤维；纤维制品"
+        ],
+        "usphone": "[ˈfaɪbər]",
+        "ukphone": "[ˈfaɪbə(r)]"
+    },
+    {
+        "name": "appreciation",
+        "trans": [
+            "n. 欣赏，鉴别；增值；感谢"
+        ],
+        "usphone": "[əˌpriːʃiˈeɪʃn]",
+        "ukphone": "[əˌpriːʃiˈeɪʃn]"
+    },
+    {
+        "name": "vessel",
+        "trans": [
+            "n. 船，舰；[组织] 脉管，血管；容器，器皿"
+        ],
+        "usphone": "[ˈvesl]",
+        "ukphone": "[ˈves(ə)l]"
+    },
+    {
+        "name": "invoke",
+        "trans": [
+            "vt. 调用；祈求；引起；恳求"
+        ],
+        "usphone": "[ɪnˈvoʊk]",
+        "ukphone": "[ɪnˈvəʊk]"
+    },
+    {
+        "name": "electoral",
+        "trans": [
+            "adj. 选举的；选举人的"
+        ],
+        "usphone": "[ɪˈlektərəl]",
+        "ukphone": "[ɪˈlektərəl]"
+    },
+    {
+        "name": "adjustment",
+        "trans": [
+            "n. 调整，调节；调节器"
+        ],
+        "usphone": "[əˈdʒʌstmənt]",
+        "ukphone": "[əˈdʒʌstmənt]"
+    },
+    {
+        "name": "accessible",
+        "trans": [
+            "adj. 易接近的；可进入的；可理解的"
+        ],
+        "usphone": "[əkˈsesəbl]",
+        "ukphone": "[əkˈsesəb(ə)l]"
+    },
+    {
+        "name": "reminder",
+        "trans": [
+            "n. 暗示；提醒的人/物；催单"
+        ],
+        "usphone": "[rɪˈmaɪndər]",
+        "ukphone": "[rɪˈmaɪndə(r)]"
+    },
+    {
+        "name": "mutual",
+        "trans": [
+            "adj. 共同的；相互的，彼此的"
+        ],
+        "usphone": "[ˈmjuːtʃuəl]",
+        "ukphone": "[ˈmjuːtʃuəl]"
+    },
+    {
+        "name": "moderate",
+        "trans": [
+            "adj. 稳健的，温和的；适度的，中等的；有节制的"
+        ],
+        "usphone": "[ˈmɑːdərət]",
+        "ukphone": "[ˈmɒdərət]"
+    },
+    {
+        "name": "breach",
+        "trans": [
+            "n. 违背，违反；缺口"
+        ],
+        "usphone": "[briːtʃ]",
+        "ukphone": "[briːtʃ]"
+    },
+    {
+        "name": "detection",
+        "trans": [
+            "n. 侦查，探测；发觉，发现；察觉"
+        ],
+        "usphone": "[dɪˈtekʃn]",
+        "ukphone": "[dɪˈtekʃ(ə)n]"
+    },
+    {
+        "name": "hardware",
+        "trans": [
+            "n. 计算机硬件；五金器具"
+        ],
+        "usphone": "[ˈhɑːrdwer]",
+        "ukphone": "[ˈhɑːdweə(r)]"
+    },
+    {
+        "name": "equation",
+        "trans": [
+            "n. 方程式，等式；相等；[化学] 反应式"
+        ],
+        "usphone": "[ɪˈkweɪʒn]",
+        "ukphone": "[ɪˈkweɪʒ(ə)n]"
+    },
+    {
+        "name": "processor",
+        "trans": [
+            "n. [计] 处理器；处理程序；加工者"
+        ],
+        "usphone": "[ˈprɑːsesər]",
+        "ukphone": "[ˈprəʊsesə(r)]"
+    },
+    {
+        "name": "straightforward",
+        "trans": [
+            "adj. 简单的；坦率的；明确的；径直的"
+        ],
+        "usphone": "[ˌstreɪtˈfɔːrwərd]",
+        "ukphone": "[ˌstreɪtˈfɔːwəd]"
+    },
+    {
+        "name": "earnings",
+        "trans": [
+            "n. 收入"
+        ],
+        "usphone": "[ˈɜːrnɪŋz]",
+        "ukphone": "[ˈɜːnɪŋz]"
+    },
+    {
+        "name": "ensue",
+        "trans": [
+            "vi. 跟着发生，接着发生；继起"
+        ],
+        "usphone": "[ɪnˈsuː]",
+        "ukphone": "[ɪnˈsjuː]"
+    },
+    {
+        "name": "suck",
+        "trans": [
+            "n. 吮吸"
+        ],
+        "usphone": "[sʌk]",
+        "ukphone": "[sʌk]"
+    },
+    {
+        "name": "foster",
+        "trans": [
+            "vt. 培养；养育，抚育；抱（希望等）"
+        ],
+        "usphone": "[ˈfɑːstər]",
+        "ukphone": "[ˈfɒstə(r)]"
+    },
+    {
+        "name": "revival",
+        "trans": [
+            "n. 复兴；复活；苏醒；恢复精神；再生效"
+        ],
+        "usphone": "[rɪˈvaɪvl]",
+        "ukphone": "[rɪˈvaɪv(ə)l]"
+    },
+    {
+        "name": "bail",
+        "trans": [
+            "n. 保释，保释人；保释金；杓"
+        ],
+        "usphone": "[beɪl]",
+        "ukphone": "[beɪl]"
+    },
+    {
+        "name": "constituency",
+        "trans": [
+            "n. （选区的）选民；支持者；（一批）顾客"
+        ],
+        "usphone": "[kənˈstɪtʃuənsi]",
+        "ukphone": "[kənˈstɪtʃuənsi]"
+    },
+    {
+        "name": "aggression",
+        "trans": [
+            "n. 侵略；进攻；侵犯；侵害"
+        ],
+        "usphone": "[əˈɡreʃn]",
+        "ukphone": "[əˈɡreʃ(ə)n]"
+    },
+    {
+        "name": "pond",
+        "trans": [
+            "n. 池塘"
+        ],
+        "usphone": "[pɑːnd]",
+        "ukphone": "[pɒnd]"
+    },
+    {
+        "name": "supervision",
+        "trans": [
+            "n. 监督，管理"
+        ],
+        "usphone": "[ˌsuːpərˈvɪʒn]",
+        "ukphone": "[ˌsuːpəˈvɪʒ(ə)n]"
+    },
+    {
+        "name": "counsellor",
+        "trans": [
+            "n. 顾问；参赞；辅导员（等于counselor）；律师；法律顾问"
+        ],
+        "usphone": "[ˈkaʊnsələr]",
+        "ukphone": "[ˈkaʊnsələ(r)]"
+    },
+    {
+        "name": "sensitivity",
+        "trans": [
+            "n. 敏感；敏感性；过敏"
+        ],
+        "usphone": "[ˌsensəˈtɪvəti]",
+        "ukphone": "[ˌsensəˈtɪvəti]"
+    },
+    {
+        "name": "inspect",
+        "trans": [
+            "vt. 检查；视察；检阅"
+        ],
+        "usphone": "[ɪnˈspekt]",
+        "ukphone": "[ɪnˈspekt]"
     },
     {
         "name": "refusal",
@@ -7792,20 +1136,2028 @@
         "ukphone": "[rɪˈfjuːzl]"
     },
     {
-        "name": "regain",
+        "name": "inequality",
         "trans": [
-            "n. 收复；取回"
+            "n. 不平等；不同；不平均"
         ],
-        "usphone": "[rɪˈɡeɪn]",
-        "ukphone": "[rɪˈɡeɪn]"
+        "usphone": "[ˌɪnɪˈkwɑːləti]",
+        "ukphone": "[ˌɪnɪˈkwɒləti]"
     },
     {
-        "name": "regardless",
+        "name": "angel",
         "trans": [
-            "adj. 不管的；不顾的；不注意的"
+            "n. 天使；守护神；善人"
         ],
-        "usphone": "[rɪˈɡɑːrdləs]",
-        "ukphone": "[rɪˈɡɑːdləs]"
+        "usphone": "[ˈeɪndʒl]",
+        "ukphone": "[ˈeɪndʒl]"
+    },
+    {
+        "name": "injection",
+        "trans": [
+            "n. 注射；注射剂；充血；射入轨道"
+        ],
+        "usphone": "[ɪnˈdʒekʃn]",
+        "ukphone": "[ɪnˈdʒekʃn]"
+    },
+    {
+        "name": "dawn",
+        "trans": [
+            "n. 黎明；开端"
+        ],
+        "usphone": "[dɔːn]",
+        "ukphone": "[dɔːn]"
+    },
+    {
+        "name": "prevail",
+        "trans": [
+            "vi. 盛行，流行；战胜，获胜"
+        ],
+        "usphone": "[prɪˈveɪl]",
+        "ukphone": "[prɪˈveɪl]"
+    },
+    {
+        "name": "behalf",
+        "trans": [
+            "n. 代表；利益"
+        ],
+        "usphone": "[bɪˈhæf]",
+        "ukphone": "[bɪˈhɑːf]"
+    },
+    {
+        "name": "coordinator",
+        "trans": [
+            "n. 协调者；[自] 协调器；同等的人或物"
+        ],
+        "usphone": "[koʊˈɔːrdɪneɪtər]",
+        "ukphone": "[kəʊˈɔːdɪneɪtə(r)]"
+    },
+    {
+        "name": "province",
+        "trans": [
+            "n. 省；领域；职权"
+        ],
+        "usphone": "[ˈprɑːvɪns]",
+        "ukphone": "[ˈprɒvɪns]"
+    },
+    {
+        "name": "thoughtful",
+        "trans": [
+            "adj. 深思的；体贴的；关切的"
+        ],
+        "usphone": "[ˈθɔːtf(ə)l]",
+        "ukphone": "[ˈθɔːtf(ə)l]"
+    },
+    {
+        "name": "disposal",
+        "trans": [
+            "n. 处理；支配；清理；安排"
+        ],
+        "usphone": "[dɪˈspoʊzl]",
+        "ukphone": "[dɪˈspəʊzl]"
+    },
+    {
+        "name": "drain",
+        "trans": [
+            "n. 排水；下水道，排水管；消耗"
+        ],
+        "usphone": "[dreɪn]",
+        "ukphone": "[dreɪn]"
+    },
+    {
+        "name": "utterly",
+        "trans": [
+            "adv. 完全地；绝对地；全然地；彻底地，十足地"
+        ],
+        "usphone": "[ˈʌtərli]",
+        "ukphone": "[ˈʌtəli]"
+    },
+    {
+        "name": "firearm",
+        "trans": [
+            "n. 火器；枪炮"
+        ],
+        "usphone": "[ˈfaɪərɑːrm]",
+        "ukphone": "[ˈfaɪərɑːm]"
+    },
+    {
+        "name": "pathway",
+        "trans": [
+            "n. 路，道；途径，路径"
+        ],
+        "usphone": "[ˈpæθweɪ]",
+        "ukphone": "[ˈpɑːθweɪ]"
+    },
+    {
+        "name": "distort",
+        "trans": [
+            "vt. 扭曲；使失真；曲解"
+        ],
+        "usphone": "[dɪˈstɔːrt]",
+        "ukphone": "[dɪˈstɔːt]"
+    },
+    {
+        "name": "caution",
+        "trans": [
+            "n. 小心，谨慎；警告，警示"
+        ],
+        "usphone": "[ˈkɔːʃn]",
+        "ukphone": "[ˈkɔːʃn]"
+    },
+    {
+        "name": "invisible",
+        "trans": [
+            "adj. 无形的，看不见的；无形的；不显眼的，暗藏的"
+        ],
+        "usphone": "[ɪnˈvɪzəbl]",
+        "ukphone": "[ɪnˈvɪzəb(ə)l]"
+    },
+    {
+        "name": "facilitate",
+        "trans": [
+            "vt. 促进；帮助；使容易"
+        ],
+        "usphone": "[fəˈsɪlɪteɪt]",
+        "ukphone": "[fəˈsɪlɪteɪt]"
+    },
+    {
+        "name": "simulation",
+        "trans": [
+            "n. 仿真；模拟；模仿；假装"
+        ],
+        "usphone": "[ˌsɪmjuˈleɪʃn]",
+        "ukphone": "[ˌsɪmjuˈleɪʃ(ə)n]"
+    },
+    {
+        "name": "representation",
+        "trans": [
+            "n. 代表；表现；表示法；陈述"
+        ],
+        "usphone": "[ˌreprɪzenˈteɪʃn]",
+        "ukphone": "[ˌreprɪzenˈteɪʃn]"
+    },
+    {
+        "name": "clinical",
+        "trans": [
+            "adj. 临床的；诊所的"
+        ],
+        "usphone": "[ˈklɪnɪkl]",
+        "ukphone": "[ˈklɪnɪk(ə)l]"
+    },
+    {
+        "name": "sentiment",
+        "trans": [
+            "n. 感情，情绪；情操；观点；多愁善感"
+        ],
+        "usphone": "[ˈsentɪmənt]",
+        "ukphone": "[ˈsentɪmənt]"
+    },
+    {
+        "name": "diplomat",
+        "trans": [
+            "n. 外交家，外交官；有外交手腕的人；处事圆滑机敏的人"
+        ],
+        "usphone": "[ˈdɪpləmæt]",
+        "ukphone": "[ˈdɪpləmæt]"
+    },
+    {
+        "name": "aftermath",
+        "trans": [
+            "n. 后果；余波"
+        ],
+        "usphone": "[ˈæftərmæθ]",
+        "ukphone": "[ˈɑːftəmæθ; ˈɑːftəmɑːθ]"
+    },
+    {
+        "name": "succession",
+        "trans": [
+            "n. 连续；继位；继承权；[生态] 演替"
+        ],
+        "usphone": "[səkˈseʃn]",
+        "ukphone": "[səkˈseʃn]"
+    },
+    {
+        "name": "adolescent",
+        "trans": [
+            "n. 青少年"
+        ],
+        "usphone": "[ˌædəˈles(ə)nt]",
+        "ukphone": "[ˌædəˈles(ə)nt]"
+    },
+    {
+        "name": "suspension",
+        "trans": [
+            "n. 悬浮；暂停；停职"
+        ],
+        "usphone": "[səˈspenʃn]",
+        "ukphone": "[səˈspenʃ(ə)n]"
+    },
+    {
+        "name": "overwhelming",
+        "trans": [
+            "adj. 压倒性的；势不可挡的"
+        ],
+        "usphone": "[ˌoʊvərˈwelmɪŋ]",
+        "ukphone": "[ˌəʊvəˈwelmɪŋ]"
+    },
+    {
+        "name": "classification",
+        "trans": [
+            "n. 分类；类别，等级"
+        ],
+        "usphone": "[ˌklæsɪfɪˈkeɪʃn]",
+        "ukphone": "[ˌklæsɪfɪˈkeɪʃ(ə)n]"
+    },
+    {
+        "name": "ruling",
+        "trans": [
+            "n. 统治，支配；裁定"
+        ],
+        "usphone": "[ˈruːlɪŋ]",
+        "ukphone": "[ˈruːlɪŋ]"
+    },
+    {
+        "name": "allegation",
+        "trans": [
+            "n. 指控; 陈述，主张; 宣称; 陈词，陈述;"
+        ],
+        "usphone": "[ˌæləˈɡeɪʃn]",
+        "ukphone": "[ˌæləˈɡeɪʃn]"
+    },
+    {
+        "name": "distinctive",
+        "trans": [
+            "adj. 有特色的，与众不同的"
+        ],
+        "usphone": "[dɪˈstɪŋktɪv]",
+        "ukphone": "[dɪˈstɪŋktɪv]"
+    },
+    {
+        "name": "concession",
+        "trans": [
+            "n. 让步；特许（权）；承认；退位"
+        ],
+        "usphone": "[kənˈseʃn]",
+        "ukphone": "[kənˈseʃn]"
+    },
+    {
+        "name": "divert",
+        "trans": [
+            "vt. 转移；使…欢娱；使…转向"
+        ],
+        "usphone": "[daɪˈvɜːrt]",
+        "ukphone": "[daɪˈvɜːt]"
+    },
+    {
+        "name": "contractor",
+        "trans": [
+            "n. 承包人；立契约者"
+        ],
+        "usphone": "[ˈkɑːntræktər]",
+        "ukphone": "[kənˈtræktə(r); ˈkɒntræktə(r)]"
+    },
+    {
+        "name": "mobilize",
+        "trans": [
+            "vt. 动员，调动；集合，组织；使…流通；使…松动"
+        ],
+        "usphone": "[ˈmoʊbəlaɪz]",
+        "ukphone": "[ˈməʊbəlaɪz]"
+    },
+    {
+        "name": "interfere",
+        "trans": [
+            "vi. 干涉；妨碍；打扰"
+        ],
+        "usphone": "[ˌɪntərˈfɪr]",
+        "ukphone": "[ˌɪntəˈfɪə(r)]"
+    },
+    {
+        "name": "kingdom",
+        "trans": [
+            "n. 王国；界；领域"
+        ],
+        "usphone": "[ˈkɪŋdəm]",
+        "ukphone": "[ˈkɪŋdəm]"
+    },
+    {
+        "name": "designate",
+        "trans": [
+            "vt. 指定；指派；标出；把…定名为"
+        ],
+        "usphone": "[ˈdezɪɡneɪt]",
+        "ukphone": "[ˈdezɪɡneɪt]"
+    },
+    {
+        "name": "eligible",
+        "trans": [
+            "n. 合格者；适任者；有资格者"
+        ],
+        "usphone": "[ˈelɪdʒəbl]",
+        "ukphone": "[ˈelɪdʒəb(ə)l]"
+    },
+    {
+        "name": "ash",
+        "trans": [
+            "n. 灰；灰烬"
+        ],
+        "usphone": "[æʃ]",
+        "ukphone": "[æʃ]"
+    },
+    {
+        "name": "breed",
+        "trans": [
+            "n. [生物] 品种；种类，类型"
+        ],
+        "usphone": "[briːd]",
+        "ukphone": "[briːd]"
+    },
+    {
+        "name": "reform",
+        "trans": [
+            "n. 改革，改良；改正"
+        ],
+        "usphone": "[rɪˈfɔːrm]",
+        "ukphone": "[rɪˈfɔːm]"
+    },
+    {
+        "name": "novel",
+        "trans": [
+            "adj. 新奇的；异常的"
+        ],
+        "usphone": "[ˈnɑːv(ə)l]",
+        "ukphone": "[ˈnɒv(ə)l]"
+    },
+    {
+        "name": "absence",
+        "trans": [
+            "n. 没有；缺乏；缺席；不注意"
+        ],
+        "usphone": "[ˈæbsəns]",
+        "ukphone": "[ˈæbsəns]"
+    },
+    {
+        "name": "presidential",
+        "trans": [
+            "adj. 总统的；首长的；统辖的"
+        ],
+        "usphone": "[ˌprezɪˈdenʃl]",
+        "ukphone": "[ˌprezɪˈdenʃl]"
+    },
+    {
+        "name": "educator",
+        "trans": [
+            "n. 教育家；教育工作者；教师"
+        ],
+        "usphone": "[ˈedʒukeɪtər]",
+        "ukphone": "[ˈedʒukeɪtə(r)]"
+    },
+    {
+        "name": "fairness",
+        "trans": [
+            "n. 公平；美好；清晰；顺利性"
+        ],
+        "usphone": "[ˈfernəs]",
+        "ukphone": "[ˈfeənəs]"
+    },
+    {
+        "name": "probe",
+        "trans": [
+            "n. 探针；调查"
+        ],
+        "usphone": "[proʊb]",
+        "ukphone": "[prəʊb]"
+    },
+    {
+        "name": "ambassador",
+        "trans": [
+            "n. 大使；代表；使节"
+        ],
+        "usphone": "[æmˈbæsədər]",
+        "ukphone": "[æmˈbæsədə(r)]"
+    },
+    {
+        "name": "summit",
+        "trans": [
+            "n. 顶点；最高级会议；最高阶层"
+        ],
+        "usphone": "[ˈsʌmɪt]",
+        "ukphone": "[ˈsʌmɪt]"
+    },
+    {
+        "name": "intermediate",
+        "trans": [
+            "n. [化学] 中间物；媒介"
+        ],
+        "usphone": "[ˌɪntərˈmiːdiət]",
+        "ukphone": "[ˌɪntəˈmiːdiət]"
+    },
+    {
+        "name": "spare",
+        "trans": [
+            "n. 剩余；备用零件"
+        ],
+        "usphone": "[sper]",
+        "ukphone": "[speə(r)]"
+    },
+    {
+        "name": "vice",
+        "trans": [
+            "prep. 代替"
+        ],
+        "usphone": "[vaɪs]",
+        "ukphone": "[vaɪs]"
+    },
+    {
+        "name": "acid",
+        "trans": [
+            "n. 酸；<俚>迷幻药"
+        ],
+        "usphone": "[ˈæsɪd]",
+        "ukphone": "[ˈæsɪd]"
+    },
+    {
+        "name": "flexibility",
+        "trans": [
+            "n. 灵活性；弹性；适应性"
+        ],
+        "usphone": "[ˌfleksəˈbɪləti]",
+        "ukphone": "[ˌfleksəˈbɪləti]"
+    },
+    {
+        "name": "authorize",
+        "trans": [
+            "vt. 批准，认可；授权给；委托代替"
+        ],
+        "usphone": "[ˈɔːθəraɪz]",
+        "ukphone": "[ˈɔːθəraɪz]"
+    },
+    {
+        "name": "magnitude",
+        "trans": [
+            "n. 大小；量级；[地震] 震级；重要；光度"
+        ],
+        "usphone": "[ˈmæɡnɪtuːd]",
+        "ukphone": "[ˈmæɡnɪtjuːd]"
+    },
+    {
+        "name": "March",
+        "trans": [
+            "n. 三月"
+        ],
+        "usphone": "[mɑːrtʃ]",
+        "ukphone": "[mɑːtʃ]"
+    },
+    {
+        "name": "amateur",
+        "trans": [
+            "n. 爱好者；业余爱好者；外行"
+        ],
+        "usphone": "[ˈæmətər; ˈæmətʃər]",
+        "ukphone": "[ˈæmətə(r)]"
+    },
+    {
+        "name": "resume",
+        "trans": [
+            "n. 摘要；[管理] 履历，简历"
+        ],
+        "usphone": "[rɪˈzuːm]",
+        "ukphone": "[rɪˈzjuːm]"
+    },
+    {
+        "name": "experimental",
+        "trans": [
+            "adj. 实验的；根据实验的；试验性的"
+        ],
+        "usphone": "[ɪkˌsperɪˈmentl]",
+        "ukphone": "[ɪkˌsperɪˈment(ə)l]"
+    },
+    {
+        "name": "mill",
+        "trans": [
+            "vi. 乱转；被碾磨"
+        ],
+        "usphone": "[mɪl]",
+        "ukphone": "[mɪl]"
+    },
+    {
+        "name": "glorious",
+        "trans": [
+            "adj. 光荣的；辉煌的；极好的"
+        ],
+        "usphone": "[ˈɡlɔːriəs]",
+        "ukphone": "[ˈɡlɔːriəs]"
+    },
+    {
+        "name": "evacuate",
+        "trans": [
+            "vt. 疏散，撤退；排泄"
+        ],
+        "usphone": "[ɪˈvækjueɪt]",
+        "ukphone": "[ɪˈvækjueɪt]"
+    },
+    {
+        "name": "nominate",
+        "trans": [
+            "vt. 推荐；提名；任命；指定"
+        ],
+        "usphone": "[ˈnɑːmɪneɪt]",
+        "ukphone": "[ˈnɒmɪneɪt]"
+    },
+    {
+        "name": "colonial",
+        "trans": [
+            "n. 殖民地居民"
+        ],
+        "usphone": "[kəˈloʊniəl]",
+        "ukphone": "[kəˈləʊniəl]"
+    },
+    {
+        "name": "theatrical",
+        "trans": [
+            "adj. 戏剧性的；剧场的，戏剧的；夸张的；做作的"
+        ],
+        "usphone": "[θiˈætrɪkl]",
+        "ukphone": "[θiˈætrɪk(ə)l]"
+    },
+    {
+        "name": "uphold",
+        "trans": [
+            "vt. 支撑；鼓励；赞成；举起"
+        ],
+        "usphone": "[ʌpˈhoʊld]",
+        "ukphone": "[ʌpˈhəʊld]"
+    },
+    {
+        "name": "attendance",
+        "trans": [
+            "n. 出席；到场；出席人数；考勤"
+        ],
+        "usphone": "[əˈtendəns]",
+        "ukphone": "[əˈtendəns]"
+    },
+    {
+        "name": "utilize",
+        "trans": [
+            "vt. 利用"
+        ],
+        "usphone": "[ˈjuːtəlaɪz]",
+        "ukphone": "[ˈjuːtəlaɪz]"
+    },
+    {
+        "name": "attribute",
+        "trans": [
+            "n. 属性；特质"
+        ],
+        "usphone": "[əˈtrɪbjuːt]",
+        "ukphone": "[əˈtrɪbjuːt]"
+    },
+    {
+        "name": "extremist",
+        "trans": [
+            "n. 极端主义者，过激分子"
+        ],
+        "usphone": "[ɪkˈstriːmɪst]",
+        "ukphone": "[ɪkˈstriːmɪst]"
+    },
+    {
+        "name": "quest",
+        "trans": [
+            "n. 追求；寻找"
+        ],
+        "usphone": "[kwest]",
+        "ukphone": "[kwest]"
+    },
+    {
+        "name": "civilian",
+        "trans": [
+            "n. 平民，百姓"
+        ],
+        "usphone": "[səˈvɪliən]",
+        "ukphone": "[səˈvɪliən]"
+    },
+    {
+        "name": "terminal",
+        "trans": [
+            "n. 末端；终点；终端机；极限"
+        ],
+        "usphone": "[ˈtɜːrmɪn(ə)l]",
+        "ukphone": "[ˈtɜːmɪn(ə)l]"
+    },
+    {
+        "name": "crawl",
+        "trans": [
+            "n. 爬行；养鱼池；匍匐而行"
+        ],
+        "usphone": "[krɔːl]",
+        "ukphone": "[krɔːl]"
+    },
+    {
+        "name": "parental",
+        "trans": [
+            "adj. 父母亲的，父母的；亲代的，亲本的"
+        ],
+        "usphone": "[pəˈrentl]",
+        "ukphone": "[pəˈrent(ə)l]"
+    },
+    {
+        "name": "guidance",
+        "trans": [
+            "n. 指导，引导；领导"
+        ],
+        "usphone": "[ˈɡaɪdns]",
+        "ukphone": "[ˈɡaɪdns]"
+    },
+    {
+        "name": "constitute",
+        "trans": [
+            "vt. 组成，构成；建立；任命"
+        ],
+        "usphone": "[ˈkɑːnstɪtuːt]",
+        "ukphone": "[ˈkɒnstɪtjuːt]"
+    },
+    {
+        "name": "inclined",
+        "trans": [
+            "v. 使…倾向（incline的过去分词）"
+        ],
+        "usphone": "[ɪnˈklaɪnd]",
+        "ukphone": "[ɪnˈklaɪnd]"
+    },
+    {
+        "name": "transformation",
+        "trans": [
+            "n. [遗] 转化；转换；改革；变形"
+        ],
+        "usphone": "[ˌtrænsfərˈmeɪʃn]",
+        "ukphone": "[ˌtrænsfəˈmeɪʃn]"
+    },
+    {
+        "name": "predominantly",
+        "trans": [
+            "adv. 主要地；显著地"
+        ],
+        "usphone": "[prɪˈdɑːmɪnəntli]",
+        "ukphone": "[prɪˈdɒmɪnəntli]"
+    },
+    {
+        "name": "content",
+        "trans": [
+            "n. 内容，目录；满足；容量"
+        ],
+        "usphone": "[ˈkɑːntent; kənˈtent]",
+        "ukphone": "[ˈkɒntent]"
+    },
+    {
+        "name": "dub",
+        "trans": [
+            "n. 笨蛋；鼓声"
+        ],
+        "usphone": "[dʌb]",
+        "ukphone": "[dʌb]"
+    },
+    {
+        "name": "buddy",
+        "trans": [
+            "n. 伙伴，好朋友；密友；小男孩"
+        ],
+        "usphone": "[ˈbʌdi]",
+        "ukphone": "[ˈbʌdi]"
+    },
+    {
+        "name": "coastal",
+        "trans": [
+            "adj. 沿海的；海岸的"
+        ],
+        "usphone": "[ˈkoʊstl]",
+        "ukphone": "[ˈkəʊst(ə)l]"
+    },
+    {
+        "name": "ballot",
+        "trans": [
+            "n. 投票；投票用纸；投票总数"
+        ],
+        "usphone": "[ˈbælət]",
+        "ukphone": "[ˈbælət]"
+    },
+    {
+        "name": "logic",
+        "trans": [
+            "n. 逻辑；逻辑学；逻辑性"
+        ],
+        "usphone": "[ˈlɑːdʒɪk]",
+        "ukphone": "[ˈlɒdʒɪk]"
+    },
+    {
+        "name": "attorney",
+        "trans": [
+            "n. 律师；代理人；检查官"
+        ],
+        "usphone": "[əˈtɜːrni]",
+        "ukphone": "[əˈtɜːni]"
+    },
+    {
+        "name": "alliance",
+        "trans": [
+            "n. 联盟，联合；联姻"
+        ],
+        "usphone": "[əˈlaɪəns]",
+        "ukphone": "[əˈlaɪəns]"
+    },
+    {
+        "name": "obsession",
+        "trans": [
+            "n. 痴迷；困扰；[内科][心理] 强迫观念"
+        ],
+        "usphone": "[əbˈseʃn]",
+        "ukphone": "[əbˈseʃn]"
+    },
+    {
+        "name": "mathematical",
+        "trans": [
+            "adj. 数学的，数学上的；精确的"
+        ],
+        "usphone": "[ˌmæθəˈmætɪkl]",
+        "ukphone": "[ˌmæθəˈmætɪk(ə)l]"
+    },
+    {
+        "name": "contempt",
+        "trans": [
+            "n. 轻视，蔑视；耻辱"
+        ],
+        "usphone": "[kənˈtempt]",
+        "ukphone": "[kənˈtempt]"
+    },
+    {
+        "name": "magical",
+        "trans": [
+            "adj. 魔术的；有魔力的"
+        ],
+        "usphone": "[ˈmædʒɪkl]",
+        "ukphone": "[ˈmædʒɪkl]"
+    },
+    {
+        "name": "vicious",
+        "trans": [
+            "adj. 恶毒的；恶意的；堕落的；有错误的；品性不端的；剧烈的"
+        ],
+        "usphone": "[ˈvɪʃəs]",
+        "ukphone": "[ˈvɪʃəs]"
+    },
+    {
+        "name": "thrive",
+        "trans": [
+            "vi. 繁荣，兴旺；茁壮成长"
+        ],
+        "usphone": "[θraɪv]",
+        "ukphone": "[θraɪv]"
+    },
+    {
+        "name": "solely",
+        "trans": [
+            "adv. 单独地，唯一地"
+        ],
+        "usphone": "[ˈsoʊlli]",
+        "ukphone": "[ˈsəʊlli]"
+    },
+    {
+        "name": "gathering",
+        "trans": [
+            "n. 聚集；集会；收款"
+        ],
+        "usphone": "[ˈɡæðərɪŋ]",
+        "ukphone": "[ˈɡæðərɪŋ]"
+    },
+    {
+        "name": "assemble",
+        "trans": [
+            "vt. 集合，聚集；装配；收集"
+        ],
+        "usphone": "[əˈsembl]",
+        "ukphone": "[əˈsemb(ə)l]"
+    },
+    {
+        "name": "deficiency",
+        "trans": [
+            "n. 缺陷，缺点；缺乏；不足的数额"
+        ],
+        "usphone": "[dɪˈfɪʃnsi]",
+        "ukphone": "[dɪˈfɪʃ(ə)nsi]"
+    },
+    {
+        "name": "deprive",
+        "trans": [
+            "vt. 使丧失，剥夺"
+        ],
+        "usphone": "[dɪˈpraɪv]",
+        "ukphone": "[dɪˈpraɪv]"
+    },
+    {
+        "name": "creator",
+        "trans": [
+            "n. 创造者；创建者"
+        ],
+        "usphone": "[kriˈeɪtər]",
+        "ukphone": "[kriˈeɪtə(r)]"
+    },
+    {
+        "name": "provoke",
+        "trans": [
+            "vt. 驱使；激怒；煽动；惹起"
+        ],
+        "usphone": "[prəˈvoʊk]",
+        "ukphone": "[prəˈvəʊk]"
+    },
+    {
+        "name": "fit",
+        "trans": [
+            "n. 合身；发作；痉挛"
+        ],
+        "usphone": "[fɪt]",
+        "ukphone": "[fɪt]"
+    },
+    {
+        "name": "underlying",
+        "trans": [
+            "adj. 潜在的；根本的；在下面的；优先的"
+        ],
+        "usphone": "[ˌʌndərˈlaɪɪŋ]",
+        "ukphone": "[ˌʌndəˈlaɪɪŋ]"
+    },
+    {
+        "name": "psychiatric",
+        "trans": [
+            "adj. 精神病学的；精神病治疗的"
+        ],
+        "usphone": "[ˌsaɪkiˈætrɪk]",
+        "ukphone": "[ˌsaɪkiˈætrɪk]"
+    },
+    {
+        "name": "superb",
+        "trans": [
+            "adj. 极好的；华丽的；宏伟的"
+        ],
+        "usphone": "[suːˈpɜːrb]",
+        "ukphone": "[suːˈpɜːb; sjuːˈpɜːb]"
+    },
+    {
+        "name": "transmission",
+        "trans": [
+            "n. 传动装置，[机] 变速器；传递；传送；播送"
+        ],
+        "usphone": "[trænzˈmɪʃnˌtrænsˈmɪʃn]",
+        "ukphone": "[trænzˈmɪʃ(ə)n]"
+    },
+    {
+        "name": "prevention",
+        "trans": [
+            "n. 预防；阻止；妨碍"
+        ],
+        "usphone": "[prɪˈvenʃn]",
+        "ukphone": "[prɪˈvenʃn]"
+    },
+    {
+        "name": "consent",
+        "trans": [
+            "n. 同意；（意见等的）一致；赞成"
+        ],
+        "usphone": "[kənˈsent]",
+        "ukphone": "[kənˈsent]"
+    },
+    {
+        "name": "eager",
+        "trans": [
+            "adj. 渴望的；热切的；热心的"
+        ],
+        "usphone": "[ˈiːɡər]",
+        "ukphone": "[ˈiːɡə(r)]"
+    },
+    {
+        "name": "whip",
+        "trans": [
+            "n. 鞭子；抽打；车夫；[机] 搅拌器"
+        ],
+        "usphone": "[wɪp]",
+        "ukphone": "[wɪp]"
+    },
+    {
+        "name": "odds",
+        "trans": [
+            "n. 几率；胜算；不平等；差别"
+        ],
+        "usphone": "[ɑːdz]",
+        "ukphone": "[ɒdz]"
+    },
+    {
+        "name": "segment",
+        "trans": [
+            "n. 段；部分"
+        ],
+        "usphone": "[ˈseɡmənt]",
+        "ukphone": "[ˈseɡmənt]"
+    },
+    {
+        "name": "transcript",
+        "trans": [
+            "n. 成绩单；抄本，副本；文字记录"
+        ],
+        "usphone": "[ˈtrænskrɪpt]",
+        "ukphone": "[ˈtrænskrɪpt]"
+    },
+    {
+        "name": "explicitly",
+        "trans": [
+            "adv. 明确地；明白地"
+        ],
+        "usphone": "[ɪkˈsplɪsɪtli]",
+        "ukphone": "[ɪkˈsplɪsɪtli]"
+    },
+    {
+        "name": "subscription",
+        "trans": [
+            "n. 捐献；订阅；订金；签署"
+        ],
+        "usphone": "[səbˈskrɪpʃn]",
+        "ukphone": "[səbˈskrɪpʃ(ə)n]"
+    },
+    {
+        "name": "seemingly",
+        "trans": [
+            "adv. 看来似乎；表面上看来"
+        ],
+        "usphone": "[ˈsiːmɪŋli]",
+        "ukphone": "[ˈsiːmɪŋli]"
+    },
+    {
+        "name": "elite",
+        "trans": [
+            "n. 精英；精华；中坚分子"
+        ],
+        "usphone": "[eɪˈliːt; ɪˈliːt]",
+        "ukphone": "[eɪˈliːt]"
+    },
+    {
+        "name": "archive",
+        "trans": [
+            "n. 档案馆；档案文件"
+        ],
+        "usphone": "[ˈɑːrkaɪv]",
+        "ukphone": "[ˈɑːkaɪv]"
+    },
+    {
+        "name": "revive",
+        "trans": [
+            "vt. 使复兴；使苏醒；回想起；重演，重播"
+        ],
+        "usphone": "[rɪˈvaɪv]",
+        "ukphone": "[rɪˈvaɪv]"
+    },
+    {
+        "name": "deed",
+        "trans": [
+            "n. 行动；功绩；证书；[法] 契据"
+        ],
+        "usphone": "[diːd]",
+        "ukphone": "[diːd]"
+    },
+    {
+        "name": "notable",
+        "trans": [
+            "adj. 值得注意的，显著的；著名的"
+        ],
+        "usphone": "[ˈnoʊtəbl]",
+        "ukphone": "[ˈnəʊtəbl]"
+    },
+    {
+        "name": "meaningful",
+        "trans": [
+            "adj. 有意义的；意味深长的"
+        ],
+        "usphone": "[ˈmiːnɪŋfl]",
+        "ukphone": "[ˈmiːnɪŋfl]"
+    },
+    {
+        "name": "magnetic",
+        "trans": [
+            "adj. 地磁的；有磁性的；有吸引力的"
+        ],
+        "usphone": "[mæɡˈnetɪk]",
+        "ukphone": "[mæɡˈnetɪk]"
+    },
+    {
+        "name": "radar",
+        "trans": [
+            "n. [雷达] 雷达，无线电探测器"
+        ],
+        "usphone": "[ˈreɪdɑːr]",
+        "ukphone": "[ˈreɪdɑː(r)]"
+    },
+    {
+        "name": "judicial",
+        "trans": [
+            "adj. 公正的，明断的；法庭的；审判上的"
+        ],
+        "usphone": "[dʒuːˈdɪʃəl]",
+        "ukphone": "[dʒuˈdɪʃl]"
+    },
+    {
+        "name": "alignment",
+        "trans": [
+            "n. 队列，成直线；校准；结盟"
+        ],
+        "usphone": "[əˈlaɪnmənt]",
+        "ukphone": "[əˈlaɪnmənt]"
+    },
+    {
+        "name": "inspection",
+        "trans": [
+            "n. 视察，检查"
+        ],
+        "usphone": "[ɪnˈspekʃn]",
+        "ukphone": "[ɪnˈspekʃ(ə)n]"
+    },
+    {
+        "name": "proclaim",
+        "trans": [
+            "vt. 宣告，公布；声明；表明；赞扬"
+        ],
+        "usphone": "[prəˈkleɪm]",
+        "ukphone": "[prəˈkleɪm]"
+    },
+    {
+        "name": "confession",
+        "trans": [
+            "n. 忏悔，告解；供认；表白"
+        ],
+        "usphone": "[kənˈfeʃn]",
+        "ukphone": "[kənˈfeʃn]"
+    },
+    {
+        "name": "franchise",
+        "trans": [
+            "n. 特权；公民权；经销权；管辖权"
+        ],
+        "usphone": "[ˈfræntʃaɪz]",
+        "ukphone": "[ˈfræntʃaɪz]"
+    },
+    {
+        "name": "articulate",
+        "trans": [
+            "adj. 发音清晰的；口才好的；有关节的"
+        ],
+        "usphone": "[ɑːrˈtɪkjuleɪt]",
+        "ukphone": "[ɑːˈtɪkjuleɪt]"
+    },
+    {
+        "name": "willingness",
+        "trans": [
+            "n. 乐意；心甘情愿；自动自发"
+        ],
+        "usphone": "[ˈwɪlɪŋnəs]",
+        "ukphone": "[ˈwɪlɪŋnəs]"
+    },
+    {
+        "name": "remainder",
+        "trans": [
+            "n. [数] 余数，残余；剩余物；其余的人"
+        ],
+        "usphone": "[rɪˈmeɪndər]",
+        "ukphone": "[rɪˈmeɪndə(r)]"
+    },
+    {
+        "name": "nursery",
+        "trans": [
+            "n. 苗圃；托儿所；温床"
+        ],
+        "usphone": "[ˈnɜːrsəri]",
+        "ukphone": "[ˈnɜːsəri]"
+    },
+    {
+        "name": "wipe",
+        "trans": [
+            "n. 擦拭；用力打"
+        ],
+        "usphone": "[waɪp]",
+        "ukphone": "[waɪp]"
+    },
+    {
+        "name": "substantially",
+        "trans": [
+            "adv. 实质上；大体上；充分地"
+        ],
+        "usphone": "[səbˈstænʃəli]",
+        "ukphone": "[səbˈstænʃəli]"
+    },
+    {
+        "name": "unveil",
+        "trans": [
+            "vt. 使公之于众，揭开；揭幕"
+        ],
+        "usphone": "[ˌʌnˈveɪl]",
+        "ukphone": "[ˌʌnˈveɪl]"
+    },
+    {
+        "name": "pole",
+        "trans": [
+            "n. 杆；极点；电极"
+        ],
+        "usphone": "[poʊl]",
+        "ukphone": "[pəʊl]"
+    },
+    {
+        "name": "tenure",
+        "trans": [
+            "n. 任期；占有"
+        ],
+        "usphone": "[ˈtenjər]",
+        "ukphone": "[ˈtenjə(r)]"
+    },
+    {
+        "name": "militia",
+        "trans": [
+            "n. 民兵组织；自卫队；义勇军；国民军"
+        ],
+        "usphone": "[məˈlɪʃə]",
+        "ukphone": "[məˈlɪʃə]"
+    },
+    {
+        "name": "exclusion",
+        "trans": [
+            "n. 排除；排斥；驱逐；被排除在外的事物"
+        ],
+        "usphone": "[ɪkˈskluːʒn]",
+        "ukphone": "[ɪkˈskluːʒ(ə)n]"
+    },
+    {
+        "name": "marketplace",
+        "trans": [
+            "n. 市场；商场；市集"
+        ],
+        "usphone": "[ˈmɑːrkɪtpleɪs]",
+        "ukphone": "[ˈmɑːkɪtpleɪs]"
+    },
+    {
+        "name": "charm",
+        "trans": [
+            "n. 魅力，吸引力；魔力"
+        ],
+        "usphone": "[tʃɑːrm]",
+        "ukphone": "[tʃɑːm]"
+    },
+    {
+        "name": "municipal",
+        "trans": [
+            "adj. 市政的，市的；地方自治的"
+        ],
+        "usphone": "[mjuːˈnɪsɪpl]",
+        "ukphone": "[mjuːˈnɪsɪpl]"
+    },
+    {
+        "name": "acre",
+        "trans": [
+            "n. 土地，地产；英亩"
+        ],
+        "usphone": "[ˈeɪkər]",
+        "ukphone": "[ˈeɪkə(r)]"
+    },
+    {
+        "name": "film-maker",
+        "trans": [
+            "n. 电影制作人"
+        ],
+        "usphone": "[ˈfɪlm meɪkər]",
+        "ukphone": "[ˈfɪlm meɪkə(r)]"
+    },
+    {
+        "name": "lengthy",
+        "trans": [
+            "adj. 漫长的，冗长的；啰唆的"
+        ],
+        "usphone": "[ˈleŋθi]",
+        "ukphone": "[ˈleŋθi]"
+    },
+    {
+        "name": "settlement",
+        "trans": [
+            "n. 解决，处理；[会计] 结算；沉降；殖民"
+        ],
+        "usphone": "[ˈsetlmənt]",
+        "ukphone": "[ˈset(ə)lmənt]"
+    },
+    {
+        "name": "cease",
+        "trans": [
+            "n. 停止"
+        ],
+        "usphone": "[siːs]",
+        "ukphone": "[siːs]"
+    },
+    {
+        "name": "reliability",
+        "trans": [
+            "n. 可靠性"
+        ],
+        "usphone": "[rɪˌlaɪəˈbɪləti]",
+        "ukphone": "[rɪˌlaɪəˈbɪləti]"
+    },
+    {
+        "name": "contender",
+        "trans": [
+            "n. 竞争者；争夺者"
+        ],
+        "usphone": "[kənˈtendər]",
+        "ukphone": "[kənˈtendə(r)]"
+    },
+    {
+        "name": "trauma",
+        "trans": [
+            "n. [外科] 创伤（由心理创伤造成精神上的异常）；外伤"
+        ],
+        "usphone": "[ˈtrɔːməˌˈtraʊmə]",
+        "ukphone": "[ˈtrɔːmə]"
+    },
+    {
+        "name": "catalogue",
+        "trans": [
+            "n. 目录；（美）大学情况一览"
+        ],
+        "usphone": "[ˈkætəlɔːɡ]",
+        "ukphone": "[ˈkætəlɒɡ]"
+    },
+    {
+        "name": "chamber",
+        "trans": [
+            "n. （身体或器官内的）室，膛；房间；会所"
+        ],
+        "usphone": "[ˈtʃeɪmbər]",
+        "ukphone": "[ˈtʃeɪmbə(r)]"
+    },
+    {
+        "name": "persist",
+        "trans": [
+            "vi. 存留，坚持；持续，固执"
+        ],
+        "usphone": "[pərˈsɪst]",
+        "ukphone": "[pəˈsɪst]"
+    },
+    {
+        "name": "surgical",
+        "trans": [
+            "n. 外科手术；外科病房"
+        ],
+        "usphone": "[ˈsɜːrdʒɪkl]",
+        "ukphone": "[ˈsɜːdʒɪkl]"
+    },
+    {
+        "name": "declaration",
+        "trans": [
+            "n. （纳税品等的）申报；宣布；公告；申诉书"
+        ],
+        "usphone": "[ˌdekləˈreɪʃn]",
+        "ukphone": "[ˌdekləˈreɪʃn]"
+    },
+    {
+        "name": "sole",
+        "trans": [
+            "n. 鞋底；脚底；基础；鳎目鱼"
+        ],
+        "usphone": "[soʊl]",
+        "ukphone": "[səʊl]"
+    },
+    {
+        "name": "notify",
+        "trans": [
+            "vt. 通告，通知；公布"
+        ],
+        "usphone": "[ˈnoʊtɪfaɪ]",
+        "ukphone": "[ˈnəʊtɪfaɪ]"
+    },
+    {
+        "name": "gallon",
+        "trans": [
+            "n. 加仑（容量单位）"
+        ],
+        "usphone": "[ˈɡælən]",
+        "ukphone": "[ˈɡælən]"
+    },
+    {
+        "name": "marginal",
+        "trans": [
+            "adj. 边缘的；临界的；末端的"
+        ],
+        "usphone": "[ˈmɑːrdʒɪnl]",
+        "ukphone": "[ˈmɑːdʒɪn(ə)l]"
+    },
+    {
+        "name": "proceeds",
+        "trans": [
+            "n. 收入，收益；实收款项"
+        ],
+        "usphone": "[ˈproʊsiːdz]",
+        "ukphone": "[ˈprəʊsiːdz]"
+    },
+    {
+        "name": "symbolic",
+        "trans": [
+            "adj. 象征的；符号的；使用符号的"
+        ],
+        "usphone": "[sɪmˈbɑːlɪk]",
+        "ukphone": "[sɪmˈbɒlɪk]"
+    },
+    {
+        "name": "detain",
+        "trans": [
+            "vt. 拘留；留住；耽搁"
+        ],
+        "usphone": "[dɪˈteɪn]",
+        "ukphone": "[dɪˈteɪn]"
+    },
+    {
+        "name": "merit",
+        "trans": [
+            "n. 优点，价值；功绩；功过"
+        ],
+        "usphone": "[ˈmerɪt]",
+        "ukphone": "[ˈmerɪt]"
+    },
+    {
+        "name": "beloved",
+        "trans": [
+            "n. 心爱的人；亲爱的教友"
+        ],
+        "usphone": "[bɪˈlʌvɪd]",
+        "ukphone": "[bɪˈlʌvɪd]"
+    },
+    {
+        "name": "coordinate",
+        "trans": [
+            "n. 坐标；同等的人或物"
+        ],
+        "usphone": "[koʊˈɔːrdɪneɪt]",
+        "ukphone": "[kəʊˈɔːdɪneɪt]"
+    },
+    {
+        "name": "nationwide",
+        "trans": [
+            "adj. 全国范围的；全国性的"
+        ],
+        "usphone": "[ˌneɪʃnˈwaɪd]",
+        "ukphone": "[ˌneɪʃnˈwaɪd]"
+    },
+    {
+        "name": "punch",
+        "trans": [
+            "n. 冲压机；打洞器；钻孔机"
+        ],
+        "usphone": "[pʌntʃ]",
+        "ukphone": "[pʌntʃ]"
+    },
+    {
+        "name": "drown",
+        "trans": [
+            "vt. 淹没；把…淹死"
+        ],
+        "usphone": "[draʊn]",
+        "ukphone": "[draʊn]"
+    },
+    {
+        "name": "non-profit",
+        "trans": [
+            "adj. 非营利的"
+        ],
+        "usphone": "[ˌnɑːn ˈprɑːfɪt]",
+        "ukphone": "[ˌnɒn ˈprɒfɪt]"
+    },
+    {
+        "name": "ironically",
+        "trans": [
+            "adv. 讽刺地；说反话地"
+        ],
+        "usphone": "[aɪˈrɑːnɪkli]",
+        "ukphone": "[aɪˈrɒnɪkli]"
+    },
+    {
+        "name": "bat",
+        "trans": [
+            "n. 蝙蝠；球棒；球拍；批处理文件的扩展名"
+        ],
+        "usphone": "[bæt]",
+        "ukphone": "[bæt]"
+    },
+    {
+        "name": "resistance",
+        "trans": [
+            "n. 阻力；电阻；抵抗；反抗；抵抗力"
+        ],
+        "usphone": "[rɪˈzɪstəns]",
+        "ukphone": "[rɪˈzɪstəns]"
+    },
+    {
+        "name": "pronounced",
+        "trans": [
+            "v. 发音；宣告；断言（pronounce的过去分词）"
+        ],
+        "usphone": "[prəˈnaʊnst]",
+        "ukphone": "[prəˈnaʊnst]"
+    },
+    {
+        "name": "confine",
+        "trans": [
+            "n. 界限，边界;约束；限制"
+        ],
+        "usphone": "[kənˈfaɪn]",
+        "ukphone": "[kənˈfaɪn]"
+    },
+    {
+        "name": "civic",
+        "trans": [
+            "adj. 市的；公民的，市民的"
+        ],
+        "usphone": "[ˈsɪvɪk]",
+        "ukphone": "[ˈsɪvɪk]"
+    },
+    {
+        "name": "parameter",
+        "trans": [
+            "n. 参数；系数；参量"
+        ],
+        "usphone": "[pəˈræmɪtər]",
+        "ukphone": "[pəˈræmɪtə(r)]"
+    },
+    {
+        "name": "whereby",
+        "trans": [
+            "adv. 凭借；通过…；借以；与…一致"
+        ],
+        "usphone": "[werˈbaɪ]",
+        "ukphone": "[weəˈbaɪ]"
+    },
+    {
+        "name": "arbitrary",
+        "trans": [
+            "adj. [数] 任意的；武断的；专制的"
+        ],
+        "usphone": "[ˈɑːrbɪtreri]",
+        "ukphone": "[ˈɑːbɪtrəri]"
+    },
+    {
+        "name": "legendary",
+        "trans": [
+            "adj. 传说的，传奇的"
+        ],
+        "usphone": "[ˈledʒənderi]",
+        "ukphone": "[ˈledʒəndri]"
+    },
+    {
+        "name": "legislature",
+        "trans": [
+            "n. 立法机关；立法机构"
+        ],
+        "usphone": "[ˈledʒɪsleɪtʃər]",
+        "ukphone": "[ˈledʒɪslətʃə(r)]"
+    },
+    {
+        "name": "dilemma",
+        "trans": [
+            "n. 困境；进退两难；两刀论法"
+        ],
+        "usphone": "[dɪˈlemə; daɪˈlemə]",
+        "ukphone": "[dɪˈlemə]"
+    },
+    {
+        "name": "imminent",
+        "trans": [
+            "adj. 即将来临的；迫近的"
+        ],
+        "usphone": "[ˈɪmɪnənt]",
+        "ukphone": "[ˈɪmɪnənt]"
+    },
+    {
+        "name": "courtesy",
+        "trans": [
+            "n. 礼貌；好意；恩惠"
+        ],
+        "usphone": "[ˈkɜːrtəsi]",
+        "ukphone": "[ˈkɜːtəsi]"
+    },
+    {
+        "name": "absent",
+        "trans": [
+            "adj. 缺席的；缺少的；心不在焉的；茫然的"
+        ],
+        "usphone": "[ˈæbsənt]",
+        "ukphone": "[ˈæbsənt]"
+    },
+    {
+        "name": "restoration",
+        "trans": [
+            "n. 恢复；复位；王政复辟；归还"
+        ],
+        "usphone": "[ˌrestəˈreɪʃn]",
+        "ukphone": "[ˌrestəˈreɪʃn]"
+    },
+    {
+        "name": "turnover",
+        "trans": [
+            "n. 翻覆；[贸易] 营业额；流通量；半圆卷饼；失误"
+        ],
+        "usphone": "[ˈtɜːrnoʊvər]",
+        "ukphone": "[ˈtɜːnəʊvə(r)]"
+    },
+    {
+        "name": "undergraduate",
+        "trans": [
+            "n. 大学生；大学肄业生"
+        ],
+        "usphone": "[ˌʌndərˈɡrædʒuət]",
+        "ukphone": "[ˌʌndəˈɡrædʒuət]"
+    },
+    {
+        "name": "disturbing",
+        "trans": [
+            "v. 干扰；打断（disturb的ing形式）"
+        ],
+        "usphone": "[dɪˈstɜːrbɪŋ]",
+        "ukphone": "[dɪˈstɜːbɪŋ]"
+    },
+    {
+        "name": "forge",
+        "trans": [
+            "n. 熔炉，锻铁炉；铁工厂"
+        ],
+        "usphone": "[fɔːrdʒ]",
+        "ukphone": "[fɔːdʒ]"
+    },
+    {
+        "name": "protective",
+        "trans": [
+            "adj. 防护的；关切保护的；保护贸易的"
+        ],
+        "usphone": "[prəˈtektɪv]",
+        "ukphone": "[prəˈtektɪv]"
+    },
+    {
+        "name": "rod",
+        "trans": [
+            "n. 棒；惩罚；枝条；权力"
+        ],
+        "usphone": "[rɑːd]",
+        "ukphone": "[rɒd]"
+    },
+    {
+        "name": "ward",
+        "trans": [
+            "n. 病房；保卫；监视"
+        ],
+        "usphone": "[wɔːrd]",
+        "ukphone": "[wɔːd]"
+    },
+    {
+        "name": "activist",
+        "trans": [
+            "n. 积极分子；激进主义分子"
+        ],
+        "usphone": "[ˈæktɪvɪst]",
+        "ukphone": "[ˈæktɪvɪst]"
+    },
+    {
+        "name": "contend",
+        "trans": [
+            "vi. 竞争；奋斗；斗争；争论"
+        ],
+        "usphone": "[kənˈtend]",
+        "ukphone": "[kənˈtend]"
+    },
+    {
+        "name": "discourse",
+        "trans": [
+            "n. 论述；谈话；演讲"
+        ],
+        "usphone": "[ˈdɪskɔːrs]",
+        "ukphone": "[ˈdɪskɔːs]"
+    },
+    {
+        "name": "niche",
+        "trans": [
+            "n. 壁龛；合适的职业；[亦称作 niche market]【商业】有利可图的市场(或形势等)"
+        ],
+        "usphone": "[niːʃˌnɪtʃ]",
+        "ukphone": "[niːʃ; nɪtʃ]"
+    },
+    {
+        "name": "divine",
+        "trans": [
+            "n. 牧师；神学家"
+        ],
+        "usphone": "[dɪˈvaɪn]",
+        "ukphone": "[dɪˈvaɪn]"
+    },
+    {
+        "name": "accused",
+        "trans": [
+            "n. 被告"
+        ],
+        "usphone": "[əˈkjuːzd]",
+        "ukphone": "[əˈkjuːzd]"
+    },
+    {
+        "name": "memorial",
+        "trans": [
+            "n. 纪念碑，纪念馆；纪念仪式；纪念物"
+        ],
+        "usphone": "[məˈmɔːriəl]",
+        "ukphone": "[məˈmɔːriəl]"
+    },
+    {
+        "name": "deployment",
+        "trans": [
+            "n. 调度，部署"
+        ],
+        "usphone": "[dɪˈplɔɪmənt]",
+        "ukphone": "[dɪˈplɔɪmənt]"
+    },
+    {
+        "name": "violate",
+        "trans": [
+            "vt. 违反；侵犯，妨碍；亵渎"
+        ],
+        "usphone": "[ˈvaɪəleɪt]",
+        "ukphone": "[ˈvaɪəleɪt]"
+    },
+    {
+        "name": "trace",
+        "trans": [
+            "n. 痕迹，踪迹；微量；[仪] 迹线；缰绳"
+        ],
+        "usphone": "[treɪs]",
+        "ukphone": "[treɪs]"
+    },
+    {
+        "name": "beneath",
+        "trans": [
+            "prep. 在…之下"
+        ],
+        "usphone": "[bɪˈniːθ]",
+        "ukphone": "[bɪˈniːθ]"
+    },
+    {
+        "name": "melody",
+        "trans": [
+            "n. 旋律；歌曲；美妙的音乐"
+        ],
+        "usphone": "[ˈmelədi]",
+        "ukphone": "[ˈmelədi]"
+    },
+    {
+        "name": "personnel",
+        "trans": [
+            "n. 人事部门；全体人员"
+        ],
+        "usphone": "[ˌpɜːrsəˈnel]",
+        "ukphone": "[ˌpɜːsəˈnel]"
+    },
+    {
+        "name": "flawed",
+        "trans": [
+            "adj. 有缺陷的；有瑕疵的；有裂纹的"
+        ],
+        "usphone": "[flɔːd]",
+        "ukphone": "[flɔːd]"
+    },
+    {
+        "name": "breakthrough",
+        "trans": [
+            "n. 突破；突破性进展"
+        ],
+        "usphone": "[ˈbreɪkθruː]",
+        "ukphone": "[ˈbreɪkθruː]"
+    },
+    {
+        "name": "sanction",
+        "trans": [
+            "n. 制裁，处罚；认可；支持"
+        ],
+        "usphone": "[ˈsæŋkʃn]",
+        "ukphone": "[ˈsæŋkʃn]"
+    },
+    {
+        "name": "portray",
+        "trans": [
+            "vt. 描绘；扮演"
+        ],
+        "usphone": "[pɔːrˈtreɪ]",
+        "ukphone": "[pɔːˈtreɪ]"
+    },
+    {
+        "name": "attain",
+        "trans": [
+            "n. 成就"
+        ],
+        "usphone": "[əˈteɪn]",
+        "ukphone": "[əˈteɪn]"
+    },
+    {
+        "name": "sceptical",
+        "trans": [
+            "adj. 怀疑的；怀疑论的；习惯怀疑的"
+        ],
+        "usphone": "[ˈskeptɪkl]",
+        "ukphone": "[ˈskeptɪk(ə)l]"
+    },
+    {
+        "name": "abortion",
+        "trans": [
+            "n. 流产，堕胎，小产；流产的胎儿；（计划等）失败，夭折"
+        ],
+        "usphone": "[əˈbɔːrʃn]",
+        "ukphone": "[əˈbɔːʃn]"
+    },
+    {
+        "name": "preliminary",
+        "trans": [
+            "n. 准备；预赛；初步措施"
+        ],
+        "usphone": "[prɪˈlɪmɪneri]",
+        "ukphone": "[prɪˈlɪmɪnəri]"
+    },
+    {
+        "name": "misleading",
+        "trans": [
+            "adj. 令人误解的；引入歧途的"
+        ],
+        "usphone": "[ˌmɪsˈliːdɪŋ]",
+        "ukphone": "[ˌmɪsˈliːdɪŋ]"
+    },
+    {
+        "name": "instrumental",
+        "trans": [
+            "n. 器乐曲；工具字，工具格"
+        ],
+        "usphone": "[ˌɪnstrəˈmentl]",
+        "ukphone": "[ˌɪnstrəˈment(ə)l]"
+    },
+    {
+        "name": "merger",
+        "trans": [
+            "n. （企业等的）合并；并购；吸收（如刑法中重罪吸收轻罪）"
+        ],
+        "usphone": "[ˈmɜːrdʒər]",
+        "ukphone": "[ˈmɜːdʒə(r)]"
+    },
+    {
+        "name": "transit",
+        "trans": [
+            "n. 运输；经过"
+        ],
+        "usphone": "[ˈtrænzɪtˌˈtrænsɪt]",
+        "ukphone": "[ˈtrænzɪt]"
+    },
+    {
+        "name": "premier",
+        "trans": [
+            "n. 总理，首相"
+        ],
+        "usphone": "[prɪˈmɪrˌprɪˈmjɪr]",
+        "ukphone": "[ˈpremiə(r)]"
+    },
+    {
+        "name": "outlook",
+        "trans": [
+            "n. 展望；观点；景色"
+        ],
+        "usphone": "[ˈaʊtlʊk]",
+        "ukphone": "[ˈaʊtlʊk]"
+    },
+    {
+        "name": "soak",
+        "trans": [
+            "n. 浸；湿透；大雨"
+        ],
+        "usphone": "[soʊk]",
+        "ukphone": "[səʊk]"
+    },
+    {
+        "name": "notorious",
+        "trans": [
+            "adj. 声名狼藉的，臭名昭著的"
+        ],
+        "usphone": "[noʊˈtɔːriəs]",
+        "ukphone": "[nəʊˈtɔːriəs]"
+    },
+    {
+        "name": "endorse",
+        "trans": [
+            "vt. 背书；认可；签署；赞同；在背面签名"
+        ],
+        "usphone": "[ɪnˈdɔːrs]",
+        "ukphone": "[ɪnˈdɔːs]"
+    },
+    {
+        "name": "harassment",
+        "trans": [
+            "n. 骚扰；烦恼"
+        ],
+        "usphone": "[həˈræsməntˌˈhærəsmənt]",
+        "ukphone": "[ˈhærəsmənt]"
+    },
+    {
+        "name": "charter",
+        "trans": [
+            "n. 宪章；执照；特许状"
+        ],
+        "usphone": "[ˈtʃɑːrtər]",
+        "ukphone": "[ˈtʃɑːtə(r)]"
+    },
+    {
+        "name": "theology",
+        "trans": [
+            "n. 神学；宗教体系"
+        ],
+        "usphone": "[θiˈɑːlədʒi]",
+        "ukphone": "[θiˈɒlədʒi]"
+    },
+    {
+        "name": "driving",
+        "trans": [
+            "n. 驾驶；操纵"
+        ],
+        "usphone": "[ˈdraɪvɪŋ]",
+        "ukphone": "[ˈdraɪvɪŋ]"
+    },
+    {
+        "name": "forthcoming",
+        "trans": [
+            "n. 来临"
+        ],
+        "usphone": "[ˌfɔːrθˈkʌmɪŋ]",
+        "ukphone": "[ˌfɔːθˈkʌmɪŋ]"
+    },
+    {
+        "name": "undermine",
+        "trans": [
+            "vt. 破坏，渐渐破坏；挖掘地基"
+        ],
+        "usphone": "[ˌʌndərˈmaɪn]",
+        "ukphone": "[ˌʌndəˈmaɪn]"
+    },
+    {
+        "name": "plead",
+        "trans": [
+            "vt. 借口；为...辩护；托称"
+        ],
+        "usphone": "[pliːd]",
+        "ukphone": "[pliːd]"
+    },
+    {
+        "name": "shipping",
+        "trans": [
+            "n. [船] 船舶，船舶吨数；海运；运送"
+        ],
+        "usphone": "[ˈʃɪpɪŋ]",
+        "ukphone": "[ˈʃɪpɪŋ]"
+    },
+    {
+        "name": "syndrome",
+        "trans": [
+            "n. [临床] 综合症状；并发症状；校验子；并发位"
+        ],
+        "usphone": "[ˈsɪndroʊm]",
+        "ukphone": "[ˈsɪndrəʊm]"
+    },
+    {
+        "name": "humanity",
+        "trans": [
+            "n. 人类；人道；仁慈；人文学科"
+        ],
+        "usphone": "[hjuːˈmænəti]",
+        "ukphone": "[hjuːˈmænəti]"
+    },
+    {
+        "name": "documentation",
+        "trans": [
+            "n. 文件, 证明文件, 史实, 文件编制"
+        ],
+        "usphone": "[ˌdɑːkjumenˈteɪʃn]",
+        "ukphone": "[ˌdɒkjumenˈteɪʃn]"
+    },
+    {
+        "name": "execute",
+        "trans": [
+            "vt. 实行；执行；处死"
+        ],
+        "usphone": "[ˈeksɪkjuːt]",
+        "ukphone": "[ˈeksɪkjuːt]"
+    },
+    {
+        "name": "kidney",
+        "trans": [
+            "n. [解剖] 肾脏；腰子；个性"
+        ],
+        "usphone": "[ˈkɪdni]",
+        "ukphone": "[ˈkɪdni]"
+    },
+    {
+        "name": "merge",
+        "trans": [
+            "vt. 合并；使合并；吞没"
+        ],
+        "usphone": "[mɜːrdʒ]",
+        "ukphone": "[mɜːdʒ]"
+    },
+    {
+        "name": "patrol",
+        "trans": [
+            "n. 巡逻；巡逻队；侦察队"
+        ],
+        "usphone": "[pəˈtroʊl]",
+        "ukphone": "[pəˈtrəʊl]"
+    },
+    {
+        "name": "circulate",
+        "trans": [
+            "vt. 使循环；使流通；使传播"
+        ],
+        "usphone": "[ˈsɜːrkjəleɪt]",
+        "ukphone": "[ˈsɜːkjəleɪt]"
+    },
+    {
+        "name": "surge",
+        "trans": [
+            "n. 汹涌；大浪，波涛；汹涌澎湃；巨涌"
+        ],
+        "usphone": "[sɜːrdʒ]",
+        "ukphone": "[sɜːdʒ]"
+    },
+    {
+        "name": "appealing",
+        "trans": [
+            "v. 恳求（appeal的ing形式）；将…上诉"
+        ],
+        "usphone": "[əˈpiːlɪŋ]",
+        "ukphone": "[əˈpiːlɪŋ]"
+    },
+    {
+        "name": "beam",
+        "trans": [
+            "n. 横梁；光线；电波；船宽；[计量] 秤杆"
+        ],
+        "usphone": "[biːm]",
+        "ukphone": "[biːm]"
+    },
+    {
+        "name": "structural",
+        "trans": [
+            "adj. 结构的；建筑的"
+        ],
+        "usphone": "[ˈstrʌktʃərəl]",
+        "ukphone": "[ˈstrʌktʃərəl]"
+    },
+    {
+        "name": "removal",
+        "trans": [
+            "n. 免职；移动；排除；搬迁"
+        ],
+        "usphone": "[rɪˈmuːvl]",
+        "ukphone": "[rɪˈmuːv(ə)l]"
+    },
+    {
+        "name": "ego",
+        "trans": [
+            "n. 自我；自负；自我意识"
+        ],
+        "usphone": "[ˈiːɡoʊ]",
+        "ukphone": "[ˈiːɡəʊ]"
+    },
+    {
+        "name": "copyright",
+        "trans": [
+            "n. 版权，著作权"
+        ],
+        "usphone": "[ˈkɑːpiraɪt]",
+        "ukphone": "[ˈkɒpiraɪt]"
+    },
+    {
+        "name": "endorsement",
+        "trans": [
+            "n. 认可，支持；背书；签注（文件）"
+        ],
+        "usphone": "[ɪnˈdɔːrsmənt]",
+        "ukphone": "[ɪnˈdɔːsmənt]"
+    },
+    {
+        "name": "prominent",
+        "trans": [
+            "adj. 突出的，显著的；杰出的；卓越的"
+        ],
+        "usphone": "[ˈprɑːmɪnənt]",
+        "ukphone": "[ˈprɒmɪnənt]"
+    },
+    {
+        "name": "banner",
+        "trans": [
+            "n. 横幅图片的广告模式"
+        ],
+        "usphone": "[ˈbænər]",
+        "ukphone": "[ˈbænə(r)]"
     },
     {
         "name": "regime",
@@ -7816,12 +3168,3132 @@
         "ukphone": "[reɪˈʒiːm]"
     },
     {
-        "name": "regulator",
+        "name": "conversion",
         "trans": [
-            "n. 调整者；监管者；校准器"
+            "n. 转换；变换；[金融] 兑换；改变信仰"
         ],
-        "usphone": "[ˈreɡjuleɪtər]",
-        "ukphone": "[ˈreɡjuleɪtə(r)]"
+        "usphone": "[kənˈvɜːrʒn]",
+        "ukphone": "[kənˈvɜːʃn]"
+    },
+    {
+        "name": "carve",
+        "trans": [
+            "vt. 雕刻；切开；开创"
+        ],
+        "usphone": "[kɑːrv]",
+        "ukphone": "[kɑːv]"
+    },
+    {
+        "name": "accusation",
+        "trans": [
+            "n. 控告，指控；谴责"
+        ],
+        "usphone": "[ˌækjuˈzeɪʃn]",
+        "ukphone": "[ˌækjuˈzeɪʃn]"
+    },
+    {
+        "name": "offering",
+        "trans": [
+            "n. 提供；祭品；奉献物；牲礼"
+        ],
+        "usphone": "[ˈɔːfərɪŋ]",
+        "ukphone": "[ˈɒfərɪŋ]"
+    },
+    {
+        "name": "prosecution",
+        "trans": [
+            "n. 起诉，检举；进行；经营"
+        ],
+        "usphone": "[ˌprɑːsɪˈkjuːʃn]",
+        "ukphone": "[ˌprɒsɪˈkjuːʃn]"
+    },
+    {
+        "name": "petition",
+        "trans": [
+            "n. 请愿；请愿书；祈求；[法] 诉状"
+        ],
+        "usphone": "[pəˈtɪʃn]",
+        "ukphone": "[pəˈtɪʃn]"
+    },
+    {
+        "name": "suite",
+        "trans": [
+            "n. （一套）家具；套房；组曲；（一批）随员，随从"
+        ],
+        "usphone": "[swiːt]",
+        "ukphone": "[swiːt]"
+    },
+    {
+        "name": "reside",
+        "trans": [
+            "vi. 住，居住；属于"
+        ],
+        "usphone": "[rɪˈzaɪd]",
+        "ukphone": "[rɪˈzaɪd]"
+    },
+    {
+        "name": "intervene",
+        "trans": [
+            "vi. 干涉；调停；插入"
+        ],
+        "usphone": "[ˌɪntərˈviːn]",
+        "ukphone": "[ˌɪntəˈviːn]"
+    },
+    {
+        "name": "abundance",
+        "trans": [
+            "n. 充裕，丰富"
+        ],
+        "usphone": "[əˈbʌndəns]",
+        "ukphone": "[əˈbʌndəns]"
+    },
+    {
+        "name": "shatter",
+        "trans": [
+            "n. 碎片；乱七八糟的状态"
+        ],
+        "usphone": "[ˈʃætər]",
+        "ukphone": "[ˈʃætə(r)]"
+    },
+    {
+        "name": "collision",
+        "trans": [
+            "n. 碰撞；冲突；（意见，看法）的抵触；（政党等的）倾轧"
+        ],
+        "usphone": "[kəˈlɪʒn]",
+        "ukphone": "[kəˈlɪʒ(ə)n]"
+    },
+    {
+        "name": "inappropriate",
+        "trans": [
+            "adj. 不适当的；不相称的"
+        ],
+        "usphone": "[ˌɪnəˈproʊpriət]",
+        "ukphone": "[ˌɪnəˈprəʊpriət]"
+    },
+    {
+        "name": "spectacle",
+        "trans": [
+            "n. 景象；场面；奇观；壮观；公开展示；表相，假相 n.（复）眼镜"
+        ],
+        "usphone": "[ˈspektəkl]",
+        "ukphone": "[ˈspektəkl]"
+    },
+    {
+        "name": "asylum",
+        "trans": [
+            "n. 庇护；收容所，救济院"
+        ],
+        "usphone": "[əˈsaɪləm]",
+        "ukphone": "[əˈsaɪləm]"
+    },
+    {
+        "name": "passive",
+        "trans": [
+            "n. 被动语态"
+        ],
+        "usphone": "[ˈpæsɪv]",
+        "ukphone": "[ˈpæsɪv]"
+    },
+    {
+        "name": "respective",
+        "trans": [
+            "adj. 分别的，各自的"
+        ],
+        "usphone": "[rɪˈspektɪv]",
+        "ukphone": "[rɪˈspektɪv]"
+    },
+    {
+        "name": "toxic",
+        "trans": [
+            "adj. 有毒的；中毒的"
+        ],
+        "usphone": "[ˈtɑːksɪk]",
+        "ukphone": "[ˈtɒksɪk]"
+    },
+    {
+        "name": "intellectual",
+        "trans": [
+            "n. 知识分子；凭理智做事者"
+        ],
+        "usphone": "[ˌɪntəˈlektʃuəl]",
+        "ukphone": "[ˌɪntəˈlektʃuəl]"
+    },
+    {
+        "name": "dip",
+        "trans": [
+            "n. 下沉，下降；倾斜；浸渍，蘸湿"
+        ],
+        "usphone": "[dɪp]",
+        "ukphone": "[dɪp]"
+    },
+    {
+        "name": "cutting",
+        "trans": [
+            "n. [机] 切断；剪辑；开凿"
+        ],
+        "usphone": "[ˈkʌtɪŋ]",
+        "ukphone": "[ˈkʌtɪŋ]"
+    },
+    {
+        "name": "decisive",
+        "trans": [
+            "adj. 决定性的；果断的，坚定的"
+        ],
+        "usphone": "[dɪˈsaɪsɪv]",
+        "ukphone": "[dɪˈsaɪsɪv]"
+    },
+    {
+        "name": "indictment",
+        "trans": [
+            "n. 起诉书；控告"
+        ],
+        "usphone": "[ɪnˈdaɪtmənt]",
+        "ukphone": "[ɪnˈdaɪtmənt]"
+    },
+    {
+        "name": "harsh",
+        "trans": [
+            "adj. 严厉的；严酷的；刺耳的；粗糙的；刺目的"
+        ],
+        "usphone": "[hɑːrʃ]",
+        "ukphone": "[hɑːʃ]"
+    },
+    {
+        "name": "loom",
+        "trans": [
+            "n. 织布机；若隐若现的景象"
+        ],
+        "usphone": "[luːm]",
+        "ukphone": "[luːm]"
+    },
+    {
+        "name": "misery",
+        "trans": [
+            "n. 痛苦，悲惨；不幸；苦恼；穷困"
+        ],
+        "usphone": "[ˈmɪzəri]",
+        "ukphone": "[ˈmɪzəri]"
+    },
+    {
+        "name": "fleet",
+        "trans": [
+            "n. 舰队；港湾；小河"
+        ],
+        "usphone": "[fliːt]",
+        "ukphone": "[fliːt]"
+    },
+    {
+        "name": "reconstruction",
+        "trans": [
+            "n. 再建，重建；改造；复兴"
+        ],
+        "usphone": "[ˌriːkənˈstrʌkʃn]",
+        "ukphone": "[ˌriːkənˈstrʌkʃn]"
+    },
+    {
+        "name": "hydrogen",
+        "trans": [
+            "n. [化学] 氢"
+        ],
+        "usphone": "[ˈhaɪdrədʒən]",
+        "ukphone": "[ˈhaɪdrədʒən]"
+    },
+    {
+        "name": "spell",
+        "trans": [
+            "n. 符咒；一段时间；魅力"
+        ],
+        "usphone": "[spel]",
+        "ukphone": "[spel]"
+    },
+    {
+        "name": "fierce",
+        "trans": [
+            "adj. 凶猛的；猛烈的；暴躁的"
+        ],
+        "usphone": "[fɪrs]",
+        "ukphone": "[fɪəs]"
+    },
+    {
+        "name": "prey",
+        "trans": [
+            "n. 捕食；牺牲者；被捕食的动物"
+        ],
+        "usphone": "[preɪ]",
+        "ukphone": "[preɪ]"
+    },
+    {
+        "name": "heritage",
+        "trans": [
+            "n. 遗产；传统；继承物；继承权"
+        ],
+        "usphone": "[ˈherɪtɪdʒ]",
+        "ukphone": "[ˈherɪtɪdʒ]"
+    },
+    {
+        "name": "orientation",
+        "trans": [
+            "n. 方向；定向；适应；情况介绍；向东方"
+        ],
+        "usphone": "[ˌɔːriənˈteɪʃn]",
+        "ukphone": "[ˌɔːriənˈteɪʃ(ə)n]"
+    },
+    {
+        "name": "aspire",
+        "trans": [
+            "vi. 渴望；立志；追求"
+        ],
+        "usphone": "[əˈspaɪər]",
+        "ukphone": "[əˈspaɪə(r)]"
+    },
+    {
+        "name": "embody",
+        "trans": [
+            "vt. 体现，使具体化；具体表达"
+        ],
+        "usphone": "[ɪmˈbɑːdi]",
+        "ukphone": "[ɪmˈbɒdi]"
+    },
+    {
+        "name": "engagement",
+        "trans": [
+            "n. 婚约；约会；交战；诺言"
+        ],
+        "usphone": "[ɪnˈɡeɪdʒmənt]",
+        "ukphone": "[ɪnˈɡeɪdʒmənt]"
+    },
+    {
+        "name": "evolutionary",
+        "trans": [
+            "adj. 进化的；发展的；渐进的"
+        ],
+        "usphone": "[ˌevəˈluːʃəneri]",
+        "ukphone": "[ˌiːvəˈluːʃən(ə)ri]"
+    },
+    {
+        "name": "storage",
+        "trans": [
+            "n. 存储；仓库；贮藏所"
+        ],
+        "usphone": "[ˈstɔːrɪdʒ]",
+        "ukphone": "[ˈstɔːrɪdʒ]"
+    },
+    {
+        "name": "custody",
+        "trans": [
+            "n. 保管；监护；拘留；抚养权"
+        ],
+        "usphone": "[ˈkʌstədi]",
+        "ukphone": "[ˈkʌstədi]"
+    },
+    {
+        "name": "rebel",
+        "trans": [
+            "n. 反叛者；叛徒"
+        ],
+        "usphone": "[ˈrebl]",
+        "ukphone": "[ˈrebl]"
+    },
+    {
+        "name": "just",
+        "trans": [
+            "adv. 只是，仅仅；刚才，刚刚；正好，恰好；实在；刚要"
+        ],
+        "usphone": "[dʒʌst]",
+        "ukphone": "[dʒʌst]"
+    },
+    {
+        "name": "atrocity",
+        "trans": [
+            "n. 暴行；凶恶，残暴"
+        ],
+        "usphone": "[əˈtrɑːsəti]",
+        "ukphone": "[əˈtrɒsəti]"
+    },
+    {
+        "name": "commodity",
+        "trans": [
+            "n. 商品，货物；日用品"
+        ],
+        "usphone": "[kəˈmɑːdəti]",
+        "ukphone": "[kəˈmɒdəti]"
+    },
+    {
+        "name": "insufficient",
+        "trans": [
+            "adj. 不足的，不充足的；不胜任的；缺乏能力的"
+        ],
+        "usphone": "[ˌɪnsəˈfɪʃ(ə)nt]",
+        "ukphone": "[ˌɪnsəˈfɪʃ(ə)nt]"
+    },
+    {
+        "name": "obsess",
+        "trans": [
+            "vt. 迷住，缠住；使…着迷；使…困扰"
+        ],
+        "usphone": "[əbˈses]",
+        "ukphone": "[əbˈses]"
+    },
+    {
+        "name": "liver",
+        "trans": [
+            "n. 肝脏；生活者，居民"
+        ],
+        "usphone": "[ˈlɪvər]",
+        "ukphone": "[ˈlɪvə(r)]"
+    },
+    {
+        "name": "hook",
+        "trans": [
+            "n. 挂钩，吊钩"
+        ],
+        "usphone": "[hʊk]",
+        "ukphone": "[hʊk]"
+    },
+    {
+        "name": "capitalist",
+        "trans": [
+            "n. 资本家；资本主义者"
+        ],
+        "usphone": "[ˈkæpɪtəlɪst]",
+        "ukphone": "[ˈkæpɪtəlɪst]"
+    },
+    {
+        "name": "spy",
+        "trans": [
+            "n. 间谍；密探"
+        ],
+        "usphone": "[spaɪ]",
+        "ukphone": "[spaɪ]"
+    },
+    {
+        "name": "meditation",
+        "trans": [
+            "n. 冥想；沉思，深思"
+        ],
+        "usphone": "[ˌmedɪˈteɪʃn]",
+        "ukphone": "[ˌmedɪˈteɪʃn]"
+    },
+    {
+        "name": "log",
+        "trans": [
+            "vi. 伐木"
+        ],
+        "usphone": "[lɔːɡ]",
+        "ukphone": "[lɒɡ]"
+    },
+    {
+        "name": "rock",
+        "trans": [
+            "n. 岩石；摇滚乐；暗礁"
+        ],
+        "usphone": "[rɑːk]",
+        "ukphone": "[rɒk]"
+    },
+    {
+        "name": "correction",
+        "trans": [
+            "n. 改正，修正"
+        ],
+        "usphone": "[kəˈrekʃn]",
+        "ukphone": "[kəˈrekʃn]"
+    },
+    {
+        "name": "inhibit",
+        "trans": [
+            "vt. 抑制；禁止"
+        ],
+        "usphone": "[ɪnˈhɪbɪt]",
+        "ukphone": "[ɪnˈhɪbɪt]"
+    },
+    {
+        "name": "intake",
+        "trans": [
+            "n. 摄取量；通风口；引入口；引入的量"
+        ],
+        "usphone": "[ˈɪnteɪk]",
+        "ukphone": "[ˈɪnteɪk]"
+    },
+    {
+        "name": "standing",
+        "trans": [
+            "n. 站立；持续；身分"
+        ],
+        "usphone": "[ˈstændɪŋ]",
+        "ukphone": "[ˈstændɪŋ]"
+    },
+    {
+        "name": "vibrant",
+        "trans": [
+            "adj. 振动的；充满生气的；响亮的；战栗的"
+        ],
+        "usphone": "[ˈvaɪbrənt]",
+        "ukphone": "[ˈvaɪbrənt]"
+    },
+    {
+        "name": "terrain",
+        "trans": [
+            "n. [地理] 地形，地势；领域；地带"
+        ],
+        "usphone": "[təˈreɪn]",
+        "ukphone": "[təˈreɪn]"
+    },
+    {
+        "name": "implementation",
+        "trans": [
+            "n. [计] 实现；履行；安装启用"
+        ],
+        "usphone": "[ˌɪmplɪmenˈteɪʃn]",
+        "ukphone": "[ˌɪmplɪmenˈteɪʃ(ə)n]"
+    },
+    {
+        "name": "filter",
+        "trans": [
+            "n. 滤波器；[化工] 过滤器；筛选；滤光器"
+        ],
+        "usphone": "[ˈfɪltər]",
+        "ukphone": "[ˈfɪltə(r)]"
+    },
+    {
+        "name": "workout",
+        "trans": [
+            "n. 锻炼；练习；试验"
+        ],
+        "usphone": "[ˈwɜːrkaʊt]",
+        "ukphone": "[ˈwɜːkaʊt]"
+    },
+    {
+        "name": "characterize",
+        "trans": [
+            "vt. 描绘…的特性；具有…的特征"
+        ],
+        "usphone": "[ˈkærəktəraɪz]",
+        "ukphone": "[ˈkærəktəraɪz]"
+    },
+    {
+        "name": "successor",
+        "trans": [
+            "n. 继承者；后续的事物"
+        ],
+        "usphone": "[səkˈsesər]",
+        "ukphone": "[səkˈsesə(r)]"
+    },
+    {
+        "name": "optimism",
+        "trans": [
+            "n. 乐观；乐观主义"
+        ],
+        "usphone": "[ˈɑːptɪmɪzəm]",
+        "ukphone": "[ˈɒptɪmɪzəm]"
+    },
+    {
+        "name": "compliance",
+        "trans": [
+            "n. 顺从，服从；承诺"
+        ],
+        "usphone": "[kəmˈplaɪəns]",
+        "ukphone": "[kəmˈplaɪəns]"
+    },
+    {
+        "name": "testimony",
+        "trans": [
+            "n. [法] 证词，证言；证据"
+        ],
+        "usphone": "[ˈtestɪmoʊni]",
+        "ukphone": "[ˈtestɪməni]"
+    },
+    {
+        "name": "profound",
+        "trans": [
+            "adj. 深厚的；意义深远的；渊博的"
+        ],
+        "usphone": "[prəˈfaʊnd]",
+        "ukphone": "[prəˈfaʊnd]"
+    },
+    {
+        "name": "propaganda",
+        "trans": [
+            "n. 宣传；传道总会"
+        ],
+        "usphone": "[ˌprɑːpəˈɡændə]",
+        "ukphone": "[ˌprɒpəˈɡændə]"
+    },
+    {
+        "name": "landmark",
+        "trans": [
+            "n. [航]陆标；地标；界标；里程碑；纪念碑；地界标；划时代的事"
+        ],
+        "usphone": "[ˈlændmɑːrk]",
+        "ukphone": "[ˈlændmɑːk]"
+    },
+    {
+        "name": "license",
+        "trans": [
+            "n. 执照，许可证；特许"
+        ],
+        "usphone": "[ˈlaɪsns]",
+        "ukphone": "[ˈlaɪsns]"
+    },
+    {
+        "name": "timely",
+        "trans": [
+            "adj. 及时的；适时的"
+        ],
+        "usphone": "[ˈtaɪmli]",
+        "ukphone": "[ˈtaɪmli]"
+    },
+    {
+        "name": "companion",
+        "trans": [
+            "n. 同伴；朋友；指南；手册"
+        ],
+        "usphone": "[kəmˈpænjən]",
+        "ukphone": "[kəmˈpænjən]"
+    },
+    {
+        "name": "closure",
+        "trans": [
+            "n. 关闭；终止，结束"
+        ],
+        "usphone": "[ˈkloʊʒər]",
+        "ukphone": "[ˈkləʊʒə(r)]"
+    },
+    {
+        "name": "intriguing",
+        "trans": [
+            "adj. 有趣的；迷人的"
+        ],
+        "usphone": "[ɪnˈtriːɡɪŋ]",
+        "ukphone": "[ɪnˈtriːɡɪŋ]"
+    },
+    {
+        "name": "verdict",
+        "trans": [
+            "n. 结论；裁定"
+        ],
+        "usphone": "[ˈvɜːrdɪkt]",
+        "ukphone": "[ˈvɜːdɪkt]"
+    },
+    {
+        "name": "allocate",
+        "trans": [
+            "vt. 分配；拨出；使坐落于"
+        ],
+        "usphone": "[ˈæləkeɪt]",
+        "ukphone": "[ˈæləkeɪt]"
+    },
+    {
+        "name": "allege",
+        "trans": [
+            "vt. 宣称，断言；提出…作为理由"
+        ],
+        "usphone": "[əˈledʒ]",
+        "ukphone": "[əˈledʒ]"
+    },
+    {
+        "name": "convict",
+        "trans": [
+            "n. 罪犯"
+        ],
+        "usphone": "[kənˈvɪkt; ˈkɑnvɪkt]",
+        "ukphone": "[kənˈvɪkt]"
+    },
+    {
+        "name": "corrupt",
+        "trans": [
+            "adj. 腐败的，贪污的；堕落的"
+        ],
+        "usphone": "[kəˈrʌpt]",
+        "ukphone": "[kəˈrʌpt]"
+    },
+    {
+        "name": "resemble",
+        "trans": [
+            "vt. 类似，像"
+        ],
+        "usphone": "[rɪˈzembl]",
+        "ukphone": "[rɪˈzemb(ə)l]"
+    },
+    {
+        "name": "circulation",
+        "trans": [
+            "n. 流通，传播；循环；发行量"
+        ],
+        "usphone": "[ˌsɜːrkjəˈleɪʃn]",
+        "ukphone": "[ˌsɜːkjəˈleɪʃn]"
+    },
+    {
+        "name": "tender",
+        "trans": [
+            "n. 偿付，清偿；看管人；小船"
+        ],
+        "usphone": "[ˈtendər]",
+        "ukphone": "[ˈtendə(r)]"
+    },
+    {
+        "name": "leap",
+        "trans": [
+            "vi. 跳，跳跃"
+        ],
+        "usphone": "[liːp]",
+        "ukphone": "[liːp]"
+    },
+    {
+        "name": "precedent",
+        "trans": [
+            "n. 先例；前例"
+        ],
+        "usphone": "[ˈpresɪdənt]",
+        "ukphone": "[ˈpresɪdənt]"
+    },
+    {
+        "name": "chaos",
+        "trans": [
+            "n. 混沌，混乱"
+        ],
+        "usphone": "[ˈkeɪɑːs]",
+        "ukphone": "[ˈkeɪɒs]"
+    },
+    {
+        "name": "spotlight",
+        "trans": [
+            "n. 聚光灯；反光灯；公众注意的中心"
+        ],
+        "usphone": "[ˈspɑːtlaɪt]",
+        "ukphone": "[ˈspɒtlaɪt]"
+    },
+    {
+        "name": "total",
+        "trans": [
+            "n. 总数，合计"
+        ],
+        "usphone": "[ˈtoʊtl]",
+        "ukphone": "[ˈtəʊt(ə)l]"
+    },
+    {
+        "name": "congratulate",
+        "trans": [
+            "vt. 祝贺；恭喜；庆贺"
+        ],
+        "usphone": "[kənˈɡrætʃuleɪt]",
+        "ukphone": "[kənˈɡrætʃuleɪt]"
+    },
+    {
+        "name": "noon",
+        "trans": [
+            "n. 中午；正午；全盛期"
+        ],
+        "usphone": "[nuːn]",
+        "ukphone": "[nuːn]"
+    },
+    {
+        "name": "sacred",
+        "trans": [
+            "adj. 神的；神圣的；宗教的；庄严的"
+        ],
+        "usphone": "[ˈseɪkrɪd]",
+        "ukphone": "[ˈseɪkrɪd]"
+    },
+    {
+        "name": "incidence",
+        "trans": [
+            "n. 发生率；影响；[光] 入射；影响范围"
+        ],
+        "usphone": "[ˈɪnsɪdəns]",
+        "ukphone": "[ˈɪnsɪdəns]"
+    },
+    {
+        "name": "aluminium",
+        "trans": [
+            "n. 铝"
+        ],
+        "usphone": "[ˌæljəˈmɪniəm; ˌæləˈmɪniəm]",
+        "ukphone": "[ˌæljəˈmɪniəm; ˌæləˈmɪniəm]"
+    },
+    {
+        "name": "minimal",
+        "trans": [
+            "adj. 最低的；最小限度的"
+        ],
+        "usphone": "[ˈmɪnɪml]",
+        "ukphone": "[ˈmɪnɪml]"
+    },
+    {
+        "name": "synthesis",
+        "trans": [
+            "n. 综合，[化学] 合成；综合体"
+        ],
+        "usphone": "[ˈsɪnθəsɪs]",
+        "ukphone": "[ˈsɪnθəsɪs]"
+    },
+    {
+        "name": "compile",
+        "trans": [
+            "vt. 编译；编制；编辑；[图情] 汇编"
+        ],
+        "usphone": "[kəmˈpaɪl]",
+        "ukphone": "[kəmˈpaɪl]"
+    },
+    {
+        "name": "indicator",
+        "trans": [
+            "n. 指示器；[试剂] 指示剂；[计] 指示符；压力计"
+        ],
+        "usphone": "[ˈɪndɪkeɪtər]",
+        "ukphone": "[ˈɪndɪkeɪtə(r)]"
+    },
+    {
+        "name": "assault",
+        "trans": [
+            "n. 攻击；袭击"
+        ],
+        "usphone": "[əˈsɔːlt]",
+        "ukphone": "[əˈsɔːlt]"
+    },
+    {
+        "name": "pulse",
+        "trans": [
+            "n. [电子] 脉冲；脉搏"
+        ],
+        "usphone": "[pʌls]",
+        "ukphone": "[pʌls]"
+    },
+    {
+        "name": "continually",
+        "trans": [
+            "adv. 不断地；频繁地"
+        ],
+        "usphone": "[kənˈtɪnjuəli]",
+        "ukphone": "[kənˈtɪnjuəli]"
+    },
+    {
+        "name": "well-being",
+        "trans": [
+            "n. 幸福；康乐"
+        ],
+        "usphone": "[ˈwel biːɪŋ]",
+        "ukphone": "[ˈwel biːɪŋ]"
+    },
+    {
+        "name": "systematic",
+        "trans": [
+            "adj. 系统的；体系的；有系统的；[图情] 分类的；一贯的，惯常的"
+        ],
+        "usphone": "[ˌsɪstəˈmætɪk]",
+        "ukphone": "[ˌsɪstəˈmætɪk]"
+    },
+    {
+        "name": "spark",
+        "trans": [
+            "n. 火花；朝气；闪光"
+        ],
+        "usphone": "[spɑːrk]",
+        "ukphone": "[spɑːk]"
+    },
+    {
+        "name": "cattle",
+        "trans": [
+            "n. 牛；牲畜（骂人的话）；家畜；无价值的人"
+        ],
+        "usphone": "[ˈkæt(ə)l]",
+        "ukphone": "[ˈkæt(ə)l]"
+    },
+    {
+        "name": "incur",
+        "trans": [
+            "vt. 招致，引发；蒙受"
+        ],
+        "usphone": "[ɪnˈkɜːr]",
+        "ukphone": "[ɪnˈkɜː(r)]"
+    },
+    {
+        "name": "shoot",
+        "trans": [
+            "n. 射击；摄影；狩猎；急流"
+        ],
+        "usphone": "[ʃuːt]",
+        "ukphone": "[ʃuːt]"
+    },
+    {
+        "name": "validity",
+        "trans": [
+            "n. [计] 有效性；正确；正确性"
+        ],
+        "usphone": "[vəˈlɪdəti]",
+        "ukphone": "[vəˈlɪdəti]"
+    },
+    {
+        "name": "principal",
+        "trans": [
+            "adj. 主要的；资本的"
+        ],
+        "usphone": "[ˈprɪnsəpl]",
+        "ukphone": "[ˈprɪnsəpl]"
+    },
+    {
+        "name": "trigger",
+        "trans": [
+            "n. 扳机；[电子] 触发器；制滑机"
+        ],
+        "usphone": "[ˈtrɪɡər]",
+        "ukphone": "[ˈtrɪɡə(r)]"
+    },
+    {
+        "name": "arm",
+        "trans": [
+            "n. 手臂；武器；袖子；装备；部门"
+        ],
+        "usphone": "[ɑːrm]",
+        "ukphone": "[ɑːm]"
+    },
+    {
+        "name": "escalate",
+        "trans": [
+            "vt. 使逐步上升"
+        ],
+        "usphone": "[ˈeskəleɪt]",
+        "ukphone": "[ˈeskəleɪt]"
+    },
+    {
+        "name": "debut",
+        "trans": [
+            "n. 初次登台；开张"
+        ],
+        "usphone": "[deɪˈbjuː]",
+        "ukphone": "[ˈdeɪbjuː]"
+    },
+    {
+        "name": "dictate",
+        "trans": [
+            "n. 命令；指示"
+        ],
+        "usphone": "[ˈdɪkteɪt]",
+        "ukphone": "[dɪkˈteɪt]"
+    },
+    {
+        "name": "essence",
+        "trans": [
+            "n. 本质，实质；精华；香精"
+        ],
+        "usphone": "[ˈesns]",
+        "ukphone": "[ˈes(ə)ns]"
+    },
+    {
+        "name": "consolidate",
+        "trans": [
+            "vt. 巩固，使固定；联合"
+        ],
+        "usphone": "[kənˈsɑːlɪdeɪt]",
+        "ukphone": "[kənˈsɒlɪdeɪt]"
+    },
+    {
+        "name": "ratio",
+        "trans": [
+            "n. 比率，比例"
+        ],
+        "usphone": "[ˈreɪʃioʊ]",
+        "ukphone": "[ˈreɪʃiəʊ]"
+    },
+    {
+        "name": "long-standing",
+        "trans": [
+            "adj. 长期存在的；存在已久的"
+        ],
+        "usphone": "[ˌlɔːŋ ˈstændɪŋ]",
+        "ukphone": "[ˌlɒŋ ˈstændɪŋ]"
+    },
+    {
+        "name": "supportive",
+        "trans": [
+            "adj. 支持的；支援的；赞助的"
+        ],
+        "usphone": "[səˈpɔːrtɪv]",
+        "ukphone": "[səˈpɔːtɪv]"
+    },
+    {
+        "name": "creep",
+        "trans": [
+            "n. 爬行；毛骨悚然的感觉；谄媚者"
+        ],
+        "usphone": "[kriːp]",
+        "ukphone": "[kriːp]"
+    },
+    {
+        "name": "costly",
+        "trans": [
+            "adj. 昂贵的；代价高的"
+        ],
+        "usphone": "[ˈkɔːstli]",
+        "ukphone": "[ˈkɒstli]"
+    },
+    {
+        "name": "thread",
+        "trans": [
+            "n. 线；螺纹；思路；衣服；线状物；玻璃纤维；路线"
+        ],
+        "usphone": "[θred]",
+        "ukphone": "[θred]"
+    },
+    {
+        "name": "mature",
+        "trans": [
+            "adj. 成熟的；充分考虑的；到期的；成年人的"
+        ],
+        "usphone": "[məˈtʃʊr; məˈtʊr]",
+        "ukphone": "[məˈtʃʊə(r)]"
+    },
+    {
+        "name": "instinct",
+        "trans": [
+            "n. 本能，直觉；天性"
+        ],
+        "usphone": "[ˈɪnstɪŋkt]",
+        "ukphone": "[ˈɪnstɪŋkt]"
+    },
+    {
+        "name": "worship",
+        "trans": [
+            "n. 崇拜；礼拜；尊敬"
+        ],
+        "usphone": "[ˈwɜːrʃɪp]",
+        "ukphone": "[ˈwɜːʃɪp]"
+    },
+    {
+        "name": "occurrence",
+        "trans": [
+            "n. 发生；出现；事件；发现"
+        ],
+        "usphone": "[əˈkɜːrəns]",
+        "ukphone": "[əˈkʌrəns]"
+    },
+    {
+        "name": "relevance",
+        "trans": [
+            "n. 关联；适当；中肯"
+        ],
+        "usphone": "[ˈreləvəns]",
+        "ukphone": "[ˈreləvəns]"
+    },
+    {
+        "name": "insult",
+        "trans": [
+            "n. 侮辱；凌辱；无礼"
+        ],
+        "usphone": "[ɪnˈsʌlt; ˈɪnsʌlt]",
+        "ukphone": "[ɪnˈsʌlt]"
+    },
+    {
+        "name": "bow",
+        "trans": [
+            "n. 弓；鞠躬；船首"
+        ],
+        "usphone": "[baʊ; boʊ]",
+        "ukphone": "[bəʊ]"
+    },
+    {
+        "name": "cop",
+        "trans": [
+            "n. 巡警，警官"
+        ],
+        "usphone": "[kɑːp]",
+        "ukphone": "[kɒp]"
+    },
+    {
+        "name": "successive",
+        "trans": [
+            "adj. 连续的；继承的；依次的；接替的"
+        ],
+        "usphone": "[səkˈsesɪv]",
+        "ukphone": "[səkˈsesɪv]"
+    },
+    {
+        "name": "thereby",
+        "trans": [
+            "adv. 从而，因此；在那附近；在那方面"
+        ],
+        "usphone": "[ˌðerˈbaɪ]",
+        "ukphone": "[ˌðeəˈbaɪ]"
+    },
+    {
+        "name": "reasoning",
+        "trans": [
+            "n. 推理；论证；评理"
+        ],
+        "usphone": "[ˈriːzənɪŋ]",
+        "ukphone": "[ˈriːzənɪŋ]"
+    },
+    {
+        "name": "irrelevant",
+        "trans": [
+            "adj. 不相干的；不切题的"
+        ],
+        "usphone": "[ɪˈreləvənt]",
+        "ukphone": "[ɪˈreləvənt]"
+    },
+    {
+        "name": "ministry",
+        "trans": [
+            "n. （政府的）部门"
+        ],
+        "usphone": "[ˈmɪnɪstri]",
+        "ukphone": "[ˈmɪnɪstri]"
+    },
+    {
+        "name": "peculiar",
+        "trans": [
+            "n. 特权；特有财产"
+        ],
+        "usphone": "[pɪˈkjuːliər]",
+        "ukphone": "[pɪˈkjuːliə(r)]"
+    },
+    {
+        "name": "boom",
+        "trans": [
+            "n. 繁荣；吊杆；隆隆声"
+        ],
+        "usphone": "[buːm]",
+        "ukphone": "[buːm]"
+    },
+    {
+        "name": "widen",
+        "trans": [
+            "vt. 放宽"
+        ],
+        "usphone": "[ˈwaɪdn]",
+        "ukphone": "[ˈwaɪd(ə)n]"
+    },
+    {
+        "name": "reverse",
+        "trans": [
+            "n. 背面；相反；倒退；失败"
+        ],
+        "usphone": "[rɪˈvɜːrs]",
+        "ukphone": "[rɪˈvɜːs]"
+    },
+    {
+        "name": "disrupt",
+        "trans": [
+            "vt. 破坏；使瓦解；使分裂；使中断；使陷于混乱"
+        ],
+        "usphone": "[dɪsˈrʌpt]",
+        "ukphone": "[dɪsˈrʌpt]"
+    },
+    {
+        "name": "sustain",
+        "trans": [
+            "vt. 维持；支撑，承担；忍受；供养；证实"
+        ],
+        "usphone": "[səˈsteɪn]",
+        "ukphone": "[səˈsteɪn]"
+    },
+    {
+        "name": "methodology",
+        "trans": [
+            "n. 方法学，方法论"
+        ],
+        "usphone": "[ˌmeθəˈdɑːlədʒi]",
+        "ukphone": "[ˌmeθəˈdɒlədʒi]"
+    },
+    {
+        "name": "top",
+        "trans": [
+            "n. 顶部，顶端；上部；首席；陀螺"
+        ],
+        "usphone": "[tɑːp]",
+        "ukphone": "[tɒp]"
+    },
+    {
+        "name": "dense",
+        "trans": [
+            "adj. 稠密的；浓厚的；愚钝的"
+        ],
+        "usphone": "[dens]",
+        "ukphone": "[dens]"
+    },
+    {
+        "name": "clash",
+        "trans": [
+            "n. 冲突，不协调；碰撞声，铿锵声"
+        ],
+        "usphone": "[klæʃ]",
+        "ukphone": "[klæʃ]"
+    },
+    {
+        "name": "minute",
+        "trans": [
+            "n. 分，分钟；片刻，一会儿；备忘录，笔记；会议记录"
+        ],
+        "usphone": "[ˈmɪnɪt]",
+        "ukphone": "[ˈmɪnɪt]"
+    },
+    {
+        "name": "blessing",
+        "trans": [
+            "n. 祝福；赐福；祷告"
+        ],
+        "usphone": "[ˈblesɪŋ]",
+        "ukphone": "[ˈblesɪŋ]"
+    },
+    {
+        "name": "hostility",
+        "trans": [
+            "n. 敌意；战争行动"
+        ],
+        "usphone": "[hɑːˈstɪləti]",
+        "ukphone": "[hɒˈstɪləti]"
+    },
+    {
+        "name": "conviction",
+        "trans": [
+            "n. 定罪；确信；证明有罪；确信，坚定的信仰"
+        ],
+        "usphone": "[kənˈvɪkʃn]",
+        "ukphone": "[kənˈvɪkʃn]"
+    },
+    {
+        "name": "secular",
+        "trans": [
+            "n. 修道院外的教士，(对宗教家而言的) 俗人"
+        ],
+        "usphone": "[ˈsekjələr]",
+        "ukphone": "[ˈsekjələ(r)]"
+    },
+    {
+        "name": "stake",
+        "trans": [
+            "n. 桩，棍子；赌注；火刑；奖金"
+        ],
+        "usphone": "[steɪk]",
+        "ukphone": "[steɪk]"
+    },
+    {
+        "name": "march",
+        "trans": [
+            "n. 三月"
+        ],
+        "usphone": "[mɑːrtʃ]",
+        "ukphone": "[mɑːtʃ]"
+    },
+    {
+        "name": "embassy",
+        "trans": [
+            "n. 大使馆；大使馆全体人员"
+        ],
+        "usphone": "[ˈembəsi]",
+        "ukphone": "[ˈembəsi]"
+    },
+    {
+        "name": "patent",
+        "trans": [
+            "n. 专利权；执照；专利品"
+        ],
+        "usphone": "[ˈpætnt; ˈpeɪtnt]",
+        "ukphone": "[ˈpæt(ə)nt]"
+    },
+    {
+        "name": "specification",
+        "trans": [
+            "n. 规格；说明书；详述"
+        ],
+        "usphone": "[ˌspesɪfɪˈkeɪʃn]",
+        "ukphone": "[ˌspesɪfɪˈkeɪʃ(ə)n]"
+    },
+    {
+        "name": "well",
+        "trans": [
+            "n. 井；源泉"
+        ],
+        "usphone": "[wel]",
+        "ukphone": "[wel]"
+    },
+    {
+        "name": "empirical",
+        "trans": [
+            "adj. 经验主义的，完全根据经验的；实证的"
+        ],
+        "usphone": "[ɪmˈpɪrɪkl]",
+        "ukphone": "[ɪmˈpɪrɪk(ə)l]"
+    },
+    {
+        "name": "tactic",
+        "trans": [
+            "n. 策略，战略"
+        ],
+        "usphone": "[ˈtæktɪk]",
+        "ukphone": "[ˈtæktɪk]"
+    },
+    {
+        "name": "seldom",
+        "trans": [
+            "adv. 很少，不常"
+        ],
+        "usphone": "[ˈseldəm]",
+        "ukphone": "[ˈseldəm]"
+    },
+    {
+        "name": "thereafter",
+        "trans": [
+            "adv. 其后；从那时以后"
+        ],
+        "usphone": "[ˌðerˈæftər]",
+        "ukphone": "[ˌðeərˈɑːftə(r)]"
+    },
+    {
+        "name": "withdrawal",
+        "trans": [
+            "n. 撤退，收回；提款；取消；退股"
+        ],
+        "usphone": "[wɪðˈdrɔːəl]",
+        "ukphone": "[wɪðˈdrɔːəl]"
+    },
+    {
+        "name": "aide",
+        "trans": [
+            "n. 助手；副官；侍从武官"
+        ],
+        "usphone": "[eɪd]",
+        "ukphone": "[eɪd]"
+    },
+    {
+        "name": "crush",
+        "trans": [
+            "n. 粉碎；迷恋；压榨；拥挤的人群"
+        ],
+        "usphone": "[krʌʃ]",
+        "ukphone": "[krʌʃ]"
+    },
+    {
+        "name": "enquire",
+        "trans": [
+            "vi. 询问；调查；问候（等于inquire）"
+        ],
+        "usphone": "[ɪnˈkwaɪər]",
+        "ukphone": "[ɪnˈkwaɪə(r)]"
+    },
+    {
+        "name": "glimpse",
+        "trans": [
+            "n. 一瞥，一看"
+        ],
+        "usphone": "[ɡlɪmps]",
+        "ukphone": "[ɡlɪmps]"
+    },
+    {
+        "name": "robust",
+        "trans": [
+            "adj. 强健的；健康的；粗野的；粗鲁的"
+        ],
+        "usphone": "[roʊˈbʌst]",
+        "ukphone": "[rəʊˈbʌst]"
+    },
+    {
+        "name": "cognitive",
+        "trans": [
+            "adj. 认知的，认识的"
+        ],
+        "usphone": "[ˈkɑːɡnətɪv]",
+        "ukphone": "[ˈkɒɡnətɪv]"
+    },
+    {
+        "name": "twist",
+        "trans": [
+            "n. 扭曲；拧；扭伤"
+        ],
+        "usphone": "[twɪst]",
+        "ukphone": "[twɪst]"
+    },
+    {
+        "name": "assassination",
+        "trans": [
+            "n. 暗杀，行刺"
+        ],
+        "usphone": "[əˌsæsɪˈneɪʃn]",
+        "ukphone": "[əˌsæsɪˈneɪʃ(ə)n]"
+    },
+    {
+        "name": "contention",
+        "trans": [
+            "n. 争论，争辩；争夺；论点"
+        ],
+        "usphone": "[kənˈtenʃn]",
+        "ukphone": "[kənˈtenʃn]"
+    },
+    {
+        "name": "amend",
+        "trans": [
+            "vt. 修改；改善，改进"
+        ],
+        "usphone": "[əˈmend]",
+        "ukphone": "[əˈmend]"
+    },
+    {
+        "name": "supplement",
+        "trans": [
+            "vt. 增补，补充"
+        ],
+        "usphone": "[ˈsʌplɪmənt]",
+        "ukphone": "[ˈsʌplɪmənt]"
+    },
+    {
+        "name": "stem",
+        "trans": [
+            "n. 干；茎；船首；血统"
+        ],
+        "usphone": "[stem]",
+        "ukphone": "[stem]"
+    },
+    {
+        "name": "endless",
+        "trans": [
+            "adj. 无止境的；连续的；环状的；漫无目的的"
+        ],
+        "usphone": "[ˈendləs]",
+        "ukphone": "[ˈendləs]"
+    },
+    {
+        "name": "displace",
+        "trans": [
+            "vt. 取代；置换；转移；把…免职；排水"
+        ],
+        "usphone": "[dɪsˈpleɪs]",
+        "ukphone": "[dɪsˈpleɪs]"
+    },
+    {
+        "name": "crown",
+        "trans": [
+            "n. 王冠；花冠；王权；顶点"
+        ],
+        "usphone": "[kraʊn]",
+        "ukphone": "[kraʊn]"
+    },
+    {
+        "name": "amendment",
+        "trans": [
+            "n. 修正案；改善；改正"
+        ],
+        "usphone": "[əˈmendmənt]",
+        "ukphone": "[əˈmendmənt]"
+    },
+    {
+        "name": "grief",
+        "trans": [
+            "n. 悲痛；忧伤；不幸"
+        ],
+        "usphone": "[ɡriːf]",
+        "ukphone": "[ɡriːf]"
+    },
+    {
+        "name": "patch",
+        "trans": [
+            "n. 眼罩；斑点；碎片；小块土地"
+        ],
+        "usphone": "[pætʃ]",
+        "ukphone": "[pætʃ]"
+    },
+    {
+        "name": "glory",
+        "trans": [
+            "n. 光荣，荣誉；赞颂"
+        ],
+        "usphone": "[ˈɡlɔːri]",
+        "ukphone": "[ˈɡlɔːri]"
+    },
+    {
+        "name": "youngster",
+        "trans": [
+            "n. 年轻人；少年"
+        ],
+        "usphone": "[ˈjʌŋstər]",
+        "ukphone": "[ˈjʌŋstə(r)]"
+    },
+    {
+        "name": "canvas",
+        "trans": [
+            "n. 帆布"
+        ],
+        "usphone": "[ˈkænvəs]",
+        "ukphone": "[ˈkænvəs]"
+    },
+    {
+        "name": "betray",
+        "trans": [
+            "vt. 背叛；出卖；泄露（秘密）；露出…迹象"
+        ],
+        "usphone": "[bɪˈtreɪ]",
+        "ukphone": "[bɪˈtreɪ]"
+    },
+    {
+        "name": "tackle",
+        "trans": [
+            "n. 滑车；装备；用具；扭倒"
+        ],
+        "usphone": "[ˈtækl]",
+        "ukphone": "[ˈtæk(ə)l]"
+    },
+    {
+        "name": "formulate",
+        "trans": [
+            "vt. 规划；用公式表示；明确地表达"
+        ],
+        "usphone": "[ˈfɔːrmjuleɪt]",
+        "ukphone": "[ˈfɔːmjuleɪt]"
+    },
+    {
+        "name": "excellence",
+        "trans": [
+            "n. 优秀；美德；长处"
+        ],
+        "usphone": "[ˈeksələns]",
+        "ukphone": "[ˈeksələns]"
+    },
+    {
+        "name": "thankfully",
+        "trans": [
+            "adv. 感谢地；感激地"
+        ],
+        "usphone": "[ˈθæŋkfəli]",
+        "ukphone": "[ˈθæŋkfəli]"
+    },
+    {
+        "name": "identification",
+        "trans": [
+            "n. 鉴定，识别；认同；身份证明"
+        ],
+        "usphone": "[aɪˌdentɪfɪˈkeɪʃn]",
+        "ukphone": "[aɪˌdentɪfɪˈkeɪʃn]"
+    },
+    {
+        "name": "humanitarian",
+        "trans": [
+            "n. 人道主义者；慈善家；博爱主义者；基督凡人论者"
+        ],
+        "usphone": "[hjuːˌmænɪˈteriən]",
+        "ukphone": "[hjuːˌmænɪˈteəriən]"
+    },
+    {
+        "name": "manifest",
+        "trans": [
+            "vt. 证明，表明；显示"
+        ],
+        "usphone": "[ˈmænɪfest]",
+        "ukphone": "[ˈmænɪfest]"
+    },
+    {
+        "name": "philosophical",
+        "trans": [
+            "adj. 哲学的（等于philosophic）；冷静的"
+        ],
+        "usphone": "[ˌfɪləˈsɑːfɪkl]",
+        "ukphone": "[ˌfɪləˈsɒfɪk(ə)l]"
+    },
+    {
+        "name": "deteriorate",
+        "trans": [
+            "vi. 恶化，变坏"
+        ],
+        "usphone": "[dɪˈtɪriəreɪt]",
+        "ukphone": "[dɪˈtɪəriəreɪt]"
+    },
+    {
+        "name": "mining",
+        "trans": [
+            "n. 矿业；采矿"
+        ],
+        "usphone": "[ˈmaɪnɪŋ]",
+        "ukphone": "[ˈmaɪnɪŋ]"
+    },
+    {
+        "name": "say",
+        "trans": [
+            "vt. 讲；说明；例如；声称；假设；指明"
+        ],
+        "usphone": "[seɪ]",
+        "ukphone": "[seɪ]"
+    },
+    {
+        "name": "beneficiary",
+        "trans": [
+            "n. [金融] 受益人，受惠者；封臣"
+        ],
+        "usphone": "[ˌbenɪˈfɪʃieri]",
+        "ukphone": "[ˌbenɪˈfɪʃəri]"
+    },
+    {
+        "name": "missile",
+        "trans": [
+            "n. 导弹；投射物"
+        ],
+        "usphone": "[ˈmɪsl]",
+        "ukphone": "[ˈmɪsaɪl]"
+    },
+    {
+        "name": "long-time",
+        "trans": [
+            "adj. 长期；长期载荷"
+        ],
+        "usphone": "[ˈlɔːŋ taɪm]",
+        "ukphone": "[ˈlɒŋ taɪm]"
+    },
+    {
+        "name": "array",
+        "trans": [
+            "n. 数组，阵列；排列，列阵；大批，一系列；衣服"
+        ],
+        "usphone": "[əˈreɪ]",
+        "ukphone": "[əˈreɪ]"
+    },
+    {
+        "name": "slavery",
+        "trans": [
+            "n. 奴役；奴隶制度；奴隶身份"
+        ],
+        "usphone": "[ˈsleɪvəri]",
+        "ukphone": "[ˈsleɪvəri]"
+    },
+    {
+        "name": "presumably",
+        "trans": [
+            "adv. 大概；推测起来；可假定"
+        ],
+        "usphone": "[prɪˈzuːməbli]",
+        "ukphone": "[prɪˈzjuːməbli]"
+    },
+    {
+        "name": "rear",
+        "trans": [
+            "n. 后面；屁股；后方部队"
+        ],
+        "usphone": "[rɪr]",
+        "ukphone": "[rɪə(r)]"
+    },
+    {
+        "name": "motive",
+        "trans": [
+            "n. 动机，目的；主题"
+        ],
+        "usphone": "[ˈməʊtɪv]",
+        "ukphone": "[ˈməʊtɪv]"
+    },
+    {
+        "name": "trademark",
+        "trans": [
+            "n. 商标"
+        ],
+        "usphone": "[ˈtreɪdmɑːrk]",
+        "ukphone": "[ˈtreɪdmɑːk]"
+    },
+    {
+        "name": "midst",
+        "trans": [
+            "n. 当中，中间"
+        ],
+        "usphone": "[mɪdst]",
+        "ukphone": "[mɪdst]"
+    },
+    {
+        "name": "mandatory",
+        "trans": [
+            "adj. 强制的；托管的；命令的"
+        ],
+        "usphone": "[ˈmændətɔːri]",
+        "ukphone": "[ˈmændətəri]"
+    },
+    {
+        "name": "await",
+        "trans": [
+            "vt. 等候，等待；期待"
+        ],
+        "usphone": "[əˈweɪt]",
+        "ukphone": "[əˈweɪt]"
+    },
+    {
+        "name": "overly",
+        "trans": [
+            "adv. 过度地；极度地"
+        ],
+        "usphone": "[ˈoʊvərli]",
+        "ukphone": "[ˈəʊvəli]"
+    },
+    {
+        "name": "backdrop",
+        "trans": [
+            "n. 背景；背景幕；交流声"
+        ],
+        "usphone": "[ˈbækdrɑːp]",
+        "ukphone": "[ˈbækdrɒp]"
+    },
+    {
+        "name": "decision-making",
+        "trans": [
+            "n. 决策"
+        ],
+        "usphone": "[dɪˈsɪʒn meɪkɪŋ]",
+        "ukphone": "[dɪˈsɪʒn meɪkɪŋ]"
+    },
+    {
+        "name": "lethal",
+        "trans": [
+            "adj. 致命的，致死的"
+        ],
+        "usphone": "[ˈliːθl]",
+        "ukphone": "[ˈliːθ(ə)l]"
+    },
+    {
+        "name": "mainland",
+        "trans": [
+            "n. 大陆；本土"
+        ],
+        "usphone": "[ˈmeɪnlənd; ˈmeɪnlænd]",
+        "ukphone": "[ˈmeɪnlənd; ˈmeɪnlænd]"
+    },
+    {
+        "name": "oversee",
+        "trans": [
+            "vt. 监督；审查；俯瞰；偷看到，无意中看到"
+        ],
+        "usphone": "[ˌoʊvərˈsiː]",
+        "ukphone": "[ˌəʊvəˈsiː]"
+    },
+    {
+        "name": "machinery",
+        "trans": [
+            "n. 机械；机器；机构；机械装置"
+        ],
+        "usphone": "[məˈʃiːnəri]",
+        "ukphone": "[məˈʃiːnəri]"
+    },
+    {
+        "name": "accumulate",
+        "trans": [
+            "vt. 积攒"
+        ],
+        "usphone": "[əˈkjuːmjəleɪt]",
+        "ukphone": "[əˈkjuːmjəleɪt]"
+    },
+    {
+        "name": "confrontation",
+        "trans": [
+            "n. 对抗；面对；对质"
+        ],
+        "usphone": "[ˌkɑːnfrənˈteɪʃn]",
+        "ukphone": "[ˌkɒnfrʌnˈteɪʃn]"
+    },
+    {
+        "name": "supreme",
+        "trans": [
+            "n. 至高；霸权"
+        ],
+        "usphone": "[suːˈpriːm]",
+        "ukphone": "[suːˈpriːm; sjuːˈpriːm]"
+    },
+    {
+        "name": "agricultural",
+        "trans": [
+            "adj. 农业的；农艺的"
+        ],
+        "usphone": "[ˌæɡrɪˈkʌltʃərəl]",
+        "ukphone": "[ˌæɡrɪˈkʌltʃərəl]"
+    },
+    {
+        "name": "lobby",
+        "trans": [
+            "n. 大厅；休息室；会客室；游说议员的团体"
+        ],
+        "usphone": "[ˈlɑːbi]",
+        "ukphone": "[ˈlɒbi]"
+    },
+    {
+        "name": "indigenous",
+        "trans": [
+            "adj. 本土的；土著的；国产的；固有的"
+        ],
+        "usphone": "[ɪnˈdɪdʒənəs]",
+        "ukphone": "[ɪnˈdɪdʒənəs]"
+    },
+    {
+        "name": "arguably",
+        "trans": [
+            "adv. 可论证地；可争辩地；正如可提出证据加以证明的那样地"
+        ],
+        "usphone": "[ˈɑːrɡjuəbli]",
+        "ukphone": "[ˈɑːɡjuəbli]"
+    },
+    {
+        "name": "tribal",
+        "trans": [
+            "adj. 部落的；种族的"
+        ],
+        "usphone": "[ˈtraɪbl]",
+        "ukphone": "[ˈtraɪb(ə)l]"
+    },
+    {
+        "name": "ideological",
+        "trans": [
+            "adj. 思想的；意识形态的"
+        ],
+        "usphone": "[ˌaɪdiəˈlɑːdʒɪklˌˌɪdiəˈlɑːdʒɪkl]",
+        "ukphone": "[ˌaɪdiəˈlɒdʒɪk(ə)l]"
+    },
+    {
+        "name": "manuscript",
+        "trans": [
+            "n. [图情] 手稿；原稿"
+        ],
+        "usphone": "[ˈmænjuskrɪpt]",
+        "ukphone": "[ˈmænjuskrɪpt]"
+    },
+    {
+        "name": "outlet",
+        "trans": [
+            "n. 出口，排放孔；[电] 电源插座；销路；发泄的方法；批发商店"
+        ],
+        "usphone": "[ˈaʊtlet]",
+        "ukphone": "[ˈaʊtlet]"
+    },
+    {
+        "name": "offspring",
+        "trans": [
+            "n. 后代，子孙；产物"
+        ],
+        "usphone": "[ˈɔːfsprɪŋ]",
+        "ukphone": "[ˈɒfsprɪŋ]"
+    },
+    {
+        "name": "preach",
+        "trans": [
+            "n. 说教"
+        ],
+        "usphone": "[priːtʃ]",
+        "ukphone": "[priːtʃ]"
+    },
+    {
+        "name": "inflict",
+        "trans": [
+            "vt. 造成；使遭受（损伤、痛苦等）；给予（打击等）"
+        ],
+        "usphone": "[ɪnˈflɪkt]",
+        "ukphone": "[ɪnˈflɪkt]"
+    },
+    {
+        "name": "transaction",
+        "trans": [
+            "n. 交易；事务；办理；会报，学报"
+        ],
+        "usphone": "[trænˈzækʃ(ə)n]",
+        "ukphone": "[trænˈzækʃ(ə)n]"
+    },
+    {
+        "name": "bizarre",
+        "trans": [
+            "adj. 奇异的（指态度，容貌，款式等）"
+        ],
+        "usphone": "[bɪˈzɑːr]",
+        "ukphone": "[bɪˈzɑː(r)]"
+    },
+    {
+        "name": "effectiveness",
+        "trans": [
+            "n. 效力"
+        ],
+        "usphone": "[ɪˈfektɪvnəs]",
+        "ukphone": "[ɪˈfektɪvnəs]"
+    },
+    {
+        "name": "liberal",
+        "trans": [
+            "adj. 自由主义的；慷慨的；不拘泥的；宽大的"
+        ],
+        "usphone": "[ˈlɪbərəl]",
+        "ukphone": "[ˈlɪbərəl]"
+    },
+    {
+        "name": "referendum",
+        "trans": [
+            "n. 公民投票权；外交官请示书"
+        ],
+        "usphone": "[ˌrefəˈrendəm]",
+        "ukphone": "[ˌrefəˈrendəm]"
+    },
+    {
+        "name": "jurisdiction",
+        "trans": [
+            "n. 司法权，审判权，管辖权；权限，权力"
+        ],
+        "usphone": "[ˌdʒʊrɪsˈdɪkʃn]",
+        "ukphone": "[ˌdʒʊərɪsˈdɪkʃn]"
+    },
+    {
+        "name": "occasional",
+        "trans": [
+            "adj. 偶然的；临时的；特殊场合的"
+        ],
+        "usphone": "[əˈkeɪʒənl]",
+        "ukphone": "[əˈkeɪʒən(ə)l]"
+    },
+    {
+        "name": "toss",
+        "trans": [
+            "n. 投掷；摇荡；投掷的距离；掷币赌胜负"
+        ],
+        "usphone": "[tɔːs]",
+        "ukphone": "[tɒs]"
+    },
+    {
+        "name": "operational",
+        "trans": [
+            "adj. 操作的；运作的"
+        ],
+        "usphone": "[ˌɑːpəˈreɪʃən(ə)l]",
+        "ukphone": "[ˌɒpəˈreɪʃən(ə)l]"
+    },
+    {
+        "name": "dynamic",
+        "trans": [
+            "n. 动态；动力"
+        ],
+        "usphone": "[daɪˈnæmɪk]",
+        "ukphone": "[daɪˈnæmɪk]"
+    },
+    {
+        "name": "inability",
+        "trans": [
+            "n. 无能力；无才能"
+        ],
+        "usphone": "[ˌɪnəˈbɪləti]",
+        "ukphone": "[ˌɪnəˈbɪləti]"
+    },
+    {
+        "name": "gambling",
+        "trans": [
+            "n. 赌博；投机"
+        ],
+        "usphone": "[ˈɡæmblɪŋ]",
+        "ukphone": "[ˈɡæmblɪŋ]"
+    },
+    {
+        "name": "clarity",
+        "trans": [
+            "n. 清楚，明晰；透明"
+        ],
+        "usphone": "[ˈklærəti]",
+        "ukphone": "[ˈklærəti]"
+    },
+    {
+        "name": "governance",
+        "trans": [
+            "n. 管理；统治；支配"
+        ],
+        "usphone": "[ˈɡʌvərnəns]",
+        "ukphone": "[ˈɡʌvənəns]"
+    },
+    {
+        "name": "verse",
+        "trans": [
+            "n. 诗，诗篇；韵文；诗节"
+        ],
+        "usphone": "[vɜːrs]",
+        "ukphone": "[vɜːs]"
+    },
+    {
+        "name": "heighten",
+        "trans": [
+            "vt. 提高；增高；加强；使更显著"
+        ],
+        "usphone": "[ˈhaɪtn]",
+        "ukphone": "[ˈhaɪtn]"
+    },
+    {
+        "name": "listing",
+        "trans": [
+            "n. 列表，清单"
+        ],
+        "usphone": "[ˈlɪstɪŋ]",
+        "ukphone": "[ˈlɪstɪŋ]"
+    },
+    {
+        "name": "consultation",
+        "trans": [
+            "n. 咨询；磋商；[临床] 会诊；讨论会"
+        ],
+        "usphone": "[ˌkɑːnslˈteɪʃn]",
+        "ukphone": "[ˌkɒns(ə)lˈteɪʃ(ə)n]"
+    },
+    {
+        "name": "smash",
+        "trans": [
+            "n. 破碎；扣球；冲突；大败"
+        ],
+        "usphone": "[smæʃ]",
+        "ukphone": "[smæʃ]"
+    },
+    {
+        "name": "elevate",
+        "trans": [
+            "vt. 提升；举起；振奋情绪等；提升…的职位"
+        ],
+        "usphone": "[ˈelɪveɪt]",
+        "ukphone": "[ˈelɪveɪt]"
+    },
+    {
+        "name": "turnout",
+        "trans": [
+            "n. 产量；出席者；参加人数；出动；清除；[公路] 岔道"
+        ],
+        "usphone": "[ˈtɜːrnaʊt]",
+        "ukphone": "[ˈtɜːnaʊt]"
+    },
+    {
+        "name": "trustee",
+        "trans": [
+            "n. 受托人；托管人"
+        ],
+        "usphone": "[trʌˈstiː]",
+        "ukphone": "[trʌˈstiː]"
+    },
+    {
+        "name": "sensation",
+        "trans": [
+            "n. 感觉；轰动；感动"
+        ],
+        "usphone": "[senˈseɪʃ(ə)n]",
+        "ukphone": "[senˈseɪʃ(ə)n]"
+    },
+    {
+        "name": "intensity",
+        "trans": [
+            "n. 强度；强烈；[电子] 亮度；紧张"
+        ],
+        "usphone": "[ɪnˈtensəti]",
+        "ukphone": "[ɪnˈtensəti]"
+    },
+    {
+        "name": "handling",
+        "trans": [
+            "n. 处理"
+        ],
+        "usphone": "[ˈhændlɪŋ]",
+        "ukphone": "[ˈhændlɪŋ]"
+    },
+    {
+        "name": "crystal",
+        "trans": [
+            "n. 结晶，晶体；水晶；水晶饰品"
+        ],
+        "usphone": "[ˈkrɪstl]",
+        "ukphone": "[ˈkrɪst(ə)l]"
+    },
+    {
+        "name": "troubled",
+        "trans": [
+            "adj. 动乱的，不安的；混乱的；困惑的"
+        ],
+        "usphone": "[ˈtrʌbld]",
+        "ukphone": "[ˈtrʌbld]"
+    },
+    {
+        "name": "limb",
+        "trans": [
+            "n. 肢，臂；分支；枝干"
+        ],
+        "usphone": "[lɪm]",
+        "ukphone": "[lɪm]"
+    },
+    {
+        "name": "loop",
+        "trans": [
+            "vi. 打环；翻筋斗"
+        ],
+        "usphone": "[luːp]",
+        "ukphone": "[luːp]"
+    },
+    {
+        "name": "pirate",
+        "trans": [
+            "n. 海盗；盗版；侵犯专利权者"
+        ],
+        "usphone": "[ˈpaɪrət]",
+        "ukphone": "[ˈpaɪrət]"
+    },
+    {
+        "name": "timber",
+        "trans": [
+            "n. 木材；木料"
+        ],
+        "usphone": "[ˈtɪmbər]",
+        "ukphone": "[ˈtɪmbə(r)]"
+    },
+    {
+        "name": "rage",
+        "trans": [
+            "n. 愤怒；狂暴，肆虐；情绪激动"
+        ],
+        "usphone": "[reɪdʒ]",
+        "ukphone": "[reɪdʒ]"
+    },
+    {
+        "name": "terminate",
+        "trans": [
+            "vt. 使终止；使结束；解雇"
+        ],
+        "usphone": "[ˈtɜːrmɪneɪt]",
+        "ukphone": "[ˈtɜːmɪneɪt]"
+    },
+    {
+        "name": "physician",
+        "trans": [
+            "n. [医] 医师；内科医师"
+        ],
+        "usphone": "[fɪˈzɪʃn]",
+        "ukphone": "[fɪˈzɪʃn]"
+    },
+    {
+        "name": "commerce",
+        "trans": [
+            "n. 贸易；商业；商务"
+        ],
+        "usphone": "[ˈkɑːmɜːrs]",
+        "ukphone": "[ˈkɒmɜːs]"
+    },
+    {
+        "name": "sexuality",
+        "trans": [
+            "n. [胚] 性别；性欲；性征；性方面的事情（比如性行为或性能力）"
+        ],
+        "usphone": "[ˌsekʃuˈæləti]",
+        "ukphone": "[ˌsekʃuˈæləti]"
+    },
+    {
+        "name": "infect",
+        "trans": [
+            "vt. 感染，传染"
+        ],
+        "usphone": "[ɪnˈfekt]",
+        "ukphone": "[ɪnˈfekt]"
+    },
+    {
+        "name": "collaboration",
+        "trans": [
+            "n. 合作；勾结；通敌"
+        ],
+        "usphone": "[kəˌlæbəˈreɪʃn]",
+        "ukphone": "[kəˌlæbəˈreɪʃ(ə)n]"
+    },
+    {
+        "name": "empower",
+        "trans": [
+            "vt. 授权，允许；使能够"
+        ],
+        "usphone": "[ɪmˈpaʊər]",
+        "ukphone": "[ɪmˈpaʊə(r)]"
+    },
+    {
+        "name": "kidnap",
+        "trans": [
+            "vt. 绑架；诱拐；拐骗"
+        ],
+        "usphone": "[ˈkɪdnæp]",
+        "ukphone": "[ˈkɪdnæp]"
+    },
+    {
+        "name": "spine",
+        "trans": [
+            "n. 脊柱，脊椎；刺；书脊"
+        ],
+        "usphone": "[spaɪn]",
+        "ukphone": "[spaɪn]"
+    },
+    {
+        "name": "allocation",
+        "trans": [
+            "n. 分配，配置；安置"
+        ],
+        "usphone": "[ˌæləˈkeɪʃ(ə)n]",
+        "ukphone": "[ˌæləˈkeɪʃ(ə)n]"
+    },
+    {
+        "name": "remedy",
+        "trans": [
+            "n. 补救；治疗；赔偿"
+        ],
+        "usphone": "[ˈremədi]",
+        "ukphone": "[ˈremədi]"
+    },
+    {
+        "name": "worthy",
+        "trans": [
+            "n. 杰出人物；知名人士"
+        ],
+        "usphone": "[ˈwɜːrði]",
+        "ukphone": "[ˈwɜːði]"
+    },
+    {
+        "name": "warrior",
+        "trans": [
+            "n. 战士，勇士；鼓吹战争的人"
+        ],
+        "usphone": "[ˈwɔːriər]",
+        "ukphone": "[ˈwɒriə(r)]"
+    },
+    {
+        "name": "persistent",
+        "trans": [
+            "adj. 固执的，坚持的；持久稳固的"
+        ],
+        "usphone": "[pərˈsɪstənt]",
+        "ukphone": "[pəˈsɪstənt]"
+    },
+    {
+        "name": "neglect",
+        "trans": [
+            "vt. 疏忽，忽视；忽略"
+        ],
+        "usphone": "[nɪˈɡlekt]",
+        "ukphone": "[nɪˈɡlekt]"
+    },
+    {
+        "name": "outrage",
+        "trans": [
+            "n. 愤怒，愤慨；暴行；侮辱"
+        ],
+        "usphone": "[ˈaʊtreɪdʒ]",
+        "ukphone": "[ˈaʊtreɪdʒ]"
+    },
+    {
+        "name": "replacement",
+        "trans": [
+            "n. 更换；复位；代替者；补充兵员"
+        ],
+        "usphone": "[rɪˈpleɪsmənt]",
+        "ukphone": "[rɪˈpleɪsmənt]"
+    },
+    {
+        "name": "fixture",
+        "trans": [
+            "n. 设备；固定装置；固定于某处不大可能移动之物"
+        ],
+        "usphone": "[ˈfɪkstʃər]",
+        "ukphone": "[ˈfɪkstʃə(r)]"
+    },
+    {
+        "name": "halt",
+        "trans": [
+            "n. 停止；立定；休息"
+        ],
+        "usphone": "[hɔːlt]",
+        "ukphone": "[hɔːlt]"
+    },
+    {
+        "name": "dependence",
+        "trans": [
+            "n. 依赖；依靠；信任；信赖"
+        ],
+        "usphone": "[dɪˈpendəns]",
+        "ukphone": "[dɪˈpendəns]"
+    },
+    {
+        "name": "distinction",
+        "trans": [
+            "n. 区别；差别；特性；荣誉、勋章"
+        ],
+        "usphone": "[dɪˈstɪŋkʃn]",
+        "ukphone": "[dɪˈstɪŋkʃn]"
+    },
+    {
+        "name": "assembly",
+        "trans": [
+            "n. 装配；集会，集合"
+        ],
+        "usphone": "[əˈsembli]",
+        "ukphone": "[əˈsembli]"
+    },
+    {
+        "name": "activation",
+        "trans": [
+            "n. [电子][物] 激活；活化作用"
+        ],
+        "usphone": "[ˌæktɪˈveɪʃn]",
+        "ukphone": "[ˌæktɪˈveɪʃn]"
+    },
+    {
+        "name": "cabinet",
+        "trans": [
+            "n. 内阁；橱柜；展览艺术品的小陈列室"
+        ],
+        "usphone": "[ˈkæbɪnət]",
+        "ukphone": "[ˈkæbɪnət]"
+    },
+    {
+        "name": "set-up",
+        "trans": [
+            "n. 计划；组织；机构；装配"
+        ],
+        "usphone": "[ˈset ʌp]",
+        "ukphone": "[ˈset ʌp]"
+    },
+    {
+        "name": "inject",
+        "trans": [
+            "vt. 注入；注射"
+        ],
+        "usphone": "[ɪnˈdʒekt]",
+        "ukphone": "[ɪnˈdʒekt]"
+    },
+    {
+        "name": "burial",
+        "trans": [
+            "n. 埋葬；葬礼；弃绝"
+        ],
+        "usphone": "[ˈberiəl]",
+        "ukphone": "[ˈberiəl]"
+    },
+    {
+        "name": "surrender",
+        "trans": [
+            "n. 投降；放弃；交出；屈服"
+        ],
+        "usphone": "[səˈrendər]",
+        "ukphone": "[səˈrendə(r)]"
+    },
+    {
+        "name": "specialized",
+        "trans": [
+            "adj. 专业的；专门的"
+        ],
+        "usphone": "[ˈspeʃəlaɪzd]",
+        "ukphone": "[ˈspeʃəlaɪzd]"
+    },
+    {
+        "name": "ecological",
+        "trans": [
+            "adj. 生态的，生态学的"
+        ],
+        "usphone": "[ˌiːkəˈlɑːdʒɪkl]",
+        "ukphone": "[ˌiːkəˈlɒdʒɪkl]"
+    },
+    {
+        "name": "lawn",
+        "trans": [
+            "n. 草地；草坪"
+        ],
+        "usphone": "[lɔːn]",
+        "ukphone": "[lɔːn]"
+    },
+    {
+        "name": "sovereignty",
+        "trans": [
+            "n. 主权；主权国家；君主；独立国"
+        ],
+        "usphone": "[ˈsɑːvrənti]",
+        "ukphone": "[ˈsɒvrənti]"
+    },
+    {
+        "name": "infant",
+        "trans": [
+            "n. 婴儿；幼儿；未成年人"
+        ],
+        "usphone": "[ˈɪnfənt]",
+        "ukphone": "[ˈɪnfənt]"
+    },
+    {
+        "name": "exile",
+        "trans": [
+            "n. 流放，充军；放逐，被放逐者；流犯"
+        ],
+        "usphone": "[ˈeksaɪlˌˈeɡzaɪl]",
+        "ukphone": "[ˈeksaɪl]"
+    },
+    {
+        "name": "tactical",
+        "trans": [
+            "adj. 战术的；策略的；善于策略的"
+        ],
+        "usphone": "[ˈtæktɪkl]",
+        "ukphone": "[ˈtæktɪkl]"
+    },
+    {
+        "name": "shrug",
+        "trans": [
+            "n. 耸肩"
+        ],
+        "usphone": "[ʃrʌɡ]",
+        "ukphone": "[ʃrʌɡ]"
+    },
+    {
+        "name": "expire",
+        "trans": [
+            "vi. 期满；终止；死亡；呼气"
+        ],
+        "usphone": "[ɪkˈspaɪər]",
+        "ukphone": "[ɪkˈspaɪə(r)]"
+    },
+    {
+        "name": "maximize",
+        "trans": [
+            "vt. 取…最大值；对…极为重视"
+        ],
+        "usphone": "[ˈmæksɪmaɪz]",
+        "ukphone": "[ˈmæksɪmaɪz]"
+    },
+    {
+        "name": "compute",
+        "trans": [
+            "n. 计算；估计；推断"
+        ],
+        "usphone": "[kəmˈpjuːt]",
+        "ukphone": "[kəmˈpjuːt]"
+    },
+    {
+        "name": "recount",
+        "trans": [
+            "n. 重算"
+        ],
+        "usphone": "[rɪˈkaʊnt]",
+        "ukphone": "[rɪˈkaʊnt; ˈriːkaʊnt; ˌriːˈkaʊnt]"
+    },
+    {
+        "name": "mob",
+        "trans": [
+            "n. 暴民，暴徒；民众；乌合之众"
+        ],
+        "usphone": "[mɑːb]",
+        "ukphone": "[mɒb]"
+    },
+    {
+        "name": "ritual",
+        "trans": [
+            "n. 仪式；惯例；礼制"
+        ],
+        "usphone": "[ˈrɪtʃuəl]",
+        "ukphone": "[ˈrɪtʃuəl]"
+    },
+    {
+        "name": "memoir",
+        "trans": [
+            "n. 回忆录；研究报告；自传；实录"
+        ],
+        "usphone": "[ˈmemwɑːr]",
+        "ukphone": "[ˈmemwɑː(r)]"
+    },
+    {
+        "name": "acquisition",
+        "trans": [
+            "n. 获得物，获得；收购"
+        ],
+        "usphone": "[ˌækwɪˈzɪʃn]",
+        "ukphone": "[ˌækwɪˈzɪʃ(ə)n]"
+    },
+    {
+        "name": "gravity",
+        "trans": [
+            "n. 重力，地心引力；严重性；庄严"
+        ],
+        "usphone": "[ˈɡrævəti]",
+        "ukphone": "[ˈɡrævəti]"
+    },
+    {
+        "name": "passing",
+        "trans": [
+            "n. 经过；及格；流逝；去世"
+        ],
+        "usphone": "[ˈpæsɪŋ]",
+        "ukphone": "[ˈpɑːsɪŋ]"
+    },
+    {
+        "name": "diagnose",
+        "trans": [
+            "vt. 诊断；断定"
+        ],
+        "usphone": "[ˌdaɪəɡˈnoʊs]",
+        "ukphone": "[ˈdaɪəɡnəʊz; ˌdaɪəɡˈnəʊz]"
+    },
+    {
+        "name": "weed",
+        "trans": [
+            "n. 杂草，野草；菸草"
+        ],
+        "usphone": "[wiːd]",
+        "ukphone": "[wiːd]"
+    },
+    {
+        "name": "formula",
+        "trans": [
+            "n. [数] 公式，准则；配方；婴儿食品"
+        ],
+        "usphone": "[ˈfɔːrmjələ]",
+        "ukphone": "[ˈfɔːmjələ]"
+    },
+    {
+        "name": "default",
+        "trans": [
+            "n. 违约；缺席；缺乏；系统默认值"
+        ],
+        "usphone": "[dɪˈfɔːltˌˈdiːfɔːlt]",
+        "ukphone": "[dɪˈfɔːlt]"
+    },
+    {
+        "name": "adverse",
+        "trans": [
+            "adj. 不利的；相反的；敌对的（名词adverseness，副词adversely）"
+        ],
+        "usphone": "[ədˈvɜːrsˌˈædvɜːrs]",
+        "ukphone": "[ˈædvɜːs]"
+    },
+    {
+        "name": "conscience",
+        "trans": [
+            "n. 道德心，良心"
+        ],
+        "usphone": "[ˈkɑːnʃəns]",
+        "ukphone": "[ˈkɒnʃəns]"
+    },
+    {
+        "name": "consciousness",
+        "trans": [
+            "n. 意识；知觉；觉悟；感觉"
+        ],
+        "usphone": "[ˈkɑːnʃəsnəs]",
+        "ukphone": "[ˈkɒnʃəsnəs]"
+    },
+    {
+        "name": "reluctant",
+        "trans": [
+            "adj. 不情愿的；勉强的；顽抗的"
+        ],
+        "usphone": "[rɪˈlʌktənt]",
+        "ukphone": "[rɪˈlʌktənt]"
+    },
+    {
+        "name": "councillor",
+        "trans": [
+            "n. 议员；顾问；参赞（等于councilor）"
+        ],
+        "usphone": "[ˈkaʊnsələr]",
+        "ukphone": "[ˈkaʊnsələ(r)]"
+    },
+    {
+        "name": "trail",
+        "trans": [
+            "n. 小径；痕迹；尾部；踪迹；一串，一系列"
+        ],
+        "usphone": "[treɪl]",
+        "ukphone": "[treɪl]"
+    },
+    {
+        "name": "grind",
+        "trans": [
+            "n. 磨；苦工作"
+        ],
+        "usphone": "[ɡraɪnd]",
+        "ukphone": "[ɡraɪnd]"
+    },
+    {
+        "name": "width",
+        "trans": [
+            "n. 宽度；广度"
+        ],
+        "usphone": "[wɪdθ; wɪtθ]",
+        "ukphone": "[wɪdθ]"
+    },
+    {
+        "name": "delicate",
+        "trans": [
+            "adj. 微妙的；精美的，雅致的；柔和的；易碎的；纤弱的；清淡可口的"
+        ],
+        "usphone": "[ˈdelɪkət]",
+        "ukphone": "[ˈdelɪkət]"
+    },
+    {
+        "name": "veteran",
+        "trans": [
+            "n. 老兵；老手；富有经验的人；老运动员"
+        ],
+        "usphone": "[ˈvetərən]",
+        "ukphone": "[ˈvetərən]"
+    },
+    {
+        "name": "solicitor",
+        "trans": [
+            "n. 律师；法务官；募捐者；掮客"
+        ],
+        "usphone": "[səˈlɪsɪtər]",
+        "ukphone": "[səˈlɪsɪtə(r)]"
+    },
+    {
+        "name": "casino",
+        "trans": [
+            "n. 俱乐部，赌场；娱乐场"
+        ],
+        "usphone": "[kəˈsiːnoʊ]",
+        "ukphone": "[kəˈsiːnəʊ]"
+    },
+    {
+        "name": "resignation",
+        "trans": [
+            "n. 辞职；放弃；辞职书；顺从"
+        ],
+        "usphone": "[ˌrezɪɡˈneɪʃn]",
+        "ukphone": "[ˌrezɪɡˈneɪʃn]"
+    },
+    {
+        "name": "defy",
+        "trans": [
+            "n. 挑战；对抗"
+        ],
+        "usphone": "[dɪˈfaɪ]",
+        "ukphone": "[dɪˈfaɪ]"
+    },
+    {
+        "name": "prospective",
+        "trans": [
+            "n. 预期；展望"
+        ],
+        "usphone": "[prəˈspektɪv]",
+        "ukphone": "[prəˈspektɪv]"
+    },
+    {
+        "name": "interactive",
+        "trans": [
+            "adj. 交互式的；相互作用的"
+        ],
+        "usphone": "[ˌɪntərˈæktɪv]",
+        "ukphone": "[ˌɪntərˈæktɪv]"
+    },
+    {
+        "name": "monopoly",
+        "trans": [
+            "n. 垄断；垄断者；专卖权"
+        ],
+        "usphone": "[məˈnɑːpəli]",
+        "ukphone": "[məˈnɒpəli]"
+    },
+    {
+        "name": "intimate",
+        "trans": [
+            "n. 知己；至交"
+        ],
+        "usphone": "[ˈɪntɪmət; ˈɪntəmət; ˈɪntɪmeɪt]",
+        "ukphone": "[ˈɪntɪmət]"
+    },
+    {
+        "name": "discretion",
+        "trans": [
+            "n. 自由裁量权；谨慎；判断力；判定；考虑周到"
+        ],
+        "usphone": "[dɪˈskreʃn]",
+        "ukphone": "[dɪˈskreʃn]"
+    },
+    {
+        "name": "miracle",
+        "trans": [
+            "n. 奇迹，奇迹般的人或物；惊人的事例"
+        ],
+        "usphone": "[ˈmɪrəkl]",
+        "ukphone": "[ˈmɪrəkl]"
+    },
+    {
+        "name": "militant",
+        "trans": [
+            "adj. 好战的"
+        ],
+        "usphone": "[ˈmɪlɪtənt]",
+        "ukphone": "[ˈmɪlɪtənt]"
+    },
+    {
+        "name": "merchant",
+        "trans": [
+            "n. 商人，批发商；店主"
+        ],
+        "usphone": "[ˈmɜːrtʃənt]",
+        "ukphone": "[ˈmɜːtʃənt]"
+    },
+    {
+        "name": "credibility",
+        "trans": [
+            "n. 可信性；确实性"
+        ],
+        "usphone": "[ˌkredəˈbɪləti]",
+        "ukphone": "[ˌkredəˈbɪləti]"
+    },
+    {
+        "name": "grave",
+        "trans": [
+            "n. 墓穴，坟墓；死亡"
+        ],
+        "usphone": "[ɡreɪv; ɡrɑːv]",
+        "ukphone": "[ɡreɪv]"
+    },
+    {
+        "name": "fine",
+        "trans": [
+            "n. 罚款"
+        ],
+        "usphone": "[faɪn]",
+        "ukphone": "[faɪn]"
+    },
+    {
+        "name": "intact",
+        "trans": [
+            "adj. 完整的；原封不动的；未受损伤的"
+        ],
+        "usphone": "[ɪnˈtækt]",
+        "ukphone": "[ɪnˈtækt]"
+    },
+    {
+        "name": "apparatus",
+        "trans": [
+            "n. 装置，设备；仪器；器官"
+        ],
+        "usphone": "[ˌæpəˈrætəs]",
+        "ukphone": "[ˌæpəˈreɪtəs]"
+    },
+    {
+        "name": "instruct",
+        "trans": [
+            "vt. 指导；通知；命令；教授"
+        ],
+        "usphone": "[ɪnˈstrʌkt]",
+        "ukphone": "[ɪnˈstrʌkt]"
+    },
+    {
+        "name": "interior",
+        "trans": [
+            "n. 内部；本质"
+        ],
+        "usphone": "[ɪnˈtɪriər]",
+        "ukphone": "[ɪnˈtɪəriə(r)]"
+    },
+    {
+        "name": "corruption",
+        "trans": [
+            "n. 贪污，腐败；堕落"
+        ],
+        "usphone": "[kəˈrʌpʃn]",
+        "ukphone": "[kəˈrʌpʃ(ə)n]"
+    },
+    {
+        "name": "encouragement",
+        "trans": [
+            "n. 鼓励"
+        ],
+        "usphone": "[ɪnˈkɜːrɪdʒmənt]",
+        "ukphone": "[ɪnˈkʌrɪdʒmənt]"
+    },
+    {
+        "name": "recipient",
+        "trans": [
+            "n. 容器，接受者；容纳者"
+        ],
+        "usphone": "[rɪˈsɪpiənt]",
+        "ukphone": "[rɪˈsɪpiənt]"
+    },
+    {
+        "name": "prescription",
+        "trans": [
+            "n. 药方；指示；惯例"
+        ],
+        "usphone": "[prɪˈskrɪpʃn]",
+        "ukphone": "[prɪˈskrɪpʃn]"
+    },
+    {
+        "name": "preside",
+        "trans": [
+            "vi. 主持，担任会议主席"
+        ],
+        "usphone": "[prɪˈzaɪd]",
+        "ukphone": "[prɪˈzaɪd]"
+    },
+    {
+        "name": "strain",
+        "trans": [
+            "n. 张力；拉紧；负担；扭伤；血缘"
+        ],
+        "usphone": "[streɪn]",
+        "ukphone": "[streɪn]"
+    },
+    {
+        "name": "bless",
+        "trans": [
+            "vt. 祝福；保佑；赞美"
+        ],
+        "usphone": "[bles]",
+        "ukphone": "[bles]"
+    },
+    {
+        "name": "texture",
+        "trans": [
+            "n. 质地；纹理；结构；本质，实质"
+        ],
+        "usphone": "[ˈtekstʃər]",
+        "ukphone": "[ˈtekstʃə(r)]"
+    },
+    {
+        "name": "abuse",
+        "trans": [
+            "n. 滥用；虐待；辱骂；弊端；恶习，陋习"
+        ],
+        "usphone": "[əˈbjuːs]",
+        "ukphone": "[əˈbjuːs]"
+    },
+    {
+        "name": "prescribe",
+        "trans": [
+            "vt. 规定；开处方"
+        ],
+        "usphone": "[prɪˈskraɪb]",
+        "ukphone": "[prɪˈskraɪb]"
+    },
+    {
+        "name": "seal",
+        "trans": [
+            "n. 密封；印章；海豹；封条；标志"
+        ],
+        "usphone": "[siːl]",
+        "ukphone": "[siːl]"
+    },
+    {
+        "name": "drift",
+        "trans": [
+            "n. 漂流，漂移；趋势；漂流物"
+        ],
+        "usphone": "[drɪft]",
+        "ukphone": "[drɪft]"
+    },
+    {
+        "name": "soar",
+        "trans": [
+            "n. 高飞；高涨"
+        ],
+        "usphone": "[sɔːr]",
+        "ukphone": "[sɔː(r)]"
+    },
+    {
+        "name": "consensus",
+        "trans": [
+            "n. 一致；舆论；合意"
+        ],
+        "usphone": "[kənˈsensəs]",
+        "ukphone": "[kənˈsensəs]"
+    },
+    {
+        "name": "violation",
+        "trans": [
+            "n. 违反；妨碍，侵害；违背；强奸"
+        ],
+        "usphone": "[ˌvaɪəˈleɪʃn]",
+        "ukphone": "[ˌvaɪəˈleɪʃ(ə)n]"
+    },
+    {
+        "name": "widow",
+        "trans": [
+            "n. 寡妇；孀妇"
+        ],
+        "usphone": "[ˈwɪdoʊ]",
+        "ukphone": "[ˈwɪdəʊ]"
+    },
+    {
+        "name": "noble",
+        "trans": [
+            "adj. 高尚的；贵族的；惰性的；宏伟的"
+        ],
+        "usphone": "[ˈnoʊbl]",
+        "ukphone": "[ˈnəʊbl]"
+    },
+    {
+        "name": "integrated",
+        "trans": [
+            "adj. 综合的；完整的；互相协调的"
+        ],
+        "usphone": "[ˈɪntɪɡreɪtɪd]",
+        "ukphone": "[ˈɪntɪɡreɪtɪd]"
+    },
+    {
+        "name": "sin",
+        "trans": [
+            "n. 罪恶；罪孽；过失"
+        ],
+        "usphone": "[sɪn]",
+        "ukphone": "[sɪn]"
+    },
+    {
+        "name": "grid",
+        "trans": [
+            "n. 网格；格子，栅格；输电网"
+        ],
+        "usphone": "[ɡrɪd]",
+        "ukphone": "[ɡrɪd]"
+    },
+    {
+        "name": "injustice",
+        "trans": [
+            "n. 不公正；不讲道义"
+        ],
+        "usphone": "[ɪnˈdʒʌstɪs]",
+        "ukphone": "[ɪnˈdʒʌstɪs]"
+    },
+    {
+        "name": "correlate",
+        "trans": [
+            "n. 相关物；相关联的人"
+        ],
+        "usphone": "[ˈkɔːrəleɪt]",
+        "ukphone": "[ˈkɒrələt]"
+    },
+    {
+        "name": "explicit",
+        "trans": [
+            "adj. 明确的；清楚的；直率的；详述的"
+        ],
+        "usphone": "[ɪkˈsplɪsɪt]",
+        "ukphone": "[ɪkˈsplɪsɪt]"
+    },
+    {
+        "name": "conquer",
+        "trans": [
+            "vt. 战胜，征服；攻克，攻取"
+        ],
+        "usphone": "[ˈkɑːŋkər]",
+        "ukphone": "[ˈkɒŋkə(r)]"
+    },
+    {
+        "name": "handy",
+        "trans": [
+            "adj. 便利的；手边的，就近的；容易取得的；敏捷的"
+        ],
+        "usphone": "[ˈhændi]",
+        "ukphone": "[ˈhændi]"
+    },
+    {
+        "name": "stabilize",
+        "trans": [
+            "vt. 使稳固，使安定"
+        ],
+        "usphone": "[ˈsteɪbəlaɪz]",
+        "ukphone": "[ˈsteɪbəlaɪz]"
+    },
+    {
+        "name": "architectural",
+        "trans": [
+            "adj. 建筑学的；建筑上的；符合建筑法的"
+        ],
+        "usphone": "[ˌɑːrkɪˈtektʃərəl]",
+        "ukphone": "[ˌɑːkɪˈtektʃərəl]"
+    },
+    {
+        "name": "rational",
+        "trans": [
+            "n. 有理数"
+        ],
+        "usphone": "[ˈræʃ(ə)nəl]",
+        "ukphone": "[ˈræʃnəl]"
+    },
+    {
+        "name": "extract",
+        "trans": [
+            "n. 汁；摘录；榨出物；选粹"
+        ],
+        "usphone": "[ˈekstrækt]",
+        "ukphone": "[ˈekstrækt]"
+    },
+    {
+        "name": "delegate",
+        "trans": [
+            "n. 代表"
+        ],
+        "usphone": "[ˈdelɪɡət, ˈdelɪɡeɪt]",
+        "ukphone": "[ˈdelɪɡət]"
+    },
+    {
+        "name": "protocol",
+        "trans": [
+            "n. 协议；草案；礼仪"
+        ],
+        "usphone": "[ˈproʊtəkɑːl]",
+        "ukphone": "[ˈprəʊtəkɒl]"
+    },
+    {
+        "name": "frustration",
+        "trans": [
+            "n. 挫折"
+        ],
+        "usphone": "[frʌˈstreɪʃn]",
+        "ukphone": "[frʌˈstreɪʃ(ə)n]"
+    },
+    {
+        "name": "execution",
+        "trans": [
+            "n. 执行，实行；完成；死刑"
+        ],
+        "usphone": "[ˌeksɪˈkjuːʃn]",
+        "ukphone": "[ˌeksɪˈkjuːʃ(ə)n]"
+    },
+    {
+        "name": "spam",
+        "trans": [
+            "v. 刷屏"
+        ],
+        "usphone": "[spæm]",
+        "ukphone": "[spæm]"
+    },
+    {
+        "name": "upgrade",
+        "trans": [
+            "n. 升级；上升；上坡"
+        ],
+        "usphone": "[ˈʌpɡreɪd]",
+        "ukphone": "[ˈʌpɡreɪd]"
+    },
+    {
+        "name": "patron",
+        "trans": [
+            "n. 赞助人；保护人；主顾"
+        ],
+        "usphone": "[ˈpeɪtrən]",
+        "ukphone": "[ˈpeɪtrən]"
+    },
+    {
+        "name": "neighbouring",
+        "trans": [
+            "adj. 邻近的；附近的；接壤的"
+        ],
+        "usphone": "[ˈneɪbərɪŋ]",
+        "ukphone": "[ˈneɪbərɪŋ]"
+    },
+    {
+        "name": "pregnancy",
+        "trans": [
+            "n. 怀孕；丰富，多产；意义深长"
+        ],
+        "usphone": "[ˈpreɡnənsi]",
+        "ukphone": "[ˈpreɡnənsi]"
+    },
+    {
+        "name": "pad",
+        "trans": [
+            "n. 衬垫；护具；便笺簿；填补"
+        ],
+        "usphone": "[pæd]",
+        "ukphone": "[pæd]"
+    },
+    {
+        "name": "versus",
+        "trans": [
+            "prep. 对；与...相对；对抗"
+        ],
+        "usphone": "[ˈvɜːrsəs]",
+        "ukphone": "[ˈvɜːsəs]"
+    },
+    {
+        "name": "vulnerable",
+        "trans": [
+            "adj. 易受攻击的，易受…的攻击；易受伤害的；有弱点的"
+        ],
+        "usphone": "[ˈvʌlnərəbl]",
+        "ukphone": "[ˈvʌlnərəbl]"
+    },
+    {
+        "name": "engaging",
+        "trans": [
+            "v. 参加（engage的ing形式）；保证；雇用"
+        ],
+        "usphone": "[ɪnˈɡeɪdʒɪŋ]",
+        "ukphone": "[ɪnˈɡeɪdʒɪŋ]"
+    },
+    {
+        "name": "liable",
+        "trans": [
+            "adj. 有责任的，有义务的；应受罚的；有…倾向的；易…的"
+        ],
+        "usphone": "[ˈlaɪəbl]",
+        "ukphone": "[ˈlaɪəb(ə)l]"
+    },
+    {
+        "name": "naval",
+        "trans": [
+            "adj. 海军的；军舰的"
+        ],
+        "usphone": "[ˈneɪvl]",
+        "ukphone": "[ˈneɪv(ə)l]"
+    },
+    {
+        "name": "defect",
+        "trans": [
+            "n. 缺点，缺陷；不足之处"
+        ],
+        "usphone": "[ˈdiːfekt; dɪˈfekt]",
+        "ukphone": "[ˈdiːfekt]"
+    },
+    {
+        "name": "hostile",
+        "trans": [
+            "n. 敌对"
+        ],
+        "usphone": "[ˈhɑːstlˌˈhɑːstaɪl]",
+        "ukphone": "[ˈhɒstaɪl]"
+    },
+    {
+        "name": "dictator",
+        "trans": [
+            "n. 独裁者；命令者"
+        ],
+        "usphone": "[ˈdɪkteɪtər]",
+        "ukphone": "[dɪkˈteɪtə(r)]"
+    },
+    {
+        "name": "privatization",
+        "trans": [
+            "n. 私有化"
+        ],
+        "usphone": "[ˌpraɪvətəˈzeɪʃn]",
+        "ukphone": "[ˌpraɪvətaɪˈzeɪʃn]"
+    },
+    {
+        "name": "profitable",
+        "trans": [
+            "adj. 有利可图的；赚钱的；有益的"
+        ],
+        "usphone": "[ˈprɑːfɪtəbl]",
+        "ukphone": "[ˈprɒfɪtəb(ə)l]"
+    },
+    {
+        "name": "rotate",
+        "trans": [
+            "vt. 使旋转；使转动；使轮流"
+        ],
+        "usphone": "[ˈroʊteɪt]",
+        "ukphone": "[rəʊˈteɪt]"
+    },
+    {
+        "name": "backing",
+        "trans": [
+            "n. 支持；后退；支持者；衬背"
+        ],
+        "usphone": "[ˈbækɪŋ]",
+        "ukphone": "[ˈbækɪŋ]"
+    },
+    {
+        "name": "squad",
+        "trans": [
+            "n. 班；小队；五人组（篮球队的非正式说法）"
+        ],
+        "usphone": "[skwɑːd]",
+        "ukphone": "[skwɒd]"
+    },
+    {
+        "name": "assurance",
+        "trans": [
+            "n. 保证，担保；（人寿）保险；确信；断言；厚脸皮，无耻"
+        ],
+        "usphone": "[əˈʃʊrəns]",
+        "ukphone": "[əˈʃʊərəns]"
+    },
+    {
+        "name": "grace",
+        "trans": [
+            "n. 优雅；恩惠；魅力；慈悲"
+        ],
+        "usphone": "[ɡreɪs]",
+        "ukphone": "[ɡreɪs]"
     },
     {
         "name": "regulatory",
@@ -7830,6 +6302,1454 @@
         ],
         "usphone": "[ˈreɡjələtɔːri]",
         "ukphone": "[ˈreɡjələtəri]"
+    },
+    {
+        "name": "line-up",
+        "trans": [
+            "vt. 排成直线；排成行"
+        ],
+        "usphone": "[ˈlaɪn ʌp]",
+        "ukphone": "[ˈlaɪn ʌp]"
+    },
+    {
+        "name": "alike",
+        "trans": [
+            "adj. 相似的；相同的"
+        ],
+        "usphone": "[əˈlaɪk]",
+        "ukphone": "[əˈlaɪk]"
+    },
+    {
+        "name": "assertion",
+        "trans": [
+            "n. 断言，声明；主张，要求；坚持；认定"
+        ],
+        "usphone": "[əˈsɜːrʃn]",
+        "ukphone": "[əˈsɜːʃ(ə)n]"
+    },
+    {
+        "name": "situated",
+        "trans": [
+            "v. 使位于；使处于（situate的过去分词）"
+        ],
+        "usphone": "[ˈsɪtʃueɪtɪd]",
+        "ukphone": "[ˈsɪtʃueɪtɪd]"
+    },
+    {
+        "name": "harmony",
+        "trans": [
+            "n. 协调；和睦；融洽；调和"
+        ],
+        "usphone": "[ˈhɑːrməni]",
+        "ukphone": "[ˈhɑːməni]"
+    },
+    {
+        "name": "selective",
+        "trans": [
+            "adj. 选择性的"
+        ],
+        "usphone": "[sɪˈlektɪv]",
+        "ukphone": "[sɪˈlektɪv]"
+    },
+    {
+        "name": "surplus",
+        "trans": [
+            "n. 剩余；[贸易] 顺差；盈余；过剩"
+        ],
+        "usphone": "[ˈsɜːrplʌs]",
+        "ukphone": "[ˈsɜːpləs]"
+    },
+    {
+        "name": "coalition",
+        "trans": [
+            "n. 联合；结合，合并"
+        ],
+        "usphone": "[ˌkoʊəˈlɪʃ(ə)n]",
+        "ukphone": "[ˌkəʊəˈlɪʃ(ə)n]"
+    },
+    {
+        "name": "administrator",
+        "trans": [
+            "n. 管理人；行政官"
+        ],
+        "usphone": "[ədˈmɪnɪstreɪtər]",
+        "ukphone": "[ədˈmɪnɪstreɪtə(r)]"
+    },
+    {
+        "name": "wholly",
+        "trans": [
+            "adv. 完全地；全部；统统"
+        ],
+        "usphone": "[ˈhoʊlli]",
+        "ukphone": "[ˈhəʊlli]"
+    },
+    {
+        "name": "residue",
+        "trans": [
+            "n. 残渣；剩余；滤渣"
+        ],
+        "usphone": "[ˈrezɪduː]",
+        "ukphone": "[ˈrezɪdjuː]"
+    },
+    {
+        "name": "lap",
+        "trans": [
+            "n. 一圈；膝盖；下摆；山坳"
+        ],
+        "usphone": "[læp]",
+        "ukphone": "[læp]"
+    },
+    {
+        "name": "liberty",
+        "trans": [
+            "n. 自由；许可；冒失"
+        ],
+        "usphone": "[ˈlɪbərti]",
+        "ukphone": "[ˈlɪbəti]"
+    },
+    {
+        "name": "rumour",
+        "trans": [
+            "n. 谣言"
+        ],
+        "usphone": "[ˈruːmər]",
+        "ukphone": "[ˈruːmə(r)]"
+    },
+    {
+        "name": "infamous",
+        "trans": [
+            "adj. 声名狼藉的；无耻的；邪恶的；不名誉的"
+        ],
+        "usphone": "[ˈɪnfəməs]",
+        "ukphone": "[ˈɪnfəməs]"
+    },
+    {
+        "name": "debris",
+        "trans": [
+            "n. 碎片，残骸"
+        ],
+        "usphone": "[dəˈbriː]",
+        "ukphone": "[ˈdebriː]"
+    },
+    {
+        "name": "academy",
+        "trans": [
+            "n. 学院；研究院；学会；专科院校"
+        ],
+        "usphone": "[əˈkædəmi]",
+        "ukphone": "[əˈkædəmi]"
+    },
+    {
+        "name": "boundary",
+        "trans": [
+            "n. 边界；范围；分界线"
+        ],
+        "usphone": "[ˈbaʊndri]",
+        "ukphone": "[ˈbaʊndri]"
+    },
+    {
+        "name": "slam",
+        "trans": [
+            "n. 猛击；砰然声"
+        ],
+        "usphone": "[slæm]",
+        "ukphone": "[slæm]"
+    },
+    {
+        "name": "conceive",
+        "trans": [
+            "vi. 怀孕；设想；考虑"
+        ],
+        "usphone": "[kənˈsiːv]",
+        "ukphone": "[kənˈsiːv]"
+    },
+    {
+        "name": "exclusive",
+        "trans": [
+            "n. 独家新闻；独家经营的项目；排外者"
+        ],
+        "usphone": "[ɪkˈskluːsɪv]",
+        "ukphone": "[ɪkˈskluːsɪv]"
+    },
+    {
+        "name": "encompass",
+        "trans": [
+            "vt. 包含；包围，环绕；完成"
+        ],
+        "usphone": "[ɪnˈkʌmpəs]",
+        "ukphone": "[ɪnˈkʌmpəs]"
+    },
+    {
+        "name": "crude",
+        "trans": [
+            "n. 原油；天然的物质"
+        ],
+        "usphone": "[kruːd]",
+        "ukphone": "[kruːd]"
+    },
+    {
+        "name": "availability",
+        "trans": [
+            "n. 可用性；有效性；实用性"
+        ],
+        "usphone": "[əˌveɪləˈbɪləti]",
+        "ukphone": "[əˌveɪləˈbɪləti]"
+    },
+    {
+        "name": "mobility",
+        "trans": [
+            "n. 移动性；机动性；[电子] 迁移率"
+        ],
+        "usphone": "[moʊˈbɪləti]",
+        "ukphone": "[məʊˈbɪləti]"
+    },
+    {
+        "name": "dumb",
+        "trans": [
+            "adj. 哑的，无说话能力的；不说话的，无声音的"
+        ],
+        "usphone": "[dʌm]",
+        "ukphone": "[dʌm]"
+    },
+    {
+        "name": "organizational",
+        "trans": [
+            "adj. 组织的；编制的"
+        ],
+        "usphone": "[ˌɔːrɡənəˈzeɪʃənl]",
+        "ukphone": "[ˌɔːɡənaɪˈzeɪʃənl]"
+    },
+    {
+        "name": "spouse",
+        "trans": [
+            "n. 配偶"
+        ],
+        "usphone": "[spaʊsˌspaʊz]",
+        "ukphone": "[spaʊs]"
+    },
+    {
+        "name": "proposition",
+        "trans": [
+            "n. [数] 命题；提议；主题；议题"
+        ],
+        "usphone": "[ˌprɑːpəˈzɪʃn]",
+        "ukphone": "[ˌprɒpəˈzɪʃ(ə)n]"
+    },
+    {
+        "name": "influential",
+        "trans": [
+            "adj. 有影响的；有势力的"
+        ],
+        "usphone": "[ˌɪnfluˈenʃl]",
+        "ukphone": "[ˌɪnfluˈenʃl]"
+    },
+    {
+        "name": "swing",
+        "trans": [
+            "n. 摇摆；摆动；秋千；音律；涨落"
+        ],
+        "usphone": "[swɪŋ]",
+        "ukphone": "[swɪŋ]"
+    },
+    {
+        "name": "discrimination",
+        "trans": [
+            "n. 歧视；区别，辨别；识别力"
+        ],
+        "usphone": "[dɪˌskrɪmɪˈneɪʃn]",
+        "ukphone": "[dɪˌskrɪmɪˈneɪʃn]"
+    },
+    {
+        "name": "layout",
+        "trans": [
+            "n. 布局；设计；安排；陈列"
+        ],
+        "usphone": "[ˈleɪaʊt]",
+        "ukphone": "[ˈleɪaʊt]"
+    },
+    {
+        "name": "cooperate",
+        "trans": [
+            "vi. 合作，配合；协力"
+        ],
+        "usphone": "[koʊˈɑːpəreɪt]",
+        "ukphone": "[kəʊˈɒpəreɪt]"
+    },
+    {
+        "name": "thrilled",
+        "trans": [
+            "adj. 非常兴奋的；极为激动的"
+        ],
+        "usphone": "[θrɪld]",
+        "ukphone": "[θrɪld]"
+    },
+    {
+        "name": "residence",
+        "trans": [
+            "n. 住宅，住处；居住"
+        ],
+        "usphone": "[ˈrezɪdəns]",
+        "ukphone": "[ˈrezɪdəns]"
+    },
+    {
+        "name": "erect",
+        "trans": [
+            "vt. 使竖立；建造；安装"
+        ],
+        "usphone": "[ɪˈrekt]",
+        "ukphone": "[ɪˈrekt]"
+    },
+    {
+        "name": "plug",
+        "trans": [
+            "n. 插头；塞子；栓"
+        ],
+        "usphone": "[plʌɡ]",
+        "ukphone": "[plʌɡ]"
+    },
+    {
+        "name": "triumph",
+        "trans": [
+            "n. 胜利，凯旋；欢欣"
+        ],
+        "usphone": "[ˈtraɪʌmf]",
+        "ukphone": "[ˈtraɪʌmf]"
+    },
+    {
+        "name": "superior",
+        "trans": [
+            "n. 上级，长官；优胜者，高手；长者"
+        ],
+        "usphone": "[suːˈpɪriər]",
+        "ukphone": "[suːˈpɪəriə(r)]"
+    },
+    {
+        "name": "idiot",
+        "trans": [
+            "n. 笨蛋，傻瓜；白痴"
+        ],
+        "usphone": "[ˈɪdiət]",
+        "ukphone": "[ˈɪdiət]"
+    },
+    {
+        "name": "albeit",
+        "trans": [
+            "conj. 虽然；即使"
+        ],
+        "usphone": "[ˌɔːlˈbiːɪt]",
+        "ukphone": "[ˌɔːlˈbiːɪt]"
+    },
+    {
+        "name": "hostage",
+        "trans": [
+            "n. 人质；抵押品"
+        ],
+        "usphone": "[ˈhɑːstɪdʒ]",
+        "ukphone": "[ˈhɒstɪdʒ]"
+    },
+    {
+        "name": "breakdown",
+        "trans": [
+            "n. 故障；崩溃；分解；分类；衰弱；跺脚曳步舞"
+        ],
+        "usphone": "[ˈbreɪkdaʊn]",
+        "ukphone": "[ˈbreɪkdaʊn]"
+    },
+    {
+        "name": "bench",
+        "trans": [
+            "n. 长凳；工作台；替补队员"
+        ],
+        "usphone": "[bentʃ]",
+        "ukphone": "[bentʃ]"
+    },
+    {
+        "name": "generic",
+        "trans": [
+            "adj. 类的；一般的；属的；非商标的"
+        ],
+        "usphone": "[dʒəˈnerɪk]",
+        "ukphone": "[dʒəˈnerɪk]"
+    },
+    {
+        "name": "subtle",
+        "trans": [
+            "adj. 微妙的；精细的；敏感的；狡猾的；稀薄的"
+        ],
+        "usphone": "[ˈsʌtl]",
+        "ukphone": "[ˈsʌt(ə)l]"
+    },
+    {
+        "name": "morality",
+        "trans": [
+            "n. 道德；品行，美德"
+        ],
+        "usphone": "[məˈræləti]",
+        "ukphone": "[məˈræləti]"
+    },
+    {
+        "name": "prestigious",
+        "trans": [
+            "adj. 有名望的；享有声望的"
+        ],
+        "usphone": "[preˈstiːdʒəs]",
+        "ukphone": "[preˈstɪdʒəs]"
+    },
+    {
+        "name": "endeavour",
+        "trans": [
+            "n. 尽力，竭力"
+        ],
+        "usphone": "[ɪnˈdevər]",
+        "ukphone": "[ɪnˈdevə(r)]"
+    },
+    {
+        "name": "hail",
+        "trans": [
+            "n. 冰雹；致敬；招呼；一阵"
+        ],
+        "usphone": "[heɪl]",
+        "ukphone": "[heɪl]"
+    },
+    {
+        "name": "sketch",
+        "trans": [
+            "n. 素描；略图；梗概"
+        ],
+        "usphone": "[sketʃ]",
+        "ukphone": "[sketʃ]"
+    },
+    {
+        "name": "screw",
+        "trans": [
+            "n. 螺旋；螺丝钉；吝啬鬼"
+        ],
+        "usphone": "[skruː]",
+        "ukphone": "[skruː]"
+    },
+    {
+        "name": "intent",
+        "trans": [
+            "n. 意图；目的；含义"
+        ],
+        "usphone": "[ɪnˈtent]",
+        "ukphone": "[ɪnˈtent]"
+    },
+    {
+        "name": "transparency",
+        "trans": [
+            "n. 透明，透明度；幻灯片；有图案的玻璃"
+        ],
+        "usphone": "[trænsˈpærənsi]",
+        "ukphone": "[trænsˈpærənsi]"
+    },
+    {
+        "name": "opt",
+        "trans": [
+            "vi. 选择"
+        ],
+        "usphone": "[ɑːpt]",
+        "ukphone": "[ɒpt]"
+    },
+    {
+        "name": "assert",
+        "trans": [
+            "vt. 维护，坚持；断言；主张；声称"
+        ],
+        "usphone": "[əˈsɜːrt]",
+        "ukphone": "[əˈsɜːt]"
+    },
+    {
+        "name": "buck",
+        "trans": [
+            "n. （美）钱，元；雄鹿；纨绔子弟；年轻的印第安人或黑人"
+        ],
+        "usphone": "[bʌk]",
+        "ukphone": "[bʌk]"
+    },
+    {
+        "name": "stability",
+        "trans": [
+            "n. 稳定性；坚定，恒心"
+        ],
+        "usphone": "[stəˈbɪləti]",
+        "ukphone": "[stəˈbɪləti]"
+    },
+    {
+        "name": "administrative",
+        "trans": [
+            "adj. 管理的，行政的"
+        ],
+        "usphone": "[ədˈmɪnɪstreɪtɪv]",
+        "ukphone": "[ədˈmɪnɪstrətɪv]"
+    },
+    {
+        "name": "directory",
+        "trans": [
+            "n. [计] 目录；工商名录；姓名地址录"
+        ],
+        "usphone": "[dəˈrektəri; daɪˈrektəri]",
+        "ukphone": "[dəˈrektəri; daɪˈrektəri]"
+    },
+    {
+        "name": "capitalism",
+        "trans": [
+            "n. 资本主义"
+        ],
+        "usphone": "[ˈkæpɪtəlɪzəm]",
+        "ukphone": "[ˈkæpɪtəlɪzəm]"
+    },
+    {
+        "name": "subsidy",
+        "trans": [
+            "n. 补贴；津贴；补助金"
+        ],
+        "usphone": "[ˈsʌbsədi]",
+        "ukphone": "[ˈsʌbsədi]"
+    },
+    {
+        "name": "prosecutor",
+        "trans": [
+            "n. 检察官；公诉人；[法] 起诉人；实行者"
+        ],
+        "usphone": "[ˈprɑːsɪkjuːtər]",
+        "ukphone": "[ˈprɒsɪkjuːtə(r)]"
+    },
+    {
+        "name": "sake",
+        "trans": [
+            "n. 目的；利益；理由；日本米酒"
+        ],
+        "usphone": "[seɪk; ˈsɑːki]",
+        "ukphone": "[seɪk]"
+    },
+    {
+        "name": "peasant",
+        "trans": [
+            "n. 农民；乡下人"
+        ],
+        "usphone": "[ˈpeznt]",
+        "ukphone": "[ˈpez(ə)nt]"
+    },
+    {
+        "name": "investigator",
+        "trans": [
+            "n. 研究者；调查者；侦查员"
+        ],
+        "usphone": "[ɪnˈvestɪɡeɪtər]",
+        "ukphone": "[ɪnˈvestɪɡeɪtə(r)]"
+    },
+    {
+        "name": "poll",
+        "trans": [
+            "n. 投票；民意测验；投票数；投票所"
+        ],
+        "usphone": "[poʊl]",
+        "ukphone": "[pəʊl]"
+    },
+    {
+        "name": "vow",
+        "trans": [
+            "n. 发誓；誓言；许愿"
+        ],
+        "usphone": "[vaʊ]",
+        "ukphone": "[vaʊ]"
+    },
+    {
+        "name": "sacrifice",
+        "trans": [
+            "n. 牺牲；祭品；供奉"
+        ],
+        "usphone": "[ˈsækrɪfaɪs]",
+        "ukphone": "[ˈsækrɪfaɪs]"
+    },
+    {
+        "name": "pastor",
+        "trans": [
+            "n. 牧师"
+        ],
+        "usphone": "[ˈpæstər]",
+        "ukphone": "[ˈpɑːstə(r)]"
+    },
+    {
+        "name": "likelihood",
+        "trans": [
+            "n. 可能性，可能"
+        ],
+        "usphone": "[ˈlaɪklihʊd]",
+        "ukphone": "[ˈlaɪklihʊd]"
+    },
+    {
+        "name": "dedicated",
+        "trans": [
+            "adj. 专用的；专注的；献身的"
+        ],
+        "usphone": "[ˈdedɪkeɪtɪd]",
+        "ukphone": "[ˈdedɪkeɪtɪd]"
+    },
+    {
+        "name": "grip",
+        "trans": [
+            "n. 紧握；柄；支配；握拍方式；拍柄绷带"
+        ],
+        "usphone": "[ɡrɪp]",
+        "ukphone": "[ɡrɪp]"
+    },
+    {
+        "name": "query",
+        "trans": [
+            "n. 疑问，质问；疑问号 ；[计] 查询"
+        ],
+        "usphone": "[ˈkwɪri]",
+        "ukphone": "[ˈkwɪəri]"
+    },
+    {
+        "name": "rejection",
+        "trans": [
+            "n. 抛弃；拒绝；被抛弃的东西；盖帽"
+        ],
+        "usphone": "[rɪˈdʒekʃn]",
+        "ukphone": "[rɪˈdʒekʃn]"
+    },
+    {
+        "name": "warfare",
+        "trans": [
+            "n. 战争；冲突"
+        ],
+        "usphone": "[ˈwɔːrfer]",
+        "ukphone": "[ˈwɔːfeə(r)]"
+    },
+    {
+        "name": "supervisor",
+        "trans": [
+            "n. 监督人，[管理] 管理人；检查员"
+        ],
+        "usphone": "[ˈsuːpərvaɪzər]",
+        "ukphone": "[ˈsuːpəvaɪzə(r)]"
+    },
+    {
+        "name": "discard",
+        "trans": [
+            "n. 抛弃；被丢弃的东西或人"
+        ],
+        "usphone": "[dɪˈskɑːrd]",
+        "ukphone": "[dɪˈskɑːd]"
+    },
+    {
+        "name": "autonomy",
+        "trans": [
+            "n. 自治，自治权"
+        ],
+        "usphone": "[ɔːˈtɑːnəmi]",
+        "ukphone": "[ɔːˈtɒnəmi]"
+    },
+    {
+        "name": "calculation",
+        "trans": [
+            "n. 计算；估计；计算的结果；深思熟虑"
+        ],
+        "usphone": "[ˌkælkjuˈleɪʃn]",
+        "ukphone": "[ˌkælkjuˈleɪʃn]"
+    },
+    {
+        "name": "tighten",
+        "trans": [
+            "vt. 变紧；使变紧"
+        ],
+        "usphone": "[ˈtaɪt(ə)n]",
+        "ukphone": "[ˈtaɪt(ə)n]"
+    },
+    {
+        "name": "exert",
+        "trans": [
+            "vt. 运用，发挥；施以影响"
+        ],
+        "usphone": "[ɪɡˈzɜːrt]",
+        "ukphone": "[ɪɡˈzɜːt]"
+    },
+    {
+        "name": "sue",
+        "trans": [
+            "vt. 控告；请求"
+        ],
+        "usphone": "[suː]",
+        "ukphone": "[suː]"
+    },
+    {
+        "name": "complement",
+        "trans": [
+            "n. 补语；余角；补足物"
+        ],
+        "usphone": "[ˈkɑːmplɪment; ˈkɑːmplɪmənt]",
+        "ukphone": "[ˈkɒmplɪment]"
+    },
+    {
+        "name": "namely",
+        "trans": [
+            "adv. 也就是；即是；换句话说"
+        ],
+        "usphone": "[ˈneɪmli]",
+        "ukphone": "[ˈneɪmli]"
+    },
+    {
+        "name": "capability",
+        "trans": [
+            "n. 才能，能力；性能，容量"
+        ],
+        "usphone": "[ˌkeɪpəˈbɪləti]",
+        "ukphone": "[ˌkeɪpəˈbɪləti]"
+    },
+    {
+        "name": "deputy",
+        "trans": [
+            "n. 代理人，代表"
+        ],
+        "usphone": "[ˈdepjuti]",
+        "ukphone": "[ˈdepjuti]"
+    },
+    {
+        "name": "denial",
+        "trans": [
+            "n. 否认；拒绝；节制；背弃"
+        ],
+        "usphone": "[dɪˈnaɪəl]",
+        "ukphone": "[dɪˈnaɪəl]"
+    },
+    {
+        "name": "elaborate",
+        "trans": [
+            "adj. 精心制作的；详尽的；煞费苦心的"
+        ],
+        "usphone": "[ɪˈlæbərət; ɪˈlæbəreɪt; ɪˈlæbərɪt]",
+        "ukphone": "[ɪˈlæbərət]"
+    },
+    {
+        "name": "rental",
+        "trans": [
+            "n. 租金收入，租金；租赁"
+        ],
+        "usphone": "[ˈrentl]",
+        "ukphone": "[ˈrentl]"
+    },
+    {
+        "name": "outing",
+        "trans": [
+            "n. 远足；短途旅游；体育比赛"
+        ],
+        "usphone": "[ˈaʊtɪŋ]",
+        "ukphone": "[ˈaʊtɪŋ]"
+    },
+    {
+        "name": "feminist",
+        "trans": [
+            "n. 女权主义者"
+        ],
+        "usphone": "[ˈfemənɪst]",
+        "ukphone": "[ˈfemənɪst]"
+    },
+    {
+        "name": "virtue",
+        "trans": [
+            "n. 美德；优点；贞操；功效"
+        ],
+        "usphone": "[ˈvɜːrtʃuː]",
+        "ukphone": "[ˈvɜːtʃuː]"
+    },
+    {
+        "name": "communist",
+        "trans": [
+            "n. 共产党员；共产主义者"
+        ],
+        "usphone": "[ˈkɑːmjənɪst]",
+        "ukphone": "[ˈkɒmjənɪst]"
+    },
+    {
+        "name": "cemetery",
+        "trans": [
+            "n. 墓地；公墓"
+        ],
+        "usphone": "[ˈseməteri]",
+        "ukphone": "[ˈsemətri]"
+    },
+    {
+        "name": "cynical",
+        "trans": [
+            "adj. 愤世嫉俗的；冷嘲的"
+        ],
+        "usphone": "[ˈsɪnɪkl]",
+        "ukphone": "[ˈsɪnɪk(ə)l]"
+    },
+    {
+        "name": "retreat",
+        "trans": [
+            "n. 撤退；休息寓所；撤退"
+        ],
+        "usphone": "[rɪˈtriːt]",
+        "ukphone": "[rɪˈtriːt]"
+    },
+    {
+        "name": "accountability",
+        "trans": [
+            "n. 有义务；有责任；可说明性"
+        ],
+        "usphone": "[əˌkaʊntəˈbɪləti]",
+        "ukphone": "[əˌkaʊntəˈbɪləti]"
+    },
+    {
+        "name": "allegedly",
+        "trans": [
+            "adv. 依其申述；据说，据称"
+        ],
+        "usphone": "[əˈledʒɪdli]",
+        "ukphone": "[əˈledʒɪdli]"
+    },
+    {
+        "name": "carriage",
+        "trans": [
+            "n. 运输；运费；四轮马车；举止；客车厢"
+        ],
+        "usphone": "[ˈkærɪdʒ]",
+        "ukphone": "[ˈkærɪdʒ]"
+    },
+    {
+        "name": "dam",
+        "trans": [
+            "n. [水利] 水坝；障碍"
+        ],
+        "usphone": "[dæm]",
+        "ukphone": "[dæm]"
+    },
+    {
+        "name": "accelerate",
+        "trans": [
+            "vt. 使……加快；使……增速"
+        ],
+        "usphone": "[əkˈseləreɪt]",
+        "ukphone": "[əkˈseləreɪt]"
+    },
+    {
+        "name": "mercy",
+        "trans": [
+            "n. 仁慈，宽容；怜悯；幸运；善行"
+        ],
+        "usphone": "[ˈmɜːrsi]",
+        "ukphone": "[ˈmɜːsi]"
+    },
+    {
+        "name": "interface",
+        "trans": [
+            "n. 界面；<计>接口；交界面"
+        ],
+        "usphone": "[ˈɪntərfeɪs]",
+        "ukphone": "[ˈɪntəfeɪs]"
+    },
+    {
+        "name": "conceal",
+        "trans": [
+            "vt. 隐藏；隐瞒"
+        ],
+        "usphone": "[kənˈsiːl]",
+        "ukphone": "[kənˈsiːl]"
+    },
+    {
+        "name": "scrutiny",
+        "trans": [
+            "n. 详细审查；监视；细看；选票复查"
+        ],
+        "usphone": "[ˈskruːtəni]",
+        "ukphone": "[ˈskruːtəni]"
+    },
+    {
+        "name": "collective",
+        "trans": [
+            "n. 集团；集合体；集合名词"
+        ],
+        "usphone": "[kəˈlektɪv]",
+        "ukphone": "[kəˈlektɪv]"
+    },
+    {
+        "name": "republic",
+        "trans": [
+            "n. 共和国；共和政体"
+        ],
+        "usphone": "[rɪˈpʌblɪk]",
+        "ukphone": "[rɪˈpʌblɪk]"
+    },
+    {
+        "name": "hint",
+        "trans": [
+            "n. 暗示；线索"
+        ],
+        "usphone": "[hɪnt]",
+        "ukphone": "[hɪnt]"
+    },
+    {
+        "name": "configuration",
+        "trans": [
+            "n. 配置；结构；外形"
+        ],
+        "usphone": "[kənˌfɪɡjəˈreɪʃn]",
+        "ukphone": "[kənˌfɪɡəˈreɪʃn]"
+    },
+    {
+        "name": "enterprise",
+        "trans": [
+            "n. 企业；事业；进取心；事业心"
+        ],
+        "usphone": "[ˈentərpraɪz]",
+        "ukphone": "[ˈentəpraɪz]"
+    },
+    {
+        "name": "prevalence",
+        "trans": [
+            "n. 流行；普遍；广泛"
+        ],
+        "usphone": "[ˈprevələns]",
+        "ukphone": "[ˈprevələns]"
+    },
+    {
+        "name": "adoption",
+        "trans": [
+            "n. 采用；收养；接受"
+        ],
+        "usphone": "[əˈdɑːpʃn]",
+        "ukphone": "[əˈdɒpʃn]"
+    },
+    {
+        "name": "doctrine",
+        "trans": [
+            "n. 主义；学说；教义；信条"
+        ],
+        "usphone": "[ˈdɑːktrɪn]",
+        "ukphone": "[ˈdɒktrɪn]"
+    },
+    {
+        "name": "sphere",
+        "trans": [
+            "n. 范围；球体"
+        ],
+        "usphone": "[sfɪr]",
+        "ukphone": "[sfɪə(r)]"
+    },
+    {
+        "name": "descend",
+        "trans": [
+            "vi. 下降；下去；下来；遗传；屈尊"
+        ],
+        "usphone": "[dɪˈsend]",
+        "ukphone": "[dɪˈsend]"
+    },
+    {
+        "name": "boast",
+        "trans": [
+            "n. 自夸；值得夸耀的事物，引以为荣的事物"
+        ],
+        "usphone": "[boʊst]",
+        "ukphone": "[bəʊst]"
+    },
+    {
+        "name": "suicide",
+        "trans": [
+            "n. 自杀；自杀行为；自杀者"
+        ],
+        "usphone": "[ˈsuːɪsaɪd]",
+        "ukphone": "[ˈsuːɪsaɪd]"
+    },
+    {
+        "name": "grin",
+        "trans": [
+            "n. 露齿笑"
+        ],
+        "usphone": "[ɡrɪn]",
+        "ukphone": "[ɡrɪn]"
+    },
+    {
+        "name": "institutional",
+        "trans": [
+            "adj. 制度的；制度上的"
+        ],
+        "usphone": "[ˌɪnstɪˈtuːʃənl]",
+        "ukphone": "[ˌɪnstɪˈtjuːʃənl]"
+    },
+    {
+        "name": "revelation",
+        "trans": [
+            "n. 启示；揭露；出乎意料的事；被揭露的真相"
+        ],
+        "usphone": "[ˌrevəˈleɪʃn]",
+        "ukphone": "[ˌrevəˈleɪʃ(ə)n]"
+    },
+    {
+        "name": "practitioner",
+        "trans": [
+            "n. 开业者，从业者，执业医生"
+        ],
+        "usphone": "[prækˈtɪʃənər]",
+        "ukphone": "[prækˈtɪʃənə(r)]"
+    },
+    {
+        "name": "nonsense",
+        "trans": [
+            "n. 胡说；废话"
+        ],
+        "usphone": "[ˈnɑːnsens; ˈnɑːnsns]",
+        "ukphone": "[ˈnɒns(ə)ns]"
+    },
+    {
+        "name": "substitute",
+        "trans": [
+            "n. 代用品；代替者"
+        ],
+        "usphone": "[ˈsʌbstɪtuːt]",
+        "ukphone": "[ˈsʌbstɪtjuːt]"
+    },
+    {
+        "name": "detention",
+        "trans": [
+            "n. 拘留；延迟；挽留"
+        ],
+        "usphone": "[dɪˈtenʃn]",
+        "ukphone": "[dɪˈtenʃn]"
+    },
+    {
+        "name": "aesthetic",
+        "trans": [
+            "adj. 美的；美学的；审美的，具有审美趣味的"
+        ],
+        "usphone": "[esˈθetɪk]",
+        "ukphone": "[iːsˈθetɪk]"
+    },
+    {
+        "name": "specimen",
+        "trans": [
+            "n. 样品，样本；标本"
+        ],
+        "usphone": "[ˈspesɪmən]",
+        "ukphone": "[ˈspesɪmən]"
+    },
+    {
+        "name": "testify",
+        "trans": [
+            "vi. 作证；证明"
+        ],
+        "usphone": "[ˈtestɪfaɪ]",
+        "ukphone": "[ˈtestɪfaɪ]"
+    },
+    {
+        "name": "alien",
+        "trans": [
+            "n. 外国人，外侨；外星人"
+        ],
+        "usphone": "[ˈeɪliən]",
+        "ukphone": "[ˈeɪliən]"
+    },
+    {
+        "name": "prosecute",
+        "trans": [
+            "vt. 检举；贯彻；从事；依法进行"
+        ],
+        "usphone": "[ˈprɑːsɪkjuːt]",
+        "ukphone": "[ˈprɒsɪkjuːt]"
+    },
+    {
+        "name": "reassure",
+        "trans": [
+            "vt. 使…安心，使消除疑虑"
+        ],
+        "usphone": "[ˌriːəˈʃʊr]",
+        "ukphone": "[ˌriːəˈʃʊə(r)]"
+    },
+    {
+        "name": "manipulation",
+        "trans": [
+            "n. 操纵；操作；处理；篡改"
+        ],
+        "usphone": "[məˌnɪpjuˈleɪʃn]",
+        "ukphone": "[məˌnɪpjuˈleɪʃn]"
+    },
+    {
+        "name": "quota",
+        "trans": [
+            "n. 配额；定额；限额"
+        ],
+        "usphone": "[ˈkwoʊtə]",
+        "ukphone": "[ˈkwəʊtə]"
+    },
+    {
+        "name": "deem",
+        "trans": [
+            "vt. 认为，视作；相信"
+        ],
+        "usphone": "[diːm]",
+        "ukphone": "[diːm]"
+    },
+    {
+        "name": "combat",
+        "trans": [
+            "n. 战斗；争论"
+        ],
+        "usphone": "[ˈkɑːmbæt]",
+        "ukphone": "[ˈkɒmbæt]"
+    },
+    {
+        "name": "imagery",
+        "trans": [
+            "n. 像；意象；比喻；形象化"
+        ],
+        "usphone": "[ˈɪmɪdʒəri]",
+        "ukphone": "[ˈɪmɪdʒəri]"
+    },
+    {
+        "name": "alert",
+        "trans": [
+            "n. 警戒，警惕；警报"
+        ],
+        "usphone": "[əˈlɜːrt]",
+        "ukphone": "[əˈlɜːt]"
+    },
+    {
+        "name": "competent",
+        "trans": [
+            "adj. 胜任的；有能力的；能干的；足够的"
+        ],
+        "usphone": "[ˈkɑːmpɪtənt]",
+        "ukphone": "[ˈkɒmpɪtənt]"
+    },
+    {
+        "name": "blend",
+        "trans": [
+            "n. 混合；掺合物"
+        ],
+        "usphone": "[blend]",
+        "ukphone": "[blend]"
+    },
+    {
+        "name": "ironic",
+        "trans": [
+            "adj. 讽刺的；反话的"
+        ],
+        "usphone": "[aɪˈrɑːnɪk]",
+        "ukphone": "[aɪˈrɒnɪk]"
+    },
+    {
+        "name": "cultivate",
+        "trans": [
+            "vt. 培养；陶冶；耕作"
+        ],
+        "usphone": "[ˈkʌltɪveɪt]",
+        "ukphone": "[ˈkʌltɪveɪt]"
+    },
+    {
+        "name": "merely",
+        "trans": [
+            "adv. 仅仅，只不过；只是"
+        ],
+        "usphone": "[ˈmɪrli]",
+        "ukphone": "[ˈmɪəli]"
+    },
+    {
+        "name": "faction",
+        "trans": [
+            "n. 派别；内讧；小集团；纪实小说"
+        ],
+        "usphone": "[ˈfækʃn]",
+        "ukphone": "[ˈfækʃ(ə)n]"
+    },
+    {
+        "name": "privilege",
+        "trans": [
+            "n. 特权；优待"
+        ],
+        "usphone": "[ˈprɪvəlɪdʒ]",
+        "ukphone": "[ˈprɪvəlɪdʒ]"
+    },
+    {
+        "name": "authentic",
+        "trans": [
+            "adj. 真正的，真实的；可信的"
+        ],
+        "usphone": "[ɔːˈθentɪk]",
+        "ukphone": "[ɔːˈθentɪk]"
+    },
+    {
+        "name": "eternal",
+        "trans": [
+            "adj. 永恒的；不朽的"
+        ],
+        "usphone": "[ɪˈtɜːrnl]",
+        "ukphone": "[ɪˈtɜːn(ə)l]"
+    },
+    {
+        "name": "handful",
+        "trans": [
+            "n. 少数；一把；棘手事"
+        ],
+        "usphone": "[ˈhændfʊl]",
+        "ukphone": "[ˈhændfʊl]"
+    },
+    {
+        "name": "momentum",
+        "trans": [
+            "n. 势头；[物] 动量；动力；冲力"
+        ],
+        "usphone": "[moʊˈmentəm]",
+        "ukphone": "[məˈmentəm]"
+    },
+    {
+        "name": "lad",
+        "trans": [
+            "n. 少年，小伙子；家伙"
+        ],
+        "usphone": "[læd]",
+        "ukphone": "[læd]"
+    },
+    {
+        "name": "efficiency",
+        "trans": [
+            "n. 效率；效能；功效"
+        ],
+        "usphone": "[ɪˈfɪʃnsi]",
+        "ukphone": "[ɪˈfɪʃ(ə)nsi]"
+    },
+    {
+        "name": "establishment",
+        "trans": [
+            "n. 确立，制定；公司；设施"
+        ],
+        "usphone": "[ɪˈstæblɪʃmənt]",
+        "ukphone": "[ɪˈstæblɪʃmənt]"
+    },
+    {
+        "name": "simulate",
+        "trans": [
+            "adj. 模仿的；假装的"
+        ],
+        "usphone": "[ˈsɪmjuleɪt]",
+        "ukphone": "[ˈsɪmjuleɪt]"
+    },
+    {
+        "name": "sigh",
+        "trans": [
+            "n. 叹息，叹气"
+        ],
+        "usphone": "[saɪ]",
+        "ukphone": "[saɪ]"
+    },
+    {
+        "name": "subscriber",
+        "trans": [
+            "n. 订户；签署者；捐献者"
+        ],
+        "usphone": "[səbˈskraɪbər]",
+        "ukphone": "[səbˈskraɪbə(r)]"
+    },
+    {
+        "name": "vacuum",
+        "trans": [
+            "n. 真空；空间；真空吸尘器"
+        ],
+        "usphone": "[ˈvækjuːm]",
+        "ukphone": "[ˈvækjuːm]"
+    },
+    {
+        "name": "theoretical",
+        "trans": [
+            "adj. 理论的；理论上的；假设的；推理的"
+        ],
+        "usphone": "[ˌθiːəˈretɪk(ə)l]",
+        "ukphone": "[ˌθɪəˈretɪkl]"
+    },
+    {
+        "name": "commissioner",
+        "trans": [
+            "n. 理事；委员；行政长官；总裁"
+        ],
+        "usphone": "[kəˈmɪʃənər]",
+        "ukphone": "[kəˈmɪʃənə(r)]"
+    },
+    {
+        "name": "rip",
+        "trans": [
+            "n. 裂口，裂缝"
+        ],
+        "usphone": "[rɪp]",
+        "ukphone": "[rɪp]"
+    },
+    {
+        "name": "submission",
+        "trans": [
+            "n. 投降；提交（物）；服从；（向法官提出的）意见；谦恭"
+        ],
+        "usphone": "[səbˈmɪʃn]",
+        "ukphone": "[səbˈmɪʃn]"
+    },
+    {
+        "name": "cautious",
+        "trans": [
+            "adj. 谨慎的；十分小心的"
+        ],
+        "usphone": "[ˈkɔːʃəs]",
+        "ukphone": "[ˈkɔːʃəs]"
+    },
+    {
+        "name": "warrant",
+        "trans": [
+            "n. 根据；证明；正当理由；委任状"
+        ],
+        "usphone": "[ˈwɔːrənt]",
+        "ukphone": "[ˈwɒrənt]"
+    },
+    {
+        "name": "seize",
+        "trans": [
+            "vt. 抓住；夺取；理解；逮捕"
+        ],
+        "usphone": "[siːz]",
+        "ukphone": "[siːz]"
+    },
+    {
+        "name": "counselling",
+        "trans": [
+            "n. 辅导；建议"
+        ],
+        "usphone": "[ˈkaʊnsəlɪŋ]",
+        "ukphone": "[ˈkaʊnsəlɪŋ]"
+    },
+    {
+        "name": "stark",
+        "trans": [
+            "adj. 完全的；荒凉的；刻板的；光秃秃的；朴实的"
+        ],
+        "usphone": "[stɑːrk]",
+        "ukphone": "[stɑːk]"
+    },
+    {
+        "name": "faculty",
+        "trans": [
+            "n. 科，系；能力；全体教员"
+        ],
+        "usphone": "[ˈfæklti]",
+        "ukphone": "[ˈfæk(ə)lti]"
+    },
+    {
+        "name": "harvest",
+        "trans": [
+            "n. 收获；产量；结果"
+        ],
+        "usphone": "[ˈhɑːrvɪst]",
+        "ukphone": "[ˈhɑːvɪst]"
+    },
+    {
+        "name": "composition",
+        "trans": [
+            "n. 作文，作曲，作品；[材] 构成；合成物；成分"
+        ],
+        "usphone": "[ˌkɑːmpəˈzɪʃn]",
+        "ukphone": "[ˌkɒmpəˈzɪʃ(ə)n]"
+    },
+    {
+        "name": "liberation",
+        "trans": [
+            "n. 释放，解放"
+        ],
+        "usphone": "[ˌlɪbəˈreɪʃn]",
+        "ukphone": "[ˌlɪbəˈreɪʃ(ə)n]"
+    },
+    {
+        "name": "suppress",
+        "trans": [
+            "vt. 抑制；镇压；废止"
+        ],
+        "usphone": "[səˈpres]",
+        "ukphone": "[səˈpres]"
+    },
+    {
+        "name": "irony",
+        "trans": [
+            "n. 讽刺；反语；具有讽刺意味的事"
+        ],
+        "usphone": "[ˈaɪrəni]",
+        "ukphone": "[ˈaɪrəni]"
+    },
+    {
+        "name": "ally",
+        "trans": [
+            "n. 同盟国；伙伴；同盟者；助手"
+        ],
+        "usphone": "[ˈælaɪ]",
+        "ukphone": "[ˈælaɪ]"
+    },
+    {
+        "name": "rally",
+        "trans": [
+            "n. 集会；回复；公路赛车会"
+        ],
+        "usphone": "[ˈræli]",
+        "ukphone": "[ˈræli]"
+    },
+    {
+        "name": "horn",
+        "trans": [
+            "n. 喇叭，号角；角"
+        ],
+        "usphone": "[hɔːrn]",
+        "ukphone": "[hɔːn]"
+    },
+    {
+        "name": "inclusion",
+        "trans": [
+            "n. 包含；内含物"
+        ],
+        "usphone": "[ɪnˈkluːʒn]",
+        "ukphone": "[ɪnˈkluːʒn]"
+    },
+    {
+        "name": "reflection",
+        "trans": [
+            "n. 反射；沉思；映象"
+        ],
+        "usphone": "[rɪˈflekʃn]",
+        "ukphone": "[rɪˈflekʃn]"
+    },
+    {
+        "name": "nomination",
+        "trans": [
+            "n. 任命，提名；提名权"
+        ],
+        "usphone": "[ˌnɑːmɪˈneɪʃn]",
+        "ukphone": "[ˌnɒmɪˈneɪʃn]"
+    },
+    {
+        "name": "citizenship",
+        "trans": [
+            "n. [法] 公民身份，公民资格；国籍；公民权"
+        ],
+        "usphone": "[ˈsɪtɪzənʃɪp]",
+        "ukphone": "[ˈsɪtɪzənʃɪp]"
+    },
+    {
+        "name": "compassion",
+        "trans": [
+            "n. 同情；怜悯"
+        ],
+        "usphone": "[kəmˈpæʃn]",
+        "ukphone": "[kəmˈpæʃn]"
+    },
+    {
+        "name": "advocate",
+        "trans": [
+            "n. 提倡者；支持者；律师"
+        ],
+        "usphone": "[ˈædvəkeɪt]",
+        "ukphone": "[ˈædvəkeɪt]"
+    },
+    {
+        "name": "appetite",
+        "trans": [
+            "n. 食欲；嗜好"
+        ],
+        "usphone": "[ˈæpɪtaɪt]",
+        "ukphone": "[ˈæpɪtaɪt]"
     },
     {
         "name": "rehabilitation",
@@ -7848,2364 +7768,20 @@
         "ukphone": "[reɪn]"
     },
     {
-        "name": "rejection",
+        "name": "deploy",
         "trans": [
-            "n. 抛弃；拒绝；被抛弃的东西；盖帽"
+            "n. 部署"
         ],
-        "usphone": "[rɪˈdʒekʃn]",
-        "ukphone": "[rɪˈdʒekʃn]"
+        "usphone": "[dɪˈplɔɪ]",
+        "ukphone": "[dɪˈplɔɪ]"
     },
     {
-        "name": "relevance",
+        "name": "loyalty",
         "trans": [
-            "n. 关联；适当；中肯"
+            "n. 忠诚；忠心；忠实；忠于…感情"
         ],
-        "usphone": "[ˈreləvəns]",
-        "ukphone": "[ˈreləvəns]"
-    },
-    {
-        "name": "reliability",
-        "trans": [
-            "n. 可靠性"
-        ],
-        "usphone": "[rɪˌlaɪəˈbɪləti]",
-        "ukphone": "[rɪˌlaɪəˈbɪləti]"
-    },
-    {
-        "name": "reluctant",
-        "trans": [
-            "adj. 不情愿的；勉强的；顽抗的"
-        ],
-        "usphone": "[rɪˈlʌktənt]",
-        "ukphone": "[rɪˈlʌktənt]"
-    },
-    {
-        "name": "remainder",
-        "trans": [
-            "n. [数] 余数，残余；剩余物；其余的人"
-        ],
-        "usphone": "[rɪˈmeɪndər]",
-        "ukphone": "[rɪˈmeɪndə(r)]"
-    },
-    {
-        "name": "remains",
-        "trans": [
-            "n. 残余；遗骸"
-        ],
-        "usphone": "[rɪˈmeɪnz]",
-        "ukphone": "[rɪˈmeɪnz]"
-    },
-    {
-        "name": "remedy",
-        "trans": [
-            "n. 补救；治疗；赔偿"
-        ],
-        "usphone": "[ˈremədi]",
-        "ukphone": "[ˈremədi]"
-    },
-    {
-        "name": "reminder",
-        "trans": [
-            "n. 暗示；提醒的人/物；催单"
-        ],
-        "usphone": "[rɪˈmaɪndər]",
-        "ukphone": "[rɪˈmaɪndə(r)]"
-    },
-    {
-        "name": "removal",
-        "trans": [
-            "n. 免职；移动；排除；搬迁"
-        ],
-        "usphone": "[rɪˈmuːvl]",
-        "ukphone": "[rɪˈmuːv(ə)l]"
-    },
-    {
-        "name": "render",
-        "trans": [
-            "n. 打底；交纳；粉刷"
-        ],
-        "usphone": "[ˈrendər]",
-        "ukphone": "[ˈrendə(r)]"
-    },
-    {
-        "name": "renew",
-        "trans": [
-            "vt. 使更新；续借；续费；复兴；重申"
-        ],
-        "usphone": "[rɪˈnuː]",
-        "ukphone": "[rɪˈnjuː]"
-    },
-    {
-        "name": "renowned",
-        "trans": [
-            "v. 使有声誉（renown的过去分词）"
-        ],
-        "usphone": "[rɪˈnaʊnd]",
-        "ukphone": "[rɪˈnaʊnd]"
-    },
-    {
-        "name": "rental",
-        "trans": [
-            "n. 租金收入，租金；租赁"
-        ],
-        "usphone": "[ˈrentl]",
-        "ukphone": "[ˈrentl]"
-    },
-    {
-        "name": "replacement",
-        "trans": [
-            "n. 更换；复位；代替者；补充兵员"
-        ],
-        "usphone": "[rɪˈpleɪsmənt]",
-        "ukphone": "[rɪˈpleɪsmənt]"
-    },
-    {
-        "name": "reportedly",
-        "trans": [
-            "adv. 据报道；据传闻"
-        ],
-        "usphone": "[rɪˈpɔːrtɪdli]",
-        "ukphone": "[rɪˈpɔːtɪdli]"
-    },
-    {
-        "name": "representation",
-        "trans": [
-            "n. 代表；表现；表示法；陈述"
-        ],
-        "usphone": "[ˌreprɪzenˈteɪʃn]",
-        "ukphone": "[ˌreprɪzenˈteɪʃn]"
-    },
-    {
-        "name": "reproduce",
-        "trans": [
-            "vt. 复制；再生；生殖；使…在脑海中重现"
-        ],
-        "usphone": "[ˌriːprəˈduːs]",
-        "ukphone": "[ˌriːprəˈdjuːs]"
-    },
-    {
-        "name": "reproduction",
-        "trans": [
-            "n. 繁殖，生殖；复制；复制品"
-        ],
-        "usphone": "[ˌriːprəˈdʌkʃn]",
-        "ukphone": "[ˌriːprəˈdʌkʃn]"
-    },
-    {
-        "name": "republic",
-        "trans": [
-            "n. 共和国；共和政体"
-        ],
-        "usphone": "[rɪˈpʌblɪk]",
-        "ukphone": "[rɪˈpʌblɪk]"
-    },
-    {
-        "name": "resemble",
-        "trans": [
-            "vt. 类似，像"
-        ],
-        "usphone": "[rɪˈzembl]",
-        "ukphone": "[rɪˈzemb(ə)l]"
-    },
-    {
-        "name": "reside",
-        "trans": [
-            "vi. 住，居住；属于"
-        ],
-        "usphone": "[rɪˈzaɪd]",
-        "ukphone": "[rɪˈzaɪd]"
-    },
-    {
-        "name": "residence",
-        "trans": [
-            "n. 住宅，住处；居住"
-        ],
-        "usphone": "[ˈrezɪdəns]",
-        "ukphone": "[ˈrezɪdəns]"
-    },
-    {
-        "name": "residential",
-        "trans": [
-            "adj. 住宅的；与居住有关的"
-        ],
-        "usphone": "[ˌrezɪˈdenʃ(ə)l]",
-        "ukphone": "[ˌrezɪˈdenʃ(ə)l]"
-    },
-    {
-        "name": "residue",
-        "trans": [
-            "n. 残渣；剩余；滤渣"
-        ],
-        "usphone": "[ˈrezɪduː]",
-        "ukphone": "[ˈrezɪdjuː]"
-    },
-    {
-        "name": "resignation",
-        "trans": [
-            "n. 辞职；放弃；辞职书；顺从"
-        ],
-        "usphone": "[ˌrezɪɡˈneɪʃn]",
-        "ukphone": "[ˌrezɪɡˈneɪʃn]"
-    },
-    {
-        "name": "resistance",
-        "trans": [
-            "n. 阻力；电阻；抵抗；反抗；抵抗力"
-        ],
-        "usphone": "[rɪˈzɪstəns]",
-        "ukphone": "[rɪˈzɪstəns]"
-    },
-    {
-        "name": "respective",
-        "trans": [
-            "adj. 分别的，各自的"
-        ],
-        "usphone": "[rɪˈspektɪv]",
-        "ukphone": "[rɪˈspektɪv]"
-    },
-    {
-        "name": "respectively",
-        "trans": [
-            "adv. 分别地；各自地，独自地"
-        ],
-        "usphone": "[rɪˈspektɪvli]",
-        "ukphone": "[rɪˈspektɪvli]"
-    },
-    {
-        "name": "restoration",
-        "trans": [
-            "n. 恢复；复位；王政复辟；归还"
-        ],
-        "usphone": "[ˌrestəˈreɪʃn]",
-        "ukphone": "[ˌrestəˈreɪʃn]"
-    },
-    {
-        "name": "restraint",
-        "trans": [
-            "n. 抑制，克制；约束"
-        ],
-        "usphone": "[rɪˈstreɪnt]",
-        "ukphone": "[rɪˈstreɪnt]"
-    },
-    {
-        "name": "resume",
-        "trans": [
-            "n. 摘要；[管理] 履历，简历"
-        ],
-        "usphone": "[rɪˈzuːm]",
-        "ukphone": "[rɪˈzjuːm]"
-    },
-    {
-        "name": "retreat",
-        "trans": [
-            "n. 撤退；休息寓所；撤退"
-        ],
-        "usphone": "[rɪˈtriːt]",
-        "ukphone": "[rɪˈtriːt]"
-    },
-    {
-        "name": "retrieve",
-        "trans": [
-            "n. [计] 检索；恢复，取回"
-        ],
-        "usphone": "[rɪˈtriːv]",
-        "ukphone": "[rɪˈtriːv]"
-    },
-    {
-        "name": "revelation",
-        "trans": [
-            "n. 启示；揭露；出乎意料的事；被揭露的真相"
-        ],
-        "usphone": "[ˌrevəˈleɪʃn]",
-        "ukphone": "[ˌrevəˈleɪʃ(ə)n]"
-    },
-    {
-        "name": "revenge",
-        "trans": [
-            "n. 报复；复仇"
-        ],
-        "usphone": "[rɪˈvendʒ]",
-        "ukphone": "[rɪˈvendʒ]"
-    },
-    {
-        "name": "reverse",
-        "trans": [
-            "n. 背面；相反；倒退；失败"
-        ],
-        "usphone": "[rɪˈvɜːrs]",
-        "ukphone": "[rɪˈvɜːs]"
-    },
-    {
-        "name": "revival",
-        "trans": [
-            "n. 复兴；复活；苏醒；恢复精神；再生效"
-        ],
-        "usphone": "[rɪˈvaɪvl]",
-        "ukphone": "[rɪˈvaɪv(ə)l]"
-    },
-    {
-        "name": "revive",
-        "trans": [
-            "vt. 使复兴；使苏醒；回想起；重演，重播"
-        ],
-        "usphone": "[rɪˈvaɪv]",
-        "ukphone": "[rɪˈvaɪv]"
-    },
-    {
-        "name": "revolutionary",
-        "trans": [
-            "n. 革命者"
-        ],
-        "usphone": "[ˌrevəˈluːʃəneri]",
-        "ukphone": "[ˌrevəˈluːʃənəri]"
-    },
-    {
-        "name": "rhetoric",
-        "trans": [
-            "n. 修辞，修辞学；华丽的词藻"
-        ],
-        "usphone": "[ˈretərɪk]",
-        "ukphone": "[ˈretərɪk]"
-    },
-    {
-        "name": "rifle",
-        "trans": [
-            "n. 步枪；来复枪"
-        ],
-        "usphone": "[ˈraɪfl]",
-        "ukphone": "[ˈraɪfl]"
-    },
-    {
-        "name": "riot",
-        "trans": [
-            "n. 暴乱；放纵；蔓延"
-        ],
-        "usphone": "[ˈraɪət]",
-        "ukphone": "[ˈraɪət]"
-    },
-    {
-        "name": "rip",
-        "trans": [
-            "n. 裂口，裂缝"
-        ],
-        "usphone": "[rɪp]",
-        "ukphone": "[rɪp]"
-    },
-    {
-        "name": "ritual",
-        "trans": [
-            "n. 仪式；惯例；礼制"
-        ],
-        "usphone": "[ˈrɪtʃuəl]",
-        "ukphone": "[ˈrɪtʃuəl]"
-    },
-    {
-        "name": "robust",
-        "trans": [
-            "adj. 强健的；健康的；粗野的；粗鲁的"
-        ],
-        "usphone": "[roʊˈbʌst]",
-        "ukphone": "[rəʊˈbʌst]"
-    },
-    {
-        "name": "rock",
-        "trans": [
-            "n. 岩石；摇滚乐；暗礁"
-        ],
-        "usphone": "[rɑːk]",
-        "ukphone": "[rɒk]"
-    },
-    {
-        "name": "rod",
-        "trans": [
-            "n. 棒；惩罚；枝条；权力"
-        ],
-        "usphone": "[rɑːd]",
-        "ukphone": "[rɒd]"
-    },
-    {
-        "name": "rotate",
-        "trans": [
-            "vt. 使旋转；使转动；使轮流"
-        ],
-        "usphone": "[ˈroʊteɪt]",
-        "ukphone": "[rəʊˈteɪt]"
-    },
-    {
-        "name": "rotation",
-        "trans": [
-            "n. 旋转；循环，轮流"
-        ],
-        "usphone": "[roʊˈteɪʃn]",
-        "ukphone": "[rəʊˈteɪʃn]"
-    },
-    {
-        "name": "ruling",
-        "trans": [
-            "n. 统治，支配；裁定"
-        ],
-        "usphone": "[ˈruːlɪŋ]",
-        "ukphone": "[ˈruːlɪŋ]"
-    },
-    {
-        "name": "rumour",
-        "trans": [
-            "n. 谣言"
-        ],
-        "usphone": "[ˈruːmər]",
-        "ukphone": "[ˈruːmə(r)]"
-    },
-    {
-        "name": "sack",
-        "trans": [
-            "n. 麻布袋；洗劫"
-        ],
-        "usphone": "[sæk]",
-        "ukphone": "[sæk]"
-    },
-    {
-        "name": "sacred",
-        "trans": [
-            "adj. 神的；神圣的；宗教的；庄严的"
-        ],
-        "usphone": "[ˈseɪkrɪd]",
-        "ukphone": "[ˈseɪkrɪd]"
-    },
-    {
-        "name": "sacrifice",
-        "trans": [
-            "n. 牺牲；祭品；供奉"
-        ],
-        "usphone": "[ˈsækrɪfaɪs]",
-        "ukphone": "[ˈsækrɪfaɪs]"
-    },
-    {
-        "name": "saint",
-        "trans": [
-            "n. 圣人；圣徒；道德崇高的人"
-        ],
-        "usphone": "[seɪnt]",
-        "ukphone": "[seɪnt; snt]"
-    },
-    {
-        "name": "sake",
-        "trans": [
-            "n. 目的；利益；理由；日本米酒"
-        ],
-        "usphone": "[seɪk; ˈsɑːki]",
-        "ukphone": "[seɪk]"
-    },
-    {
-        "name": "sanction",
-        "trans": [
-            "n. 制裁，处罚；认可；支持"
-        ],
-        "usphone": "[ˈsæŋkʃn]",
-        "ukphone": "[ˈsæŋkʃn]"
-    },
-    {
-        "name": "say",
-        "trans": [
-            "vt. 讲；说明；例如；声称；假设；指明"
-        ],
-        "usphone": "[seɪ]",
-        "ukphone": "[seɪ]"
-    },
-    {
-        "name": "scattered",
-        "trans": [
-            "adj. 分散的；散乱的"
-        ],
-        "usphone": "[ˈskætərd]",
-        "ukphone": "[ˈskætəd]"
-    },
-    {
-        "name": "sceptical",
-        "trans": [
-            "adj. 怀疑的；怀疑论的；习惯怀疑的"
-        ],
-        "usphone": "[ˈskeptɪkl]",
-        "ukphone": "[ˈskeptɪk(ə)l]"
-    },
-    {
-        "name": "scope",
-        "trans": [
-            "n. 范围；余地；视野；眼界；导弹射程"
-        ],
-        "usphone": "[skoʊp]",
-        "ukphone": "[skəʊp]"
-    },
-    {
-        "name": "screw",
-        "trans": [
-            "n. 螺旋；螺丝钉；吝啬鬼"
-        ],
-        "usphone": "[skruː]",
-        "ukphone": "[skruː]"
-    },
-    {
-        "name": "scrutiny",
-        "trans": [
-            "n. 详细审查；监视；细看；选票复查"
-        ],
-        "usphone": "[ˈskruːtəni]",
-        "ukphone": "[ˈskruːtəni]"
-    },
-    {
-        "name": "seal",
-        "trans": [
-            "n. 密封；印章；海豹；封条；标志"
-        ],
-        "usphone": "[siːl]",
-        "ukphone": "[siːl]"
-    },
-    {
-        "name": "secular",
-        "trans": [
-            "n. 修道院外的教士，(对宗教家而言的) 俗人"
-        ],
-        "usphone": "[ˈsekjələr]",
-        "ukphone": "[ˈsekjələ(r)]"
-    },
-    {
-        "name": "seemingly",
-        "trans": [
-            "adv. 看来似乎；表面上看来"
-        ],
-        "usphone": "[ˈsiːmɪŋli]",
-        "ukphone": "[ˈsiːmɪŋli]"
-    },
-    {
-        "name": "segment",
-        "trans": [
-            "n. 段；部分"
-        ],
-        "usphone": "[ˈseɡmənt]",
-        "ukphone": "[ˈseɡmənt]"
-    },
-    {
-        "name": "seize",
-        "trans": [
-            "vt. 抓住；夺取；理解；逮捕"
-        ],
-        "usphone": "[siːz]",
-        "ukphone": "[siːz]"
-    },
-    {
-        "name": "seldom",
-        "trans": [
-            "adv. 很少，不常"
-        ],
-        "usphone": "[ˈseldəm]",
-        "ukphone": "[ˈseldəm]"
-    },
-    {
-        "name": "selective",
-        "trans": [
-            "adj. 选择性的"
-        ],
-        "usphone": "[sɪˈlektɪv]",
-        "ukphone": "[sɪˈlektɪv]"
-    },
-    {
-        "name": "senator",
-        "trans": [
-            "n. 参议员；（古罗马的）元老院议员；评议员，理事"
-        ],
-        "usphone": "[ˈsenətər]",
-        "ukphone": "[ˈsenətə(r)]"
-    },
-    {
-        "name": "sensation",
-        "trans": [
-            "n. 感觉；轰动；感动"
-        ],
-        "usphone": "[senˈseɪʃ(ə)n]",
-        "ukphone": "[senˈseɪʃ(ə)n]"
-    },
-    {
-        "name": "sensitivity",
-        "trans": [
-            "n. 敏感；敏感性；过敏"
-        ],
-        "usphone": "[ˌsensəˈtɪvəti]",
-        "ukphone": "[ˌsensəˈtɪvəti]"
-    },
-    {
-        "name": "sentiment",
-        "trans": [
-            "n. 感情，情绪；情操；观点；多愁善感"
-        ],
-        "usphone": "[ˈsentɪmənt]",
-        "ukphone": "[ˈsentɪmənt]"
-    },
-    {
-        "name": "separation",
-        "trans": [
-            "n. 分离，分开；间隔，距离；[法] 分居；缺口"
-        ],
-        "usphone": "[ˌsepəˈreɪʃn]",
-        "ukphone": "[ˌsepəˈreɪʃn]"
-    },
-    {
-        "name": "serial",
-        "trans": [
-            "n. 电视连续剧；[图情] 期刊；连载小说"
-        ],
-        "usphone": "[ˈsɪriəl]",
-        "ukphone": "[ˈsɪəriəl]"
-    },
-    {
-        "name": "settlement",
-        "trans": [
-            "n. 解决，处理；[会计] 结算；沉降；殖民"
-        ],
-        "usphone": "[ˈsetlmənt]",
-        "ukphone": "[ˈset(ə)lmənt]"
-    },
-    {
-        "name": "set-up",
-        "trans": [
-            "n. 计划；组织；机构；装配"
-        ],
-        "usphone": "[ˈset ʌp]",
-        "ukphone": "[ˈset ʌp]"
-    },
-    {
-        "name": "sexuality",
-        "trans": [
-            "n. [胚] 性别；性欲；性征；性方面的事情（比如性行为或性能力）"
-        ],
-        "usphone": "[ˌsekʃuˈæləti]",
-        "ukphone": "[ˌsekʃuˈæləti]"
-    },
-    {
-        "name": "shareholder",
-        "trans": [
-            "n. 股东；股票持有人"
-        ],
-        "usphone": "[ˈʃerhoʊldər]",
-        "ukphone": "[ˈʃeəhəʊldə(r)]"
-    },
-    {
-        "name": "shatter",
-        "trans": [
-            "n. 碎片；乱七八糟的状态"
-        ],
-        "usphone": "[ˈʃætər]",
-        "ukphone": "[ˈʃætə(r)]"
-    },
-    {
-        "name": "shed",
-        "trans": [
-            "n. 小屋，棚；分水岭"
-        ],
-        "usphone": "[ʃed]",
-        "ukphone": "[ʃed]"
-    },
-    {
-        "name": "sheer",
-        "trans": [
-            "n. 偏航；透明薄织物"
-        ],
-        "usphone": "[ʃɪr]",
-        "ukphone": "[ʃɪə(r)]"
-    },
-    {
-        "name": "shipping",
-        "trans": [
-            "n. [船] 船舶，船舶吨数；海运；运送"
-        ],
-        "usphone": "[ˈʃɪpɪŋ]",
-        "ukphone": "[ˈʃɪpɪŋ]"
-    },
-    {
-        "name": "shoot",
-        "trans": [
-            "n. 射击；摄影；狩猎；急流"
-        ],
-        "usphone": "[ʃuːt]",
-        "ukphone": "[ʃuːt]"
-    },
-    {
-        "name": "shrink",
-        "trans": [
-            "vi. 收缩；畏缩"
-        ],
-        "usphone": "[ʃrɪŋk]",
-        "ukphone": "[ʃrɪŋk]"
-    },
-    {
-        "name": "shrug",
-        "trans": [
-            "n. 耸肩"
-        ],
-        "usphone": "[ʃrʌɡ]",
-        "ukphone": "[ʃrʌɡ]"
-    },
-    {
-        "name": "sigh",
-        "trans": [
-            "n. 叹息，叹气"
-        ],
-        "usphone": "[saɪ]",
-        "ukphone": "[saɪ]"
-    },
-    {
-        "name": "simulate",
-        "trans": [
-            "adj. 模仿的；假装的"
-        ],
-        "usphone": "[ˈsɪmjuleɪt]",
-        "ukphone": "[ˈsɪmjuleɪt]"
-    },
-    {
-        "name": "simulation",
-        "trans": [
-            "n. 仿真；模拟；模仿；假装"
-        ],
-        "usphone": "[ˌsɪmjuˈleɪʃn]",
-        "ukphone": "[ˌsɪmjuˈleɪʃ(ə)n]"
-    },
-    {
-        "name": "simultaneously",
-        "trans": [
-            "adv. 同时地"
-        ],
-        "usphone": "[ˌsaɪmlˈteɪniəsli]",
-        "ukphone": "[ˌsɪm(ə)lˈteɪniəsli]"
-    },
-    {
-        "name": "sin",
-        "trans": [
-            "n. 罪恶；罪孽；过失"
-        ],
-        "usphone": "[sɪn]",
-        "ukphone": "[sɪn]"
-    },
-    {
-        "name": "situated",
-        "trans": [
-            "v. 使位于；使处于（situate的过去分词）"
-        ],
-        "usphone": "[ˈsɪtʃueɪtɪd]",
-        "ukphone": "[ˈsɪtʃueɪtɪd]"
-    },
-    {
-        "name": "sketch",
-        "trans": [
-            "n. 素描；略图；梗概"
-        ],
-        "usphone": "[sketʃ]",
-        "ukphone": "[sketʃ]"
-    },
-    {
-        "name": "skip",
-        "trans": [
-            "n. 跳跃；跳读"
-        ],
-        "usphone": "[skɪp]",
-        "ukphone": "[skɪp]"
-    },
-    {
-        "name": "slam",
-        "trans": [
-            "n. 猛击；砰然声"
-        ],
-        "usphone": "[slæm]",
-        "ukphone": "[slæm]"
-    },
-    {
-        "name": "slap",
-        "trans": [
-            "n. 掴；侮辱；掌击；拍打声"
-        ],
-        "usphone": "[slæp]",
-        "ukphone": "[slæp]"
-    },
-    {
-        "name": "slash",
-        "trans": [
-            "n. 削减；斜线；猛砍；砍痕；沼泽低地"
-        ],
-        "usphone": "[slæʃ]",
-        "ukphone": "[slæʃ]"
-    },
-    {
-        "name": "slavery",
-        "trans": [
-            "n. 奴役；奴隶制度；奴隶身份"
-        ],
-        "usphone": "[ˈsleɪvəri]",
-        "ukphone": "[ˈsleɪvəri]"
-    },
-    {
-        "name": "slot",
-        "trans": [
-            "n. 位置；狭槽；水沟；硬币投币口"
-        ],
-        "usphone": "[slɑːt]",
-        "ukphone": "[slɒt]"
-    },
-    {
-        "name": "smash",
-        "trans": [
-            "n. 破碎；扣球；冲突；大败"
-        ],
-        "usphone": "[smæʃ]",
-        "ukphone": "[smæʃ]"
-    },
-    {
-        "name": "snap",
-        "trans": [
-            "n. 猛咬；劈啪声；突然折断"
-        ],
-        "usphone": "[snæp]",
-        "ukphone": "[snæp]"
-    },
-    {
-        "name": "soak",
-        "trans": [
-            "n. 浸；湿透；大雨"
-        ],
-        "usphone": "[soʊk]",
-        "ukphone": "[səʊk]"
-    },
-    {
-        "name": "soar",
-        "trans": [
-            "n. 高飞；高涨"
-        ],
-        "usphone": "[sɔːr]",
-        "ukphone": "[sɔː(r)]"
-    },
-    {
-        "name": "socialist",
-        "trans": [
-            "n. 社会主义者；社会党党员"
-        ],
-        "usphone": "[ˈsoʊʃəlɪst]",
-        "ukphone": "[ˈsəʊʃəlɪst]"
-    },
-    {
-        "name": "sole",
-        "trans": [
-            "n. 鞋底；脚底；基础；鳎目鱼"
-        ],
-        "usphone": "[soʊl]",
-        "ukphone": "[səʊl]"
-    },
-    {
-        "name": "solely",
-        "trans": [
-            "adv. 单独地，唯一地"
-        ],
-        "usphone": "[ˈsoʊlli]",
-        "ukphone": "[ˈsəʊlli]"
-    },
-    {
-        "name": "solicitor",
-        "trans": [
-            "n. 律师；法务官；募捐者；掮客"
-        ],
-        "usphone": "[səˈlɪsɪtər]",
-        "ukphone": "[səˈlɪsɪtə(r)]"
-    },
-    {
-        "name": "solidarity",
-        "trans": [
-            "n. 团结，团结一致"
-        ],
-        "usphone": "[ˌsɑːlɪˈdærəti]",
-        "ukphone": "[ˌsɒlɪˈdærəti]"
-    },
-    {
-        "name": "solo",
-        "trans": [
-            "n. 独奏；独唱；独奏曲"
-        ],
-        "usphone": "[ˈsoʊloʊ]",
-        "ukphone": "[ˈsəʊləʊ]"
-    },
-    {
-        "name": "sound",
-        "trans": [
-            "n. 声音，语音；噪音；海峡；吵闹；听力范围；[医] 探条"
-        ],
-        "usphone": "[saʊnd]",
-        "ukphone": "[saʊnd]"
-    },
-    {
-        "name": "sovereignty",
-        "trans": [
-            "n. 主权；主权国家；君主；独立国"
-        ],
-        "usphone": "[ˈsɑːvrənti]",
-        "ukphone": "[ˈsɒvrənti]"
-    },
-    {
-        "name": "spam",
-        "trans": [
-            "v. 刷屏"
-        ],
-        "usphone": "[spæm]",
-        "ukphone": "[spæm]"
-    },
-    {
-        "name": "span",
-        "trans": [
-            "n. 跨度，跨距；范围"
-        ],
-        "usphone": "[spæn]",
-        "ukphone": "[spæn]"
-    },
-    {
-        "name": "spare",
-        "trans": [
-            "n. 剩余；备用零件"
-        ],
-        "usphone": "[sper]",
-        "ukphone": "[speə(r)]"
-    },
-    {
-        "name": "spark",
-        "trans": [
-            "n. 火花；朝气；闪光"
-        ],
-        "usphone": "[spɑːrk]",
-        "ukphone": "[spɑːk]"
-    },
-    {
-        "name": "specialized",
-        "trans": [
-            "adj. 专业的；专门的"
-        ],
-        "usphone": "[ˈspeʃəlaɪzd]",
-        "ukphone": "[ˈspeʃəlaɪzd]"
-    },
-    {
-        "name": "specification",
-        "trans": [
-            "n. 规格；说明书；详述"
-        ],
-        "usphone": "[ˌspesɪfɪˈkeɪʃn]",
-        "ukphone": "[ˌspesɪfɪˈkeɪʃ(ə)n]"
-    },
-    {
-        "name": "specimen",
-        "trans": [
-            "n. 样品，样本；标本"
-        ],
-        "usphone": "[ˈspesɪmən]",
-        "ukphone": "[ˈspesɪmən]"
-    },
-    {
-        "name": "spectacle",
-        "trans": [
-            "n. 景象；场面；奇观；壮观；公开展示；表相，假相 n.（复）眼镜"
-        ],
-        "usphone": "[ˈspektəkl]",
-        "ukphone": "[ˈspektəkl]"
-    },
-    {
-        "name": "spectrum",
-        "trans": [
-            "n. 光谱；频谱；范围；余象"
-        ],
-        "usphone": "[ˈspektrəm]",
-        "ukphone": "[ˈspektrəm]"
-    },
-    {
-        "name": "spell",
-        "trans": [
-            "n. 符咒；一段时间；魅力"
-        ],
-        "usphone": "[spel]",
-        "ukphone": "[spel]"
-    },
-    {
-        "name": "sphere",
-        "trans": [
-            "n. 范围；球体"
-        ],
-        "usphone": "[sfɪr]",
-        "ukphone": "[sfɪə(r)]"
-    },
-    {
-        "name": "spin",
-        "trans": [
-            "n. 旋转；疾驰"
-        ],
-        "usphone": "[spɪn]",
-        "ukphone": "[spɪn]"
-    },
-    {
-        "name": "spine",
-        "trans": [
-            "n. 脊柱，脊椎；刺；书脊"
-        ],
-        "usphone": "[spaɪn]",
-        "ukphone": "[spaɪn]"
-    },
-    {
-        "name": "spotlight",
-        "trans": [
-            "n. 聚光灯；反光灯；公众注意的中心"
-        ],
-        "usphone": "[ˈspɑːtlaɪt]",
-        "ukphone": "[ˈspɒtlaɪt]"
-    },
-    {
-        "name": "spouse",
-        "trans": [
-            "n. 配偶"
-        ],
-        "usphone": "[spaʊsˌspaʊz]",
-        "ukphone": "[spaʊs]"
-    },
-    {
-        "name": "spy",
-        "trans": [
-            "n. 间谍；密探"
-        ],
-        "usphone": "[spaɪ]",
-        "ukphone": "[spaɪ]"
-    },
-    {
-        "name": "squad",
-        "trans": [
-            "n. 班；小队；五人组（篮球队的非正式说法）"
-        ],
-        "usphone": "[skwɑːd]",
-        "ukphone": "[skwɒd]"
-    },
-    {
-        "name": "squeeze",
-        "trans": [
-            "n. 压榨；紧握；拥挤；佣金"
-        ],
-        "usphone": "[skwiːz]",
-        "ukphone": "[skwiːz]"
-    },
-    {
-        "name": "stab",
-        "trans": [
-            "n. 刺；戳；尝试；突发的一阵"
-        ],
-        "usphone": "[stæb]",
-        "ukphone": "[stæb]"
-    },
-    {
-        "name": "stability",
-        "trans": [
-            "n. 稳定性；坚定，恒心"
-        ],
-        "usphone": "[stəˈbɪləti]",
-        "ukphone": "[stəˈbɪləti]"
-    },
-    {
-        "name": "stabilize",
-        "trans": [
-            "vt. 使稳固，使安定"
-        ],
-        "usphone": "[ˈsteɪbəlaɪz]",
-        "ukphone": "[ˈsteɪbəlaɪz]"
-    },
-    {
-        "name": "stake",
-        "trans": [
-            "n. 桩，棍子；赌注；火刑；奖金"
-        ],
-        "usphone": "[steɪk]",
-        "ukphone": "[steɪk]"
-    },
-    {
-        "name": "standing",
-        "trans": [
-            "n. 站立；持续；身分"
-        ],
-        "usphone": "[ˈstændɪŋ]",
-        "ukphone": "[ˈstændɪŋ]"
-    },
-    {
-        "name": "stark",
-        "trans": [
-            "adj. 完全的；荒凉的；刻板的；光秃秃的；朴实的"
-        ],
-        "usphone": "[stɑːrk]",
-        "ukphone": "[stɑːk]"
-    },
-    {
-        "name": "statistical",
-        "trans": [
-            "adj. 统计的；统计学的"
-        ],
-        "usphone": "[stəˈtɪstɪkl]",
-        "ukphone": "[stəˈtɪstɪk(ə)l]"
-    },
-    {
-        "name": "steer",
-        "trans": [
-            "vt. 控制，引导；驾驶"
-        ],
-        "usphone": "[stɪr]",
-        "ukphone": "[stɪə(r)]"
-    },
-    {
-        "name": "stem",
-        "trans": [
-            "n. 干；茎；船首；血统"
-        ],
-        "usphone": "[stem]",
-        "ukphone": "[stem]"
-    },
-    {
-        "name": "stereotype",
-        "trans": [
-            "n. 陈腔滥调，老套；铅版"
-        ],
-        "usphone": "[ˈsteriətaɪp]",
-        "ukphone": "[ˈsteriətaɪp]"
-    },
-    {
-        "name": "stimulus",
-        "trans": [
-            "n. 刺激；激励；刺激物"
-        ],
-        "usphone": "[ˈstɪmjələs]",
-        "ukphone": "[ˈstɪmjələs]"
-    },
-    {
-        "name": "stir",
-        "trans": [
-            "n. 搅拌；轰动"
-        ],
-        "usphone": "[stɜːr]",
-        "ukphone": "[stɜː(r)]"
-    },
-    {
-        "name": "storage",
-        "trans": [
-            "n. 存储；仓库；贮藏所"
-        ],
-        "usphone": "[ˈstɔːrɪdʒ]",
-        "ukphone": "[ˈstɔːrɪdʒ]"
-    },
-    {
-        "name": "straightforward",
-        "trans": [
-            "adj. 简单的；坦率的；明确的；径直的"
-        ],
-        "usphone": "[ˌstreɪtˈfɔːrwərd]",
-        "ukphone": "[ˌstreɪtˈfɔːwəd]"
-    },
-    {
-        "name": "strain",
-        "trans": [
-            "n. 张力；拉紧；负担；扭伤；血缘"
-        ],
-        "usphone": "[streɪn]",
-        "ukphone": "[streɪn]"
-    },
-    {
-        "name": "strand",
-        "trans": [
-            "n. 线；串；海滨"
-        ],
-        "usphone": "[strænd]",
-        "ukphone": "[strænd]"
-    },
-    {
-        "name": "strategic",
-        "trans": [
-            "adj. 战略上的，战略的"
-        ],
-        "usphone": "[strəˈtiːdʒɪk]",
-        "ukphone": "[strəˈtiːdʒɪk]"
-    },
-    {
-        "name": "striking",
-        "trans": [
-            "v. 打（strike的ing形式）"
-        ],
-        "usphone": "[ˈstraɪkɪŋ]",
-        "ukphone": "[ˈstraɪkɪŋ]"
-    },
-    {
-        "name": "strip",
-        "trans": [
-            "n. 带；条状；脱衣舞"
-        ],
-        "usphone": "[strɪp]",
-        "ukphone": "[strɪp]"
-    },
-    {
-        "name": "strive",
-        "trans": [
-            "vi. 努力；奋斗；抗争"
-        ],
-        "usphone": "[straɪv]",
-        "ukphone": "[straɪv]"
-    },
-    {
-        "name": "structural",
-        "trans": [
-            "adj. 结构的；建筑的"
-        ],
-        "usphone": "[ˈstrʌktʃərəl]",
-        "ukphone": "[ˈstrʌktʃərəl]"
-    },
-    {
-        "name": "stumble",
-        "trans": [
-            "n. 绊倒；蹒跚而行"
-        ],
-        "usphone": "[ˈstʌmbl]",
-        "ukphone": "[ˈstʌmb(ə)l]"
-    },
-    {
-        "name": "stun",
-        "trans": [
-            "n. 昏迷；打昏；惊倒；令人惊叹的事物"
-        ],
-        "usphone": "[stʌn]",
-        "ukphone": "[stʌn]"
-    },
-    {
-        "name": "submission",
-        "trans": [
-            "n. 投降；提交（物）；服从；（向法官提出的）意见；谦恭"
-        ],
-        "usphone": "[səbˈmɪʃn]",
-        "ukphone": "[səbˈmɪʃn]"
-    },
-    {
-        "name": "subscriber",
-        "trans": [
-            "n. 订户；签署者；捐献者"
-        ],
-        "usphone": "[səbˈskraɪbər]",
-        "ukphone": "[səbˈskraɪbə(r)]"
-    },
-    {
-        "name": "subscription",
-        "trans": [
-            "n. 捐献；订阅；订金；签署"
-        ],
-        "usphone": "[səbˈskrɪpʃn]",
-        "ukphone": "[səbˈskrɪpʃ(ə)n]"
-    },
-    {
-        "name": "subsidy",
-        "trans": [
-            "n. 补贴；津贴；补助金"
-        ],
-        "usphone": "[ˈsʌbsədi]",
-        "ukphone": "[ˈsʌbsədi]"
-    },
-    {
-        "name": "substantial",
-        "trans": [
-            "n. 本质；重要材料"
-        ],
-        "usphone": "[səbˈstænʃl]",
-        "ukphone": "[səbˈstænʃ(ə)l]"
-    },
-    {
-        "name": "substantially",
-        "trans": [
-            "adv. 实质上；大体上；充分地"
-        ],
-        "usphone": "[səbˈstænʃəli]",
-        "ukphone": "[səbˈstænʃəli]"
-    },
-    {
-        "name": "substitute",
-        "trans": [
-            "n. 代用品；代替者"
-        ],
-        "usphone": "[ˈsʌbstɪtuːt]",
-        "ukphone": "[ˈsʌbstɪtjuːt]"
-    },
-    {
-        "name": "substitution",
-        "trans": [
-            "n. 代替；[数] 置换；代替物"
-        ],
-        "usphone": "[ˌsʌbstɪˈtuːʃn]",
-        "ukphone": "[ˌsʌbstɪˈtjuːʃn]"
-    },
-    {
-        "name": "subtle",
-        "trans": [
-            "adj. 微妙的；精细的；敏感的；狡猾的；稀薄的"
-        ],
-        "usphone": "[ˈsʌtl]",
-        "ukphone": "[ˈsʌt(ə)l]"
-    },
-    {
-        "name": "suburban",
-        "trans": [
-            "n. 郊区居民"
-        ],
-        "usphone": "[səˈbɜːrbən]",
-        "ukphone": "[səˈbɜːbən]"
-    },
-    {
-        "name": "succession",
-        "trans": [
-            "n. 连续；继位；继承权；[生态] 演替"
-        ],
-        "usphone": "[səkˈseʃn]",
-        "ukphone": "[səkˈseʃn]"
-    },
-    {
-        "name": "successive",
-        "trans": [
-            "adj. 连续的；继承的；依次的；接替的"
-        ],
-        "usphone": "[səkˈsesɪv]",
-        "ukphone": "[səkˈsesɪv]"
-    },
-    {
-        "name": "successor",
-        "trans": [
-            "n. 继承者；后续的事物"
-        ],
-        "usphone": "[səkˈsesər]",
-        "ukphone": "[səkˈsesə(r)]"
-    },
-    {
-        "name": "suck",
-        "trans": [
-            "n. 吮吸"
-        ],
-        "usphone": "[sʌk]",
-        "ukphone": "[sʌk]"
-    },
-    {
-        "name": "sue",
-        "trans": [
-            "vt. 控告；请求"
-        ],
-        "usphone": "[suː]",
-        "ukphone": "[suː]"
-    },
-    {
-        "name": "suicide",
-        "trans": [
-            "n. 自杀；自杀行为；自杀者"
-        ],
-        "usphone": "[ˈsuːɪsaɪd]",
-        "ukphone": "[ˈsuːɪsaɪd]"
-    },
-    {
-        "name": "suite",
-        "trans": [
-            "n. （一套）家具；套房；组曲；（一批）随员，随从"
-        ],
-        "usphone": "[swiːt]",
-        "ukphone": "[swiːt]"
-    },
-    {
-        "name": "summit",
-        "trans": [
-            "n. 顶点；最高级会议；最高阶层"
-        ],
-        "usphone": "[ˈsʌmɪt]",
-        "ukphone": "[ˈsʌmɪt]"
-    },
-    {
-        "name": "superb",
-        "trans": [
-            "adj. 极好的；华丽的；宏伟的"
-        ],
-        "usphone": "[suːˈpɜːrb]",
-        "ukphone": "[suːˈpɜːb; sjuːˈpɜːb]"
-    },
-    {
-        "name": "superior",
-        "trans": [
-            "n. 上级，长官；优胜者，高手；长者"
-        ],
-        "usphone": "[suːˈpɪriər]",
-        "ukphone": "[suːˈpɪəriə(r)]"
-    },
-    {
-        "name": "supervise",
-        "trans": [
-            "vt. 监督，管理；指导"
-        ],
-        "usphone": "[ˈsuːpərvaɪz]",
-        "ukphone": "[ˈsuːpəvaɪz]"
-    },
-    {
-        "name": "supervision",
-        "trans": [
-            "n. 监督，管理"
-        ],
-        "usphone": "[ˌsuːpərˈvɪʒn]",
-        "ukphone": "[ˌsuːpəˈvɪʒ(ə)n]"
-    },
-    {
-        "name": "supervisor",
-        "trans": [
-            "n. 监督人，[管理] 管理人；检查员"
-        ],
-        "usphone": "[ˈsuːpərvaɪzər]",
-        "ukphone": "[ˈsuːpəvaɪzə(r)]"
-    },
-    {
-        "name": "supplement",
-        "trans": [
-            "vt. 增补，补充"
-        ],
-        "usphone": "[ˈsʌplɪmənt]",
-        "ukphone": "[ˈsʌplɪmənt]"
-    },
-    {
-        "name": "supportive",
-        "trans": [
-            "adj. 支持的；支援的；赞助的"
-        ],
-        "usphone": "[səˈpɔːrtɪv]",
-        "ukphone": "[səˈpɔːtɪv]"
-    },
-    {
-        "name": "supposedly",
-        "trans": [
-            "adv. 可能；按照推测；恐怕"
-        ],
-        "usphone": "[səˈpoʊzɪdli]",
-        "ukphone": "[səˈpəʊzɪdli]"
-    },
-    {
-        "name": "suppress",
-        "trans": [
-            "vt. 抑制；镇压；废止"
-        ],
-        "usphone": "[səˈpres]",
-        "ukphone": "[səˈpres]"
-    },
-    {
-        "name": "supreme",
-        "trans": [
-            "n. 至高；霸权"
-        ],
-        "usphone": "[suːˈpriːm]",
-        "ukphone": "[suːˈpriːm; sjuːˈpriːm]"
-    },
-    {
-        "name": "surge",
-        "trans": [
-            "n. 汹涌；大浪，波涛；汹涌澎湃；巨涌"
-        ],
-        "usphone": "[sɜːrdʒ]",
-        "ukphone": "[sɜːdʒ]"
-    },
-    {
-        "name": "surgical",
-        "trans": [
-            "n. 外科手术；外科病房"
-        ],
-        "usphone": "[ˈsɜːrdʒɪkl]",
-        "ukphone": "[ˈsɜːdʒɪkl]"
-    },
-    {
-        "name": "surplus",
-        "trans": [
-            "n. 剩余；[贸易] 顺差；盈余；过剩"
-        ],
-        "usphone": "[ˈsɜːrplʌs]",
-        "ukphone": "[ˈsɜːpləs]"
-    },
-    {
-        "name": "surrender",
-        "trans": [
-            "n. 投降；放弃；交出；屈服"
-        ],
-        "usphone": "[səˈrendər]",
-        "ukphone": "[səˈrendə(r)]"
-    },
-    {
-        "name": "surveillance",
-        "trans": [
-            "n. 监督；监视"
-        ],
-        "usphone": "[sɜːrˈveɪləns]",
-        "ukphone": "[sɜːˈveɪləns]"
-    },
-    {
-        "name": "suspension",
-        "trans": [
-            "n. 悬浮；暂停；停职"
-        ],
-        "usphone": "[səˈspenʃn]",
-        "ukphone": "[səˈspenʃ(ə)n]"
-    },
-    {
-        "name": "suspicion",
-        "trans": [
-            "n. 怀疑；嫌疑；疑心；一点儿"
-        ],
-        "usphone": "[səˈspɪʃn]",
-        "ukphone": "[səˈspɪʃ(ə)n]"
-    },
-    {
-        "name": "suspicious",
-        "trans": [
-            "adj. 可疑的；怀疑的；多疑的"
-        ],
-        "usphone": "[səˈspɪʃəs]",
-        "ukphone": "[səˈspɪʃəs]"
-    },
-    {
-        "name": "sustain",
-        "trans": [
-            "vt. 维持；支撑，承担；忍受；供养；证实"
-        ],
-        "usphone": "[səˈsteɪn]",
-        "ukphone": "[səˈsteɪn]"
-    },
-    {
-        "name": "swing",
-        "trans": [
-            "n. 摇摆；摆动；秋千；音律；涨落"
-        ],
-        "usphone": "[swɪŋ]",
-        "ukphone": "[swɪŋ]"
-    },
-    {
-        "name": "sword",
-        "trans": [
-            "n. 刀，剑；武力，战争"
-        ],
-        "usphone": "[sɔːrd]",
-        "ukphone": "[sɔːd]"
-    },
-    {
-        "name": "symbolic",
-        "trans": [
-            "adj. 象征的；符号的；使用符号的"
-        ],
-        "usphone": "[sɪmˈbɑːlɪk]",
-        "ukphone": "[sɪmˈbɒlɪk]"
-    },
-    {
-        "name": "syndrome",
-        "trans": [
-            "n. [临床] 综合症状；并发症状；校验子；并发位"
-        ],
-        "usphone": "[ˈsɪndroʊm]",
-        "ukphone": "[ˈsɪndrəʊm]"
-    },
-    {
-        "name": "synthesis",
-        "trans": [
-            "n. 综合，[化学] 合成；综合体"
-        ],
-        "usphone": "[ˈsɪnθəsɪs]",
-        "ukphone": "[ˈsɪnθəsɪs]"
-    },
-    {
-        "name": "systematic",
-        "trans": [
-            "adj. 系统的；体系的；有系统的；[图情] 分类的；一贯的，惯常的"
-        ],
-        "usphone": "[ˌsɪstəˈmætɪk]",
-        "ukphone": "[ˌsɪstəˈmætɪk]"
-    },
-    {
-        "name": "tackle",
-        "trans": [
-            "n. 滑车；装备；用具；扭倒"
-        ],
-        "usphone": "[ˈtækl]",
-        "ukphone": "[ˈtæk(ə)l]"
-    },
-    {
-        "name": "tactic",
-        "trans": [
-            "n. 策略，战略"
-        ],
-        "usphone": "[ˈtæktɪk]",
-        "ukphone": "[ˈtæktɪk]"
-    },
-    {
-        "name": "tactical",
-        "trans": [
-            "adj. 战术的；策略的；善于策略的"
-        ],
-        "usphone": "[ˈtæktɪkl]",
-        "ukphone": "[ˈtæktɪkl]"
-    },
-    {
-        "name": "taxpayer",
-        "trans": [
-            "n. 纳税人；所收租金只够支付地产税的建筑物"
-        ],
-        "usphone": "[ˈtækspeɪər]",
-        "ukphone": "[ˈtækspeɪə(r)]"
-    },
-    {
-        "name": "tempt",
-        "trans": [
-            "vt. 诱惑；引起；冒…的风险；使感兴趣"
-        ],
-        "usphone": "[tempt]",
-        "ukphone": "[tempt]"
-    },
-    {
-        "name": "tenant",
-        "trans": [
-            "n. 承租人；房客；佃户；居住者"
-        ],
-        "usphone": "[ˈtenənt]",
-        "ukphone": "[ˈtenənt]"
-    },
-    {
-        "name": "tender",
-        "trans": [
-            "n. 偿付，清偿；看管人；小船"
-        ],
-        "usphone": "[ˈtendər]",
-        "ukphone": "[ˈtendə(r)]"
-    },
-    {
-        "name": "tenure",
-        "trans": [
-            "n. 任期；占有"
-        ],
-        "usphone": "[ˈtenjər]",
-        "ukphone": "[ˈtenjə(r)]"
-    },
-    {
-        "name": "terminal",
-        "trans": [
-            "n. 末端；终点；终端机；极限"
-        ],
-        "usphone": "[ˈtɜːrmɪn(ə)l]",
-        "ukphone": "[ˈtɜːmɪn(ə)l]"
-    },
-    {
-        "name": "terminate",
-        "trans": [
-            "vt. 使终止；使结束；解雇"
-        ],
-        "usphone": "[ˈtɜːrmɪneɪt]",
-        "ukphone": "[ˈtɜːmɪneɪt]"
-    },
-    {
-        "name": "terrain",
-        "trans": [
-            "n. [地理] 地形，地势；领域；地带"
-        ],
-        "usphone": "[təˈreɪn]",
-        "ukphone": "[təˈreɪn]"
-    },
-    {
-        "name": "terrific",
-        "trans": [
-            "adj. 极好的；极其的，非常的；可怕的"
-        ],
-        "usphone": "[təˈrɪfɪk]",
-        "ukphone": "[təˈrɪfɪk]"
-    },
-    {
-        "name": "testify",
-        "trans": [
-            "vi. 作证；证明"
-        ],
-        "usphone": "[ˈtestɪfaɪ]",
-        "ukphone": "[ˈtestɪfaɪ]"
-    },
-    {
-        "name": "testimony",
-        "trans": [
-            "n. [法] 证词，证言；证据"
-        ],
-        "usphone": "[ˈtestɪmoʊni]",
-        "ukphone": "[ˈtestɪməni]"
-    },
-    {
-        "name": "texture",
-        "trans": [
-            "n. 质地；纹理；结构；本质，实质"
-        ],
-        "usphone": "[ˈtekstʃər]",
-        "ukphone": "[ˈtekstʃə(r)]"
-    },
-    {
-        "name": "thankfully",
-        "trans": [
-            "adv. 感谢地；感激地"
-        ],
-        "usphone": "[ˈθæŋkfəli]",
-        "ukphone": "[ˈθæŋkfəli]"
-    },
-    {
-        "name": "theatrical",
-        "trans": [
-            "adj. 戏剧性的；剧场的，戏剧的；夸张的；做作的"
-        ],
-        "usphone": "[θiˈætrɪkl]",
-        "ukphone": "[θiˈætrɪk(ə)l]"
-    },
-    {
-        "name": "theology",
-        "trans": [
-            "n. 神学；宗教体系"
-        ],
-        "usphone": "[θiˈɑːlədʒi]",
-        "ukphone": "[θiˈɒlədʒi]"
-    },
-    {
-        "name": "theoretical",
-        "trans": [
-            "adj. 理论的；理论上的；假设的；推理的"
-        ],
-        "usphone": "[ˌθiːəˈretɪk(ə)l]",
-        "ukphone": "[ˌθɪəˈretɪkl]"
-    },
-    {
-        "name": "thereafter",
-        "trans": [
-            "adv. 其后；从那时以后"
-        ],
-        "usphone": "[ˌðerˈæftər]",
-        "ukphone": "[ˌðeərˈɑːftə(r)]"
-    },
-    {
-        "name": "thereby",
-        "trans": [
-            "adv. 从而，因此；在那附近；在那方面"
-        ],
-        "usphone": "[ˌðerˈbaɪ]",
-        "ukphone": "[ˌðeəˈbaɪ]"
-    },
-    {
-        "name": "thoughtful",
-        "trans": [
-            "adj. 深思的；体贴的；关切的"
-        ],
-        "usphone": "[ˈθɔːtf(ə)l]",
-        "ukphone": "[ˈθɔːtf(ə)l]"
-    },
-    {
-        "name": "thought-provoking",
-        "trans": [
-            "adj. 发人深省的；引起思考的"
-        ],
-        "usphone": "[ˈθɔːt prəvoʊkɪŋ]",
-        "ukphone": "[ˈθɔːt prəvəʊkɪŋ]"
-    },
-    {
-        "name": "thread",
-        "trans": [
-            "n. 线；螺纹；思路；衣服；线状物；玻璃纤维；路线"
-        ],
-        "usphone": "[θred]",
-        "ukphone": "[θred]"
-    },
-    {
-        "name": "threshold",
-        "trans": [
-            "n. 入口；门槛；开始；极限；临界值"
-        ],
-        "usphone": "[ˈθreʃhoʊld]",
-        "ukphone": "[ˈθreʃhəʊld]"
-    },
-    {
-        "name": "thrilled",
-        "trans": [
-            "adj. 非常兴奋的；极为激动的"
-        ],
-        "usphone": "[θrɪld]",
-        "ukphone": "[θrɪld]"
-    },
-    {
-        "name": "thrive",
-        "trans": [
-            "vi. 繁荣，兴旺；茁壮成长"
-        ],
-        "usphone": "[θraɪv]",
-        "ukphone": "[θraɪv]"
-    },
-    {
-        "name": "tide",
-        "trans": [
-            "n. 趋势，潮流；潮汐"
-        ],
-        "usphone": "[taɪd]",
-        "ukphone": "[taɪd]"
-    },
-    {
-        "name": "tighten",
-        "trans": [
-            "vt. 变紧；使变紧"
-        ],
-        "usphone": "[ˈtaɪt(ə)n]",
-        "ukphone": "[ˈtaɪt(ə)n]"
-    },
-    {
-        "name": "timber",
-        "trans": [
-            "n. 木材；木料"
-        ],
-        "usphone": "[ˈtɪmbər]",
-        "ukphone": "[ˈtɪmbə(r)]"
-    },
-    {
-        "name": "timely",
-        "trans": [
-            "adj. 及时的；适时的"
-        ],
-        "usphone": "[ˈtaɪmli]",
-        "ukphone": "[ˈtaɪmli]"
-    },
-    {
-        "name": "tobacco",
-        "trans": [
-            "n. 烟草，烟叶；烟草制品；抽烟"
-        ],
-        "usphone": "[təˈbækoʊ]",
-        "ukphone": "[təˈbækəʊ]"
-    },
-    {
-        "name": "tolerance",
-        "trans": [
-            "n. 公差；宽容；容忍；公差"
-        ],
-        "usphone": "[ˈtɑːlərəns]",
-        "ukphone": "[ˈtɒlərəns]"
-    },
-    {
-        "name": "tolerate",
-        "trans": [
-            "vt. 忍受；默许；宽恕"
-        ],
-        "usphone": "[ˈtɑːləreɪt]",
-        "ukphone": "[ˈtɒləreɪt]"
-    },
-    {
-        "name": "toll",
-        "trans": [
-            "vt. 征收；敲钟"
-        ],
-        "usphone": "[toʊl]",
-        "ukphone": "[təʊl]"
-    },
-    {
-        "name": "top",
-        "trans": [
-            "n. 顶部，顶端；上部；首席；陀螺"
-        ],
-        "usphone": "[tɑːp]",
-        "ukphone": "[tɒp]"
-    },
-    {
-        "name": "torture",
-        "trans": [
-            "n. 折磨；拷问；歪曲"
-        ],
-        "usphone": "[ˈtɔːrtʃər]",
-        "ukphone": "[ˈtɔːtʃə(r)]"
-    },
-    {
-        "name": "toss",
-        "trans": [
-            "n. 投掷；摇荡；投掷的距离；掷币赌胜负"
-        ],
-        "usphone": "[tɔːs]",
-        "ukphone": "[tɒs]"
-    },
-    {
-        "name": "total",
-        "trans": [
-            "n. 总数，合计"
-        ],
-        "usphone": "[ˈtoʊtl]",
-        "ukphone": "[ˈtəʊt(ə)l]"
-    },
-    {
-        "name": "toxic",
-        "trans": [
-            "adj. 有毒的；中毒的"
-        ],
-        "usphone": "[ˈtɑːksɪk]",
-        "ukphone": "[ˈtɒksɪk]"
-    },
-    {
-        "name": "trace",
-        "trans": [
-            "n. 痕迹，踪迹；微量；[仪] 迹线；缰绳"
-        ],
-        "usphone": "[treɪs]",
-        "ukphone": "[treɪs]"
-    },
-    {
-        "name": "trademark",
-        "trans": [
-            "n. 商标"
-        ],
-        "usphone": "[ˈtreɪdmɑːrk]",
-        "ukphone": "[ˈtreɪdmɑːk]"
-    },
-    {
-        "name": "trail",
-        "trans": [
-            "n. 小径；痕迹；尾部；踪迹；一串，一系列"
-        ],
-        "usphone": "[treɪl]",
-        "ukphone": "[treɪl]"
-    },
-    {
-        "name": "trailer",
-        "trans": [
-            "n. 拖车；[电视] 预告片；追踪者"
-        ],
-        "usphone": "[ˈtreɪlər]",
-        "ukphone": "[ˈtreɪlə(r)]"
-    },
-    {
-        "name": "transaction",
-        "trans": [
-            "n. 交易；事务；办理；会报，学报"
-        ],
-        "usphone": "[trænˈzækʃ(ə)n]",
-        "ukphone": "[trænˈzækʃ(ə)n]"
-    },
-    {
-        "name": "transcript",
-        "trans": [
-            "n. 成绩单；抄本，副本；文字记录"
-        ],
-        "usphone": "[ˈtrænskrɪpt]",
-        "ukphone": "[ˈtrænskrɪpt]"
-    },
-    {
-        "name": "transformation",
-        "trans": [
-            "n. [遗] 转化；转换；改革；变形"
-        ],
-        "usphone": "[ˌtrænsfərˈmeɪʃn]",
-        "ukphone": "[ˌtrænsfəˈmeɪʃn]"
-    },
-    {
-        "name": "transit",
-        "trans": [
-            "n. 运输；经过"
-        ],
-        "usphone": "[ˈtrænzɪtˌˈtrænsɪt]",
-        "ukphone": "[ˈtrænzɪt]"
-    },
-    {
-        "name": "transmission",
-        "trans": [
-            "n. 传动装置，[机] 变速器；传递；传送；播送"
-        ],
-        "usphone": "[trænzˈmɪʃnˌtrænsˈmɪʃn]",
-        "ukphone": "[trænzˈmɪʃ(ə)n]"
-    },
-    {
-        "name": "transparency",
-        "trans": [
-            "n. 透明，透明度；幻灯片；有图案的玻璃"
-        ],
-        "usphone": "[trænsˈpærənsi]",
-        "ukphone": "[trænsˈpærənsi]"
-    },
-    {
-        "name": "transparent",
-        "trans": [
-            "adj. 透明的；显然的；坦率的；易懂的"
-        ],
-        "usphone": "[trænsˈpærənt]",
-        "ukphone": "[trænsˈpærənt]"
-    },
-    {
-        "name": "trauma",
-        "trans": [
-            "n. [外科] 创伤（由心理创伤造成精神上的异常）；外伤"
-        ],
-        "usphone": "[ˈtrɔːməˌˈtraʊmə]",
-        "ukphone": "[ˈtrɔːmə]"
-    },
-    {
-        "name": "treaty",
-        "trans": [
-            "n. 条约，协议；谈判"
-        ],
-        "usphone": "[ˈtriːti]",
-        "ukphone": "[ˈtriːti]"
-    },
-    {
-        "name": "tremendous",
-        "trans": [
-            "adj. 极大的，巨大的；惊人的；极好的"
-        ],
-        "usphone": "[trəˈmendəs]",
-        "ukphone": "[trəˈmendəs]"
-    },
-    {
-        "name": "tribal",
-        "trans": [
-            "adj. 部落的；种族的"
-        ],
-        "usphone": "[ˈtraɪbl]",
-        "ukphone": "[ˈtraɪb(ə)l]"
-    },
-    {
-        "name": "tribunal",
-        "trans": [
-            "n. 法庭；裁决；法官席"
-        ],
-        "usphone": "[traɪˈbjuːnl]",
-        "ukphone": "[traɪˈbjuːnl]"
-    },
-    {
-        "name": "tribute",
-        "trans": [
-            "n. 礼物；[税收] 贡物；颂词；（尤指对死者的）致敬，悼念，吊唁礼物"
-        ],
-        "usphone": "[ˈtrɪbjuːt]",
-        "ukphone": "[ˈtrɪbjuːt]"
-    },
-    {
-        "name": "trigger",
-        "trans": [
-            "n. 扳机；[电子] 触发器；制滑机"
-        ],
-        "usphone": "[ˈtrɪɡər]",
-        "ukphone": "[ˈtrɪɡə(r)]"
-    },
-    {
-        "name": "trio",
-        "trans": [
-            "n. 三重唱；三件一套；三个一组"
-        ],
-        "usphone": "[ˈtriːoʊ]",
-        "ukphone": "[ˈtriːəʊ]"
-    },
-    {
-        "name": "triumph",
-        "trans": [
-            "n. 胜利，凯旋；欢欣"
-        ],
-        "usphone": "[ˈtraɪʌmf]",
-        "ukphone": "[ˈtraɪʌmf]"
-    },
-    {
-        "name": "trophy",
-        "trans": [
-            "n. 奖品；战利品；纪念品"
-        ],
-        "usphone": "[ˈtroʊfi]",
-        "ukphone": "[ˈtrəʊfi]"
-    },
-    {
-        "name": "troubled",
-        "trans": [
-            "adj. 动乱的，不安的；混乱的；困惑的"
-        ],
-        "usphone": "[ˈtrʌbld]",
-        "ukphone": "[ˈtrʌbld]"
-    },
-    {
-        "name": "trustee",
-        "trans": [
-            "n. 受托人；托管人"
-        ],
-        "usphone": "[trʌˈstiː]",
-        "ukphone": "[trʌˈstiː]"
-    },
-    {
-        "name": "tuition",
-        "trans": [
-            "n. 学费；讲授"
-        ],
-        "usphone": "[tuˈɪʃn]",
-        "ukphone": "[tjuˈɪʃ(ə)n]"
-    },
-    {
-        "name": "turnout",
-        "trans": [
-            "n. 产量；出席者；参加人数；出动；清除；[公路] 岔道"
-        ],
-        "usphone": "[ˈtɜːrnaʊt]",
-        "ukphone": "[ˈtɜːnaʊt]"
-    },
-    {
-        "name": "turnover",
-        "trans": [
-            "n. 翻覆；[贸易] 营业额；流通量；半圆卷饼；失误"
-        ],
-        "usphone": "[ˈtɜːrnoʊvər]",
-        "ukphone": "[ˈtɜːnəʊvə(r)]"
-    },
-    {
-        "name": "twist",
-        "trans": [
-            "n. 扭曲；拧；扭伤"
-        ],
-        "usphone": "[twɪst]",
-        "ukphone": "[twɪst]"
-    },
-    {
-        "name": "undergraduate",
-        "trans": [
-            "n. 大学生；大学肄业生"
-        ],
-        "usphone": "[ˌʌndərˈɡrædʒuət]",
-        "ukphone": "[ˌʌndəˈɡrædʒuət]"
-    },
-    {
-        "name": "underlying",
-        "trans": [
-            "adj. 潜在的；根本的；在下面的；优先的"
-        ],
-        "usphone": "[ˌʌndərˈlaɪɪŋ]",
-        "ukphone": "[ˌʌndəˈlaɪɪŋ]"
-    },
-    {
-        "name": "undermine",
-        "trans": [
-            "vt. 破坏，渐渐破坏；挖掘地基"
-        ],
-        "usphone": "[ˌʌndərˈmaɪn]",
-        "ukphone": "[ˌʌndəˈmaɪn]"
-    },
-    {
-        "name": "undoubtedly",
-        "trans": [
-            "adv. 确实地，毋庸置疑的"
-        ],
-        "usphone": "[ʌnˈdaʊtɪdli]",
-        "ukphone": "[ʌnˈdaʊtɪdli]"
-    },
-    {
-        "name": "unify",
-        "trans": [
-            "vt. 统一；使相同，使一致"
-        ],
-        "usphone": "[ˈjuːnɪfaɪ]",
-        "ukphone": "[ˈjuːnɪfaɪ]"
-    },
-    {
-        "name": "unprecedented",
-        "trans": [
-            "adj. 空前的；无前例的"
-        ],
-        "usphone": "[ʌnˈpresɪdentɪd]",
-        "ukphone": "[ʌnˈpresɪdentɪd]"
-    },
-    {
-        "name": "unveil",
-        "trans": [
-            "vt. 使公之于众，揭开；揭幕"
-        ],
-        "usphone": "[ˌʌnˈveɪl]",
-        "ukphone": "[ˌʌnˈveɪl]"
-    },
-    {
-        "name": "upcoming",
-        "trans": [
-            "adj. 即将来临的"
-        ],
-        "usphone": "[ˈʌpkʌmɪŋ]",
-        "ukphone": "[ˈʌpkʌmɪŋ]"
-    },
-    {
-        "name": "upgrade",
-        "trans": [
-            "n. 升级；上升；上坡"
-        ],
-        "usphone": "[ˈʌpɡreɪd]",
-        "ukphone": "[ˈʌpɡreɪd]"
-    },
-    {
-        "name": "uphold",
-        "trans": [
-            "vt. 支撑；鼓励；赞成；举起"
-        ],
-        "usphone": "[ʌpˈhoʊld]",
-        "ukphone": "[ʌpˈhəʊld]"
-    },
-    {
-        "name": "utility",
-        "trans": [
-            "n. 实用；效用；公共设施；功用"
-        ],
-        "usphone": "[juːˈtɪləti]",
-        "ukphone": "[juːˈtɪləti]"
-    },
-    {
-        "name": "utilize",
-        "trans": [
-            "vt. 利用"
-        ],
-        "usphone": "[ˈjuːtəlaɪz]",
-        "ukphone": "[ˈjuːtəlaɪz]"
-    },
-    {
-        "name": "utterly",
-        "trans": [
-            "adv. 完全地；绝对地；全然地；彻底地，十足地"
-        ],
-        "usphone": "[ˈʌtərli]",
-        "ukphone": "[ˈʌtəli]"
-    },
-    {
-        "name": "vacuum",
-        "trans": [
-            "n. 真空；空间；真空吸尘器"
-        ],
-        "usphone": "[ˈvækjuːm]",
-        "ukphone": "[ˈvækjuːm]"
-    },
-    {
-        "name": "vague",
-        "trans": [
-            "adj. 模糊的；含糊的；不明确的；暧昧的"
-        ],
-        "usphone": "[veɪɡ]",
-        "ukphone": "[veɪɡ]"
-    },
-    {
-        "name": "validity",
-        "trans": [
-            "n. [计] 有效性；正确；正确性"
-        ],
-        "usphone": "[vəˈlɪdəti]",
-        "ukphone": "[vəˈlɪdəti]"
-    },
-    {
-        "name": "vanish",
-        "trans": [
-            "n. 弱化音"
-        ],
-        "usphone": "[ˈvænɪʃ]",
-        "ukphone": "[ˈvænɪʃ]"
-    },
-    {
-        "name": "variable",
-        "trans": [
-            "n. [数] 变量；可变物，可变因素"
-        ],
-        "usphone": "[ˈveriəblˌˈværiəbl]",
-        "ukphone": "[ˈveəriəb(ə)l]"
-    },
-    {
-        "name": "varied",
-        "trans": [
-            "v. 改变；使多样化（vary的过去式和过去分词形式）"
-        ],
-        "usphone": "[ˈveridˌˈværid]",
-        "ukphone": "[ˈveərid]"
-    },
-    {
-        "name": "vein",
-        "trans": [
-            "n. 血管；叶脉；[地质] 岩脉；纹理；翅脉；性情"
-        ],
-        "usphone": "[veɪn]",
-        "ukphone": "[veɪn]"
-    },
-    {
-        "name": "venture",
-        "trans": [
-            "n. 企业；风险；冒险"
-        ],
-        "usphone": "[ˈventʃər]",
-        "ukphone": "[ˈventʃə(r)]"
-    },
-    {
-        "name": "verbal",
-        "trans": [
-            "n. 动词的非谓语形式"
-        ],
-        "usphone": "[ˈvɜːrbl]",
-        "ukphone": "[ˈvɜːb(ə)l]"
-    },
-    {
-        "name": "verdict",
-        "trans": [
-            "n. 结论；裁定"
-        ],
-        "usphone": "[ˈvɜːrdɪkt]",
-        "ukphone": "[ˈvɜːdɪkt]"
-    },
-    {
-        "name": "verify",
-        "trans": [
-            "vt. 核实；查证"
-        ],
-        "usphone": "[ˈverɪfaɪ]",
-        "ukphone": "[ˈverɪfaɪ]"
-    },
-    {
-        "name": "verse",
-        "trans": [
-            "n. 诗，诗篇；韵文；诗节"
-        ],
-        "usphone": "[vɜːrs]",
-        "ukphone": "[vɜːs]"
-    },
-    {
-        "name": "versus",
-        "trans": [
-            "prep. 对；与...相对；对抗"
-        ],
-        "usphone": "[ˈvɜːrsəs]",
-        "ukphone": "[ˈvɜːsəs]"
-    },
-    {
-        "name": "vessel",
-        "trans": [
-            "n. 船，舰；[组织] 脉管，血管；容器，器皿"
-        ],
-        "usphone": "[ˈvesl]",
-        "ukphone": "[ˈves(ə)l]"
-    },
-    {
-        "name": "veteran",
-        "trans": [
-            "n. 老兵；老手；富有经验的人；老运动员"
-        ],
-        "usphone": "[ˈvetərən]",
-        "ukphone": "[ˈvetərən]"
-    },
-    {
-        "name": "viable",
-        "trans": [
-            "adj. 可行的；能养活的；能生育的"
-        ],
-        "usphone": "[ˈvaɪəbl]",
-        "ukphone": "[ˈvaɪəb(ə)l]"
-    },
-    {
-        "name": "vibrant",
-        "trans": [
-            "adj. 振动的；充满生气的；响亮的；战栗的"
-        ],
-        "usphone": "[ˈvaɪbrənt]",
-        "ukphone": "[ˈvaɪbrənt]"
-    },
-    {
-        "name": "vice",
-        "trans": [
-            "prep. 代替"
-        ],
-        "usphone": "[vaɪs]",
-        "ukphone": "[vaɪs]"
-    },
-    {
-        "name": "vicious",
-        "trans": [
-            "adj. 恶毒的；恶意的；堕落的；有错误的；品性不端的；剧烈的"
-        ],
-        "usphone": "[ˈvɪʃəs]",
-        "ukphone": "[ˈvɪʃəs]"
+        "usphone": "[ˈlɔɪəlti]",
+        "ukphone": "[ˈlɔɪəlti]"
     },
     {
         "name": "villager",
@@ -10216,68 +7792,68 @@
         "ukphone": "[ˈvɪlɪdʒə(r)]"
     },
     {
-        "name": "violate",
+        "name": "cocktail",
         "trans": [
-            "vt. 违反；侵犯，妨碍；亵渎"
+            "n. 鸡尾酒；开胃食品"
         ],
-        "usphone": "[ˈvaɪəleɪt]",
-        "ukphone": "[ˈvaɪəleɪt]"
+        "usphone": "[ˈkɑːkteɪl]",
+        "ukphone": "[ˈkɒkteɪl]"
     },
     {
-        "name": "violation",
+        "name": "substitution",
         "trans": [
-            "n. 违反；妨碍，侵害；违背；强奸"
+            "n. 代替；[数] 置换；代替物"
         ],
-        "usphone": "[ˌvaɪəˈleɪʃn]",
-        "ukphone": "[ˌvaɪəˈleɪʃ(ə)n]"
+        "usphone": "[ˌsʌbstɪˈtuːʃn]",
+        "ukphone": "[ˌsʌbstɪˈtjuːʃn]"
     },
     {
-        "name": "virtue",
+        "name": "literacy",
         "trans": [
-            "n. 美德；优点；贞操；功效"
+            "n. 读写能力；精通文学"
         ],
-        "usphone": "[ˈvɜːrtʃuː]",
-        "ukphone": "[ˈvɜːtʃuː]"
+        "usphone": "[ˈlɪtərəsi]",
+        "ukphone": "[ˈlɪtərəsi]"
     },
     {
-        "name": "vocal",
+        "name": "dignity",
         "trans": [
-            "adj. 直言不讳的"
+            "n. 尊严；高贵"
         ],
-        "usphone": "[ˈvoʊkl]",
-        "ukphone": "[ˈvəʊk(ə)l]"
+        "usphone": "[ˈdɪɡnəti]",
+        "ukphone": "[ˈdɪɡnəti]"
     },
     {
-        "name": "vow",
+        "name": "allowance",
         "trans": [
-            "n. 发誓；誓言；许愿"
+            "n. 津贴，零用钱；允许；限额"
         ],
-        "usphone": "[vaʊ]",
-        "ukphone": "[vaʊ]"
+        "usphone": "[əˈlaʊəns]",
+        "ukphone": "[əˈlaʊəns]"
     },
     {
-        "name": "vulnerability",
+        "name": "descent",
         "trans": [
-            "n. 易损性；弱点"
+            "n. 下降；血统；袭击"
         ],
-        "usphone": "[ˌvʌlnərəˈbɪləti]",
-        "ukphone": "[ˌvʌlnərəˈbɪləti]"
+        "usphone": "[dɪˈsent]",
+        "ukphone": "[dɪˈsent]"
     },
     {
-        "name": "vulnerable",
+        "name": "verbal",
         "trans": [
-            "adj. 易受攻击的，易受…的攻击；易受伤害的；有弱点的"
+            "n. 动词的非谓语形式"
         ],
-        "usphone": "[ˈvʌlnərəbl]",
-        "ukphone": "[ˈvʌlnərəbl]"
+        "usphone": "[ˈvɜːrbl]",
+        "ukphone": "[ˈvɜːb(ə)l]"
     },
     {
-        "name": "ward",
+        "name": "fatal",
         "trans": [
-            "n. 病房；保卫；监视"
+            "adj. 致命的；重大的；毁灭性的；命中注定的"
         ],
-        "usphone": "[wɔːrd]",
-        "ukphone": "[wɔːd]"
+        "usphone": "[ˈfeɪtl]",
+        "ukphone": "[ˈfeɪt(ə)l]"
     },
     {
         "name": "warehouse",
@@ -10288,28 +7864,308 @@
         "ukphone": "[ˈweəhaʊs]"
     },
     {
-        "name": "warfare",
+        "name": "proceeding",
         "trans": [
-            "n. 战争；冲突"
+            "n. 进行；程序；诉讼；事项"
         ],
-        "usphone": "[ˈwɔːrfer]",
-        "ukphone": "[ˈwɔːfeə(r)]"
+        "usphone": "[prəˈsiːdɪŋ]",
+        "ukphone": "[prəˈsiːdɪŋ]"
     },
     {
-        "name": "warrant",
+        "name": "affection",
         "trans": [
-            "n. 根据；证明；正当理由；委任状"
+            "n. 喜爱，感情；影响；感染"
         ],
-        "usphone": "[ˈwɔːrənt]",
-        "ukphone": "[ˈwɒrənt]"
+        "usphone": "[əˈfekʃn]",
+        "ukphone": "[əˈfekʃn]"
     },
     {
-        "name": "warrior",
+        "name": "donor",
         "trans": [
-            "n. 战士，勇士；鼓吹战争的人"
+            "n. 捐赠者；供者；赠送人"
         ],
-        "usphone": "[ˈwɔːriər]",
-        "ukphone": "[ˈwɒriə(r)]"
+        "usphone": "[ˈdoʊnər]",
+        "ukphone": "[ˈdəʊnə(r)]"
+    },
+    {
+        "name": "tremendous",
+        "trans": [
+            "adj. 极大的，巨大的；惊人的；极好的"
+        ],
+        "usphone": "[trəˈmendəs]",
+        "ukphone": "[trəˈmendəs]"
+    },
+    {
+        "name": "large-scale",
+        "trans": [
+            "adj. 大规模的，大范围的；大比例尺的"
+        ],
+        "usphone": "[ˌlɑːrdʒ ˈskeɪl]",
+        "ukphone": "[ˌlɑːdʒ ˈskeɪl]"
+    },
+    {
+        "name": "gaze",
+        "trans": [
+            "n. 凝视；注视"
+        ],
+        "usphone": "[ɡeɪz]",
+        "ukphone": "[ɡeɪz]"
+    },
+    {
+        "name": "mask",
+        "trans": [
+            "n. 面具；口罩；掩饰"
+        ],
+        "usphone": "[mæsk]",
+        "ukphone": "[mɑːsk]"
+    },
+    {
+        "name": "presently",
+        "trans": [
+            "adv. （美）目前；不久"
+        ],
+        "usphone": "[ˈprezntli]",
+        "ukphone": "[ˈprezntli]"
+    },
+    {
+        "name": "ideology",
+        "trans": [
+            "n. 意识形态；思想意识；观念学"
+        ],
+        "usphone": "[ˌaɪdiˈɑːlədʒi]",
+        "ukphone": "[ˌaɪdiˈɒlədʒi]"
+    },
+    {
+        "name": "nest",
+        "trans": [
+            "n. 巢，窝；安乐窝；温床"
+        ],
+        "usphone": "[nest]",
+        "ukphone": "[nest]"
+    },
+    {
+        "name": "legitimate",
+        "trans": [
+            "adj. 合法的；正当的；合理的；正统的"
+        ],
+        "usphone": "[lɪˈdʒɪtɪmət]",
+        "ukphone": "[lɪˈdʒɪtɪmət]"
+    },
+    {
+        "name": "dispute",
+        "trans": [
+            "n. 辩论；争吵"
+        ],
+        "usphone": "[dɪˈspjuːt; ˈdɪspjuːt]",
+        "ukphone": "[dɪˈspjuːt]"
+    },
+    {
+        "name": "columnist",
+        "trans": [
+            "n. 专栏作家"
+        ],
+        "usphone": "[ˈkɑːləmnɪst]",
+        "ukphone": "[ˈkɒləmnɪst]"
+    },
+    {
+        "name": "congressional",
+        "trans": [
+            "adj. 国会的；会议的；议会的"
+        ],
+        "usphone": "[kənˈɡreʃənl]",
+        "ukphone": "[kənˈɡreʃənl]"
+    },
+    {
+        "name": "compelling",
+        "trans": [
+            "adj. 引人注目的；强制的；激发兴趣的"
+        ],
+        "usphone": "[kəmˈpelɪŋ]",
+        "ukphone": "[kəmˈpelɪŋ]"
+    },
+    {
+        "name": "shareholder",
+        "trans": [
+            "n. 股东；股票持有人"
+        ],
+        "usphone": "[ˈʃerhoʊldər]",
+        "ukphone": "[ˈʃeəhəʊldə(r)]"
+    },
+    {
+        "name": "exploitation",
+        "trans": [
+            "n. 开发，开采；利用；广告推销；剥削"
+        ],
+        "usphone": "[ˌeksplɔɪˈteɪʃn]",
+        "ukphone": "[ˌeksplɔɪˈteɪʃ(ə)n]"
+    },
+    {
+        "name": "critique",
+        "trans": [
+            "n. 批评；评论文章"
+        ],
+        "usphone": "[krɪˈtiːk]",
+        "ukphone": "[krɪˈtiːk]"
+    },
+    {
+        "name": "applaud",
+        "trans": [
+            "vt. 赞同；称赞；向…喝彩"
+        ],
+        "usphone": "[əˈplɔːd]",
+        "ukphone": "[əˈplɔːd]"
+    },
+    {
+        "name": "vanish",
+        "trans": [
+            "n. 弱化音"
+        ],
+        "usphone": "[ˈvænɪʃ]",
+        "ukphone": "[ˈvænɪʃ]"
+    },
+    {
+        "name": "sound",
+        "trans": [
+            "n. 声音，语音；噪音；海峡；吵闹；听力范围；[医] 探条"
+        ],
+        "usphone": "[saʊnd]",
+        "ukphone": "[saʊnd]"
+    },
+    {
+        "name": "lifelong",
+        "trans": [
+            "adj. 终身的"
+        ],
+        "usphone": "[ˈlaɪflɔːŋ]",
+        "ukphone": "[ˈlaɪflɒŋ]"
+    },
+    {
+        "name": "spectrum",
+        "trans": [
+            "n. 光谱；频谱；范围；余象"
+        ],
+        "usphone": "[ˈspektrəm]",
+        "ukphone": "[ˈspektrəm]"
+    },
+    {
+        "name": "serial",
+        "trans": [
+            "n. 电视连续剧；[图情] 期刊；连载小说"
+        ],
+        "usphone": "[ˈsɪriəl]",
+        "ukphone": "[ˈsɪəriəl]"
+    },
+    {
+        "name": "battlefield",
+        "trans": [
+            "n. 战场；沙场"
+        ],
+        "usphone": "[ˈbætlfiːld]",
+        "ukphone": "[ˈbætlfiːld]"
+    },
+    {
+        "name": "pit",
+        "trans": [
+            "n. 矿井；深坑；陷阱；（物体或人体表面上的）凹陷；（英国剧场的）正厅后排；正厅后排的观众"
+        ],
+        "usphone": "[pɪt]",
+        "ukphone": "[pɪt]"
+    },
+    {
+        "name": "reportedly",
+        "trans": [
+            "adv. 据报道；据传闻"
+        ],
+        "usphone": "[rɪˈpɔːrtɪdli]",
+        "ukphone": "[rɪˈpɔːtɪdli]"
+    },
+    {
+        "name": "stab",
+        "trans": [
+            "n. 刺；戳；尝试；突发的一阵"
+        ],
+        "usphone": "[stæb]",
+        "ukphone": "[stæb]"
+    },
+    {
+        "name": "nonetheless",
+        "trans": [
+            "adv. 尽管如此，但是"
+        ],
+        "usphone": "[ˌnʌnðəˈles]",
+        "ukphone": "[ˌnʌnðəˈles]"
+    },
+    {
+        "name": "auto",
+        "trans": [
+            "n. 汽车（等于automobile）；自动"
+        ],
+        "usphone": "[ˈɔːtoʊ]",
+        "ukphone": "[ˈɔːtəʊ]"
+    },
+    {
+        "name": "senator",
+        "trans": [
+            "n. 参议员；（古罗马的）元老院议员；评议员，理事"
+        ],
+        "usphone": "[ˈsenətər]",
+        "ukphone": "[ˈsenətə(r)]"
+    },
+    {
+        "name": "viable",
+        "trans": [
+            "adj. 可行的；能养活的；能生育的"
+        ],
+        "usphone": "[ˈvaɪəbl]",
+        "ukphone": "[ˈvaɪəb(ə)l]"
+    },
+    {
+        "name": "thought-provoking",
+        "trans": [
+            "adj. 发人深省的；引起思考的"
+        ],
+        "usphone": "[ˈθɔːt prəvoʊkɪŋ]",
+        "ukphone": "[ˈθɔːt prəvəʊkɪŋ]"
+    },
+    {
+        "name": "rhetoric",
+        "trans": [
+            "n. 修辞，修辞学；华丽的词藻"
+        ],
+        "usphone": "[ˈretərɪk]",
+        "ukphone": "[ˈretərɪk]"
+    },
+    {
+        "name": "exclusively",
+        "trans": [
+            "adv. 唯一地；专有地；排外地"
+        ],
+        "usphone": "[ɪkˈskluːsɪvli]",
+        "ukphone": "[ɪkˈskluːsɪvli]"
+    },
+    {
+        "name": "correspond",
+        "trans": [
+            "vi. 符合，一致；相应；通信"
+        ],
+        "usphone": "[ˌkɔːrəˈspɑːnd]",
+        "ukphone": "[ˌkɒrəˈspɒnd]"
+    },
+    {
+        "name": "legislation",
+        "trans": [
+            "n. 立法；法律"
+        ],
+        "usphone": "[ˌledʒɪsˈleɪʃn]",
+        "ukphone": "[ˌledʒɪsˈleɪʃn]"
+    },
+    {
+        "name": "burden",
+        "trans": [
+            "n. 负担；责任；船的载货量"
+        ],
+        "usphone": "[ˈbɜːrdn]",
+        "ukphone": "[ˈbɜːdn]"
     },
     {
         "name": "weaken",
@@ -10320,156 +8176,132 @@
         "ukphone": "[ˈwiːkən]"
     },
     {
-        "name": "weave",
+        "name": "density",
         "trans": [
-            "vi. 纺织；编成；迂回行进"
+            "n. 密度"
         ],
-        "usphone": "[wiːv]",
-        "ukphone": "[wiːv]"
+        "usphone": "[ˈdensəti]",
+        "ukphone": "[ˈdensəti]"
     },
     {
-        "name": "weed",
+        "name": "supposedly",
         "trans": [
-            "n. 杂草，野草；菸草"
+            "adv. 可能；按照推测；恐怕"
         ],
-        "usphone": "[wiːd]",
-        "ukphone": "[wiːd]"
+        "usphone": "[səˈpoʊzɪdli]",
+        "ukphone": "[səˈpəʊzɪdli]"
     },
     {
-        "name": "well",
+        "name": "burst",
         "trans": [
-            "n. 井；源泉"
+            "n. 爆发，突发；爆炸"
         ],
-        "usphone": "[wel]",
-        "ukphone": "[wel]"
+        "usphone": "[bɜːrst]",
+        "ukphone": "[bɜːst]"
     },
     {
-        "name": "well-being",
+        "name": "latter",
         "trans": [
-            "n. 幸福；康乐"
+            "adj. 后者的；近来的；后面的；较后的"
         ],
-        "usphone": "[ˈwel biːɪŋ]",
-        "ukphone": "[ˈwel biːɪŋ]"
+        "usphone": "[ˈlætər]",
+        "ukphone": "[ˈlætə(r)]"
     },
     {
-        "name": "whatever",
+        "name": "ranking",
         "trans": [
-            "conj. 无论什么"
+            "n. 等级；地位"
         ],
-        "usphone": "[wətˈevər]",
-        "ukphone": "[wɒtˈevə(r)]"
+        "usphone": "[ˈræŋkɪŋ]",
+        "ukphone": "[ˈræŋkɪŋ]"
     },
     {
-        "name": "whatsoever",
+        "name": "induce",
         "trans": [
-            "pron. 无论什么"
+            "vt. 诱导；引起；引诱；感应"
         ],
-        "usphone": "[ˌhwɑtsoˈevər]",
-        "ukphone": "[ˌwɒtsəʊˈevə(r)]"
+        "usphone": "[ɪnˈduːs]",
+        "ukphone": "[ɪnˈdjuːs]"
     },
     {
-        "name": "whereby",
+        "name": "sheer",
         "trans": [
-            "adv. 凭借；通过…；借以；与…一致"
+            "n. 偏航；透明薄织物"
         ],
-        "usphone": "[werˈbaɪ]",
-        "ukphone": "[weəˈbaɪ]"
+        "usphone": "[ʃɪr]",
+        "ukphone": "[ʃɪə(r)]"
     },
     {
-        "name": "whilst",
+        "name": "duo",
         "trans": [
-            "conj. 同时；时时，有时；当…的时候"
+            "n. 二重奏；二重唱；二人组"
         ],
-        "usphone": "[waɪlst]",
-        "ukphone": "[waɪlst]"
+        "usphone": "[ˈduːoʊ]",
+        "ukphone": "[ˈdjuːəʊ]"
     },
     {
-        "name": "whip",
+        "name": "medieval",
         "trans": [
-            "n. 鞭子；抽打；车夫；[机] 搅拌器"
+            "adj. 中世纪的；原始的；仿中世纪的；老式的"
         ],
-        "usphone": "[wɪp]",
-        "ukphone": "[wɪp]"
+        "usphone": "[ˌmediˈiːvlˌˌmiːdˈiːvl]",
+        "ukphone": "[ˌmediˈiːvl]"
     },
     {
-        "name": "wholly",
+        "name": "stereotype",
         "trans": [
-            "adv. 完全地；全部；统统"
+            "n. 陈腔滥调，老套；铅版"
         ],
-        "usphone": "[ˈhoʊlli]",
-        "ukphone": "[ˈhəʊlli]"
+        "usphone": "[ˈsteriətaɪp]",
+        "ukphone": "[ˈsteriətaɪp]"
     },
     {
-        "name": "widen",
+        "name": "lesser",
         "trans": [
-            "vt. 放宽"
+            "adj. 较少的；次要的；更小的"
         ],
-        "usphone": "[ˈwaɪdn]",
-        "ukphone": "[ˈwaɪd(ə)n]"
+        "usphone": "[ˈlesər]",
+        "ukphone": "[ˈlesə(r)]"
     },
     {
-        "name": "widow",
+        "name": "vein",
         "trans": [
-            "n. 寡妇；孀妇"
+            "n. 血管；叶脉；[地质] 岩脉；纹理；翅脉；性情"
         ],
-        "usphone": "[ˈwɪdoʊ]",
-        "ukphone": "[ˈwɪdəʊ]"
+        "usphone": "[veɪn]",
+        "ukphone": "[veɪn]"
     },
     {
-        "name": "width",
+        "name": "sword",
         "trans": [
-            "n. 宽度；广度"
+            "n. 刀，剑；武力，战争"
         ],
-        "usphone": "[wɪdθ; wɪtθ]",
-        "ukphone": "[wɪdθ]"
+        "usphone": "[sɔːrd]",
+        "ukphone": "[sɔːd]"
     },
     {
-        "name": "willingness",
+        "name": "high-profile",
         "trans": [
-            "n. 乐意；心甘情愿；自动自发"
+            "adj. 高调的；备受瞩目的；知名度高的"
         ],
-        "usphone": "[ˈwɪlɪŋnəs]",
-        "ukphone": "[ˈwɪlɪŋnəs]"
+        "usphone": "[ˌhaɪ ˈproʊfaɪl]",
+        "ukphone": "[ˌhaɪ ˈprəʊfaɪl]"
     },
     {
-        "name": "wipe",
+        "name": "oblige",
         "trans": [
-            "n. 擦拭；用力打"
+            "vt. 迫使；强制；赐，施恩惠；责成；义务"
         ],
-        "usphone": "[waɪp]",
-        "ukphone": "[waɪp]"
+        "usphone": "[əˈblaɪdʒ]",
+        "ukphone": "[əˈblaɪdʒ]"
     },
     {
-        "name": "wit",
+        "name": "striking",
         "trans": [
-            "n. 智慧；才智；智力"
+            "v. 打（strike的ing形式）"
         ],
-        "usphone": "[wɪt]",
-        "ukphone": "[wɪt]"
-    },
-    {
-        "name": "withdrawal",
-        "trans": [
-            "n. 撤退，收回；提款；取消；退股"
-        ],
-        "usphone": "[wɪðˈdrɔːəl]",
-        "ukphone": "[wɪðˈdrɔːəl]"
-    },
-    {
-        "name": "workout",
-        "trans": [
-            "n. 锻炼；练习；试验"
-        ],
-        "usphone": "[ˈwɜːrkaʊt]",
-        "ukphone": "[ˈwɜːkaʊt]"
-    },
-    {
-        "name": "worship",
-        "trans": [
-            "n. 崇拜；礼拜；尊敬"
-        ],
-        "usphone": "[ˈwɜːrʃɪp]",
-        "ukphone": "[ˈwɜːʃɪp]"
+        "usphone": "[ˈstraɪkɪŋ]",
+        "ukphone": "[ˈstraɪkɪŋ]"
     },
     {
         "name": "worthwhile",
@@ -10480,12 +8312,1676 @@
         "ukphone": "[ˌwɜːθˈwaɪl]"
     },
     {
-        "name": "worthy",
+        "name": "strip",
         "trans": [
-            "n. 杰出人物；知名人士"
+            "n. 带；条状；脱衣舞"
         ],
-        "usphone": "[ˈwɜːrði]",
-        "ukphone": "[ˈwɜːði]"
+        "usphone": "[strɪp]",
+        "ukphone": "[strɪp]"
+    },
+    {
+        "name": "render",
+        "trans": [
+            "n. 打底；交纳；粉刷"
+        ],
+        "usphone": "[ˈrendər]",
+        "ukphone": "[ˈrendə(r)]"
+    },
+    {
+        "name": "constitutional",
+        "trans": [
+            "n. 保健散步；保健运动"
+        ],
+        "usphone": "[ˌkɑːnstɪˈtuːʃənl]",
+        "ukphone": "[ˌkɒnstɪˈtjuːʃənl]"
+    },
+    {
+        "name": "distress",
+        "trans": [
+            "n. 危难，不幸；贫困；悲痛"
+        ],
+        "usphone": "[dɪˈstres]",
+        "ukphone": "[dɪˈstres]"
+    },
+    {
+        "name": "junction",
+        "trans": [
+            "n. 连接，接合；交叉点；接合点"
+        ],
+        "usphone": "[ˈdʒʌŋkʃn]",
+        "ukphone": "[ˈdʒʌŋkʃn]"
+    },
+    {
+        "name": "compensate",
+        "trans": [
+            "vt. 补偿，赔偿；付报酬"
+        ],
+        "usphone": "[ˈkɑːmpenseɪt]",
+        "ukphone": "[ˈkɒmpenseɪt]"
+    },
+    {
+        "name": "motorist",
+        "trans": [
+            "n. 驾车旅行的人，开汽车的人"
+        ],
+        "usphone": "[ˈmoʊtərɪst]",
+        "ukphone": "[ˈməʊtərɪst]"
+    },
+    {
+        "name": "accomplishment",
+        "trans": [
+            "n. 成就；完成；技艺，技能"
+        ],
+        "usphone": "[əˈkɑːmplɪʃmənt]",
+        "ukphone": "[əˈkʌmplɪʃmənt]"
+    },
+    {
+        "name": "squeeze",
+        "trans": [
+            "n. 压榨；紧握；拥挤；佣金"
+        ],
+        "usphone": "[skwiːz]",
+        "ukphone": "[skwiːz]"
+    },
+    {
+        "name": "consistency",
+        "trans": [
+            "n. [计] 一致性；稠度；相容性"
+        ],
+        "usphone": "[kənˈsɪstənsi]",
+        "ukphone": "[kənˈsɪstənsi]"
+    },
+    {
+        "name": "undoubtedly",
+        "trans": [
+            "adv. 确实地，毋庸置疑的"
+        ],
+        "usphone": "[ʌnˈdaʊtɪdli]",
+        "ukphone": "[ʌnˈdaʊtɪdli]"
+    },
+    {
+        "name": "anchor",
+        "trans": [
+            "n. 锚；抛锚停泊；靠山；新闻节目主播"
+        ],
+        "usphone": "[ˈæŋkər]",
+        "ukphone": "[ˈæŋkə(r)]"
+    },
+    {
+        "name": "respectively",
+        "trans": [
+            "adv. 分别地；各自地，独自地"
+        ],
+        "usphone": "[rɪˈspektɪvli]",
+        "ukphone": "[rɪˈspektɪvli]"
+    },
+    {
+        "name": "steer",
+        "trans": [
+            "vt. 控制，引导；驾驶"
+        ],
+        "usphone": "[stɪr]",
+        "ukphone": "[stɪə(r)]"
+    },
+    {
+        "name": "disclosure",
+        "trans": [
+            "n. [审计] 披露；揭发；被揭发出来的事情"
+        ],
+        "usphone": "[dɪsˈkloʊʒər]",
+        "ukphone": "[dɪsˈkləʊʒə(r)]"
+    },
+    {
+        "name": "separation",
+        "trans": [
+            "n. 分离，分开；间隔，距离；[法] 分居；缺口"
+        ],
+        "usphone": "[ˌsepəˈreɪʃn]",
+        "ukphone": "[ˌsepəˈreɪʃn]"
+    },
+    {
+        "name": "pledge",
+        "trans": [
+            "n. 保证，誓言；抵押；抵押品，典当物"
+        ],
+        "usphone": "[pledʒ]",
+        "ukphone": "[pledʒ]"
+    },
+    {
+        "name": "plea",
+        "trans": [
+            "n. 恳求，请求；辩解，辩护；借口，托辞"
+        ],
+        "usphone": "[pliː]",
+        "ukphone": "[pliː]"
+    },
+    {
+        "name": "intervention",
+        "trans": [
+            "n. 介入；调停；妨碍"
+        ],
+        "usphone": "[ˌɪntərˈvenʃn]",
+        "ukphone": "[ˌɪntəˈvenʃ(ə)n]"
+    },
+    {
+        "name": "skip",
+        "trans": [
+            "n. 跳跃；跳读"
+        ],
+        "usphone": "[skɪp]",
+        "ukphone": "[skɪp]"
+    },
+    {
+        "name": "vulnerability",
+        "trans": [
+            "n. 易损性；弱点"
+        ],
+        "usphone": "[ˌvʌlnərəˈbɪləti]",
+        "ukphone": "[ˌvʌlnərəˈbɪləti]"
+    },
+    {
+        "name": "grasp",
+        "trans": [
+            "n. 抓住；理解；控制"
+        ],
+        "usphone": "[ɡræsp]",
+        "ukphone": "[ɡrɑːsp]"
+    },
+    {
+        "name": "mandate",
+        "trans": [
+            "n. 授权；命令，指令；委托管理；受命进行的工作"
+        ],
+        "usphone": "[ˈmændeɪt]",
+        "ukphone": "[ˈmændeɪt]"
+    },
+    {
+        "name": "processing",
+        "trans": [
+            "v. 加工；[自] 处理；对…起诉（process的ing形式）"
+        ],
+        "usphone": "[ˈprɑːsesɪŋ]",
+        "ukphone": "[ˈprəʊsesɪŋ]"
+    },
+    {
+        "name": "enrich",
+        "trans": [
+            "vt. 使充实；使肥沃；使富足"
+        ],
+        "usphone": "[ɪnˈrɪtʃ]",
+        "ukphone": "[ɪnˈrɪtʃ]"
+    },
+    {
+        "name": "deficit",
+        "trans": [
+            "n. 赤字；不足额"
+        ],
+        "usphone": "[ˈdefɪsɪt]",
+        "ukphone": "[ˈdefɪsɪt]"
+    },
+    {
+        "name": "constitution",
+        "trans": [
+            "n. 宪法；体制；章程；构造；建立，组成；体格"
+        ],
+        "usphone": "[ˌkɑːnstɪˈtuːʃn]",
+        "ukphone": "[ˌkɒnstɪˈtjuːʃ(ə)n]"
+    },
+    {
+        "name": "condemn",
+        "trans": [
+            "vt. 谴责；判刑，定罪；声讨"
+        ],
+        "usphone": "[kənˈdem]",
+        "ukphone": "[kənˈdem]"
+    },
+    {
+        "name": "predecessor",
+        "trans": [
+            "n. 前任，前辈"
+        ],
+        "usphone": "[ˈpredəsesər]",
+        "ukphone": "[ˈpriːdəsesə(r)]"
+    },
+    {
+        "name": "comparable",
+        "trans": [
+            "adj. 可比较的；比得上的"
+        ],
+        "usphone": "[ˈkɑːmpərəbl]",
+        "ukphone": "[ˈkɒmpərəb(ə)l]"
+    },
+    {
+        "name": "tempt",
+        "trans": [
+            "vt. 诱惑；引起；冒…的风险；使感兴趣"
+        ],
+        "usphone": "[tempt]",
+        "ukphone": "[tempt]"
+    },
+    {
+        "name": "casualty",
+        "trans": [
+            "n. 意外事故；伤亡人员；急诊室"
+        ],
+        "usphone": "[ˈkæʒuəlti]",
+        "ukphone": "[ˈkæʒuəlti]"
+    },
+    {
+        "name": "disruption",
+        "trans": [
+            "n. 破坏，毁坏；分裂，瓦解"
+        ],
+        "usphone": "[dɪsˈrʌpʃn]",
+        "ukphone": "[dɪsˈrʌpʃn]"
+    },
+    {
+        "name": "destructive",
+        "trans": [
+            "adj. 破坏的；毁灭性的；有害的，消极的"
+        ],
+        "usphone": "[dɪˈstrʌktɪv]",
+        "ukphone": "[dɪˈstrʌktɪv]"
+    },
+    {
+        "name": "compensation",
+        "trans": [
+            "n. 补偿；报酬；赔偿金"
+        ],
+        "usphone": "[ˌkɑːmpenˈseɪʃn]",
+        "ukphone": "[ˌkɒmpenˈseɪʃ(ə)n]"
+    },
+    {
+        "name": "administer",
+        "trans": [
+            "vt. 管理；执行；给予"
+        ],
+        "usphone": "[ədˈmɪnɪstər]",
+        "ukphone": "[ədˈmɪnɪstə(r)]"
+    },
+    {
+        "name": "imprisonment",
+        "trans": [
+            "n. 监禁，关押；坐牢；下狱"
+        ],
+        "usphone": "[ɪmˈprɪznmənt]",
+        "ukphone": "[ɪmˈprɪznmənt]"
+    },
+    {
+        "name": "raid",
+        "trans": [
+            "n. 袭击；突袭；搜捕；抢劫"
+        ],
+        "usphone": "[reɪd]",
+        "ukphone": "[reɪd]"
+    },
+    {
+        "name": "radical",
+        "trans": [
+            "n. 基础；激进分子；[物化] 原子团；[数] 根数"
+        ],
+        "usphone": "[ˈrædɪkl]",
+        "ukphone": "[ˈrædɪk(ə)l]"
+    },
+    {
+        "name": "wit",
+        "trans": [
+            "n. 智慧；才智；智力"
+        ],
+        "usphone": "[wɪt]",
+        "ukphone": "[wɪt]"
+    },
+    {
+        "name": "enrol",
+        "trans": [
+            "vi. 注册；参军"
+        ],
+        "usphone": "[ɪnˈroʊl]",
+        "ukphone": "[ɪnˈrəʊl]"
+    },
+    {
+        "name": "contradiction",
+        "trans": [
+            "n. 矛盾；否认；反驳"
+        ],
+        "usphone": "[ˌkɑːntrəˈdɪkʃn]",
+        "ukphone": "[ˌkɒntrəˈdɪkʃn]"
+    },
+    {
+        "name": "fundraising",
+        "trans": [
+            "n. 筹款；资金募集"
+        ],
+        "usphone": "[ˈfʌndreɪzɪŋ]",
+        "ukphone": "[ˈfʌndreɪzɪŋ]"
+    },
+    {
+        "name": "insertion",
+        "trans": [
+            "n. 插入；嵌入；插入物"
+        ],
+        "usphone": "[ɪnˈsɜːrʃn]",
+        "ukphone": "[ɪnˈsɜːʃn]"
+    },
+    {
+        "name": "anonymous",
+        "trans": [
+            "adj. 匿名的，无名的；无个性特征的"
+        ],
+        "usphone": "[əˈnɑːnɪməs]",
+        "ukphone": "[əˈnɒnɪməs]"
+    },
+    {
+        "name": "minimize",
+        "trans": [
+            "vt. 使减到最少；小看，极度轻视"
+        ],
+        "usphone": "[ˈmɪnɪmaɪz]",
+        "ukphone": "[ˈmɪnɪmaɪz]"
+    },
+    {
+        "name": "genocide",
+        "trans": [
+            "n. 种族灭绝；灭绝整个种族的大屠杀"
+        ],
+        "usphone": "[ˈdʒenəsaɪd]",
+        "ukphone": "[ˈdʒenəsaɪd]"
+    },
+    {
+        "name": "regardless",
+        "trans": [
+            "adj. 不管的；不顾的；不注意的"
+        ],
+        "usphone": "[rɪˈɡɑːrdləs]",
+        "ukphone": "[rɪˈɡɑːdləs]"
+    },
+    {
+        "name": "contributor",
+        "trans": [
+            "n. 贡献者；投稿者；捐助者"
+        ],
+        "usphone": "[kənˈtrɪbjətər]",
+        "ukphone": "[kənˈtrɪbjətə(r)]"
+    },
+    {
+        "name": "productive",
+        "trans": [
+            "adj. 能生产的；生产的，生产性的；多产的；富有成效的"
+        ],
+        "usphone": "[prəˈdʌktɪv]",
+        "ukphone": "[prəˈdʌktɪv]"
+    },
+    {
+        "name": "notably",
+        "trans": [
+            "adv. 显著地；尤其"
+        ],
+        "usphone": "[ˈnoʊtəbli]",
+        "ukphone": "[ˈnəʊtəbli]"
+    },
+    {
+        "name": "cling",
+        "trans": [
+            "vi. 坚持，墨守；紧贴；附着"
+        ],
+        "usphone": "[klɪŋ]",
+        "ukphone": "[klɪŋ]"
+    },
+    {
+        "name": "tolerance",
+        "trans": [
+            "n. 公差；宽容；容忍；公差"
+        ],
+        "usphone": "[ˈtɑːlərəns]",
+        "ukphone": "[ˈtɒlərəns]"
+    },
+    {
+        "name": "blade",
+        "trans": [
+            "n. 叶片；刀片，刀锋；剑"
+        ],
+        "usphone": "[bleɪd]",
+        "ukphone": "[bleɪd]"
+    },
+    {
+        "name": "accumulation",
+        "trans": [
+            "n. 积聚，累积；堆积物"
+        ],
+        "usphone": "[əˌkjuːmjəˈleɪʃn]",
+        "ukphone": "[əˌkjuːmjəˈleɪʃn]"
+    },
+    {
+        "name": "dismissal",
+        "trans": [
+            "n. 解雇；免职"
+        ],
+        "usphone": "[dɪsˈmɪsl]",
+        "ukphone": "[dɪsˈmɪs(ə)l]"
+    },
+    {
+        "name": "copper",
+        "trans": [
+            "n. 铜；铜币；警察"
+        ],
+        "usphone": "[ˈkɑːpər]",
+        "ukphone": "[ˈkɒpə(r)]"
+    },
+    {
+        "name": "outbreak",
+        "trans": [
+            "n. （战争的）爆发；（疾病的）发作"
+        ],
+        "usphone": "[ˈaʊtbreɪk]",
+        "ukphone": "[ˈaʊtbreɪk]"
+    },
+    {
+        "name": "benchmark",
+        "trans": [
+            "n. 基准；标准检查程序"
+        ],
+        "usphone": "[ˈbentʃmɑːrk]",
+        "ukphone": "[ˈbentʃmɑːk]"
+    },
+    {
+        "name": "realization",
+        "trans": [
+            "n. 实现；领悟"
+        ],
+        "usphone": "[ˌriːələˈzeɪʃn]",
+        "ukphone": "[ˌriːəlaɪˈzeɪʃn; ˌrɪəlaɪˈzeɪʃn]"
+    },
+    {
+        "name": "fate",
+        "trans": [
+            "n. 命运"
+        ],
+        "usphone": "[feɪt]",
+        "ukphone": "[feɪt]"
+    },
+    {
+        "name": "linear",
+        "trans": [
+            "adj. 线的，线型的；直线的，线状的；长度的"
+        ],
+        "usphone": "[ˈlɪniər]",
+        "ukphone": "[ˈlɪniə(r)]"
+    },
+    {
+        "name": "renowned",
+        "trans": [
+            "v. 使有声誉（renown的过去分词）"
+        ],
+        "usphone": "[rɪˈnaʊnd]",
+        "ukphone": "[rɪˈnaʊnd]"
+    },
+    {
+        "name": "scope",
+        "trans": [
+            "n. 范围；余地；视野；眼界；导弹射程"
+        ],
+        "usphone": "[skoʊp]",
+        "ukphone": "[skəʊp]"
+    },
+    {
+        "name": "guilt",
+        "trans": [
+            "n. 犯罪，过失；内疚"
+        ],
+        "usphone": "[ɡɪlt]",
+        "ukphone": "[ɡɪlt]"
+    },
+    {
+        "name": "isolation",
+        "trans": [
+            "n. 隔离；孤立；[电] 绝缘；[化学] 离析"
+        ],
+        "usphone": "[ˌaɪsəˈleɪʃn]",
+        "ukphone": "[ˌaɪsəˈleɪʃn]"
+    },
+    {
+        "name": "nod",
+        "trans": [
+            "n. 点头；打盹；摆动"
+        ],
+        "usphone": "[nɑːd]",
+        "ukphone": "[nɒd]"
+    },
+    {
+        "name": "pioneer",
+        "trans": [
+            "n. 先锋；拓荒者"
+        ],
+        "usphone": "[ˌpaɪəˈnɪr]",
+        "ukphone": "[ˌpaɪəˈnɪə(r)]"
+    },
+    {
+        "name": "tuition",
+        "trans": [
+            "n. 学费；讲授"
+        ],
+        "usphone": "[tuˈɪʃn]",
+        "ukphone": "[tjuˈɪʃ(ə)n]"
+    },
+    {
+        "name": "expenditure",
+        "trans": [
+            "n. 支出，花费；经费，消费额"
+        ],
+        "usphone": "[ɪkˈspendɪtʃər]",
+        "ukphone": "[ɪkˈspendɪtʃə(r)]"
+    },
+    {
+        "name": "contemplate",
+        "trans": [
+            "vt. 沉思；注视；思忖；预期"
+        ],
+        "usphone": "[ˈkɑːntəmpleɪt]",
+        "ukphone": "[ˈkɒntəmpleɪt]"
+    },
+    {
+        "name": "intensive",
+        "trans": [
+            "n. 加强器"
+        ],
+        "usphone": "[ɪnˈtensɪv]",
+        "ukphone": "[ɪnˈtensɪv]"
+    },
+    {
+        "name": "commence",
+        "trans": [
+            "v. 开始；着手；<英>获得学位"
+        ],
+        "usphone": "[kəˈmens]",
+        "ukphone": "[kəˈmens]"
+    },
+    {
+        "name": "oral",
+        "trans": [
+            "n. 口试"
+        ],
+        "usphone": "[ˈɔːrəl]",
+        "ukphone": "[ˈɔːrəl]"
+    },
+    {
+        "name": "embarrassment",
+        "trans": [
+            "n. 窘迫，难堪；使人为难的人或事物；拮据"
+        ],
+        "usphone": "[ɪmˈbærəsmənt]",
+        "ukphone": "[ɪmˈbærəsmənt]"
+    },
+    {
+        "name": "originate",
+        "trans": [
+            "vt. 引起；创作"
+        ],
+        "usphone": "[əˈrɪdʒɪneɪt]",
+        "ukphone": "[əˈrɪdʒɪneɪt]"
+    },
+    {
+        "name": "exaggerate",
+        "trans": [
+            "vt. 使扩大；使增大"
+        ],
+        "usphone": "[ɪɡˈzædʒəreɪt]",
+        "ukphone": "[ɪɡˈzædʒəreɪt]"
+    },
+    {
+        "name": "plunge",
+        "trans": [
+            "n. 投入；跳进"
+        ],
+        "usphone": "[plʌndʒ]",
+        "ukphone": "[plʌndʒ]"
+    },
+    {
+        "name": "correlation",
+        "trans": [
+            "n. [数] 相关，关联；相互关系"
+        ],
+        "usphone": "[ˌkɔːrəˈleɪʃ(ə)n]",
+        "ukphone": "[ˌkɒrəˈleɪʃ(ə)n]"
+    },
+    {
+        "name": "bass",
+        "trans": [
+            "n. 鲈鱼；男低音；低音部；椴树"
+        ],
+        "usphone": "[beɪs; bæs]",
+        "ukphone": "[beɪs]"
+    },
+    {
+        "name": "indulge",
+        "trans": [
+            "vi. 沉溺；满足；放任"
+        ],
+        "usphone": "[ɪnˈdʌldʒ]",
+        "ukphone": "[ɪnˈdʌldʒ]"
+    },
+    {
+        "name": "adhere",
+        "trans": [
+            "vi. 坚持；依附；粘着；追随"
+        ],
+        "usphone": "[ədˈhɪr]",
+        "ukphone": "[ədˈhɪə(r)]"
+    },
+    {
+        "name": "hierarchy",
+        "trans": [
+            "n. 层级；等级制度"
+        ],
+        "usphone": "[ˈhaɪərɑːrki]",
+        "ukphone": "[ˈhaɪərɑːki]"
+    },
+    {
+        "name": "commentary",
+        "trans": [
+            "n. 评论；注释；评注；说明"
+        ],
+        "usphone": "[ˈkɑːmənteri]",
+        "ukphone": "[ˈkɒmənt(ə)ri]"
+    },
+    {
+        "name": "lawsuit",
+        "trans": [
+            "n. 诉讼（尤指非刑事案件）；诉讼案件"
+        ],
+        "usphone": "[ˈlɔːsuːt]",
+        "ukphone": "[ˈlɔːsuːt]"
+    },
+    {
+        "name": "tribute",
+        "trans": [
+            "n. 礼物；[税收] 贡物；颂词；（尤指对死者的）致敬，悼念，吊唁礼物"
+        ],
+        "usphone": "[ˈtrɪbjuːt]",
+        "ukphone": "[ˈtrɪbjuːt]"
+    },
+    {
+        "name": "suburban",
+        "trans": [
+            "n. 郊区居民"
+        ],
+        "usphone": "[səˈbɜːrbən]",
+        "ukphone": "[səˈbɜːbən]"
+    },
+    {
+        "name": "ease",
+        "trans": [
+            "n. 轻松，舒适；安逸，悠闲"
+        ],
+        "usphone": "[iːz]",
+        "ukphone": "[iːz]"
+    },
+    {
+        "name": "admission",
+        "trans": [
+            "n. 承认；入场费；进入许可；坦白；录用"
+        ],
+        "usphone": "[ədˈmɪʃn]",
+        "ukphone": "[ədˈmɪʃ(ə)n]"
+    },
+    {
+        "name": "strategic",
+        "trans": [
+            "adj. 战略上的，战略的"
+        ],
+        "usphone": "[strəˈtiːdʒɪk]",
+        "ukphone": "[strəˈtiːdʒɪk]"
+    },
+    {
+        "name": "coordination",
+        "trans": [
+            "n. 协调，调和；对等，同等"
+        ],
+        "usphone": "[koʊˌɔːrdɪˈneɪʃn]",
+        "ukphone": "[kəʊˌɔːdɪˈneɪʃn]"
+    },
+    {
+        "name": "confirmation",
+        "trans": [
+            "n. 确认；证实；证明；批准"
+        ],
+        "usphone": "[ˌkɑːnfərˈmeɪʃn]",
+        "ukphone": "[ˌkɒnfəˈmeɪʃ(ə)n]"
+    },
+    {
+        "name": "encouraging",
+        "trans": [
+            "v. 鼓励，支持（encourage的ing形式）"
+        ],
+        "usphone": "[ɪnˈkɜːrɪdʒɪŋ]",
+        "ukphone": "[ɪnˈkʌrɪdʒɪŋ]"
+    },
+    {
+        "name": "defensive",
+        "trans": [
+            "n. 防御；守势"
+        ],
+        "usphone": "[dɪˈfensɪv]",
+        "ukphone": "[dɪˈfensɪv]"
+    },
+    {
+        "name": "whilst",
+        "trans": [
+            "conj. 同时；时时，有时；当…的时候"
+        ],
+        "usphone": "[waɪlst]",
+        "ukphone": "[waɪlst]"
+    },
+    {
+        "name": "glance",
+        "trans": [
+            "n. 一瞥；一滑；闪光"
+        ],
+        "usphone": "[ɡlæns]",
+        "ukphone": "[ɡlɑːns]"
+    },
+    {
+        "name": "flourish",
+        "trans": [
+            "n. 兴旺；茂盛；挥舞；炫耀；华饰"
+        ],
+        "usphone": "[ˈflɜːrɪʃ]",
+        "ukphone": "[ˈflʌrɪʃ]"
+    },
+    {
+        "name": "gear",
+        "trans": [
+            "n. 齿轮；装置，工具；传动装置"
+        ],
+        "usphone": "[ɡɪr]",
+        "ukphone": "[ɡɪə(r)]"
+    },
+    {
+        "name": "cargo",
+        "trans": [
+            "n. 货物，船货"
+        ],
+        "usphone": "[ˈkɑːrɡoʊ]",
+        "ukphone": "[ˈkɑːɡəʊ]"
+    },
+    {
+        "name": "insider",
+        "trans": [
+            "n. 内部的人，会员；熟悉内情者"
+        ],
+        "usphone": "[ɪnˈsaɪdər]",
+        "ukphone": "[ɪnˈsaɪdə(r)]"
+    },
+    {
+        "name": "excess",
+        "trans": [
+            "n. 超过，超额；过度，过量；无节制"
+        ],
+        "usphone": "[ɪkˈses]",
+        "ukphone": "[ɪkˈses]"
+    },
+    {
+        "name": "fragile",
+        "trans": [
+            "adj. 脆的；易碎的"
+        ],
+        "usphone": "[ˈfrædʒl]",
+        "ukphone": "[ˈfrædʒaɪl]"
+    },
+    {
+        "name": "suspicious",
+        "trans": [
+            "adj. 可疑的；怀疑的；多疑的"
+        ],
+        "usphone": "[səˈspɪʃəs]",
+        "ukphone": "[səˈspɪʃəs]"
+    },
+    {
+        "name": "integration",
+        "trans": [
+            "n. 集成；综合"
+        ],
+        "usphone": "[ˌɪntɪˈɡreɪʃn]",
+        "ukphone": "[ˌɪntɪˈɡreɪʃ(ə)n]"
+    },
+    {
+        "name": "objection",
+        "trans": [
+            "n. 异议，反对；缺陷，缺点；妨碍；拒绝的理由"
+        ],
+        "usphone": "[əbˈdʒekʃn]",
+        "ukphone": "[əbˈdʒekʃn]"
+    },
+    {
+        "name": "functional",
+        "trans": [
+            "adj. 功能的"
+        ],
+        "usphone": "[ˈfʌŋkʃənl]",
+        "ukphone": "[ˈfʌŋkʃən(ə)l]"
+    },
+    {
+        "name": "cater",
+        "trans": [
+            "vt. 投合，迎合；满足需要；提供饮食及服务"
+        ],
+        "usphone": "[ˈkeɪtər]",
+        "ukphone": "[ˈkeɪtə(r)]"
+    },
+    {
+        "name": "retrieve",
+        "trans": [
+            "n. [计] 检索；恢复，取回"
+        ],
+        "usphone": "[rɪˈtriːv]",
+        "ukphone": "[rɪˈtriːv]"
+    },
+    {
+        "name": "suspicion",
+        "trans": [
+            "n. 怀疑；嫌疑；疑心；一点儿"
+        ],
+        "usphone": "[səˈspɪʃn]",
+        "ukphone": "[səˈspɪʃ(ə)n]"
+    },
+    {
+        "name": "frankly",
+        "trans": [
+            "adv. 真诚地，坦白地"
+        ],
+        "usphone": "[ˈfræŋkli]",
+        "ukphone": "[ˈfræŋkli]"
+    },
+    {
+        "name": "chunk",
+        "trans": [
+            "n. 大块；矮胖的人或物"
+        ],
+        "usphone": "[tʃʌŋk]",
+        "ukphone": "[tʃʌŋk]"
+    },
+    {
+        "name": "trailer",
+        "trans": [
+            "n. 拖车；[电视] 预告片；追踪者"
+        ],
+        "usphone": "[ˈtreɪlər]",
+        "ukphone": "[ˈtreɪlə(r)]"
+    },
+    {
+        "name": "lesbian",
+        "trans": [
+            "adj. [心理] 女同性恋的"
+        ],
+        "usphone": "[ˈlezbiən]",
+        "ukphone": "[ˈlezbiən]"
+    },
+    {
+        "name": "upcoming",
+        "trans": [
+            "adj. 即将来临的"
+        ],
+        "usphone": "[ˈʌpkʌmɪŋ]",
+        "ukphone": "[ˈʌpkʌmɪŋ]"
+    },
+    {
+        "name": "justification",
+        "trans": [
+            "n. 理由；辩护；认为有理，认为正当；释罪"
+        ],
+        "usphone": "[ˌdʒʌstɪfɪˈkeɪʃn]",
+        "ukphone": "[ˌdʒʌstɪfɪˈkeɪʃn]"
+    },
+    {
+        "name": "equality",
+        "trans": [
+            "n. 平等；相等；[数] 等式"
+        ],
+        "usphone": "[iˈkwɑːləti]",
+        "ukphone": "[iˈkwɒləti]"
+    },
+    {
+        "name": "blast",
+        "trans": [
+            "n. 爆炸；冲击波；一阵"
+        ],
+        "usphone": "[blæst]",
+        "ukphone": "[blɑːst]"
+    },
+    {
+        "name": "hatred",
+        "trans": [
+            "n. 憎恨；怨恨；敌意"
+        ],
+        "usphone": "[ˈheɪtrɪd]",
+        "ukphone": "[ˈheɪtrɪd]"
+    },
+    {
+        "name": "outsider",
+        "trans": [
+            "n. 外人；无取胜希望者"
+        ],
+        "usphone": "[ˌaʊtˈsaɪdər]",
+        "ukphone": "[ˌaʊtˈsaɪdə(r)]"
+    },
+    {
+        "name": "flee",
+        "trans": [
+            "vt. 逃跑，逃走；逃避"
+        ],
+        "usphone": "[fliː]",
+        "ukphone": "[fliː]"
+    },
+    {
+        "name": "strive",
+        "trans": [
+            "vi. 努力；奋斗；抗争"
+        ],
+        "usphone": "[straɪv]",
+        "ukphone": "[straɪv]"
+    },
+    {
+        "name": "cult",
+        "trans": [
+            "n. 祭仪（尤其指宗教上的）；礼拜；狂热信徒"
+        ],
+        "usphone": "[kʌlt]",
+        "ukphone": "[kʌlt]"
+    },
+    {
+        "name": "conserve",
+        "trans": [
+            "n. 果酱；蜜饯"
+        ],
+        "usphone": "[kənˈsɜːrv]",
+        "ukphone": "[kənˈsɜːv]"
+    },
+    {
+        "name": "desirable",
+        "trans": [
+            "n. 合意的人或事物"
+        ],
+        "usphone": "[dɪˈzaɪərəbl]",
+        "ukphone": "[dɪˈzaɪərəb(ə)l]"
+    },
+    {
+        "name": "provincial",
+        "trans": [
+            "n. 粗野的人；乡下人；外地人"
+        ],
+        "usphone": "[prəˈvɪnʃl]",
+        "ukphone": "[prəˈvɪnʃl]"
+    },
+    {
+        "name": "arena",
+        "trans": [
+            "n. 舞台；竞技场"
+        ],
+        "usphone": "[əˈriːnə]",
+        "ukphone": "[əˈriːnə]"
+    },
+    {
+        "name": "simultaneously",
+        "trans": [
+            "adv. 同时地"
+        ],
+        "usphone": "[ˌsaɪmlˈteɪniəsli]",
+        "ukphone": "[ˌsɪm(ə)lˈteɪniəsli]"
+    },
+    {
+        "name": "contrary",
+        "trans": [
+            "n. 相反；反面"
+        ],
+        "usphone": "[ˈkɑːntreri]",
+        "ukphone": "[ˈkɒntrəri]"
+    },
+    {
+        "name": "enforcement",
+        "trans": [
+            "n. 执行，实施；强制"
+        ],
+        "usphone": "[ɪnˈfɔːrsmənt]",
+        "ukphone": "[ɪnˈfɔːsmənt]"
+    },
+    {
+        "name": "inspiration",
+        "trans": [
+            "n. 灵感；鼓舞；吸气；妙计"
+        ],
+        "usphone": "[ˌɪnspəˈreɪʃn]",
+        "ukphone": "[ˌɪnspəˈreɪʃ(ə)n]"
+    },
+    {
+        "name": "correspondence",
+        "trans": [
+            "n. 通信；一致；相当"
+        ],
+        "usphone": "[ˌkɔːrəˈspɑːndəns]",
+        "ukphone": "[ˌkɒrəˈspɒndəns]"
+    },
+    {
+        "name": "countless",
+        "trans": [
+            "adj. 无数的；数不尽的"
+        ],
+        "usphone": "[ˈkaʊntləs]",
+        "ukphone": "[ˈkaʊntləs]"
+    },
+    {
+        "name": "embed",
+        "trans": [
+            "vt. 栽种；使嵌入，使插入；使深留脑中"
+        ],
+        "usphone": "[ɪmˈbed]",
+        "ukphone": "[ɪmˈbed]"
+    },
+    {
+        "name": "readily",
+        "trans": [
+            "adv. 容易地；乐意地；无困难地"
+        ],
+        "usphone": "[ˈredɪli]",
+        "ukphone": "[ˈredɪli]"
+    },
+    {
+        "name": "dose",
+        "trans": [
+            "n. 剂量；一剂，一服"
+        ],
+        "usphone": "[doʊs]",
+        "ukphone": "[dəʊs]"
+    },
+    {
+        "name": "complexity",
+        "trans": [
+            "n. 复杂，复杂性；复杂错综的事物"
+        ],
+        "usphone": "[kəmˈpleksəti]",
+        "ukphone": "[kəmˈpleksəti]"
+    },
+    {
+        "name": "beast",
+        "trans": [
+            "n. 野兽；畜生，人面兽心的人"
+        ],
+        "usphone": "[biːst]",
+        "ukphone": "[biːst]"
+    },
+    {
+        "name": "analogy",
+        "trans": [
+            "n. 类比；类推；类似"
+        ],
+        "usphone": "[əˈnælədʒi]",
+        "ukphone": "[əˈnælədʒi]"
+    },
+    {
+        "name": "initiate",
+        "trans": [
+            "n. 开始；新加入者，接受初步知识者"
+        ],
+        "usphone": "[ɪˈnɪʃieɪt]",
+        "ukphone": "[ɪˈnɪʃieɪt]"
+    },
+    {
+        "name": "vague",
+        "trans": [
+            "adj. 模糊的；含糊的；不明确的；暧昧的"
+        ],
+        "usphone": "[veɪɡ]",
+        "ukphone": "[veɪɡ]"
+    },
+    {
+        "name": "saint",
+        "trans": [
+            "n. 圣人；圣徒；道德崇高的人"
+        ],
+        "usphone": "[seɪnt]",
+        "ukphone": "[seɪnt; snt]"
+    },
+    {
+        "name": "stun",
+        "trans": [
+            "n. 昏迷；打昏；惊倒；令人惊叹的事物"
+        ],
+        "usphone": "[stʌn]",
+        "ukphone": "[stʌn]"
+    },
+    {
+        "name": "congregation",
+        "trans": [
+            "n. 集会；集合；圣会"
+        ],
+        "usphone": "[ˌkɑːŋɡrɪˈɡeɪʃn]",
+        "ukphone": "[ˌkɒŋɡrɪˈɡeɪʃ(ə)n]"
+    },
+    {
+        "name": "pop",
+        "trans": [
+            "abbr. 卖点广告（Point of Purchase）"
+        ],
+        "usphone": "[pɑːp]",
+        "ukphone": "[pɒp]"
+    },
+    {
+        "name": "premise",
+        "trans": [
+            "n. 前提；上述各项；房屋连地基"
+        ],
+        "usphone": "[ˈpremɪs]",
+        "ukphone": "[ˈpremɪs]"
+    },
+    {
+        "name": "whatsoever",
+        "trans": [
+            "pron. 无论什么"
+        ],
+        "usphone": "[ˌhwɑtsoˈevər]",
+        "ukphone": "[ˌwɒtsəʊˈevə(r)]"
+    },
+    {
+        "name": "denounce",
+        "trans": [
+            "vt. 谴责；告发；公然抨击；通告废除"
+        ],
+        "usphone": "[dɪˈnaʊns]",
+        "ukphone": "[dɪˈnaʊns]"
+    },
+    {
+        "name": "bind",
+        "trans": [
+            "n. 捆绑；困境；讨厌的事情；植物的藤蔓"
+        ],
+        "usphone": "[baɪnd]",
+        "ukphone": "[baɪnd]"
+    },
+    {
+        "name": "portfolio",
+        "trans": [
+            "n. 公文包；文件夹；证券投资组合；部长职务"
+        ],
+        "usphone": "[pɔːrtˈfoʊlioʊ]",
+        "ukphone": "[pɔːtˈfəʊliəʊ]"
+    },
+    {
+        "name": "bay",
+        "trans": [
+            "n. 海湾；狗吠声"
+        ],
+        "usphone": "[beɪ]",
+        "ukphone": "[beɪ]"
+    },
+    {
+        "name": "shed",
+        "trans": [
+            "n. 小屋，棚；分水岭"
+        ],
+        "usphone": "[ʃed]",
+        "ukphone": "[ʃed]"
+    },
+    {
+        "name": "overwhelm",
+        "trans": [
+            "vt. 淹没；压倒；受打击；覆盖；压垮"
+        ],
+        "usphone": "[ˌoʊvərˈwelm]",
+        "ukphone": "[ˌəʊvəˈwelm]"
+    },
+    {
+        "name": "overturn",
+        "trans": [
+            "vt. 推翻；倾覆；破坏"
+        ],
+        "usphone": "[ˌoʊvərˈtɜːrn]",
+        "ukphone": "[ˌəʊvəˈtɜːn]"
+    },
+    {
+        "name": "mere",
+        "trans": [
+            "adj. 仅仅的；只不过的"
+        ],
+        "usphone": "[mɪr]",
+        "ukphone": "[mɪə(r)]"
+    },
+    {
+        "name": "legacy",
+        "trans": [
+            "n. 遗赠，遗产"
+        ],
+        "usphone": "[ˈleɡəsi]",
+        "ukphone": "[ˈleɡəsi]"
+    },
+    {
+        "name": "slash",
+        "trans": [
+            "n. 削减；斜线；猛砍；砍痕；沼泽低地"
+        ],
+        "usphone": "[slæʃ]",
+        "ukphone": "[slæʃ]"
+    },
+    {
+        "name": "cluster",
+        "trans": [
+            "n. 群；簇；丛；串"
+        ],
+        "usphone": "[ˈklʌstər]",
+        "ukphone": "[ˈklʌstə(r)]"
+    },
+    {
+        "name": "humble",
+        "trans": [
+            "adj. 谦逊的；简陋的；（级别或地位）低下的；不大的"
+        ],
+        "usphone": "[ˈhʌmbl]",
+        "ukphone": "[ˈhʌmb(ə)l]"
+    },
+    {
+        "name": "disastrous",
+        "trans": [
+            "adj. 灾难性的；损失惨重的；悲伤的"
+        ],
+        "usphone": "[dɪˈzæstrəs]",
+        "ukphone": "[dɪˈzɑːstrəs]"
+    },
+    {
+        "name": "meantime",
+        "trans": [
+            "n. 其时，其间"
+        ],
+        "usphone": "[ˈmiːntaɪm]",
+        "ukphone": "[ˈmiːntaɪm]"
+    },
+    {
+        "name": "dedication",
+        "trans": [
+            "n. 奉献；献身；赠言"
+        ],
+        "usphone": "[ˌdedɪˈkeɪʃn]",
+        "ukphone": "[ˌdedɪˈkeɪʃ(ə)n]"
+    },
+    {
+        "name": "rifle",
+        "trans": [
+            "n. 步枪；来复枪"
+        ],
+        "usphone": "[ˈraɪfl]",
+        "ukphone": "[ˈraɪfl]"
+    },
+    {
+        "name": "collaborate",
+        "trans": [
+            "vi. 合作；勾结，通敌"
+        ],
+        "usphone": "[kəˈlæbəreɪt]",
+        "ukphone": "[kəˈlæbəreɪt]"
+    },
+    {
+        "name": "tolerate",
+        "trans": [
+            "vt. 忍受；默许；宽恕"
+        ],
+        "usphone": "[ˈtɑːləreɪt]",
+        "ukphone": "[ˈtɒləreɪt]"
+    },
+    {
+        "name": "echo",
+        "trans": [
+            "n. 回音；效仿"
+        ],
+        "usphone": "[ˈekoʊ]",
+        "ukphone": "[ˈekəʊ]"
+    },
+    {
+        "name": "frustrated",
+        "trans": [
+            "v. 挫败；阻挠（frustrate的过去式和过去分词形式）"
+        ],
+        "usphone": "[ˈfrʌstreɪtɪd]",
+        "ukphone": "[frʌˈstreɪtɪd]"
+    },
+    {
+        "name": "revenge",
+        "trans": [
+            "n. 报复；复仇"
+        ],
+        "usphone": "[rɪˈvendʒ]",
+        "ukphone": "[rɪˈvendʒ]"
+    },
+    {
+        "name": "footage",
+        "trans": [
+            "n. 英尺长度；连续镜头；以尺计算长度"
+        ],
+        "usphone": "[ˈfʊtɪdʒ]",
+        "ukphone": "[ˈfʊtɪdʒ]"
+    },
+    {
+        "name": "interim",
+        "trans": [
+            "n. 过渡时期，中间时期；暂定"
+        ],
+        "usphone": "[ˈɪntərɪm]",
+        "ukphone": "[ˈɪntərɪm]"
+    },
+    {
+        "name": "treaty",
+        "trans": [
+            "n. 条约，协议；谈判"
+        ],
+        "usphone": "[ˈtriːti]",
+        "ukphone": "[ˈtriːti]"
+    },
+    {
+        "name": "delegation",
+        "trans": [
+            "n. 代表团；授权；委托"
+        ],
+        "usphone": "[ˌdelɪˈɡeɪʃn]",
+        "ukphone": "[ˌdelɪˈɡeɪʃn]"
+    },
+    {
+        "name": "regain",
+        "trans": [
+            "n. 收复；取回"
+        ],
+        "usphone": "[rɪˈɡeɪn]",
+        "ukphone": "[rɪˈɡeɪn]"
+    },
+    {
+        "name": "variable",
+        "trans": [
+            "n. [数] 变量；可变物，可变因素"
+        ],
+        "usphone": "[ˈveriəblˌˈværiəbl]",
+        "ukphone": "[ˈveəriəb(ə)l]"
+    },
+    {
+        "name": "homeland",
+        "trans": [
+            "n. 祖国；故乡"
+        ],
+        "usphone": "[ˈhoʊmlænd]",
+        "ukphone": "[ˈhəʊmlænd]"
+    },
+    {
+        "name": "prejudice",
+        "trans": [
+            "n. 偏见；侵害"
+        ],
+        "usphone": "[ˈpredʒudɪs]",
+        "ukphone": "[ˈpredʒədɪs]"
+    },
+    {
+        "name": "gut",
+        "trans": [
+            "n. 内脏；肠子；剧情；胆量；海峡；勇气；直觉；肠"
+        ],
+        "usphone": "[ɡʌt]",
+        "ukphone": "[ɡʌt]"
+    },
+    {
+        "name": "linger",
+        "trans": [
+            "vi. 徘徊；苟延残喘；磨蹭"
+        ],
+        "usphone": "[ˈlɪŋɡər]",
+        "ukphone": "[ˈlɪŋɡə(r)]"
+    },
+    {
+        "name": "ray",
+        "trans": [
+            "n. 射线；光线；【鱼类】鳐形目(Rajiformes)鱼"
+        ],
+        "usphone": "[reɪ]",
+        "ukphone": "[reɪ]"
+    },
+    {
+        "name": "pipeline",
+        "trans": [
+            "n. 管道；输油管；传递途径"
+        ],
+        "usphone": "[ˈpaɪplaɪn]",
+        "ukphone": "[ˈpaɪplaɪn]"
+    },
+    {
+        "name": "confront",
+        "trans": [
+            "vt. 面对；遭遇；比较"
+        ],
+        "usphone": "[kənˈfrʌnt]",
+        "ukphone": "[kənˈfrʌnt]"
+    },
+    {
+        "name": "comply",
+        "trans": [
+            "vi. 遵守；顺从，遵从；答应"
+        ],
+        "usphone": "[kəmˈplaɪ]",
+        "ukphone": "[kəmˈplaɪ]"
+    },
+    {
+        "name": "modification",
+        "trans": [
+            "n. 修改，修正；改变"
+        ],
+        "usphone": "[ˌmɑːdɪfɪˈkeɪʃn]",
+        "ukphone": "[ˌmɒdɪfɪˈkeɪʃn]"
+    },
+    {
+        "name": "aspiration",
+        "trans": [
+            "n. 渴望；抱负；送气；吸气；吸引术"
+        ],
+        "usphone": "[ˌæspəˈreɪʃn]",
+        "ukphone": "[ˌæspəˈreɪʃ(ə)n]"
+    },
+    {
+        "name": "backup",
+        "trans": [
+            "n. 支持；后援；阻塞"
+        ],
+        "usphone": "[ˈbækʌp]",
+        "ukphone": "[ˈbækʌp]"
+    },
+    {
+        "name": "integrity",
+        "trans": [
+            "n. 完整；正直；诚实；廉正"
+        ],
+        "usphone": "[ɪnˈteɡrəti]",
+        "ukphone": "[ɪnˈteɡrəti]"
+    },
+    {
+        "name": "tide",
+        "trans": [
+            "n. 趋势，潮流；潮汐"
+        ],
+        "usphone": "[taɪd]",
+        "ukphone": "[taɪd]"
+    },
+    {
+        "name": "magistrate",
+        "trans": [
+            "n. 地方法官；文职官员；治安推事"
+        ],
+        "usphone": "[ˈmædʒɪstreɪt]",
+        "ukphone": "[ˈmædʒɪstreɪt]"
+    },
+    {
+        "name": "peak",
+        "trans": [
+            "n. 山峰；最高点；顶点；帽舌"
+        ],
+        "usphone": "[piːk]",
+        "ukphone": "[piːk]"
+    },
+    {
+        "name": "dominance",
+        "trans": [
+            "n. 优势；统治；支配"
+        ],
+        "usphone": "[ˈdɑːmɪnəns]",
+        "ukphone": "[ˈdɒmɪnəns]"
+    },
+    {
+        "name": "halfway",
+        "trans": [
+            "adj. 中途的；不彻底的"
+        ],
+        "usphone": "[ˌhæfˈweɪ]",
+        "ukphone": "[ˌhɑːfˈweɪ]"
+    },
+    {
+        "name": "restraint",
+        "trans": [
+            "n. 抑制，克制；约束"
+        ],
+        "usphone": "[rɪˈstreɪnt]",
+        "ukphone": "[rɪˈstreɪnt]"
+    },
+    {
+        "name": "depict",
+        "trans": [
+            "vt. 描述；描画"
+        ],
+        "usphone": "[dɪˈpɪkt]",
+        "ukphone": "[dɪˈpɪkt]"
+    },
+    {
+        "name": "spin",
+        "trans": [
+            "n. 旋转；疾驰"
+        ],
+        "usphone": "[spɪn]",
+        "ukphone": "[spɪn]"
+    },
+    {
+        "name": "buffer",
+        "trans": [
+            "n. [计] 缓冲区；缓冲器，[车辆] 减震器"
+        ],
+        "usphone": "[ˈbʌfər]",
+        "ukphone": "[ˈbʌfə(r)]"
+    },
+    {
+        "name": "shrink",
+        "trans": [
+            "vi. 收缩；畏缩"
+        ],
+        "usphone": "[ʃrɪŋk]",
+        "ukphone": "[ʃrɪŋk]"
+    },
+    {
+        "name": "hopeful",
+        "trans": [
+            "n. 有希望成功的人"
+        ],
+        "usphone": "[ˈhoʊpfl]",
+        "ukphone": "[ˈhəʊpf(ə)l]"
+    },
+    {
+        "name": "preservation",
+        "trans": [
+            "n. 保存，保留"
+        ],
+        "usphone": "[ˌprezərˈveɪʃn]",
+        "ukphone": "[ˌprezəˈveɪʃ(ə)n]"
+    },
+    {
+        "name": "post-war",
+        "trans": [
+            "adj. 战后的"
+        ],
+        "usphone": "[ˌpoʊst ˈwɔːr]",
+        "ukphone": "[ˌpəʊst ˈwɔː(r)]"
+    },
+    {
+        "name": "devastate",
+        "trans": [
+            "vt. 毁灭；毁坏"
+        ],
+        "usphone": "[ˈdevəsteɪt]",
+        "ukphone": "[ˈdevəsteɪt]"
+    },
+    {
+        "name": "craft",
+        "trans": [
+            "n. 工艺；手艺；太空船"
+        ],
+        "usphone": "[kræft]",
+        "ukphone": "[krɑːft]"
+    },
+    {
+        "name": "supervise",
+        "trans": [
+            "vt. 监督，管理；指导"
+        ],
+        "usphone": "[ˈsuːpərvaɪz]",
+        "ukphone": "[ˈsuːpəvaɪz]"
+    },
+    {
+        "name": "varied",
+        "trans": [
+            "v. 改变；使多样化（vary的过去式和过去分词形式）"
+        ],
+        "usphone": "[ˈveridˌˈværid]",
+        "ukphone": "[ˈveərid]"
+    },
+    {
+        "name": "prosperity",
+        "trans": [
+            "n. 繁荣，成功"
+        ],
+        "usphone": "[prɑːˈsperəti]",
+        "ukphone": "[prɒˈsperəti]"
+    },
+    {
+        "name": "solo",
+        "trans": [
+            "n. 独奏；独唱；独奏曲"
+        ],
+        "usphone": "[ˈsoʊloʊ]",
+        "ukphone": "[ˈsəʊləʊ]"
+    },
+    {
+        "name": "entity",
+        "trans": [
+            "n. 实体；存在；本质"
+        ],
+        "usphone": "[ˈentəti]",
+        "ukphone": "[ˈentəti]"
+    },
+    {
+        "name": "corresponding",
+        "trans": [
+            "adj. 相当的，相应的；一致的；通信的"
+        ],
+        "usphone": "[ˌkɔːrəˈspɑːndɪŋ]",
+        "ukphone": "[ˌkɒrəˈspɒndɪŋ]"
+    },
+    {
+        "name": "projection",
+        "trans": [
+            "n. 投射；规划；突出；发射；推测"
+        ],
+        "usphone": "[prəˈdʒekʃn]",
+        "ukphone": "[prəˈdʒekʃn]"
+    },
+    {
+        "name": "venture",
+        "trans": [
+            "n. 企业；风险；冒险"
+        ],
+        "usphone": "[ˈventʃər]",
+        "ukphone": "[ˈventʃə(r)]"
+    },
+    {
+        "name": "credible",
+        "trans": [
+            "adj. 可靠的，可信的"
+        ],
+        "usphone": "[ˈkredəbl]",
+        "ukphone": "[ˈkredəb(ə)l]"
     },
     {
         "name": "yell",
@@ -10496,6 +9992,238 @@
         "ukphone": "[jel]"
     },
     {
+        "name": "realm",
+        "trans": [
+            "n. 领域，范围；王国"
+        ],
+        "usphone": "[relm]",
+        "ukphone": "[relm]"
+    },
+    {
+        "name": "threshold",
+        "trans": [
+            "n. 入口；门槛；开始；极限；临界值"
+        ],
+        "usphone": "[ˈθreʃhoʊld]",
+        "ukphone": "[ˈθreʃhəʊld]"
+    },
+    {
+        "name": "unprecedented",
+        "trans": [
+            "adj. 空前的；无前例的"
+        ],
+        "usphone": "[ʌnˈpresɪdentɪd]",
+        "ukphone": "[ʌnˈpresɪdentɪd]"
+    },
+    {
+        "name": "snap",
+        "trans": [
+            "n. 猛咬；劈啪声；突然折断"
+        ],
+        "usphone": "[snæp]",
+        "ukphone": "[snæp]"
+    },
+    {
+        "name": "adjacent",
+        "trans": [
+            "adj. 邻近的，毗连的"
+        ],
+        "usphone": "[əˈdʒeɪs(ə)nt]",
+        "ukphone": "[əˈdʒeɪs(ə)nt]"
+    },
+    {
+        "name": "intensify",
+        "trans": [
+            "vt. 使加强，使强化；使变激烈"
+        ],
+        "usphone": "[ɪnˈtensɪfaɪ]",
+        "ukphone": "[ɪnˈtensɪfaɪ]"
+    },
+    {
+        "name": "feat",
+        "trans": [
+            "n. 功绩，壮举；技艺表演"
+        ],
+        "usphone": "[fiːt]",
+        "ukphone": "[fiːt]"
+    },
+    {
+        "name": "parliamentary",
+        "trans": [
+            "adj. 议会的；国会的；议会制度的"
+        ],
+        "usphone": "[ˌpɑːrləˈmentri]",
+        "ukphone": "[ˌpɑːləˈmentri]"
+    },
+    {
+        "name": "verify",
+        "trans": [
+            "vt. 核实；查证"
+        ],
+        "usphone": "[ˈverɪfaɪ]",
+        "ukphone": "[ˈverɪfaɪ]"
+    },
+    {
+        "name": "rotation",
+        "trans": [
+            "n. 旋转；循环，轮流"
+        ],
+        "usphone": "[roʊˈteɪʃn]",
+        "ukphone": "[rəʊˈteɪʃn]"
+    },
+    {
+        "name": "exit",
+        "trans": [
+            "n. 出口，通道；退场"
+        ],
+        "usphone": "[ˈeksɪt; ˈeɡzɪt]",
+        "ukphone": "[ˈeksɪt]"
+    },
+    {
+        "name": "surveillance",
+        "trans": [
+            "n. 监督；监视"
+        ],
+        "usphone": "[sɜːrˈveɪləns]",
+        "ukphone": "[sɜːˈveɪləns]"
+    },
+    {
+        "name": "memo",
+        "trans": [
+            "n. 备忘录"
+        ],
+        "usphone": "[ˈmemoʊ]",
+        "ukphone": "[ˈmeməʊ]"
+    },
+    {
+        "name": "forth",
+        "trans": [
+            "adv. 向前，向外；自…以后"
+        ],
+        "usphone": "[fɔːrθ]",
+        "ukphone": "[fɔːθ]"
+    },
+    {
+        "name": "enthusiast",
+        "trans": [
+            "n. 狂热者，热心家"
+        ],
+        "usphone": "[ɪnˈθuːziæst]",
+        "ukphone": "[ɪnˈθjuːziæst]"
+    },
+    {
+        "name": "newsletter",
+        "trans": [
+            "n. 时事通讯"
+        ],
+        "usphone": "[ˈnuːzletər]",
+        "ukphone": "[ˈnjuːzletə(r)]"
+    },
+    {
+        "name": "diagnosis",
+        "trans": [
+            "n. 诊断"
+        ],
+        "usphone": "[ˌdaɪəɡˈnoʊsɪs]",
+        "ukphone": "[ˌdaɪəɡˈnəʊsɪs]"
+    },
+    {
+        "name": "bonus",
+        "trans": [
+            "n. 奖金；红利；额外津贴"
+        ],
+        "usphone": "[ˈboʊnəs]",
+        "ukphone": "[ˈbəʊnəs]"
+    },
+    {
+        "name": "manipulate",
+        "trans": [
+            "vt. 操纵；操作；巧妙地处理；篡改"
+        ],
+        "usphone": "[məˈnɪpjuleɪt]",
+        "ukphone": "[məˈnɪpjuleɪt]"
+    },
+    {
+        "name": "endure",
+        "trans": [
+            "vt. 忍耐；容忍"
+        ],
+        "usphone": "[ɪnˈdʊr]",
+        "ukphone": "[ɪnˈdjʊə(r)]"
+    },
+    {
+        "name": "whatever",
+        "trans": [
+            "conj. 无论什么"
+        ],
+        "usphone": "[wətˈevər]",
+        "ukphone": "[wɒtˈevə(r)]"
+    },
+    {
+        "name": "precision",
+        "trans": [
+            "n. 精度，[数] 精密度；精确"
+        ],
+        "usphone": "[prɪˈsɪʒn]",
+        "ukphone": "[prɪˈsɪʒn]"
+    },
+    {
+        "name": "exceptional",
+        "trans": [
+            "n. 超常的学生"
+        ],
+        "usphone": "[ɪkˈsepʃənl]",
+        "ukphone": "[ɪkˈsepʃən(ə)l]"
+    },
+    {
+        "name": "productivity",
+        "trans": [
+            "n. 生产力；生产率；生产能力"
+        ],
+        "usphone": "[ˌproʊdʌkˈtɪvətiˌˌprɑːdʌkˈtɪvəti]",
+        "ukphone": "[ˌprɒdʌkˈtɪvəti]"
+    },
+    {
+        "name": "diplomatic",
+        "trans": [
+            "adj. 外交的；外交上的；老练的"
+        ],
+        "usphone": "[ˌdɪpləˈmætɪk]",
+        "ukphone": "[ˌdɪpləˈmætɪk]"
+    },
+    {
+        "name": "involvement",
+        "trans": [
+            "n. 牵连；包含；混乱；财政困难"
+        ],
+        "usphone": "[ɪnˈvɑːlvmənt]",
+        "ukphone": "[ɪnˈvɒlvmənt]"
+    },
+    {
+        "name": "confer",
+        "trans": [
+            "vt. 授予；给予"
+        ],
+        "usphone": "[kənˈfɜːr]",
+        "ukphone": "[kənˈfɜː(r)]"
+    },
+    {
+        "name": "damaging",
+        "trans": [
+            "v. 破坏（damage的现在分词形式）；损害"
+        ],
+        "usphone": "[ˈdæmɪdʒɪŋ]",
+        "ukphone": "[ˈdæmɪdʒɪŋ]"
+    },
+    {
+        "name": "competence",
+        "trans": [
+            "n. 能力，胜任；权限；作证能力；足以过舒适生活的收入"
+        ],
+        "usphone": "[ˈkɑːmpɪtəns]",
+        "ukphone": "[ˈkɒmpɪtəns]"
+    },
+    {
         "name": "yield",
         "trans": [
             "n. 产量；收益"
@@ -10504,11 +10232,283 @@
         "ukphone": "[jiːld]"
     },
     {
-        "name": "youngster",
+        "name": "accountable",
         "trans": [
-            "n. 年轻人；少年"
+            "adj. 有责任的；有解释义务的；可解释的"
         ],
-        "usphone": "[ˈjʌŋstər]",
-        "ukphone": "[ˈjʌŋstə(r)]"
+        "usphone": "[əˈkaʊntəbl]",
+        "ukphone": "[əˈkaʊntəbl]"
+    },
+    {
+        "name": "devil",
+        "trans": [
+            "n. 魔鬼；撒旦；家伙；恶棍；淘气鬼；冒失鬼"
+        ],
+        "usphone": "[ˈdevl]",
+        "ukphone": "[ˈdev(ə)l]"
+    },
+    {
+        "name": "reproduce",
+        "trans": [
+            "vt. 复制；再生；生殖；使…在脑海中重现"
+        ],
+        "usphone": "[ˌriːprəˈduːs]",
+        "ukphone": "[ˌriːprəˈdjuːs]"
+    },
+    {
+        "name": "absurd",
+        "trans": [
+            "n. 荒诞；荒诞作品"
+        ],
+        "usphone": "[əbˈsɜːrd]",
+        "ukphone": "[əbˈsɜːd]"
+    },
+    {
+        "name": "tribunal",
+        "trans": [
+            "n. 法庭；裁决；法官席"
+        ],
+        "usphone": "[traɪˈbjuːnl]",
+        "ukphone": "[traɪˈbjuːnl]"
+    },
+    {
+        "name": "bulk",
+        "trans": [
+            "n. 体积，容量；大多数，大部分；大块"
+        ],
+        "usphone": "[bʌlk]",
+        "ukphone": "[bʌlk]"
+    },
+    {
+        "name": "frustrating",
+        "trans": [
+            "v. 使沮丧（frustrate的ing形式）"
+        ],
+        "usphone": "[ˈfrʌstreɪtɪŋ]",
+        "ukphone": "[frʌˈstreɪtɪŋ]"
+    },
+    {
+        "name": "dual",
+        "trans": [
+            "n. 双数；双数词"
+        ],
+        "usphone": "[ˈduːəl]",
+        "ukphone": "[ˈdjuːəl]"
+    },
+    {
+        "name": "remains",
+        "trans": [
+            "n. 残余；遗骸"
+        ],
+        "usphone": "[rɪˈmeɪnz]",
+        "ukphone": "[rɪˈmeɪnz]"
+    },
+    {
+        "name": "discharge",
+        "trans": [
+            "n. 排放；卸货；解雇"
+        ],
+        "usphone": "[dɪsˈtʃɑːrdʒ]",
+        "ukphone": "[dɪsˈtʃɑːdʒ]"
+    },
+    {
+        "name": "reproduction",
+        "trans": [
+            "n. 繁殖，生殖；复制；复制品"
+        ],
+        "usphone": "[ˌriːprəˈdʌkʃn]",
+        "ukphone": "[ˌriːprəˈdʌkʃn]"
+    },
+    {
+        "name": "fade",
+        "trans": [
+            "n. [电影][电视] 淡出；[电影][电视] 淡入"
+        ],
+        "usphone": "[feɪd]",
+        "ukphone": "[feɪd]"
+    },
+    {
+        "name": "complication",
+        "trans": [
+            "n. 并发症；复杂；复杂化；混乱"
+        ],
+        "usphone": "[ˌkɑːmplɪˈkeɪʃn]",
+        "ukphone": "[ˌkɒmplɪˈkeɪʃn]"
+    },
+    {
+        "name": "presume",
+        "trans": [
+            "vi. 相信；擅自行为"
+        ],
+        "usphone": "[prɪˈzuːm]",
+        "ukphone": "[prɪˈzjuːm]"
+    },
+    {
+        "name": "partial",
+        "trans": [
+            "adj. 局部的；偏爱的；不公平的"
+        ],
+        "usphone": "[ˈpɑːrʃl]",
+        "ukphone": "[ˈpɑːʃ(ə)l]"
+    },
+    {
+        "name": "philosopher",
+        "trans": [
+            "n. 哲学家；哲人"
+        ],
+        "usphone": "[fəˈlɑːsəfər]",
+        "ukphone": "[fəˈlɒsəfə(r)]"
+    },
+    {
+        "name": "audit",
+        "trans": [
+            "n. 审计；[审计] 查账"
+        ],
+        "usphone": "[ˈɔːdɪt]",
+        "ukphone": "[ˈɔːdɪt]"
+    },
+    {
+        "name": "browser",
+        "trans": [
+            "n. [计] 浏览器；吃嫩叶的动物；浏览书本的人"
+        ],
+        "usphone": "[ˈbraʊzər]",
+        "ukphone": "[ˈbraʊzə(r)]"
+    },
+    {
+        "name": "immense",
+        "trans": [
+            "adj. 巨大的，广大的；无边无际的；非常好的"
+        ],
+        "usphone": "[ɪˈmens]",
+        "ukphone": "[ɪˈmens]"
+    },
+    {
+        "name": "stumble",
+        "trans": [
+            "n. 绊倒；蹒跚而行"
+        ],
+        "usphone": "[ˈstʌmbl]",
+        "ukphone": "[ˈstʌmb(ə)l]"
+    },
+    {
+        "name": "torture",
+        "trans": [
+            "n. 折磨；拷问；歪曲"
+        ],
+        "usphone": "[ˈtɔːrtʃər]",
+        "ukphone": "[ˈtɔːtʃə(r)]"
+    },
+    {
+        "name": "substantial",
+        "trans": [
+            "n. 本质；重要材料"
+        ],
+        "usphone": "[səbˈstænʃl]",
+        "ukphone": "[səbˈstænʃ(ə)l]"
+    },
+    {
+        "name": "vocal",
+        "trans": [
+            "adj. 直言不讳的"
+        ],
+        "usphone": "[ˈvoʊkl]",
+        "ukphone": "[ˈvəʊk(ə)l]"
+    },
+    {
+        "name": "deposit",
+        "trans": [
+            "n. 存款；押金；订金；保证金；沉淀物"
+        ],
+        "usphone": "[dɪˈpɑːzɪt]",
+        "ukphone": "[dɪˈpɒzɪt]"
+    },
+    {
+        "name": "solidarity",
+        "trans": [
+            "n. 团结，团结一致"
+        ],
+        "usphone": "[ˌsɑːlɪˈdærəti]",
+        "ukphone": "[ˌsɒlɪˈdærəti]"
+    },
+    {
+        "name": "landlord",
+        "trans": [
+            "n. 房东，老板；地主"
+        ],
+        "usphone": "[ˈlændlɔːrd]",
+        "ukphone": "[ˈlændlɔːd]"
+    },
+    {
+        "name": "constraint",
+        "trans": [
+            "n. [数] 约束；局促，态度不自然；强制"
+        ],
+        "usphone": "[kənˈstreɪnt]",
+        "ukphone": "[kənˈstreɪnt]"
+    },
+    {
+        "name": "dimension",
+        "trans": [
+            "n. 方面;[数] 维；尺寸；次元；容积 vt. 标出尺寸"
+        ],
+        "usphone": "[daɪˈmenʃn; dɪˈmenʃn]",
+        "ukphone": "[daɪˈmenʃn; dɪˈmenʃn]"
+    },
+    {
+        "name": "curiosity",
+        "trans": [
+            "n. 好奇，好奇心；珍品，古董，古玩"
+        ],
+        "usphone": "[ˌkjʊriˈɑːsəti]",
+        "ukphone": "[ˌkjʊəriˈɒsəti]"
+    },
+    {
+        "name": "slap",
+        "trans": [
+            "n. 掴；侮辱；掌击；拍打声"
+        ],
+        "usphone": "[slæp]",
+        "ukphone": "[slæp]"
+    },
+    {
+        "name": "applicable",
+        "trans": [
+            "adj. 可适用的；可应用的；合适的"
+        ],
+        "usphone": "[ˈæplɪkəblˌəˈplɪkəbl]",
+        "ukphone": "[əˈplɪkəb(ə)l]"
+    },
+    {
+        "name": "nominee",
+        "trans": [
+            "n. 被任命者；被提名的人；代名人"
+        ],
+        "usphone": "[ˌnɑːmɪˈniː]",
+        "ukphone": "[ˌnɒmɪˈniː]"
+    },
+    {
+        "name": "imprison",
+        "trans": [
+            "vt. 监禁；关押；使…下狱"
+        ],
+        "usphone": "[ɪmˈprɪzn]",
+        "ukphone": "[ɪmˈprɪzn]"
+    },
+    {
+        "name": "broadband",
+        "trans": [
+            "n. 宽频；宽波段"
+        ],
+        "usphone": "[ˈbrɔːdbænd]",
+        "ukphone": "[ˈbrɔːdbænd]"
+    },
+    {
+        "name": "laser",
+        "trans": [
+            "n. 激光"
+        ],
+        "usphone": "[ˈleɪzər]",
+        "ukphone": "[ˈleɪzə(r)]"
     }
 ]


### PR DESCRIPTION
## Summary
- shuffle the existing Duolingo B1, B2, and C1 vocabulary dictionaries
- keep all word entries, translations, and dictionary lengths unchanged
- make the default practice sequence less alphabetical for these dictionaries

## Validation
- parsed all three JSON files and verified lengths remain 801, 1423, and 1314
- verified the first items are no longer alphabetical after deterministic shuffle
- ran `node scripts/update-dict-size.js` and confirmed no dictionary index changes were needed
- ran `git diff --check`