### PR TITLE
docs: update Gossip repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ JS API 来自于[react-code-game](https://github.com/webzhd/react-code-game) ，
 
 也感谢在项目初期跟我讨论 idea、提供建议并时不时 Push 一下我的朋友们，没有你们这个 idea 可能还得再拖一年（🐶
 
-感谢 [Pear Mini](https://github.com/pearmini) ，最开始跟我讨论 idea 给我项目支持，也是他的项目让我相信即使是一个学生的 idea 实现出来也可以很酷。 他的 [Gossip](https://github.com/pearmini/gossip) 项目完全是 Next Generation Slides 级别的创意！
+感谢 [Pear Mini](https://github.com/pearmini) ，最开始跟我讨论 idea 给我项目支持，也是他的项目让我相信即使是一个学生的 idea 实现出来也可以很酷。 他的 [Gossip](https://github.com/gossip-ink/gossip) 项目完全是 Next Generation Slides 级别的创意！
 
 感谢 [AZ](https://github.com/sailist)，鼓励我把 idea 实现出来（虽然我还是拖了很久），他无与伦比的行动力影响了我。他是一个非常酷的 lib maker，写了很多非常棒的 python 库，例如中文语音识别的框架[ASRFrame](https://github.com/sailist/ASRFrame)
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -210,7 +210,7 @@ Thanks to [libregd][libregd] for designing the icon, contributing several lovely
 [sorrycc]: https://github.com/sorrycc
 [sheng]: https://github.com/shengxinjing
 [pearmini]: https://github.com/pearmini
-[gossip]: https://github.com/pearmini/gossip
+[gossip]: https://github.com/gossip-ink/gossip
 [sailist]: https://github.com/sailist
 [asrframe]: https://github.com/sailist/ASRFrame
 [chengluyu]: https://github.com/chengluyu

--- a/docs/README_JP.md
+++ b/docs/README_JP.md
@@ -286,7 +286,7 @@ JS API は [react-code-game](https://github.com/webzhd/react-code-game) から�
 
 プロジェクトの初期段階でアイデアを議論し、提案を提供し、時折プッシュしてくれた友人たちにも感謝します。彼らがいなければ、このアイデアはさらに 1 年遅れることになったかもしれません（🐶
 
-[Pear Mini](https://github.com/pearmini) に感謝します。最初にアイデアを議論し、プロジェクトにサポートを提供してくれました。また、彼のプロジェクトは、学生のアイデアでもクールなものになることを信じさせてくれました。彼の [Gossip](https://github.com/pearmini/gossip) プロジェクトは次世代のプレゼンテーションツールです！
+[Pear Mini](https://github.com/pearmini) に感謝します。最初にアイデアを議論し、プロジェクトにサポートを提供してくれました。また、彼のプロジェクトは、学生のアイデアでもクールなものになることを信じさせてくれました。彼の [Gossip](https://github.com/gossip-ink/gossip) プロジェクトは次世代のプレゼンテーションツールです！
 
 [AZ](https://github.com/sailist) に感謝します。アイデアを実現するように励ましてくれました（ただし、私はまだしばらく遅れました）。彼の無比の行動力は私に影響を与えました。彼は非常にクールなライブラリメーカーであり、多くの優れた Python パッケージを作成しています。たとえば、中国語音声認識のフレームワーク [ASRFrame](https://github.com/sailist/ASRFrame) などです。
 


### PR DESCRIPTION
## Summary
- update the Gossip project link from the unavailable pearmini/gossip repository to gossip-ink/gossip
- keep the Chinese, English, and Japanese README files consistent

## Validation
- verified README files no longer reference pearmini/gossip
- verified https://github.com/gossip-ink/gossip is reachable