### PR TITLE
fix: resolve promise on git error to prevent vite from hanging

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,7 @@ import type { PluginOption } from 'vite'
 // https://vitejs.dev/config/
 export default defineConfig(async ({ mode }) => {
   const latestCommitHash = await new Promise<string>((resolve) => {
-    return getLastCommit((err, commit) => (err ? 'unknown' : resolve(commit.shortHash)))
+    return getLastCommit((err, commit) => (err ? resolve('unknown') : resolve(commit.shortHash)))
   })
   return {
     plugins: [


### PR DESCRIPTION
## Problem

When running the project in a non-git directory (e.g., after downloading the ZIP from GitHub), Vite hangs indefinitely with no output and no port listening.

## Root Cause

In ite.config.ts, the git-last-commit callback returns 'unknown' on error but **does not call esolve()**:

`	ypescript
return getLastCommit((err, commit) => (err ? 'unknown' : resolve(commit.shortHash)))
``

When there is no .git directory, err is truthy. The expression evaluates to 'unknown' (the return value of the ternary), but the Promise's esolve function is **never invoked**, causing the wait to hang forever. Vite's defineConfig async factory never completes, so the dev server never starts.

## Fix

Wrap the 'unknown' fallback in esolve() so the Promise settles properly:

`	ypescript
return getLastCommit((err, commit) => (err ? resolve('unknown') : resolve(commit.shortHash)))
``

With this fix, Vite starts normally (~300ms) even without a .git directory, with LATEST_COMMIT_HASH defaulting to 'unknown'.

## Related

Fixes #1091