### PR TITLE
chore: update GitHub links from Kaiyiwing to RealKai42

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,5 +31,5 @@ jobs:
         env:
           SSH_PRIVATE_KEY: ${{ secrets.GITEE }}
         with:
-          source-repo: git@github.com:Kaiyiwing/qwerty-learner.git
+          source-repo: git@github.com:RealKai42/qwerty-learner.git
           destination-repo: git@gitee.com:KaiyiWing/qwerty-learner.git

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -1,5 +1,5 @@
 <div align=center>
-  <img src="https://github.com/Kaiyiwing/qwerty-learner/blob/master/src/assets/logo.svg"/>
+  <img src="https://github.com/RealKai42/qwerty-learner/blob/master/src/assets/logo.svg"/>
 </div>
 
 <h1 align="center">
@@ -10,11 +10,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Kaiyiwing/qwerty-learner/blob/master/LICENSE">
-    <img src="https://img.shields.io/github/license/KaiyiWing/qwerty-learner" alt="License">
-  </a>
-  <a>
-    <img src="https://travis-ci.com/Kaiyiwing/qwerty-learner.svg?branch=master" alt="Build State">
+  <a href="https://github.com/RealKai42/qwerty-learner/blob/master/LICENSE">
+    <img src="https://img.shields.io/github/license/RealKai42/qwerty-learner" alt="License">
   </a>
   <a>
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"/>
@@ -33,13 +30,13 @@
 We have deployed QWERTY Learner on many platforms. You can try QWERTY Learner in following ways.
 
 - Vercel: <https://qwerty.kaiyi.cool/>, or <https://qwerty-learner.vercel.app/>.
-- GitHub Pages: <https://kaiyiwing.github.io/qwerty-learner/>.
+- GitHub Pages: <https://realkai42.github.io/qwerty-learner/>.
 - Gitee Pages (recommended for people in mainland China): <https://kaiyiwing.gitee.io/qwerty-learner/>.
 
 QWERTY Learner also has a Visual Studio Code plugin. With a single click and you will be able to practice anytime.
 
 - Plugin: [VSCode Plugin Market](https://marketplace.visualstudio.com/items?itemName=Kaiyi.qwerty-learner)
-- Project: [GitHub](https://github.com/Kaiyiwing/qwerty-learner-vscode)
+- Project: [GitHub](https://github.com/RealKai42/qwerty-learner-vscode)
 
 ## ✨ Design Goals
 
@@ -54,7 +51,7 @@ QWERTY Learner is very useful for people who are going to take computer-based En
 QWERTY Learner is also helpful for developers. It has built-in dictionaries of words and phrases which are common in code and documentations. We believe these dictionaries will improve developers’ typing speed. Besides, It also has built-in API dictionaries of many languages, which helps developers quickly familiarize with common APIs. More and more APIs are coming soon.
 
 <div align="center">
-  <img src="https://github.com/Kaiyiwing/qwerty-learner/blob/master/docs/coder.png"/>
+  <img src="https://github.com/RealKai42/qwerty-learner/blob/master/docs/coder.png"/>
 </div>
 
 [mm]: https://en.wikipedia.org/wiki/Muscle_memory
@@ -78,7 +75,7 @@ While typing, QWERTY Learner shows the [IPA][ipa] of current word and reads the 
 After people finish a chapter, QWERTY Learner will ask if people are willing to dictate the chapter. This is intended to consolidate words learned in the chapter.
 
 <div align=center>
-  <img src="https://github.com/Kaiyiwing/qwerty-learner/blob/master/docs/phonetic.jpeg"/>
+  <img src="https://github.com/RealKai42/qwerty-learner/blob/master/docs/phonetic.jpeg"/>
 </div>
 
 ### Speed and Accuracy
@@ -86,7 +83,7 @@ After people finish a chapter, QWERTY Learner will ask if people are willing to 
 QWERTY Learner counts how many strokes people have typed and shows the speed and accuracy in real time. By doing so, people can acknowledge how much they have improved.
 
 <div align=center>
-  <img src="https://github.com/Kaiyiwing/qwerty-learner/blob/master/docs/dictation.png"/>
+  <img src="https://github.com/RealKai42/qwerty-learner/blob/master/docs/dictation.png"/>
 </div>
 
 ## 🏆 Honors
@@ -124,9 +121,9 @@ There are also many other unlisted vocabularies. If you need more vocabularies, 
 - Linux Command. Thanks to [@Riddler](https://github.com/vhxubo).
 - C# List API. Thanks to [@nidbCN](https://github.com/nidbCN).
 
-If you want to contribute your own API thesaurus, please have a look at [issue #40](https://github.com/Kaiyiwing/qwerty-learner/issues/40) and [PR #67][67] in order to learn how to contribute.
+If you want to contribute your own API thesaurus, please have a look at [issue #40](https://github.com/RealKai42/qwerty-learner/issues/40) and [PR #67][67] in order to learn how to contribute.
 
-[67]: https://github.com/Kaiyiwing/qwerty-learner/pull/67
+[67]: https://github.com/RealKai42/qwerty-learner/pull/67
 
 ## 🎙 Suggestions
 
@@ -136,7 +133,7 @@ The current progress and future plans are described in [this issue][issue-42]. T
 
 If you like the idea of QWERTY Learner, please feel free to submit PRs. We would be grateful for your contributions.
 
-[issue-42]: https://github.com/Kaiyiwing/qwerty-learner/issues/42
+[issue-42]: https://github.com/RealKai42/qwerty-learner/issues/42
 
 ## 🏄‍♂️ Contribution Guidelines
 
@@ -152,14 +149,14 @@ After all, thanks for your contribution! 🎉
 
 Currently, QWERTY Learner is mainly maintained by three people in their spare time. In the future, we hope to purchase a separate domain and host an backend server for data synchronization. Therefore, if you like QWERTY Learner, please consider donation. This will definitely motivate us on the way of making QWERTY Learner better!
 
-<img src="https://github.com/Kaiyiwing/qwerty-learner/blob/master/docs/alipay.png" width="200px"/>
+<img src="https://github.com/RealKai42/qwerty-learner/blob/master/docs/alipay.png" width="200px"/>
 
 Note: we only accept donation from Alipay at present.
 
 ## 👨‍💻 Contributors
 
-<a href="https://github.com/Kaiyiwing/qwerty-learner/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=Kaiyiwing/qwerty-learner" />
+<a href="https://github.com/RealKai42/qwerty-learner/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=RealKai42/qwerty-learner" />
 </a>
 
 ## 🎁 Acknowledgements
@@ -217,4 +214,4 @@ Thanks to [libregd][libregd] for designing the icon, contributing several lovely
 
 ## 🌟 Stargazers over time
 
-[![Stargazers over time](https://starchart.cc/Kaiyiwing/qwerty-learner.svg)](https://starchart.cc/Kaiyiwing/qwerty-learner)
+[![Stargazers over time](https://starchart.cc/RealKai42/qwerty-learner.svg)](https://starchart.cc/RealKai42/qwerty-learner)

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="dns-prefetch" href="https://qwerty.kaiyi.cool" />
-    <link rel="source" href="https://github.com/Kaiyiwing/qwerty-learner" />
+    <link rel="source" href="https://github.com/RealKai42/qwerty-learner" />
     <link rel="source" href="https://qwerty.kaiyi.cool" />
     <link rel="manifest" href="/manifest.json" />
 

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -87,7 +87,7 @@ const Footer: React.FC = () => {
           可以在任意文件中一键开启，开启后单词显示在状态栏中，且插件会拦截用户对文档的输入，不会影响到原始文档。
         </p>
         <br /> <br />
-        <a className="mr-5 underline dark:text-gray-300" href="https://github.com/Kaiyiwing/qwerty-learner-vscode">
+        <a className="mr-5 underline dark:text-gray-300" href="https://github.com/RealKai42/qwerty-learner-vscode">
           GitHub 项目
         </a>
         <a className="underline dark:text-gray-300" href="https://marketplace.visualstudio.com/items?itemName=Kaiyi.qwerty-learner">
@@ -148,7 +148,7 @@ const Footer: React.FC = () => {
       </InfoPanel>
 
       <footer className="mb-1 mt-4 flex w-full items-center justify-center gap-2.5 text-sm ease-in" onClick={(e) => e.currentTarget.blur()}>
-        <a href="https://github.com/Kaiyiwing/qwerty-learner" target="_blank" rel="noreferrer" aria-label="前往 GitHub 项目主页">
+        <a href="https://github.com/RealKai42/qwerty-learner" target="_blank" rel="noreferrer" aria-label="前往 GitHub 项目主页">
           <IconGithub fontSize={15} className="text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-100" />
         </a>
 

--- a/src/pages/Gallery-N/DictRequest.tsx
+++ b/src/pages/Gallery-N/DictRequest.tsx
@@ -38,7 +38,7 @@ export default function DictRequest() {
           <p className="text-sm text-gray-600 dark:text-gray-300">
             如果您具备一定的编程技能，欢迎参考我们的
             <a
-              href="https://github.com/Kaiyiwing/qwerty-learner/blob/master/docs/toBuildDict.md"
+              href="https://github.com/RealKai42/qwerty-learner/blob/master/docs/toBuildDict.md"
               className="mx-1 font-medium text-blue-500 hover:text-blue-600"
               target="_blank"
               rel="noreferrer"

--- a/src/pages/Typing/components/ResultScreen/index.tsx
+++ b/src/pages/Typing/components/ResultScreen/index.tsx
@@ -282,7 +282,7 @@ const ResultScreen = () => {
                   <IconWechat fontSize={16} className="text-gray-500 hover:text-green-500 focus:outline-none" />
                 </button>
 
-                <a href="https://github.com/Kaiyiwing/qwerty-learner" target="_blank" rel="noreferrer" className="leading-[0px]">
+                <a href="https://github.com/RealKai42/qwerty-learner" target="_blank" rel="noreferrer" className="leading-[0px]">
                   <IconGithub fontSize={16} className="text-gray-500 hover:text-green-800 focus:outline-none" />
                 </a>
               </div>


### PR DESCRIPTION
## Summary

Update GitHub URLs from the old `Kaiyiwing` username to `RealKai42` after the account rename. The old URLs still work via GitHub's redirects, but this points everything at the canonical address.

## Changes

**Site code (user-facing):**
- `src/components/Footer/index.tsx` — footer GitHub icon link and the qwerty-learner-vscode repo link (the vscode repo was also verified to redirect to RealKai42)
- `src/pages/Typing/components/ResultScreen/index.tsx` — GitHub icon in the share result panel
- `src/pages/Gallery-N/DictRequest.tsx` — dictionary contribution guide link
- `index.html` — `<link rel="source">` meta

**Docs & CI:**
- `docs/README_EN.md` — 16 links/images/badges (incl. contrib.rocks, starchart.cc, shields.io), GitHub Pages URL updated to `realkai42.github.io`, and the defunct travis-ci badge removed
- `.github/workflows/deploy-pages.yml` — `source-repo` for the Gitee mirror sync

## Intentionally unchanged

- Gitee links (`kaiyiwing.gitee.io`, `gitee.com/KaiyiWing`, mirror `destination-repo`) — separate platform account
- `qwerty.kaiyi.cool` / `me@kaiyi.cool` — personal domain and email
- VSCode Marketplace publisher ID `Kaiyi.qwerty-learner` — unrelated to GitHub, changing it would break the link