### PR TITLE
feat(dict): 新增 TOEFL 正序版与 TOEFL 写作高频词

### DIFF
--- a/public/dicts/TOEFL_Writing_HighFreq.json
+++ b/public/dicts/TOEFL_Writing_HighFreq.json
@@ -1,0 +1,4029 @@
+[
+    {
+        "name": "moreover",
+        "trans": [
+            "而且， 再者， 此外 (adv.)"
+        ],
+        "usphone": "mɔr'ovɚ",
+        "ukphone": "mɔːr'əuvə"
+    },
+    {
+        "name": "furthermore",
+        "trans": [
+            "而且， 此外 (adv.)"
+        ],
+        "usphone": ",fɝðɚ'mɔr",
+        "ukphone": "ˌfɜːðə'mɔː"
+    },
+    {
+        "name": "however",
+        "trans": [
+            "adv. 无论如何，不管怎样",
+            "conj. 然而，但是"
+        ],
+        "usphone": "haʊˈevər",
+        "ukphone": "haʊˈevə(r)"
+    },
+    {
+        "name": "nevertheless",
+        "trans": [
+            "然而， 不过"
+        ],
+        "usphone": ",nɛvɚðə'lɛs",
+        "ukphone": "ˌnevərðə'les"
+    },
+    {
+        "name": "nonetheless",
+        "trans": [
+            "虽然如此， 但是， 依然"
+        ],
+        "usphone": "'nʌnðə'lɛs",
+        "ukphone": "ˌnʌnðə'les"
+    },
+    {
+        "name": "therefore",
+        "trans": [
+            "因此，从而",
+            "因此"
+        ],
+        "usphone": "'ðɛrfɔr",
+        "ukphone": "'ðerfɔːr"
+    },
+    {
+        "name": "thus",
+        "trans": [
+            "adv. 因此，从而；这样，如此；如此，这样；到如此程度"
+        ],
+        "usphone": "ðʌs",
+        "ukphone": "ðʌs"
+    },
+    {
+        "name": "hence",
+        "trans": [
+            "adv. 因此；之后"
+        ],
+        "usphone": "hens",
+        "ukphone": "hens"
+    },
+    {
+        "name": "consequently",
+        "trans": [
+            "因此， 因而"
+        ],
+        "usphone": "'kɑnsəkwɛntli",
+        "ukphone": "'kɒnsɪkwəntli"
+    },
+    {
+        "name": "accordingly",
+        "trans": [
+            "因此， 所以； 照着"
+        ],
+        "usphone": "ə'kɔrdɪŋli",
+        "ukphone": "ə'kɔːdɪŋli"
+    },
+    {
+        "name": "meanwhile",
+        "trans": [
+            "与此同时"
+        ],
+        "usphone": "'minwaɪl",
+        "ukphone": "'miːnwaɪl"
+    },
+    {
+        "name": "whereas",
+        "trans": [
+            "然而， 但是"
+        ],
+        "usphone": "'wɛr'æz",
+        "ukphone": "ˌweər'æz"
+    },
+    {
+        "name": "conversely",
+        "trans": [
+            "相反地， 颠倒地"
+        ],
+        "usphone": "'kɑnvɝsli",
+        "ukphone": "'kɒnvɜːsli"
+    },
+    {
+        "name": "likewise",
+        "trans": [
+            "同样； 也"
+        ],
+        "usphone": "'laɪkwaɪz",
+        "ukphone": "'laɪkwaɪz"
+    },
+    {
+        "name": "similarly",
+        "trans": [
+            "同样地， 类似地"
+        ],
+        "usphone": "'sɪməlɚli",
+        "ukphone": "'sɪmələlɪ"
+    },
+    {
+        "name": "besides",
+        "trans": [
+            "而且， 还有",
+            "除…之外"
+        ],
+        "usphone": "bɪ'saɪdz",
+        "ukphone": "bɪ'saɪdz"
+    },
+    {
+        "name": "additionally",
+        "trans": [
+            "adv. 此外；又，加之"
+        ],
+        "usphone": "əˈdɪʃənəli",
+        "ukphone": "əˈdɪʃənəli"
+    },
+    {
+        "name": "otherwise",
+        "trans": [
+            "另样，用别的方法；在其他方面",
+            "要不然， 否则"
+        ],
+        "usphone": "'ʌðɚwaɪz",
+        "ukphone": "'ʌðərwaɪz"
+    },
+    {
+        "name": "regardless",
+        "trans": [
+            "不顾， 不管"
+        ],
+        "usphone": "rɪ'ɡɑrdləs",
+        "ukphone": "rɪ'gɑːrdləs"
+    },
+    {
+        "name": "alternatively",
+        "trans": [
+            "adv. 非此即彼；二者择一地；作为一种选择"
+        ],
+        "usphone": "ɔl'tɝnətɪvli",
+        "ukphone": "ɔːl'tɜːnətɪvlɪ"
+    },
+    {
+        "name": "subsequently",
+        "trans": [
+            "adv. 随后，后来，之后"
+        ],
+        "usphone": "ˈsʌbsɪkwəntli",
+        "ukphone": "ˈsʌbsɪkwəntli"
+    },
+    {
+        "name": "ultimately",
+        "trans": [
+            "最后， 终于"
+        ],
+        "usphone": "'ʌltəmɪtlɪ",
+        "ukphone": "'ʌltɪmətli"
+    },
+    {
+        "name": "initially",
+        "trans": [
+            "adv. 起初，最初"
+        ],
+        "usphone": "ɪˈnɪʃəli",
+        "ukphone": "ɪˈnɪʃəli"
+    },
+    {
+        "name": "primarily",
+        "trans": [
+            "adv. 主要地，首要地，根本地"
+        ],
+        "usphone": "praɪ'merəli",
+        "ukphone": "praɪ'merəli"
+    },
+    {
+        "name": "particularly",
+        "trans": [
+            "adv. 非常，尤其；特别是；清楚地，明确地"
+        ],
+        "usphone": "pər'tɪkjələrli",
+        "ukphone": "pə'tɪkjələli"
+    },
+    {
+        "name": "especially",
+        "trans": [
+            "adv. 尤其，特别；专门，特地；在很大程度上，非常"
+        ],
+        "usphone": "ɪ'speʃəli",
+        "ukphone": "ɪ'speʃəli"
+    },
+    {
+        "name": "notably",
+        "trans": [
+            "adv. 特别地，显著地；尤其，特别是"
+        ],
+        "usphone": "ˈnoʊtəbli",
+        "ukphone": "ˈnəʊtəbli"
+    },
+    {
+        "name": "arguably",
+        "trans": [
+            "adv. 可论证地；可争辩地；正如可提出证据加以证明的那样地",
+            "可能，大概"
+        ],
+        "usphone": "ˈɑːɡjuəbli",
+        "ukphone": "ˈɑːrɡjuəbli"
+    },
+    {
+        "name": "undoubtedly",
+        "trans": [
+            "adv. 无疑，肯定"
+        ],
+        "usphone": "ʌn'daʊtɪdli",
+        "ukphone": "ʌn'daʊtɪdli"
+    },
+    {
+        "name": "admittedly",
+        "trans": [
+            "adv. 公认地；无可否认地；明白地"
+        ],
+        "usphone": "əd'mɪtɪdli",
+        "ukphone": "əd'mɪtɪdlɪ"
+    },
+    {
+        "name": "presumably",
+        "trans": [
+            "推测起来， 大概"
+        ],
+        "usphone": "prɪ'zuməbli",
+        "ukphone": "prɪ'zjuːməbli"
+    },
+    {
+        "name": "apparently",
+        "trans": [
+            "显然； 看来， 似乎"
+        ],
+        "usphone": "ə'pærəntli",
+        "ukphone": "ə'pærəntli"
+    },
+    {
+        "name": "essentially",
+        "trans": [
+            "本质上； 基本上"
+        ],
+        "usphone": "ɪ'sɛnʃəli",
+        "ukphone": "ɪ'senʃəli"
+    },
+    {
+        "name": "fundamentally",
+        "trans": [
+            "adv. 根本上地，从根本上，基本上"
+        ],
+        "usphone": "ˌfʌndəˈmentəli",
+        "ukphone": "ˌfʌndəˈmentəli"
+    },
+    {
+        "name": "generally",
+        "trans": [
+            "adv. 笼统地，大概；通常，普遍地"
+        ],
+        "usphone": "'dʒen(ə)rəli",
+        "ukphone": "'dʒen(ə)rəli"
+    },
+    {
+        "name": "typically",
+        "trans": [
+            "adv. 通常地，一般地；典型地，代表性地"
+        ],
+        "usphone": "ˈtɪpɪkli",
+        "ukphone": "ˈtɪpɪkli"
+    },
+    {
+        "name": "occasionally",
+        "trans": [
+            "adv. 偶尔；间或"
+        ],
+        "usphone": "o'keʒənəli",
+        "ukphone": "əˈkeɪʒnəli"
+    },
+    {
+        "name": "frequently",
+        "trans": [
+            "adv. 经常地，频繁地"
+        ],
+        "usphone": "ˈfriːkwəntli",
+        "ukphone": "ˈfriːkwəntli"
+    },
+    {
+        "name": "rarely",
+        "trans": [
+            "不常， 难得 (adv.)"
+        ],
+        "usphone": "'rɛrli",
+        "ukphone": "'reəli"
+    },
+    {
+        "name": "seldom",
+        "trans": [
+            "adv. 很少，不常"
+        ],
+        "usphone": "ˈseldəm",
+        "ukphone": "ˈseldəm"
+    },
+    {
+        "name": "argue",
+        "trans": [
+            "争论， 辩论； 主张， 论证； 说服， 劝说"
+        ],
+        "usphone": "'ɑrgjʊ",
+        "ukphone": "'ɑːrgjuː"
+    },
+    {
+        "name": "claim",
+        "trans": [
+            "声称， 断言； 要求； 索赔"
+        ],
+        "usphone": "klem",
+        "ukphone": "kleɪm"
+    },
+    {
+        "name": "assert",
+        "trans": [
+            "断言， 声称"
+        ],
+        "usphone": "ə'sɝt",
+        "ukphone": "ə'sɜːrt"
+    },
+    {
+        "name": "contend",
+        "trans": [
+            "v. 声称，主张；竞争，争夺；处理，对付"
+        ],
+        "usphone": "kən'tend",
+        "ukphone": "kən'tend"
+    },
+    {
+        "name": "maintain",
+        "trans": [
+            "维持， 保持； 维修， 保养； 主张， 坚持； 赡养， 负担"
+        ],
+        "usphone": "men'ten",
+        "ukphone": "meɪn'teɪn"
+    },
+    {
+        "name": "suggest",
+        "trans": [
+            "v. 提议，建议；推荐，举荐；显示，表明；暗示，暗指；使人想到，使人联想到"
+        ],
+        "usphone": "sə'dʒest",
+        "ukphone": "sə'dʒest"
+    },
+    {
+        "name": "indicate",
+        "trans": [
+            "表明， 显示； 指出， 指示； 象征， 预示； 暗示， 间接提及"
+        ],
+        "usphone": "'ɪndɪket",
+        "ukphone": "'ɪndɪkeɪt"
+    },
+    {
+        "name": "demonstrate",
+        "trans": [
+            "论证， 证明； 表现， 显露； 示范， 演示； 游行示威"
+        ],
+        "usphone": "'dɛmən'stret",
+        "ukphone": "'demənstreɪt"
+    },
+    {
+        "name": "illustrate",
+        "trans": [
+            "说明， 解释； 加插图于； 显示…存在"
+        ],
+        "usphone": "'ɪləstret",
+        "ukphone": "'ɪləstreɪt"
+    },
+    {
+        "name": "imply",
+        "trans": [
+            "意味着， 暗示； 说明， 表明； 使有必要"
+        ],
+        "usphone": "ɪm'plai",
+        "ukphone": "ɪm'plaɪ"
+    },
+    {
+        "name": "reveal",
+        "trans": [
+            "暴露， 揭露； 展现"
+        ],
+        "usphone": "rɪ'vil",
+        "ukphone": "rɪ'viːl"
+    },
+    {
+        "name": "highlight",
+        "trans": [
+            "强调，突出；以强烈光线照射",
+            "最精彩部分"
+        ],
+        "usphone": "'haɪlaɪt",
+        "ukphone": "'haɪlaɪt"
+    },
+    {
+        "name": "emphasize",
+        "trans": [
+            "强调， 着重"
+        ],
+        "usphone": "'ɛmfəsaɪz",
+        "ukphone": "'emfəsaɪz"
+    },
+    {
+        "name": "stress",
+        "trans": [
+            "强调； 重读； 焦虑不安",
+            "压力；强调；精神压力，紧张；重音，重读"
+        ],
+        "usphone": "strɛs",
+        "ukphone": "stres"
+    },
+    {
+        "name": "underline",
+        "trans": [
+            "画线于…之下； 强调"
+        ],
+        "usphone": "'ʌndəlaɪn",
+        "ukphone": "ˌʌndə'laɪn"
+    },
+    {
+        "name": "acknowledge",
+        "trans": [
+            "承认， 确认； 对…表示感谢"
+        ],
+        "usphone": "ək'nɑlɪdʒ",
+        "ukphone": "ək'nɑːlɪdʒ"
+    },
+    {
+        "name": "admit",
+        "trans": [
+            "承认； 准许…进入， 接纳"
+        ],
+        "usphone": "əd'mɪt",
+        "ukphone": "əd'mɪt"
+    },
+    {
+        "name": "concede",
+        "trans": [
+            "承认； 让步； 允许"
+        ],
+        "usphone": "kən'sid",
+        "ukphone": "kən'siːd"
+    },
+    {
+        "name": "refute",
+        "trans": [
+            "反驳， 驳斥"
+        ],
+        "usphone": "ri'fjʊt",
+        "ukphone": "rɪ'fjuːt"
+    },
+    {
+        "name": "contradict",
+        "trans": [
+            "反驳； 同…矛盾， 相抵触"
+        ],
+        "usphone": "'kɑntrə'dɪkt",
+        "ukphone": "ˌkɑːntrə'dɪkt"
+    },
+    {
+        "name": "oppose",
+        "trans": [
+            "反对， 对抗"
+        ],
+        "usphone": "ə'poz",
+        "ukphone": "ə'pouz"
+    },
+    {
+        "name": "challenge",
+        "trans": [
+            "挑战；艰巨任务，难题；质疑，质问",
+            "向…挑战； 公然反抗； 对…质疑"
+        ],
+        "usphone": "'tʃælɪndʒ",
+        "ukphone": "'tʃælɪndʒ"
+    },
+    {
+        "name": "question",
+        "trans": [
+            "n. 问题，疑问；询问，提问；怀疑，质疑；议题，话题",
+            "v. 询问，提问；怀疑，质疑"
+        ],
+        "usphone": "ˈkwesʧən",
+        "ukphone": "ˈkwestʃən"
+    },
+    {
+        "name": "doubt",
+        "trans": [
+            "v. 怀疑，不确定；不信任 n. 怀疑，不确定"
+        ],
+        "usphone": "daʊt",
+        "ukphone": "daʊt"
+    },
+    {
+        "name": "dispute",
+        "trans": [
+            "争论； 对…表示异议",
+            "争论；纠纷"
+        ],
+        "usphone": "'dɪs'pjʊt",
+        "ukphone": "dɪ'spjuːt"
+    },
+    {
+        "name": "justify",
+        "trans": [
+            "证明…是正当的； 为…辩护"
+        ],
+        "usphone": "'dʒʌstə'fai",
+        "ukphone": "'dʒʌstɪfaɪ"
+    },
+    {
+        "name": "support",
+        "trans": [
+            "支撑；支持；供养；证实",
+            "支持， 支撑物， 支持者"
+        ],
+        "usphone": "sə'pɔrt",
+        "ukphone": "sə'pɔːt"
+    },
+    {
+        "name": "confirm",
+        "trans": [
+            "证实； 使巩固； 批准"
+        ],
+        "usphone": "kən'fɝm",
+        "ukphone": "kən'fɜːrm"
+    },
+    {
+        "name": "verify",
+        "trans": [
+            "检验， 核实"
+        ],
+        "usphone": "'vɛrɪfaɪ",
+        "ukphone": "'verɪfaɪ"
+    },
+    {
+        "name": "prove",
+        "trans": [
+            "证实， 证明； 结果是"
+        ],
+        "usphone": "pruv",
+        "ukphone": "pruːv"
+    },
+    {
+        "name": "establish",
+        "trans": [
+            "建立， 设立； 安置， 使定居； 确定， 证实"
+        ],
+        "usphone": "ɪˈstæblɪʃ",
+        "ukphone": "ɪ'stæblɪʃ"
+    },
+    {
+        "name": "define",
+        "trans": [
+            "定义， 解释； 限定"
+        ],
+        "usphone": "dɪ'faɪn",
+        "ukphone": "dɪ'faɪn"
+    },
+    {
+        "name": "clarify",
+        "trans": [
+            "澄清， 阐明"
+        ],
+        "usphone": "'klærəfaɪ",
+        "ukphone": "'klærəfaɪ"
+    },
+    {
+        "name": "elaborate",
+        "trans": [
+            "精心制作的， 复杂精美的",
+            "详述； 详细制订， 精心制作"
+        ],
+        "usphone": "ɪ'læbəret",
+        "ukphone": "ɪ'læb(ə)rət"
+    },
+    {
+        "name": "summarize",
+        "trans": [
+            "概括， 总结"
+        ],
+        "usphone": "'sʌməraɪz",
+        "ukphone": "'sʌməraɪz"
+    },
+    {
+        "name": "conclude",
+        "trans": [
+            "推断出； 作结论"
+        ],
+        "usphone": "kən'klud",
+        "ukphone": "kən'kluːd"
+    },
+    {
+        "name": "infer",
+        "trans": [
+            "v. 推断，推论；暗示，暗指"
+        ],
+        "usphone": "ɪn'fɜːr",
+        "ukphone": "ɪn'fɜː(r)"
+    },
+    {
+        "name": "deduce",
+        "trans": [
+            "演绎， 推断"
+        ],
+        "usphone": "dɪ'dʊs",
+        "ukphone": "dɪ'djuːs"
+    },
+    {
+        "name": "assume",
+        "trans": [
+            "假定； 承担"
+        ],
+        "usphone": "ə'sum",
+        "ukphone": "ə'suːm"
+    },
+    {
+        "name": "presume",
+        "trans": [
+            "擅自行事 (vi.)",
+            "推测，假定，相信；冒昧，擅自；认定，推定 (vt.)"
+        ],
+        "usphone": "prɪ'zum",
+        "ukphone": "prɪ'zjuːm"
+    },
+    {
+        "name": "evaluate",
+        "trans": [
+            "评价， 估计"
+        ],
+        "usphone": "ɪ'væljʊ'et",
+        "ukphone": "ɪ'væljueɪt"
+    },
+    {
+        "name": "assess",
+        "trans": [
+            "估价； 评定"
+        ],
+        "usphone": "ə'sɛs",
+        "ukphone": "ə'ses"
+    },
+    {
+        "name": "analyze",
+        "trans": [
+            "分析， 研究"
+        ],
+        "usphone": "'ænə,laɪz",
+        "ukphone": "'ænəlaɪz"
+    },
+    {
+        "name": "examine",
+        "trans": [
+            "检查； 调查， 研究； 测验"
+        ],
+        "usphone": "ɪg'zæmɪn",
+        "ukphone": "ɪg'zæmɪn"
+    },
+    {
+        "name": "explore",
+        "trans": [
+            "探索， 勘探； 探险； 探究"
+        ],
+        "usphone": "ɪk'splɔr",
+        "ukphone": "ɪk'splɔːr"
+    },
+    {
+        "name": "investigate",
+        "trans": [
+            "研究， 调查"
+        ],
+        "usphone": "ɪn'vɛstɪɡet",
+        "ukphone": "ɪn'vestɪgeɪt"
+    },
+    {
+        "name": "compare",
+        "trans": [
+            "比较， 相比， 对比"
+        ],
+        "usphone": "kəm'pɛr",
+        "ukphone": "kəm'per"
+    },
+    {
+        "name": "contrast",
+        "trans": [
+            "对比， 对照",
+            "对比， 对照"
+        ],
+        "usphone": "'kɑntræst",
+        "ukphone": "'kɒntrɑːst"
+    },
+    {
+        "name": "distinguish",
+        "trans": [
+            "区别， 辨别； 使有别于， 成为…的特征； 看清， 听出； 使杰出， 使著名"
+        ],
+        "usphone": "dɪ'stɪŋɡwɪʃ",
+        "ukphone": "dɪ'stɪŋgwɪʃ"
+    },
+    {
+        "name": "classify",
+        "trans": [
+            "分类； 分等"
+        ],
+        "usphone": "'klæsɪfaɪ",
+        "ukphone": "'klæsɪfaɪ"
+    },
+    {
+        "name": "attribute",
+        "trans": [
+            "属性， 特征",
+            "把…归于"
+        ],
+        "usphone": "ə'trɪbjut",
+        "ukphone": "ə'trɪbjuːt"
+    },
+    {
+        "name": "ascribe",
+        "trans": [
+            "把…归于； 归咎于"
+        ],
+        "usphone": "ə'skraɪb",
+        "ukphone": "ə'skraɪb"
+    },
+    {
+        "name": "derive",
+        "trans": [
+            "取得； 起源"
+        ],
+        "usphone": "dɪ'raɪv",
+        "ukphone": "dɪ'raɪv"
+    },
+    {
+        "name": "stem",
+        "trans": [
+            "阻止，遏制；起源",
+            "茎， 干"
+        ],
+        "usphone": "stɛm",
+        "ukphone": "stem"
+    },
+    {
+        "name": "arise",
+        "trans": [
+            "出现； 由…引起； 起身， 起床"
+        ],
+        "usphone": "ə'raɪz",
+        "ukphone": "ə'raɪz"
+    },
+    {
+        "name": "generate",
+        "trans": [
+            "产生； 引起， 导致"
+        ],
+        "usphone": "'dʒɛnəret",
+        "ukphone": "'dʒenəreɪt"
+    },
+    {
+        "name": "trigger",
+        "trans": [
+            "引发，导致",
+            "扳机"
+        ],
+        "usphone": "'trɪɡɚ",
+        "ukphone": "'trɪgər"
+    },
+    {
+        "name": "prompt",
+        "trans": [
+            "敏捷的；及时的，迅速的",
+            "促进，推动；提示；鼓励",
+            "提词， 提示"
+        ],
+        "usphone": "prɑmpt",
+        "ukphone": "prɑːmpt"
+    },
+    {
+        "name": "facilitate",
+        "trans": [
+            "推动， 促进"
+        ],
+        "usphone": "fə'sɪlə'tet",
+        "ukphone": "fə'sɪlɪteɪt"
+    },
+    {
+        "name": "hinder",
+        "trans": [
+            "阻碍， 妨碍"
+        ],
+        "usphone": "'hɪndɚ",
+        "ukphone": "'hɪndər"
+    },
+    {
+        "name": "impede",
+        "trans": [
+            "妨碍， 阻碍， 阻止"
+        ],
+        "usphone": "ɪm'pid",
+        "ukphone": "ɪm'piːd"
+    },
+    {
+        "name": "undermine",
+        "trans": [
+            "削弱； 破坏"
+        ],
+        "usphone": "'ʌndɚ'maɪn",
+        "ukphone": "ˌʌndə'maɪn"
+    },
+    {
+        "name": "reinforce",
+        "trans": [
+            "加固， 加强； 增援"
+        ],
+        "usphone": ",riɪn'fɔrs",
+        "ukphone": "ˌriːɪn'fɔːrs"
+    },
+    {
+        "name": "enhance",
+        "trans": [
+            "提高； 增强"
+        ],
+        "usphone": "ɪn'hæns",
+        "ukphone": "ɪn'hæns"
+    },
+    {
+        "name": "diminish",
+        "trans": [
+            "降低， 贬低； 减少， 减弱"
+        ],
+        "usphone": "dɪ'mɪnɪʃ",
+        "ukphone": "dɪ'mɪnɪʃ"
+    },
+    {
+        "name": "alleviate",
+        "trans": [
+            "减轻， 缓解， 缓和"
+        ],
+        "usphone": "ə'livɪ'et",
+        "ukphone": "ə'liːvieɪt"
+    },
+    {
+        "name": "aggravate",
+        "trans": [
+            "恶化， 加重； 激怒"
+        ],
+        "usphone": "'æɡrəvet",
+        "ukphone": "'ægrəveɪt"
+    },
+    {
+        "name": "mitigate",
+        "trans": [
+            "使缓和， 使减轻"
+        ],
+        "usphone": "'mɪtɪɡet",
+        "ukphone": "'mɪtɪgeɪt"
+    },
+    {
+        "name": "offset",
+        "trans": [
+            "分支；补偿；抵消",
+            "补偿； 抵消"
+        ],
+        "usphone": ",ɔf'sɛt",
+        "ukphone": "'ɔːfset"
+    },
+    {
+        "name": "compensate",
+        "trans": [
+            "赔偿， 弥补"
+        ],
+        "usphone": "'kɑmpɛnset",
+        "ukphone": "'kɑːmpenseɪt"
+    },
+    {
+        "name": "outweigh",
+        "trans": [
+            "超过"
+        ],
+        "usphone": "'aʊt'we",
+        "ukphone": "ˌaut'weɪ"
+    },
+    {
+        "name": "exceed",
+        "trans": [
+            "超过， 超出"
+        ],
+        "usphone": "ɪk'sid",
+        "ukphone": "ɪk'siːd"
+    },
+    {
+        "name": "surpass",
+        "trans": [
+            "超过， 超越， 胜过"
+        ],
+        "usphone": "sə'pæs",
+        "ukphone": "sər'pæs"
+    },
+    {
+        "name": "prevail",
+        "trans": [
+            "盛行， 流行； 战胜， 压倒； 劝说"
+        ],
+        "usphone": "pri'vel",
+        "ukphone": "prɪ'veɪl"
+    },
+    {
+        "name": "dominate",
+        "trans": [
+            "支配， 统治； 控制； 盛行"
+        ],
+        "usphone": "'dɑmɪnet",
+        "ukphone": "'dɑːmɪneɪt"
+    },
+    {
+        "name": "prioritize",
+        "trans": [
+            "划分优先顺序； 优先处理"
+        ],
+        "usphone": "praɪ'ɔrətaɪz",
+        "ukphone": "praɪ'ɔːrətaɪz"
+    },
+    {
+        "name": "advocate",
+        "trans": [
+            "提倡",
+            "倡导者"
+        ],
+        "usphone": "ˈædvəkeɪt；-et",
+        "ukphone": "'ædvəkeɪt；-ət"
+    },
+    {
+        "name": "endorse",
+        "trans": [
+            "签名； 宣传， 代言； 签署； 赞同， 支持"
+        ],
+        "usphone": "ɪn'dɔrs",
+        "ukphone": "ɪn'dɔːrs"
+    },
+    {
+        "name": "promote",
+        "trans": [
+            "促进； 提升； 宣传， 推销"
+        ],
+        "usphone": "prə'mot",
+        "ukphone": "prə'mout"
+    },
+    {
+        "name": "discourage",
+        "trans": [
+            "使泄气， 使灰心； 阻止， 劝阻"
+        ],
+        "usphone": "dɪs'kɝɪdʒ",
+        "ukphone": "dɪs'kɜːrɪdʒ"
+    },
+    {
+        "name": "prohibit",
+        "trans": [
+            "禁止， 阻止"
+        ],
+        "usphone": "prə'hɪbɪt",
+        "ukphone": "prə'hɪbɪt"
+    },
+    {
+        "name": "restrict",
+        "trans": [
+            "限制， 约束"
+        ],
+        "usphone": "rɪ'strɪkt",
+        "ukphone": "rɪ'strɪkt"
+    },
+    {
+        "name": "constrain",
+        "trans": [
+            "束缚， 限制"
+        ],
+        "usphone": "kən'stren",
+        "ukphone": "kən'streɪn"
+    },
+    {
+        "name": "regulate",
+        "trans": [
+            "管理， 控制； 调整， 调节； 校准"
+        ],
+        "usphone": "'rɛɡjulet",
+        "ukphone": "'regjuleɪt"
+    },
+    {
+        "name": "implement",
+        "trans": [
+            "使生效， 执行， 实施"
+        ],
+        "usphone": "'ɪmplɪmɛnt",
+        "ukphone": "'ɪmplɪm(ə)nt"
+    },
+    {
+        "name": "adopt",
+        "trans": [
+            "采用； 收养， 领养； 正式通过， 批准"
+        ],
+        "usphone": "ə'dɑpt",
+        "ukphone": "ə'dɑːpt"
+    },
+    {
+        "name": "pursue",
+        "trans": [
+            "继续； 从事于； 追击， 追踪； 追求"
+        ],
+        "usphone": "pə'sʊ",
+        "ukphone": "pər'sjuː"
+    },
+    {
+        "name": "achieve",
+        "trans": [
+            "v. （经努力）达到，取得，实现；获得成功"
+        ],
+        "usphone": "ə'tʃiːv",
+        "ukphone": "ə'tʃiːv"
+    },
+    {
+        "name": "accomplish",
+        "trans": [
+            "达到； 完成； 实现"
+        ],
+        "usphone": "ə'kɑmplɪʃ",
+        "ukphone": "ə'kɑːmplɪʃ"
+    },
+    {
+        "name": "obtain",
+        "trans": [
+            "获得； 通用， 流行"
+        ],
+        "usphone": "əb'ten",
+        "ukphone": "əb'teɪn"
+    },
+    {
+        "name": "acquire",
+        "trans": [
+            "获得， 取得"
+        ],
+        "usphone": "ə'kwaɪr",
+        "ukphone": "ə'kwaɪər"
+    },
+    {
+        "name": "allocate",
+        "trans": [
+            "分配， 分派， 把…拨给"
+        ],
+        "usphone": "'æləket",
+        "ukphone": "'æləkeɪt"
+    },
+    {
+        "name": "distribute",
+        "trans": [
+            "分配， 分发； 散布"
+        ],
+        "usphone": "dɪ'strɪbjut",
+        "ukphone": "dɪ'strɪbjuːt"
+    },
+    {
+        "name": "integrate",
+        "trans": [
+            "合并， 成为一体"
+        ],
+        "usphone": "'ɪntɪɡret",
+        "ukphone": "'ɪntɪgreɪt"
+    },
+    {
+        "name": "incorporate",
+        "trans": [
+            "v. 包含，吸收；合并，合为一体；注册成立（公司）；使具体化，体现",
+            "adj. 合并的，组成公司的"
+        ],
+        "usphone": "ɪnˈkɔːrpəreɪt",
+        "ukphone": "ɪnˈkɔːpəreɪt"
+    },
+    {
+        "name": "transform",
+        "trans": [
+            "使变形； 改造， 改革； 转换"
+        ],
+        "usphone": "træns'fɔrm",
+        "ukphone": "træns'fɔːrm"
+    },
+    {
+        "name": "modify",
+        "trans": [
+            "修改， 更改； 缓和； 【语】修饰"
+        ],
+        "usphone": "'mɑdɪfaɪ",
+        "ukphone": "'mɑːdɪfaɪ"
+    },
+    {
+        "name": "adapt",
+        "trans": [
+            "适合； 适应； 调整； 改编， 改写"
+        ],
+        "usphone": "ə'dæpt",
+        "ukphone": "ə'dæpt"
+    },
+    {
+        "name": "adjust",
+        "trans": [
+            "调整， 调节； 适合， 适应； 校正， 校准"
+        ],
+        "usphone": "ə'dʒʌst",
+        "ukphone": "ə'dʒʌst"
+    },
+    {
+        "name": "sustain",
+        "trans": [
+            "保持， 维持； 支持， 支撑； 经受， 承受"
+        ],
+        "usphone": "sə'sten",
+        "ukphone": "sə'steɪn"
+    },
+    {
+        "name": "preserve",
+        "trans": [
+            "保护， 维护； 保存， 保养"
+        ],
+        "usphone": "prɪ'zɝv",
+        "ukphone": "prɪ'zɜːrv"
+    },
+    {
+        "name": "restore",
+        "trans": [
+            "恢复； 修复； 归还， 交还"
+        ],
+        "usphone": "rɪ'stɔr",
+        "ukphone": "rɪ'stɔːr"
+    },
+    {
+        "name": "eliminate",
+        "trans": [
+            "消除； 淘汰"
+        ],
+        "usphone": "ɪ'lɪmɪnet",
+        "ukphone": "ɪ'lɪmɪneɪt"
+    },
+    {
+        "name": "minimize",
+        "trans": [
+            "将…减到最少， 使最小化； 降低， 贬低"
+        ],
+        "usphone": "'mɪnɪmaɪz",
+        "ukphone": "'mɪnɪmaɪz"
+    },
+    {
+        "name": "maximize",
+        "trans": [
+            "v. 使最大化，使达到最大限度"
+        ],
+        "usphone": "ˈmæksɪmaɪz",
+        "ukphone": "ˈmæksɪmaɪz"
+    },
+    {
+        "name": "significant",
+        "trans": [
+            "有重大意义的， 重要的， 显著的； 意味深长的"
+        ],
+        "usphone": "sɪɡ'nɪfɪkənt",
+        "ukphone": "sɪg'nɪfɪkənt"
+    },
+    {
+        "name": "substantial",
+        "trans": [
+            "实质的； 坚固的； 可观的， 大量的"
+        ],
+        "usphone": "səbˈstænʃəl",
+        "ukphone": "sʌb'stænʃl"
+    },
+    {
+        "name": "considerable",
+        "trans": [
+            "adj. 相当大的，相当重要的；（人）显要的，值得尊敬的"
+        ],
+        "usphone": "kən'sɪdərəb(ə)l",
+        "ukphone": "kən'sɪdərəb(ə)l"
+    },
+    {
+        "name": "remarkable",
+        "trans": [
+            "显著的， 值得注意的； 非凡的"
+        ],
+        "usphone": "rɪ'mɑrkəbl",
+        "ukphone": "rɪ'mɑːrkəbl"
+    },
+    {
+        "name": "crucial",
+        "trans": [
+            "至关重要的， 决定性的"
+        ],
+        "usphone": "'krʊʃəl",
+        "ukphone": "'kruːʃl"
+    },
+    {
+        "name": "vital",
+        "trans": [
+            "生死攸关的； 至关重要的； 精力充沛的， 有活力的"
+        ],
+        "usphone": "'vaɪtl",
+        "ukphone": "'vaɪtl"
+    },
+    {
+        "name": "essential",
+        "trans": [
+            "基本的，本质的；极其重要的，必不可少的",
+            "要素， 实质； 必需品"
+        ],
+        "usphone": "ɪ'sɛnʃl",
+        "ukphone": "ɪ'senʃl"
+    },
+    {
+        "name": "indispensable",
+        "trans": [
+            "必不可少的"
+        ],
+        "usphone": "'ɪndɪ'spɛnsəbl",
+        "ukphone": "ˌɪndɪ'spensəbl"
+    },
+    {
+        "name": "fundamental",
+        "trans": [
+            "基础的，基本的，根本的",
+            "基本原则； 基础"
+        ],
+        "usphone": ",fʌndə'mɛntl",
+        "ukphone": "ˌfʌndə'mentl"
+    },
+    {
+        "name": "dominant",
+        "trans": [
+            "统治的， 支配的， 占优势的； 有统治权的"
+        ],
+        "usphone": "'dɑmɪnənt",
+        "ukphone": "'dɑːmɪnənt"
+    },
+    {
+        "name": "prevalent",
+        "trans": [
+            "流行的， 普遍的"
+        ],
+        "usphone": "'prɛvələnt",
+        "ukphone": "'prevələnt"
+    },
+    {
+        "name": "widespread",
+        "trans": [
+            "分布广泛的， 普遍的"
+        ],
+        "usphone": "ˈwʌɪdsprɛd",
+        "ukphone": "'waɪdspred"
+    },
+    {
+        "name": "universal",
+        "trans": [
+            "普遍的， 全体的； 通用的， 万能的； 宇宙的， 全世界的"
+        ],
+        "usphone": "'jʊnə'vɝsl",
+        "ukphone": "ˌjuːnɪ'vɜːrsl"
+    },
+    {
+        "name": "comprehensive",
+        "trans": [
+            "全面的； 综合的"
+        ],
+        "usphone": "ˌkɑːmprɪˈhensɪv",
+        "ukphone": "ˌkɑːmprɪ'hensɪv"
+    },
+    {
+        "name": "thorough",
+        "trans": [
+            "彻底的； 详尽的； 一丝不苟的"
+        ],
+        "usphone": "ˈθʌrəʊ; θʌro",
+        "ukphone": "'θɜːrou"
+    },
+    {
+        "name": "adequate",
+        "trans": [
+            "适当的； 足够的； 适当的， 胜任的"
+        ],
+        "usphone": "ˈædɪkwət",
+        "ukphone": "'ædɪkwət"
+    },
+    {
+        "name": "sufficient",
+        "trans": [
+            "足够的， 充分的"
+        ],
+        "usphone": "səˈfɪʃənt",
+        "ukphone": "sə'fɪʃnt"
+    },
+    {
+        "name": "insufficient",
+        "trans": [
+            "不足的， 不够的"
+        ],
+        "usphone": ",ɪnsə'fɪʃnt",
+        "ukphone": "ˌɪnsə'fɪʃnt"
+    },
+    {
+        "name": "inadequate",
+        "trans": [
+            "不充分的； 不适当的"
+        ],
+        "usphone": "ɪn'ædɪkwət",
+        "ukphone": "ɪn'ædɪkwət"
+    },
+    {
+        "name": "excessive",
+        "trans": [
+            "adj. 过度的，过多的"
+        ],
+        "usphone": "ɪk'sesɪv",
+        "ukphone": "ɪk'sesɪv"
+    },
+    {
+        "name": "moderate",
+        "trans": [
+            "适度的； 温和的； 普通的",
+            "缓和，使适中",
+            "持温和意见的人"
+        ],
+        "usphone": "ˈmɑdərɪt; (for v.,) ˈmɑdərˌeɪt",
+        "ukphone": "'mɒd(ə)rət"
+    },
+    {
+        "name": "minimal",
+        "trans": [
+            "最小的； 最低限度的"
+        ],
+        "usphone": "'mɪnɪməl",
+        "ukphone": "'mɪnɪməl"
+    },
+    {
+        "name": "negligible",
+        "trans": [
+            "可以忽略的， 微不足道的； 无关紧要的"
+        ],
+        "usphone": "'nɛɡlɪdʒəbl",
+        "ukphone": "'neglɪdʒəbl"
+    },
+    {
+        "name": "superior",
+        "trans": [
+            "较高的；更好的；有优越感的，高傲的；超群的",
+            "上级， 长官"
+        ],
+        "usphone": "sʊˈpɪrɪɚ",
+        "ukphone": "suː'pɪriər"
+    },
+    {
+        "name": "inferior",
+        "trans": [
+            "劣等的，较差的；次要的；级别低的",
+            "下级， 下属， 晚辈"
+        ],
+        "usphone": "ɪn'fɪrɪɚ",
+        "ukphone": "ɪn'fɪriər"
+    },
+    {
+        "name": "beneficial",
+        "trans": [
+            "有益的， 有利的"
+        ],
+        "usphone": ",bɛnɪ'fɪʃl",
+        "ukphone": "ˌbenɪ'fɪʃl"
+    },
+    {
+        "name": "detrimental",
+        "trans": [
+            "adj. 有害的，不利的 n. 有害的人（或物）"
+        ],
+        "usphone": "ˌdetrɪ'ment(ə)l",
+        "ukphone": "ˌdetrɪ'ment(ə)l"
+    },
+    {
+        "name": "harmful",
+        "trans": [
+            "adj. 有害的，造成伤害的"
+        ],
+        "usphone": "'hɑːrmf(ə)l",
+        "ukphone": "'hɑːmf(ə)l"
+    },
+    {
+        "name": "adverse",
+        "trans": [
+            "负面的； 不利的； 逆的"
+        ],
+        "usphone": "ædˈvɚs, ˈædˌvɚs",
+        "ukphone": "'ædvɜːrs"
+    },
+    {
+        "name": "favorable",
+        "trans": [
+            "赞许的； 有利的， 顺利的"
+        ],
+        "usphone": "'fevərəbl",
+        "ukphone": "'feɪvərəbl"
+    },
+    {
+        "name": "desirable",
+        "trans": [
+            "adj. 令人向往的，值得拥有的；可取的；性感的 n. 称心合意的人（或物），好的品质"
+        ],
+        "usphone": "dɪ'zaɪərəb(ə)l",
+        "ukphone": "dɪ'zaɪərəb(ə)l"
+    },
+    {
+        "name": "undesirable",
+        "trans": [
+            "不受欢迎的， 令人不快的"
+        ],
+        "usphone": ",ʌndɪ'zaɪərəbl",
+        "ukphone": "ˌʌndɪ'zaɪərəbl"
+    },
+    {
+        "name": "feasible",
+        "trans": [
+            "可行的， 行得通的"
+        ],
+        "usphone": "'fizəbl",
+        "ukphone": "'fiːzəbl"
+    },
+    {
+        "name": "viable",
+        "trans": [
+            "可行的， 可实施的； 可生长发育的"
+        ],
+        "usphone": "'vaiəbl",
+        "ukphone": "'vaɪəbl"
+    },
+    {
+        "name": "practical",
+        "trans": [
+            "实用的； 实际的； 现实的"
+        ],
+        "usphone": "'præktɪkl",
+        "ukphone": "'præktɪkl"
+    },
+    {
+        "name": "realistic",
+        "trans": [
+            "现实的； 逼真的"
+        ],
+        "usphone": ",riə'lɪstɪk",
+        "ukphone": "ˌriːə'lɪstɪk"
+    },
+    {
+        "name": "plausible",
+        "trans": [
+            "似有道理的， 似乎正确的"
+        ],
+        "usphone": "'plɔzəbl",
+        "ukphone": "'plɔːzəbl"
+    },
+    {
+        "name": "convincing",
+        "trans": [
+            "令人信服的；有说服力的",
+            "使相信；使明白（convince的现在分词）"
+        ],
+        "usphone": "kən'vɪnsɪŋ",
+        "ukphone": "kən'vɪnsɪŋ"
+    },
+    {
+        "name": "persuasive",
+        "trans": [
+            "有说服力的， 让人信服的"
+        ],
+        "usphone": "pɚ'swesɪv",
+        "ukphone": "pər'sweɪsɪv"
+    },
+    {
+        "name": "compelling",
+        "trans": [
+            "极具说服力的"
+        ],
+        "usphone": "kəmˈpɛlɪŋ",
+        "ukphone": "kəmˈpelɪŋ"
+    },
+    {
+        "name": "credible",
+        "trans": [
+            "可信的， 可靠的 (adj.)"
+        ],
+        "usphone": "'krɛdəbl",
+        "ukphone": "'kredəbl"
+    },
+    {
+        "name": "reliable",
+        "trans": [
+            "可靠的， 可信赖的"
+        ],
+        "usphone": "rɪ'laɪəbl",
+        "ukphone": "rɪ'laɪəbl"
+    },
+    {
+        "name": "valid",
+        "trans": [
+            "有根据的， 合理的； 有效的"
+        ],
+        "usphone": "'vælɪd",
+        "ukphone": "'vælɪd"
+    },
+    {
+        "name": "invalid",
+        "trans": [
+            "无效的； 无可靠根据的， 站不住脚的",
+            "病弱者， 残疾者"
+        ],
+        "usphone": "ˈɪnvəlɪd；ɪnˈvælɪd",
+        "ukphone": "ˈɪnvəlɪd；ɪnˈvælɪd"
+    },
+    {
+        "name": "questionable",
+        "trans": [
+            "adj. 可疑的，有问题的；值得怀疑的，不可靠的"
+        ],
+        "usphone": "ˈkwesʧənəbəl",
+        "ukphone": "ˈkwestʃənəbl"
+    },
+    {
+        "name": "controversial",
+        "trans": [
+            "引起争论的， 有争议的"
+        ],
+        "usphone": ",kɑntrə'vɝʃl",
+        "ukphone": "ˌkɑːntrə'vɜːrʃl"
+    },
+    {
+        "name": "ambiguous",
+        "trans": [
+            "不明确的， 模棱两可的"
+        ],
+        "usphone": "æm'bɪɡjuəs",
+        "ukphone": "æm'bɪgjuəs"
+    },
+    {
+        "name": "obvious",
+        "trans": [
+            "adj. 明显的，显然的；明确表示的，毫不掩饰的；平淡无奇的，缺乏想象力的；合情合理的，当然的"
+        ],
+        "usphone": "'ɑːbviəs",
+        "ukphone": "'ɒbviəs"
+    },
+    {
+        "name": "evident",
+        "trans": [
+            "adj. 清楚的，显然的"
+        ],
+        "usphone": "'evɪdənt",
+        "ukphone": "'evɪdənt"
+    },
+    {
+        "name": "explicit",
+        "trans": [
+            "清楚的； 直率的"
+        ],
+        "usphone": "ɪk'splɪsɪt",
+        "ukphone": "ɪk'splɪsɪt"
+    },
+    {
+        "name": "implicit",
+        "trans": [
+            "含蓄的； 绝对的； 内含的"
+        ],
+        "usphone": "ɪm'plɪsɪt",
+        "ukphone": "ɪm'plɪsɪt"
+    },
+    {
+        "name": "subtle",
+        "trans": [
+            "细微的， 微妙的； 精巧的， 巧妙的； 狡猾的； 敏锐的"
+        ],
+        "usphone": "'sʌtl",
+        "ukphone": "'sʌtl"
+    },
+    {
+        "name": "complex",
+        "trans": [
+            "合成的， 综合的； 复杂的， 错综的， 难以理解的",
+            "建筑群； 综合体， 集合体； 情结"
+        ],
+        "usphone": "ˈkɑmplɛks;kəmˈplɛks",
+        "ukphone": "'kɒmpleks"
+    },
+    {
+        "name": "sophisticated",
+        "trans": [
+            "老练的， 见多识广的； 精密的； 复杂的， 先进的； 高雅的， 有教养的"
+        ],
+        "usphone": "sə'fɪstɪketɪd",
+        "ukphone": "sə'fɪstɪkeɪtɪd"
+    },
+    {
+        "name": "straightforward",
+        "trans": [
+            "正直的， 坦率的； 易懂的， 简单的 (adj.)"
+        ],
+        "usphone": ",stret'fɔrwɚd",
+        "ukphone": "ˌstreɪt'fɔːwəd"
+    },
+    {
+        "name": "efficient",
+        "trans": [
+            "有效的， 有效率的； 有能力的， 能胜任的"
+        ],
+        "usphone": "ɪ'fɪʃnt",
+        "ukphone": "ɪ'fɪʃnt"
+    },
+    {
+        "name": "effective",
+        "trans": [
+            "有效的， 生效的； 显著的； 实际的， 事实上的"
+        ],
+        "usphone": "ɪ'fɛktɪv",
+        "ukphone": "ɪ'fektɪv"
+    },
+    {
+        "name": "productive",
+        "trans": [
+            "生产的； 能产的， 多产的； 富有成效的"
+        ],
+        "usphone": "prə'dʌktɪv",
+        "ukphone": "prə'dʌktɪv"
+    },
+    {
+        "name": "innovative",
+        "trans": [
+            "革新的， 创新的； 富有革新精神的"
+        ],
+        "usphone": "'ɪnəvetɪv",
+        "ukphone": "'ɪnəveɪtɪv"
+    },
+    {
+        "name": "creative",
+        "trans": [
+            "有创造力的， 创造性的"
+        ],
+        "usphone": "krɪ'etɪv",
+        "ukphone": "kri'eɪtɪv"
+    },
+    {
+        "name": "flexible",
+        "trans": [
+            "易弯曲的； 柔韧的； 灵活的， 可变通的"
+        ],
+        "usphone": "'flɛksəbl",
+        "ukphone": "'fleksəbl"
+    },
+    {
+        "name": "rigid",
+        "trans": [
+            "严格的； 刚硬的， 不易弯曲的； 死板的， 刻板的； 僵硬的"
+        ],
+        "usphone": "'rɪdʒɪd",
+        "ukphone": "'rɪdʒɪd"
+    },
+    {
+        "name": "consistent",
+        "trans": [
+            "一致的； 稳定的； 调和的； 始终如一的"
+        ],
+        "usphone": "kən'sɪstənt",
+        "ukphone": "kən'sɪstənt"
+    },
+    {
+        "name": "inconsistent",
+        "trans": [
+            "adj. 不一致的；前后矛盾的"
+        ],
+        "usphone": "ˌɪnkənˈsɪstənt",
+        "ukphone": "ˌɪnkənˈsɪstənt"
+    },
+    {
+        "name": "stable",
+        "trans": [
+            "稳定的，安定的；牢固的；沉稳的",
+            "马厩"
+        ],
+        "usphone": "'stebl",
+        "ukphone": "'steɪbl"
+    },
+    {
+        "name": "diverse",
+        "trans": [
+            "不同的； 多样的"
+        ],
+        "usphone": "daɪ'vɝs",
+        "ukphone": "daɪ'vɜːrs"
+    },
+    {
+        "name": "distinct",
+        "trans": [
+            "明显的， 清楚的； 确实的； 截然不同的"
+        ],
+        "usphone": "dɪ'stɪŋkt",
+        "ukphone": "dɪ'stɪŋkt"
+    },
+    {
+        "name": "identical",
+        "trans": [
+            "相同的； 同一的"
+        ],
+        "usphone": "aɪ'dɛntɪkl",
+        "ukphone": "aɪ'dentɪkl"
+    },
+    {
+        "name": "equivalent",
+        "trans": [
+            "相同的； 相当的",
+            "对等物；等价物"
+        ],
+        "usphone": "ɪ'kwɪvələnt",
+        "ukphone": "ɪ'kwɪvələnt"
+    },
+    {
+        "name": "comparable",
+        "trans": [
+            "可比较的， 类似的； 比得上的"
+        ],
+        "usphone": "'kɑmpərəbl",
+        "ukphone": "'kɑːmpərəbl"
+    },
+    {
+        "name": "relevant",
+        "trans": [
+            "相关的， 有关的； 中肯的， 贴切的； 有价值的， 有意义的"
+        ],
+        "usphone": "'rɛləvənt",
+        "ukphone": "'reləvənt"
+    },
+    {
+        "name": "irrelevant",
+        "trans": [
+            "adj. 不相关的，不相干的"
+        ],
+        "usphone": "ɪ'reləvənt",
+        "ukphone": "ɪ'reləvənt"
+    },
+    {
+        "name": "appropriate",
+        "trans": [
+            "适当的",
+            "拨款； 占用， 挪用"
+        ],
+        "usphone": "əˈproprɪət;(for v.) əˈproprɪet",
+        "ukphone": "əˈprəʊprɪət;(for v.)əˈprəʊprɪeɪt"
+    },
+    {
+        "name": "inappropriate",
+        "trans": [
+            "不恰当的， 不适宜的"
+        ],
+        "usphone": "'ɪnə'proprɪət",
+        "ukphone": "ˌɪnə'proupriət"
+    },
+    {
+        "name": "legitimate",
+        "trans": [
+            "合法的， 法定的； 正当合理的， 合情合理的"
+        ],
+        "usphone": "ləˈdʒɪtəmɪt",
+        "ukphone": "lɪ'dʒɪtɪmət"
+    },
+    {
+        "name": "ethical",
+        "trans": [
+            "道德的"
+        ],
+        "usphone": "'ɛθɪkl",
+        "ukphone": "'eθɪkl"
+    },
+    {
+        "name": "objective",
+        "trans": [
+            "客观的",
+            "目标，目的"
+        ],
+        "usphone": "əb'dʒɛktɪv",
+        "ukphone": "əb'dʒektɪv"
+    },
+    {
+        "name": "subjective",
+        "trans": [
+            "主观的， 个人的"
+        ],
+        "usphone": "səb'dʒɛktɪv",
+        "ukphone": "səb'dʒektɪv"
+    },
+    {
+        "name": "biased",
+        "trans": [
+            "有偏见的； 片面的"
+        ],
+        "usphone": "'baɪəst",
+        "ukphone": "'baɪəst"
+    },
+    {
+        "name": "neutral",
+        "trans": [
+            "中性的； 中立的"
+        ],
+        "usphone": "'nʊtrəl",
+        "ukphone": "'njuːtrəl"
+    },
+    {
+        "name": "potential",
+        "trans": [
+            "潜在的； 可能的",
+            "潜能，潜力"
+        ],
+        "usphone": "pə'tɛnʃl",
+        "ukphone": "pə'tenʃl"
+    },
+    {
+        "name": "inevitable",
+        "trans": [
+            "adj. 必然发生的，不可避免的；总会发生的，惯常的 n. 必然发生的事，不可避免的事"
+        ],
+        "usphone": "ɪn'evɪtəb(ə)l",
+        "ukphone": "ɪn'evɪtəb(ə)l"
+    },
+    {
+        "name": "temporary",
+        "trans": [
+            "暂时的， 临时的"
+        ],
+        "usphone": "ˈtempəreri",
+        "ukphone": "'tempəreri"
+    },
+    {
+        "name": "permanent",
+        "trans": [
+            "持久的， 永久的； 固定不变的"
+        ],
+        "usphone": "'pɝmənənt",
+        "ukphone": "'pɜːrmənənt"
+    },
+    {
+        "name": "gradual",
+        "trans": [
+            "逐渐的， 逐步的； 坡度平缓的， 不陡的"
+        ],
+        "usphone": "'ɡrædʒuəl",
+        "ukphone": "'grædʒuəl"
+    },
+    {
+        "name": "dramatic",
+        "trans": [
+            "戏剧的； 引人注目的； 突然的， 巨大的； 戏剧性的"
+        ],
+        "usphone": "drə'mætɪk",
+        "ukphone": "drə'mætɪk"
+    },
+    {
+        "name": "abrupt",
+        "trans": [
+            "突然的， 意外的； 唐突的， 鲁莽的"
+        ],
+        "usphone": "ə'brʌpt",
+        "ukphone": "ə'brʌpt"
+    },
+    {
+        "name": "profound",
+        "trans": [
+            "巨大的， 深远的； 知识渊博的； 深奥的"
+        ],
+        "usphone": "prə'faʊnd",
+        "ukphone": "prə'faund"
+    },
+    {
+        "name": "argument",
+        "trans": [
+            "争吵， 争论； 观点， 论据； 说理， 论证"
+        ],
+        "usphone": "'ɑrɡjumənt",
+        "ukphone": "'ɑːgjʊmənt"
+    },
+    {
+        "name": "evidence",
+        "trans": [
+            "证明",
+            "证据； 迹象； 根据"
+        ],
+        "usphone": "'ɛvɪdəns",
+        "ukphone": "'evɪdəns"
+    },
+    {
+        "name": "factor",
+        "trans": [
+            "要素， 因素； 因数； 系数"
+        ],
+        "usphone": "'fæktɚ",
+        "ukphone": "'fæktər"
+    },
+    {
+        "name": "aspect",
+        "trans": [
+            "方面； 朝向， 方向； 外表， 外观"
+        ],
+        "usphone": "'æspɛkt",
+        "ukphone": "'æspekt"
+    },
+    {
+        "name": "element",
+        "trans": [
+            "n. 要素，成分；元素；自然环境；基本原理；少量；适合的环境"
+        ],
+        "usphone": "ˈeləmənt",
+        "ukphone": "ˈelɪmənt"
+    },
+    {
+        "name": "component",
+        "trans": [
+            "组成的， 构成的",
+            "成分，组成部分"
+        ],
+        "usphone": "kəm'ponənt",
+        "ukphone": "kəm'pounənt"
+    },
+    {
+        "name": "phenomenon",
+        "trans": [
+            "现象， 迹象； 非凡的人"
+        ],
+        "usphone": "fə'nɑmɪnən",
+        "ukphone": "fə'nɑːmɪnən"
+    },
+    {
+        "name": "tendency",
+        "trans": [
+            "n. 经常性行为，偏好；趋势，趋向；（性格中不良的）倾向；（政党内的）极端派别"
+        ],
+        "usphone": "'tendənsi",
+        "ukphone": "'tendənsi"
+    },
+    {
+        "name": "trend",
+        "trans": [
+            "趋势， 倾向"
+        ],
+        "usphone": "trɛnd",
+        "ukphone": "trend"
+    },
+    {
+        "name": "pattern",
+        "trans": [
+            "模式，方式；样式，图案；样品，样本",
+            "仿制； 使形成， 促成"
+        ],
+        "usphone": "'pætɚn",
+        "ukphone": "'pætərn"
+    },
+    {
+        "name": "principle",
+        "trans": [
+            "原则； 原理； 道德准则， 行为规范； 信念"
+        ],
+        "usphone": "'prɪnsəpl",
+        "ukphone": "'prɪnsəpl"
+    },
+    {
+        "name": "concept",
+        "trans": [
+            "概念， 观念； 设想"
+        ],
+        "usphone": "'kɑnsɛpt",
+        "ukphone": "'kɑːnsept"
+    },
+    {
+        "name": "notion",
+        "trans": [
+            "概念， 观念； 想法"
+        ],
+        "usphone": "'noʃən",
+        "ukphone": "'nouʃn"
+    },
+    {
+        "name": "perspective",
+        "trans": [
+            "展望； 观点， 看法； 远景； 透视图， 透视法； 前途"
+        ],
+        "usphone": "pɚ'spɛktɪv",
+        "ukphone": "pər'spektɪv"
+    },
+    {
+        "name": "viewpoint",
+        "trans": [
+            "观点， 看法"
+        ],
+        "usphone": "'vjupɔɪnt",
+        "ukphone": "'vjuːpɔɪnt"
+    },
+    {
+        "name": "standpoint",
+        "trans": [
+            "立场； 观点"
+        ],
+        "usphone": "'stændpɔɪnt",
+        "ukphone": "'stændpɔɪnt"
+    },
+    {
+        "name": "assumption",
+        "trans": [
+            "n. 假定，假设；取得，承担"
+        ],
+        "usphone": "ə'sʌmpʃ(ə)n",
+        "ukphone": "ə'sʌmpʃn"
+    },
+    {
+        "name": "hypothesis",
+        "trans": [
+            "假设， 假说； 前提"
+        ],
+        "usphone": "haɪ'pɑθəsɪs",
+        "ukphone": "haɪ'pɑːθəsɪs"
+    },
+    {
+        "name": "theory",
+        "trans": [
+            "理论， 原理； 学说； 见解， 看法"
+        ],
+        "usphone": "'θiəri",
+        "ukphone": "'θɪəri"
+    },
+    {
+        "name": "framework",
+        "trans": [
+            "框架， 构架； 原则， 准则； 机制， 结构"
+        ],
+        "usphone": "'fremwɝk",
+        "ukphone": "'freɪmwɜːrk"
+    },
+    {
+        "name": "approach",
+        "trans": [
+            "靠近，接近；来临",
+            "靠近， 接近； 方法， 途径"
+        ],
+        "usphone": "ə'protʃ",
+        "ukphone": "ə'prəutʃ"
+    },
+    {
+        "name": "method",
+        "trans": [
+            "方法， 办法， 措施； 秩序"
+        ],
+        "usphone": "'mɛθəd",
+        "ukphone": "'meθəd"
+    },
+    {
+        "name": "strategy",
+        "trans": [
+            "战略， 策略"
+        ],
+        "usphone": "'strætədʒi",
+        "ukphone": "'strætədʒi"
+    },
+    {
+        "name": "procedure",
+        "trans": [
+            "程序， 手续， 步骤"
+        ],
+        "usphone": "prə'sidʒɚ",
+        "ukphone": "prə'siːdʒər"
+    },
+    {
+        "name": "mechanism",
+        "trans": [
+            "机械装置； 机制， 机理； 办法"
+        ],
+        "usphone": "'mɛkənɪzəm",
+        "ukphone": "'mekənɪzəm"
+    },
+    {
+        "name": "criterion",
+        "trans": [
+            "〔判断、决定的〕标准，准则"
+        ],
+        "usphone": "kraɪˈtɪriən",
+        "ukphone": "kraɪ'tɪriən"
+    },
+    {
+        "name": "standard",
+        "trans": [
+            "标准的",
+            "标准，准则"
+        ],
+        "usphone": "'stændɚd",
+        "ukphone": "'stændərd"
+    },
+    {
+        "name": "norm",
+        "trans": [
+            "标准， 规范； 准则 (n.)"
+        ],
+        "usphone": "nɔrm",
+        "ukphone": "nɔːm"
+    },
+    {
+        "name": "priority",
+        "trans": [
+            "优先权， 优先； 优先考虑的事， 最重要的事"
+        ],
+        "usphone": "praɪ'ɔrəti",
+        "ukphone": "praɪ'ɔːrəti"
+    },
+    {
+        "name": "purpose",
+        "trans": [
+            "打算， 企图， 决心",
+            "目的，意图；用途，效果"
+        ],
+        "usphone": "'pɝpəs",
+        "ukphone": "'pɜːpəs"
+    },
+    {
+        "name": "motivation",
+        "trans": [
+            "n. 动机，原因；激励，鼓舞；积极性，动力"
+        ],
+        "usphone": "ˌmoʊtɪˈveɪʃn",
+        "ukphone": "ˌməʊtɪˈveɪʃn"
+    },
+    {
+        "name": "incentive",
+        "trans": [
+            "刺激； 动机"
+        ],
+        "usphone": "ɪn'sɛntɪv",
+        "ukphone": "ɪn'sentɪv"
+    },
+    {
+        "name": "initiative",
+        "trans": [
+            "倡议， 新方案； 主动性， 积极性； 主动权"
+        ],
+        "usphone": "ɪ'nɪʃətɪv",
+        "ukphone": "ɪ'nɪʃətɪv"
+    },
+    {
+        "name": "consequence",
+        "trans": [
+            "结果； 影响； 推理； 重要， 重大"
+        ],
+        "usphone": "'kɑnsəkwɛns",
+        "ukphone": "'kɑːnsəkwens"
+    },
+    {
+        "name": "outcome",
+        "trans": [
+            "结果， 成果"
+        ],
+        "usphone": "'aʊt'kʌm",
+        "ukphone": "'autkʌm"
+    },
+    {
+        "name": "impact",
+        "trans": [
+            "影响； 冲击， 撞击",
+            "影响； 冲击， 撞击"
+        ],
+        "usphone": "ɪm'pækt",
+        "ukphone": "'ɪmpækt"
+    },
+    {
+        "name": "influence",
+        "trans": [
+            "影响(力)，作用",
+            "影响，对…起作用"
+        ],
+        "usphone": "'ɪnfluəns",
+        "ukphone": "'ɪnfluəns"
+    },
+    {
+        "name": "implication",
+        "trans": [
+            "含义； 暗示， 暗指； 卷入， 牵连"
+        ],
+        "usphone": "'ɪmplɪ'keʃən",
+        "ukphone": "ˌɪmplɪ'keɪʃn"
+    },
+    {
+        "name": "significance",
+        "trans": [
+            "重要性， 意义"
+        ],
+        "usphone": "sɪɡ'nɪfɪkəns",
+        "ukphone": "sɪg'nɪfɪkəns"
+    },
+    {
+        "name": "contribution",
+        "trans": [
+            "贡献； 促成作用； 捐款， 捐献物； 稿件 (n.)"
+        ],
+        "usphone": ",kɑntrɪ'bjuʃən",
+        "ukphone": "ˌkɒntrɪ'bjuːʃn"
+    },
+    {
+        "name": "benefit",
+        "trans": [
+            "受益； 得益于",
+            "益处，好处；恩惠；津贴"
+        ],
+        "usphone": "'bɛnɪfɪt",
+        "ukphone": "'benɪfɪt"
+    },
+    {
+        "name": "drawback",
+        "trans": [
+            "缺点， 障碍， 不利条件； 退款， 退税"
+        ],
+        "usphone": "'drɔbæk",
+        "ukphone": "'drɔːbæk"
+    },
+    {
+        "name": "disadvantage",
+        "trans": [
+            "缺点， 障碍， 不利之处"
+        ],
+        "usphone": ",dɪsəd'væntɪdʒ",
+        "ukphone": "ˌdɪsəd'væntɪdʒ"
+    },
+    {
+        "name": "limitation",
+        "trans": [
+            "限制； 局限性"
+        ],
+        "usphone": ",lɪmɪ'teʃən",
+        "ukphone": "ˌlɪmɪ'teɪʃn"
+    },
+    {
+        "name": "constraint",
+        "trans": [
+            "强制， 强迫； 对感情的压抑"
+        ],
+        "usphone": "kən'strent",
+        "ukphone": "kən'streɪnt"
+    },
+    {
+        "name": "obstacle",
+        "trans": [
+            "障碍， 妨害物"
+        ],
+        "usphone": "'ɑbstəkl",
+        "ukphone": "'ɑːbstəkl"
+    },
+    {
+        "name": "barrier",
+        "trans": [
+            "屏障， 障碍物； 检票口； 障碍， 阻力； 隔阂"
+        ],
+        "usphone": "'bærɪɚ",
+        "ukphone": "'bæriər"
+    },
+    {
+        "name": "dilemma",
+        "trans": [
+            "困境， 进退两难的局面"
+        ],
+        "usphone": "dəˈlɛmə, daɪ-",
+        "ukphone": "dɪ'lemə"
+    },
+    {
+        "name": "conflict",
+        "trans": [
+            "冲突； 不一致； 争论",
+            "冲突； 争论"
+        ],
+        "usphone": "'kɑnflɪkt",
+        "ukphone": "'kɒnflɪkt"
+    },
+    {
+        "name": "controversy",
+        "trans": [
+            "争论， 辩论"
+        ],
+        "usphone": "ˈkɑntrəvɝ​sɪ",
+        "ukphone": "'kɑːntrəvɜːrsi"
+    },
+    {
+        "name": "debate",
+        "trans": [
+            "辩论； 讨论， 争论"
+        ],
+        "usphone": "dɪ'bet",
+        "ukphone": "dɪ'beɪt"
+    },
+    {
+        "name": "consensus",
+        "trans": [
+            "共识， 一致同意； 舆论"
+        ],
+        "usphone": "kən'sɛnsəs",
+        "ukphone": "kən'sensəs"
+    },
+    {
+        "name": "compromise",
+        "trans": [
+            "妥协， 折中"
+        ],
+        "usphone": "'kɑmprəmaɪz",
+        "ukphone": "'kɑːmprəmaɪz"
+    },
+    {
+        "name": "alternative",
+        "trans": [
+            "可供替代的； 非传统的",
+            "可供选择的事物；选择的自由，选择的余地"
+        ],
+        "usphone": "ɔl'tɝnətɪv",
+        "ukphone": "ɔːl'tɜːrnətɪv"
+    },
+    {
+        "name": "option",
+        "trans": [
+            "选择； 选择的物； 选课"
+        ],
+        "usphone": "'ɑpʃən",
+        "ukphone": "'ɒpʃn"
+    },
+    {
+        "name": "solution",
+        "trans": [
+            "溶液； 解答， 解决"
+        ],
+        "usphone": "sə'luʃən",
+        "ukphone": "sə'luːʃn"
+    },
+    {
+        "name": "resolution",
+        "trans": [
+            "正式决定， 决议； 决心， 决意； 解决， 解答； 分辨率， 清晰度"
+        ],
+        "usphone": ",rɛzə'luʃən",
+        "ukphone": "ˌrezə'luːʃn"
+    },
+    {
+        "name": "distinction",
+        "trans": [
+            "差别， 不同， 区分"
+        ],
+        "usphone": "dɪ'stɪŋkʃən",
+        "ukphone": "dɪ'stɪŋkʃn"
+    },
+    {
+        "name": "comparison",
+        "trans": [
+            "比较， 对比； 比拟， 比喻"
+        ],
+        "usphone": "kəm'pærɪsn",
+        "ukphone": "kəm'pærɪsn"
+    },
+    {
+        "name": "correlation",
+        "trans": [
+            "相互关系， 相关"
+        ],
+        "usphone": ",kɔrə'leʃən",
+        "ukphone": "ˌkɒrə'leɪʃn"
+    },
+    {
+        "name": "relationship",
+        "trans": [
+            "关系， 关联"
+        ],
+        "usphone": "rɪ'leʃən'ʃɪp",
+        "ukphone": "rɪ'leɪʃnʃɪp"
+    },
+    {
+        "name": "interaction",
+        "trans": [
+            "相互作用 (n.)"
+        ],
+        "usphone": ",ɪntə'rækʃən",
+        "ukphone": "ˌɪntər'ækʃn"
+    },
+    {
+        "name": "balance",
+        "trans": [
+            "使平衡，使均衡",
+            "天平， 秤； 平衡； 差额； 余款"
+        ],
+        "usphone": "'bæləns",
+        "ukphone": "'bæləns"
+    },
+    {
+        "name": "proportion",
+        "trans": [
+            "比例； 部分； 均衡， 相称"
+        ],
+        "usphone": "prə'pɔrʃən",
+        "ukphone": "prə'pɔːrʃn"
+    },
+    {
+        "name": "majority",
+        "trans": [
+            "多数， 大多数"
+        ],
+        "usphone": "mə'dʒɔrəti",
+        "ukphone": "mə'dʒɒrətɪ"
+    },
+    {
+        "name": "minority",
+        "trans": [
+            "少数； 少数民族"
+        ],
+        "usphone": "maɪ'nɔrəti",
+        "ukphone": "maɪ'nɔːrəti"
+    },
+    {
+        "name": "portion",
+        "trans": [
+            "部分；一份",
+            "划分， 分配"
+        ],
+        "usphone": "'pɔrʃən",
+        "ukphone": "'pɔːrʃn"
+    },
+    {
+        "name": "extent",
+        "trans": [
+            "程度， 范围"
+        ],
+        "usphone": "ɪk'stɛnt",
+        "ukphone": "ɪk'stent"
+    },
+    {
+        "name": "degree",
+        "trans": [
+            "程度； 度数； 学位； 等级"
+        ],
+        "usphone": "dɪ'ɡri",
+        "ukphone": "dɪ'griː"
+    },
+    {
+        "name": "scale",
+        "trans": [
+            "鳞；规模；比例；刻度；【音】音阶；等级，级别",
+            "攀登"
+        ],
+        "usphone": "skel",
+        "ukphone": "skeɪl"
+    },
+    {
+        "name": "scope",
+        "trans": [
+            "范围， 界限； 眼界， 见识； 余地， 机会"
+        ],
+        "usphone": "skop",
+        "ukphone": "skoup"
+    },
+    {
+        "name": "range",
+        "trans": [
+            "变动； 散布； 漫游",
+            "范围；山脉；一系列；射程，距离"
+        ],
+        "usphone": "rendʒ",
+        "ukphone": "reɪndʒ"
+    },
+    {
+        "name": "capacity",
+        "trans": [
+            "能力； 容量； 职责， 职位； 生产力"
+        ],
+        "usphone": "kə'pæsəti",
+        "ukphone": "kə'pæsəti"
+    },
+    {
+        "name": "resource",
+        "trans": [
+            "资源〔指土地、矿产等〕",
+            "向…提供资源"
+        ],
+        "usphone": "'risɔrs",
+        "ukphone": "'riːsɔːrs"
+    },
+    {
+        "name": "expenditure",
+        "trans": [
+            "花费， 支出"
+        ],
+        "usphone": "ɪk'spɛndɪtʃɚ",
+        "ukphone": "ek'spendɪtʃər"
+    },
+    {
+        "name": "investment",
+        "trans": [
+            "投资， 投资额； 投入"
+        ],
+        "usphone": "ɪn'vɛstmənt",
+        "ukphone": "ɪn'vestmənt"
+    },
+    {
+        "name": "efficiency",
+        "trans": [
+            "效率， 功效"
+        ],
+        "usphone": "ɪˈfɪʃənsɪ",
+        "ukphone": "ɪ'fɪʃnsi"
+    },
+    {
+        "name": "productivity",
+        "trans": [
+            "生产力， 生产率"
+        ],
+        "usphone": ",prodʌk'tɪvəti",
+        "ukphone": "ˌprɑːdʌk'tɪvəti"
+    },
+    {
+        "name": "quality",
+        "trans": [
+            "优良的， 优质的",
+            "质，质量；品德，品质；性质，特性"
+        ],
+        "usphone": "'kwɑləti",
+        "ukphone": "'kwɑːləti"
+    },
+    {
+        "name": "quantity",
+        "trans": [
+            "n. 量，数目；大量，大批；（尤指和质量相对的）数量；（语音）音量；值，参量；代表数量（或参量）的数（或符号）"
+        ],
+        "usphone": "'kwɑːntəti",
+        "ukphone": "'kwɒntəti"
+    },
+    {
+        "name": "accuracy",
+        "trans": [
+            "准确， 精确"
+        ],
+        "usphone": "'ækjərəsi",
+        "ukphone": "'ækjərəsi"
+    },
+    {
+        "name": "reliability",
+        "trans": [
+            "n. 可靠性"
+        ],
+        "usphone": "rɪˌlaɪəˈbɪlɪti",
+        "ukphone": "rɪˌlaɪəˈbɪləti"
+    },
+    {
+        "name": "stability",
+        "trans": [
+            "稳定， 稳固 (n.)"
+        ],
+        "usphone": "stə'bɪləti",
+        "ukphone": "stə'bɪləti"
+    },
+    {
+        "name": "diversity",
+        "trans": [
+            "多样性"
+        ],
+        "usphone": "dɪˈvəsɪti",
+        "ukphone": "dɪ'vɜːrsəti"
+    },
+    {
+        "name": "complexity",
+        "trans": [
+            "复杂， 复杂性； 复杂的事物"
+        ],
+        "usphone": "kəm'plɛksəti",
+        "ukphone": "kəm'pleksəti"
+    },
+    {
+        "name": "flexibility",
+        "trans": [
+            "灵活性； 弹性， 韧性； 适应性"
+        ],
+        "usphone": ",flɛksə'bɪləti",
+        "ukphone": "ˌfleksə'bɪlətɪ"
+    },
+    {
+        "name": "education",
+        "trans": [
+            "n. 教育，教育事业；教育学；培养；训练"
+        ],
+        "usphone": "ˌedʒəˈkeɪʃn",
+        "ukphone": "ˌedjuˈkeɪʃn"
+    },
+    {
+        "name": "academic",
+        "trans": [
+            "学术的；学校的，学院的；纯理论的",
+            "大学教师"
+        ],
+        "usphone": ",ækə'dɛmɪk",
+        "ukphone": "ˌækə'demɪk"
+    },
+    {
+        "name": "curriculum",
+        "trans": [
+            "课程"
+        ],
+        "usphone": "kə'rɪkjələm",
+        "ukphone": "kə'rɪkjələm"
+    },
+    {
+        "name": "discipline",
+        "trans": [
+            "训练；惩罚",
+            "纪律； 学科"
+        ],
+        "usphone": "'dɪsəplɪn",
+        "ukphone": "'dɪsəplɪn"
+    },
+    {
+        "name": "faculty",
+        "trans": [
+            "学院； 全体教职员工； 能力"
+        ],
+        "usphone": "'fæklti",
+        "ukphone": "'fæklti"
+    },
+    {
+        "name": "tuition",
+        "trans": [
+            "学费； 教学， 讲授"
+        ],
+        "usphone": "tʊ'ɪʃən",
+        "ukphone": "tu'ɪʃn"
+    },
+    {
+        "name": "scholarship",
+        "trans": [
+            "奖学金； 学问， 学识"
+        ],
+        "usphone": "'skɑlɚʃɪp",
+        "ukphone": "'skɑːlərʃɪp"
+    },
+    {
+        "name": "enrollment",
+        "trans": [
+            "登记， 注册； 入学"
+        ],
+        "usphone": "ɪn'rolmənt",
+        "ukphone": "ɪn'roulmənt"
+    },
+    {
+        "name": "graduate",
+        "trans": [
+            "n. 毕业生",
+            "v. 毕业；逐渐变化，逐渐过渡",
+            "adj. 研究生的，毕业的"
+        ],
+        "usphone": "ˈɡrædʒuət",
+        "ukphone": "ˈɡrædʒueɪt"
+    },
+    {
+        "name": "undergraduate",
+        "trans": [
+            "大学肄业生； 大学本科生"
+        ],
+        "usphone": ",ʌndɚ'ɡrædʒuət",
+        "ukphone": "ˌʌndər'grædʒət"
+    },
+    {
+        "name": "diploma",
+        "trans": [
+            "毕业文凭； 资格证书"
+        ],
+        "usphone": "dɪ'plomə",
+        "ukphone": "dɪ'pləumə"
+    },
+    {
+        "name": "literacy",
+        "trans": [
+            "有文化， 有教养； 读写能力"
+        ],
+        "usphone": "'lɪtərəsi",
+        "ukphone": "'lɪtərəsi"
+    },
+    {
+        "name": "instruction",
+        "trans": [
+            "命令， 指示； 用法说明； 教学， 教导"
+        ],
+        "usphone": "ɪn'strʌkʃən",
+        "ukphone": "ɪn'strʌkʃn"
+    },
+    {
+        "name": "lecture",
+        "trans": [
+            "演讲， 讲课"
+        ],
+        "usphone": "'lɛktʃɚ",
+        "ukphone": "'lektʃə(r)"
+    },
+    {
+        "name": "seminar",
+        "trans": [
+            "研讨会； 研讨班"
+        ],
+        "usphone": "'sɛmɪnɑr",
+        "ukphone": "'semɪnɑːr"
+    },
+    {
+        "name": "assignment",
+        "trans": [
+            "任务， 工作"
+        ],
+        "usphone": "ə'saɪnmənt",
+        "ukphone": "ə'saɪnmənt"
+    },
+    {
+        "name": "examination",
+        "trans": [
+            "n. 考试，测验；检查，调查；审查，审核"
+        ],
+        "usphone": "ɪɡˌzæməˈneɪʃən",
+        "ukphone": "ɪɡˌzæmɪˈneɪʃn"
+    },
+    {
+        "name": "assessment",
+        "trans": [
+            "判定， 评定； 核定的付款额； 看法， 评价"
+        ],
+        "usphone": "ə'sɛsmənt",
+        "ukphone": "ə'sesmənt"
+    },
+    {
+        "name": "competence",
+        "trans": [
+            "能力， 胜任； 权限； 技能"
+        ],
+        "usphone": "'kɑmpɪtəns",
+        "ukphone": "'kɑːmpɪtəns"
+    },
+    {
+        "name": "proficiency",
+        "trans": [
+            "熟练， 精通 (n.)"
+        ],
+        "usphone": "prə'fɪʃənsi",
+        "ukphone": "prə'fɪʃnsi"
+    },
+    {
+        "name": "expertise",
+        "trans": [
+            "专门知识， 专长"
+        ],
+        "usphone": "'ɛkspɝ'tiz",
+        "ukphone": "ˌekspɜːr'tiːz"
+    },
+    {
+        "name": "knowledge",
+        "trans": [
+            "n. 知识，学问；了解，认识；学识，见闻"
+        ],
+        "usphone": "ˈnɑːlɪdʒ",
+        "ukphone": "ˈnɒlɪdʒ"
+    },
+    {
+        "name": "intellectual",
+        "trans": [
+            "adj. 智力的，理智的；才智超群的；需智力的；思想的，思维的 n. 知识分子"
+        ],
+        "usphone": "ˌɪntə'lektʃuəl",
+        "ukphone": "ˌɪntə'lektʃuəl"
+    },
+    {
+        "name": "cognitive",
+        "trans": [
+            "认识的； 认知的， 有感知的"
+        ],
+        "usphone": "'kɑɡnətɪv",
+        "ukphone": "'kɑːgnətɪv"
+    },
+    {
+        "name": "memorize",
+        "trans": [
+            "记住， 记忆， 熟记"
+        ],
+        "usphone": "'mɛmə'raɪz",
+        "ukphone": "'meməraɪz"
+    },
+    {
+        "name": "comprehension",
+        "trans": [
+            "理解； 理解力"
+        ],
+        "usphone": ",kɑmprɪ'hɛnʃən",
+        "ukphone": "ˌkɒmprɪ'henʃn"
+    },
+    {
+        "name": "cultivate",
+        "trans": [
+            "耕种； 培养"
+        ],
+        "usphone": "'kʌltɪvet",
+        "ukphone": "'kʌltɪveɪt"
+    },
+    {
+        "name": "nurture",
+        "trans": [
+            "养育，养护，培养；扶植，支持；滋长，助长",
+            "养育， 培养"
+        ],
+        "usphone": "'nɝtʃɚ",
+        "ukphone": "'nɜːrtʃər"
+    },
+    {
+        "name": "inspire",
+        "trans": [
+            "鼓舞， 激励； 给…以灵感"
+        ],
+        "usphone": "ɪn'spaɪɚ",
+        "ukphone": "ɪn'spaɪər"
+    },
+    {
+        "name": "motivate",
+        "trans": [
+            "激励； 激发"
+        ],
+        "usphone": "'motə'vet",
+        "ukphone": "'moutɪveɪt"
+    },
+    {
+        "name": "mentor",
+        "trans": [
+            "导师； 顾问， 指导者"
+        ],
+        "usphone": "'mɛn'tɔr",
+        "ukphone": "'mentɔː(r)"
+    },
+    {
+        "name": "tutor",
+        "trans": [
+            "辅导",
+            "导师；家庭教师"
+        ],
+        "usphone": "'tʊtɚ",
+        "ukphone": "'tuːtər"
+    },
+    {
+        "name": "peer",
+        "trans": [
+            "n. 同龄人，同辈；贵族，同等地位的人",
+            "v. 仔细看，端详；隐约出现，露出"
+        ],
+        "usphone": "pɪr",
+        "ukphone": "pɪə(r)"
+    },
+    {
+        "name": "campus",
+        "trans": [
+            "校园"
+        ],
+        "usphone": "'kæmpəs",
+        "ukphone": "'kæmpəs"
+    },
+    {
+        "name": "extracurricular",
+        "trans": [
+            "课外的"
+        ],
+        "usphone": ",ɛkstrəkə'rɪkjəlɚ",
+        "ukphone": "ˌekstrəkə'rɪkjələ(r)"
+    },
+    {
+        "name": "textbook",
+        "trans": [
+            "n. 教科书，课本",
+            "adj. 教科书式的，标准的，典型的"
+        ],
+        "usphone": "ˈtekstbʊk",
+        "ukphone": "ˈtekstbʊk"
+    },
+    {
+        "name": "vocational",
+        "trans": [
+            "职业的， 业务的"
+        ],
+        "usphone": "vo'keʃənl",
+        "ukphone": "vəu'keɪʃənl"
+    },
+    {
+        "name": "elementary",
+        "trans": [
+            "初级的， 基础的； 基本的； 简单的"
+        ],
+        "usphone": ",ɛlɪ'mɛntri",
+        "ukphone": "ˌelɪ'mentri"
+    },
+    {
+        "name": "kindergarten",
+        "trans": [
+            "幼儿园"
+        ],
+        "usphone": "'kɪndɚɡɑrtn",
+        "ukphone": "'kɪndəgɑːtn"
+    },
+    {
+        "name": "technology",
+        "trans": [
+            "工艺学； 工艺， 技术"
+        ],
+        "usphone": "tɛkˈnɑlədʒɪ",
+        "ukphone": "tek'nɒlədʒi"
+    },
+    {
+        "name": "innovation",
+        "trans": [
+            "n. 新事物，新方法；革新，创新"
+        ],
+        "usphone": "ˌɪnə'veɪʃ(ə)n",
+        "ukphone": "ˌɪnə'veɪʃ(ə)n"
+    },
+    {
+        "name": "invention",
+        "trans": [
+            "发明， 创造； 捏造"
+        ],
+        "usphone": "ɪn'vɛnʃən",
+        "ukphone": "ɪn'venʃn"
+    },
+    {
+        "name": "device",
+        "trans": [
+            "装置， 设备； 手法， 策略"
+        ],
+        "usphone": "dɪ'vaɪs",
+        "ukphone": "dɪ'vaɪs"
+    },
+    {
+        "name": "digital",
+        "trans": [
+            "数码的， 数字的"
+        ],
+        "usphone": "'dɪdʒɪtl",
+        "ukphone": "'dɪdʒɪtl"
+    },
+    {
+        "name": "artificial",
+        "trans": [
+            "人工的， 人造的， 假的； 矫揉造作的， 假装"
+        ],
+        "usphone": ",ɑrtɪ'fɪʃl",
+        "ukphone": "ˌɑːrtɪ'fɪʃl"
+    },
+    {
+        "name": "automation",
+        "trans": [
+            "n. 自动化；自动操作"
+        ],
+        "usphone": "ˌɔːtəˈmeɪʃn",
+        "ukphone": "ˌɔːtəˈmeɪʃn"
+    },
+    {
+        "name": "algorithm",
+        "trans": [
+            "n. 算法，运算法则"
+        ],
+        "usphone": "ˈælɡəˌrɪðəm",
+        "ukphone": "ˈælɡərɪðəm"
+    },
+    {
+        "name": "network",
+        "trans": [
+            "网状物； 广播网， 电视网； 网络"
+        ],
+        "usphone": "'nɛtwɝk",
+        "ukphone": "'netwɜːk"
+    },
+    {
+        "name": "internet",
+        "trans": [
+            "n. 互联网，因特网"
+        ],
+        "usphone": "ˈɪntərnɛt",
+        "ukphone": "ˈɪntənet"
+    },
+    {
+        "name": "software",
+        "trans": [
+            "软件"
+        ],
+        "usphone": "'sɔftwɛr",
+        "ukphone": "'sɒftweə"
+    },
+    {
+        "name": "hardware",
+        "trans": [
+            "五金制品， 金属制品； 硬件"
+        ],
+        "usphone": "'hɑrdwɛr",
+        "ukphone": "'hɑːrdwer"
+    },
+    {
+        "name": "database",
+        "trans": [
+            "数据库"
+        ],
+        "usphone": "'detəbes",
+        "ukphone": "'deɪtəbeɪs"
+    },
+    {
+        "name": "virtual",
+        "trans": [
+            "模拟的， 虚拟的； 实际上的， 事实上的"
+        ],
+        "usphone": "ˈvɝ​tʃʊəl",
+        "ukphone": "'vɜːrtʃuəl"
+    },
+    {
+        "name": "robot",
+        "trans": [
+            "n. 机器人；自动机，机械般行事的人"
+        ],
+        "usphone": "ˈroʊbɑːt",
+        "ukphone": "ˈrəʊbɒt"
+    },
+    {
+        "name": "machine",
+        "trans": [
+            "n. 机器，机械；机构，组织",
+            "v. 用机器制造"
+        ],
+        "usphone": "məˈʃiːn",
+        "ukphone": "məˈʃiːn"
+    },
+    {
+        "name": "mechanical",
+        "trans": [
+            "adj. 机械（方面）的；机械般的，呆板的；精通机械的；机械学的，力学的；独家灌录权的 n. 技工，机修工；劳工，工匠"
+        ],
+        "usphone": "mə'kænɪk(ə)l",
+        "ukphone": "mə'kænɪkl"
+    },
+    {
+        "name": "electronic",
+        "trans": [
+            "adj. 电子的，电子学的"
+        ],
+        "usphone": "ɪˌlek'trɑːnɪk",
+        "ukphone": "ɪˌlek'trɒnɪk"
+    },
+    {
+        "name": "engineer",
+        "trans": [
+            "n. 工程师；技师；工程兵；技工",
+            "v. 设计；策划；精心安排"
+        ],
+        "usphone": "ˌendʒɪˈnɪr",
+        "ukphone": "ˌendʒɪˈnɪə(r)"
+    },
+    {
+        "name": "laboratory",
+        "trans": [
+            "实验室， 研究室"
+        ],
+        "usphone": "ˈlæbrəˌtɔrɪ",
+        "ukphone": "'læbrətɔːri"
+    },
+    {
+        "name": "experiment",
+        "trans": [
+            "n. 实验，试验；尝试，实践",
+            "v. 做实验，进行试验；尝试，体验"
+        ],
+        "usphone": "ɪkˈsper.ə.mənt",
+        "ukphone": "ɪkˈsper.ɪ.mənt"
+    },
+    {
+        "name": "research",
+        "trans": [
+            "n. 研究，调查；研究成果，研究报告",
+            "v. 研究，调查"
+        ],
+        "usphone": "ˈriːsɜːrtʃ, rɪˈsɜːrtʃ",
+        "ukphone": "rɪˈsɜːtʃ"
+    },
+    {
+        "name": "discovery",
+        "trans": [
+            "发现"
+        ],
+        "usphone": "dɪ'skʌvəri",
+        "ukphone": "dɪ'skʌvəri"
+    },
+    {
+        "name": "breakthrough",
+        "trans": [
+            "突破， 重大进展"
+        ],
+        "usphone": "'brek'θrʊ",
+        "ukphone": "'breɪkθruː"
+    },
+    {
+        "name": "application",
+        "trans": [
+            "请求， 申请； 应用， 运用； 敷用"
+        ],
+        "usphone": "ˌæpləˈkeʃən",
+        "ukphone": "ˌæplɪ'keɪʃn"
+    },
+    {
+        "name": "privacy",
+        "trans": [
+            "隐私， 私事； 隐私权"
+        ],
+        "usphone": "'praɪvəsi",
+        "ukphone": "'prɪvəsi"
+    },
+    {
+        "name": "security",
+        "trans": [
+            "安全， 保障； 抵押品； 证券 (n.)"
+        ],
+        "usphone": "sə'kjʊrəti",
+        "ukphone": "sɪ'kjuərəti"
+    },
+    {
+        "name": "surveillance",
+        "trans": [
+            "监视， 盯梢"
+        ],
+        "usphone": "sɝ'veləns",
+        "ukphone": "sɜː'veɪləns"
+    },
+    {
+        "name": "addiction",
+        "trans": [
+            "瘾； 沉溺"
+        ],
+        "usphone": "ə'dɪkʃən",
+        "ukphone": "ə'dɪkʃn"
+    },
+    {
+        "name": "screen",
+        "trans": [
+            "掩蔽；审查；筛选",
+            "屏幕"
+        ],
+        "usphone": "skrin",
+        "ukphone": "skriːn"
+    },
+    {
+        "name": "environment",
+        "trans": [
+            "周围状况； 环境"
+        ],
+        "usphone": "ɪn'vaɪrənmənt",
+        "ukphone": "ɪn'vaɪərənmənt"
+    },
+    {
+        "name": "ecology",
+        "trans": [
+            "生态； 生态学； 生态环境"
+        ],
+        "usphone": "ɪ'kɑlədʒi",
+        "ukphone": "i'kɑːlədʒi"
+    },
+    {
+        "name": "ecosystem",
+        "trans": [
+            "生态系统"
+        ],
+        "usphone": "'ɛko,sɪstəm",
+        "ukphone": "'iːkousɪstəm"
+    },
+    {
+        "name": "climate",
+        "trans": [
+            "气候； 气候区， 地带； 风气， 氛围； 思潮"
+        ],
+        "usphone": "ˈklaɪmɪt",
+        "ukphone": "'klaɪmət"
+    },
+    {
+        "name": "pollution",
+        "trans": [
+            "n. 污染；污染物；噪音污染，（夜间扰人的）强烈灯光"
+        ],
+        "usphone": "pə'luːʃ(ə)n",
+        "ukphone": "pə'luːʃ(ə)n"
+    },
+    {
+        "name": "emission",
+        "trans": [
+            "散发物， 排放物； 发射， 排放"
+        ],
+        "usphone": "ɪ'mɪʃən",
+        "ukphone": "i'mɪʃn"
+    },
+    {
+        "name": "carbon",
+        "trans": [
+            "碳"
+        ],
+        "usphone": "'kɑrbən",
+        "ukphone": "'kɑːrbən"
+    },
+    {
+        "name": "greenhouse",
+        "trans": [
+            "n. 温室，暖房 adj. 温室效应的"
+        ],
+        "usphone": "'ɡriːnhaʊs",
+        "ukphone": "'ɡriːnhaʊs"
+    },
+    {
+        "name": "atmosphere",
+        "trans": [
+            "大气， 大气层； 空气； 气氛， 氛围"
+        ],
+        "usphone": "'ætməsfɪr",
+        "ukphone": "'ætməsfɪr"
+    },
+    {
+        "name": "contamination",
+        "trans": [
+            "污染； 玷污"
+        ],
+        "usphone": "kən,tæmi'neiʃən",
+        "ukphone": "kənˌtæmɪ'neɪʃn"
+    },
+    {
+        "name": "waste",
+        "trans": [
+            "无用的，废弃的；荒芜的",
+            "浪费；废料，废弃物",
+            "浪费， 消耗"
+        ],
+        "usphone": "west",
+        "ukphone": "weɪst"
+    },
+    {
+        "name": "recycle",
+        "trans": [
+            "回收利用， 再应用"
+        ],
+        "usphone": ",ri'saɪkl",
+        "ukphone": "ˌriː'saɪkl"
+    },
+    {
+        "name": "renewable",
+        "trans": [
+            "可更新的， 可再生的， 可恢复的； 可延长有效期的， 可续期的"
+        ],
+        "usphone": "rɪ'nuəbl",
+        "ukphone": "rɪ'njuːəbl"
+    },
+    {
+        "name": "sustainable",
+        "trans": [
+            "不破坏生态平衡的， 可持续的； 足可支撑的； 可忍受的"
+        ],
+        "usphone": "sə'stenəbl",
+        "ukphone": "sə'steɪnəbl"
+    },
+    {
+        "name": "conservation",
+        "trans": [
+            "守恒； 保存； 保护"
+        ],
+        "usphone": ",kɑnsɚ'veʃən",
+        "ukphone": "ˌkɑːnsər'veɪʃn"
+    },
+    {
+        "name": "extinction",
+        "trans": [
+            "n. 灭绝，消亡；（债务的）偿清；消光"
+        ],
+        "usphone": "ɪk'stɪŋkʃ(ə)n",
+        "ukphone": "ɪk'stɪŋkʃn"
+    },
+    {
+        "name": "species",
+        "trans": [
+            "种类， 类群"
+        ],
+        "usphone": "'spiʃiz",
+        "ukphone": "'spiːsiːz"
+    },
+    {
+        "name": "habitat",
+        "trans": [
+            "自然环境， 栖息地"
+        ],
+        "usphone": "'hæbə'tæt",
+        "ukphone": "'hæbɪtæt"
+    },
+    {
+        "name": "biodiversity",
+        "trans": [
+            "生物多样性"
+        ],
+        "usphone": ",baɪodaɪ'vɝsəti",
+        "ukphone": "ˌbaɪəudaɪ'vəːsəti"
+    },
+    {
+        "name": "deforestation",
+        "trans": [
+            "n.采伐森林，森林开伐"
+        ],
+        "usphone": "ˌdi:ˌfɔ:rɪˈsteɪʃn",
+        "ukphone": "ˌdi:ˌfɒrɪˈsteɪʃn"
+    },
+    {
+        "name": "energy",
+        "trans": [
+            "n. 能量，精力；活力，干劲；能源；劲头，力量"
+        ],
+        "usphone": "ˈenərdʒi",
+        "ukphone": "ˈenədʒi"
+    },
+    {
+        "name": "fossil",
+        "trans": [
+            "化石的；陈腐的",
+            "化石； 老顽固"
+        ],
+        "usphone": "'fɑsl",
+        "ukphone": "'fɑːsl"
+    },
+    {
+        "name": "fuel",
+        "trans": [
+            "给…加燃料",
+            "燃料"
+        ],
+        "usphone": "'fjuəl",
+        "ukphone": "'fjʊːəl"
+    },
+    {
+        "name": "solar",
+        "trans": [
+            "太阳的， 日光的； 太阳能的"
+        ],
+        "usphone": "'solɚ",
+        "ukphone": "'soulər"
+    },
+    {
+        "name": "consumption",
+        "trans": [
+            "消耗； 消费； 食用"
+        ],
+        "usphone": "kən'sʌmpʃən",
+        "ukphone": "kən'sʌmpʃn"
+    },
+    {
+        "name": "degradation",
+        "trans": [
+            "n. 退化；降格，降级；堕落"
+        ],
+        "usphone": "ˌdeɡrəˈdeɪʃn",
+        "ukphone": "ˌdeɡrəˈdeɪʃn"
+    },
+    {
+        "name": "hazard",
+        "trans": [
+            "危险；风险",
+            "尝试着做； 冒…风险， 使处于危险"
+        ],
+        "usphone": "'hæzɚd",
+        "ukphone": "'hæzərd"
+    },
+    {
+        "name": "pesticide",
+        "trans": [
+            "杀虫剂， 农药"
+        ],
+        "usphone": "'pɛstɪsaɪd",
+        "ukphone": "'pestɪsaɪd"
+    },
+    {
+        "name": "drought",
+        "trans": [
+            "干旱， 旱灾"
+        ],
+        "usphone": "draʊt",
+        "ukphone": "draut"
+    },
+    {
+        "name": "society",
+        "trans": [
+            "n. 社会；社团，协会；上流社会；交际圈"
+        ],
+        "usphone": "səˈsaɪəti",
+        "ukphone": "səˈsaɪəti"
+    },
+    {
+        "name": "community",
+        "trans": [
+            "社会； 社团； 群落； 共同体"
+        ],
+        "usphone": "kəˈmjunətɪ",
+        "ukphone": "kə'mjuːnəti"
+    },
+    {
+        "name": "government",
+        "trans": [
+            "n. 政府；政体；管理；统治；管辖；政权"
+        ],
+        "usphone": "ˈɡʌvərnmənt",
+        "ukphone": "ˈɡʌvənmənt"
+    },
+    {
+        "name": "policy",
+        "trans": [
+            "政策， 方针； 原则； 保险单"
+        ],
+        "usphone": "'pɑləsi",
+        "ukphone": "'pɑːləsi"
+    },
+    {
+        "name": "legislation",
+        "trans": [
+            "n. 法规，法律；立法，制订法律"
+        ],
+        "usphone": "ˌledʒɪs'leɪʃ(ə)n",
+        "ukphone": "ˌledʒɪs'leɪʃn"
+    },
+    {
+        "name": "regulation",
+        "trans": [
+            "规章， 规则； 管理， 控制， 调节 (n.)"
+        ],
+        "usphone": "ˌrɛɡjəˈleʃən",
+        "ukphone": "ˌregju'leɪʃn"
+    },
+    {
+        "name": "authority",
+        "trans": [
+            "n. 专家，权威人士；行政管理机构；权利，权限；权威，威信；许可，授权；当局，官方"
+        ],
+        "usphone": "ə'θɔːrəti",
+        "ukphone": "ɔː'θɒrəti"
+    },
+    {
+        "name": "citizen",
+        "trans": [
+            "n. 公民，市民；居民"
+        ],
+        "usphone": "ˈsɪtɪzən",
+        "ukphone": "ˈsɪtɪzən"
+    },
+    {
+        "name": "public",
+        "trans": [
+            "adj. 公共的，公众的；公开的，公然的；政府的，国家的",
+            "n. 公众，民众"
+        ],
+        "usphone": "ˈpʌblɪk",
+        "ukphone": "ˈpʌblɪk"
+    },
+    {
+        "name": "welfare",
+        "trans": [
+            "福利； 安宁， 幸福"
+        ],
+        "usphone": "'wɛl'fɛr",
+        "ukphone": "'welfer"
+    },
+    {
+        "name": "taxation",
+        "trans": [
+            "n. 课税，征税；税款"
+        ],
+        "usphone": "tæk'seʃən",
+        "ukphone": "tæk'seɪʃ(ə)n"
+    },
+    {
+        "name": "budget",
+        "trans": [
+            "做预算",
+            "价格低廉的",
+            "预算"
+        ],
+        "usphone": "'bʌdʒɪt",
+        "ukphone": "'bʌdʒɪt"
+    },
+    {
+        "name": "economy",
+        "trans": [
+            "经济； 节约， 节省 (n.)"
+        ],
+        "usphone": "ɪˈkɑnəmɪ",
+        "ukphone": "i'kɒnəmi"
+    },
+    {
+        "name": "economic",
+        "trans": [
+            "经济的； 经济上的； 经济学的； 合算的"
+        ],
+        "usphone": "ˌikəˈnɑmɪk, ˌɛkəˈ-nɑmɪk",
+        "ukphone": "ˌiːkə'nɑːmɪk"
+    },
+    {
+        "name": "commercial",
+        "trans": [
+            "商业的，商品化的，贸易的",
+            "商业广告"
+        ],
+        "usphone": "kə'mɝʃəl",
+        "ukphone": "kə'mɜːʃl"
+    },
+    {
+        "name": "industry",
+        "trans": [
+            "勤劳， 勤奋； 工业， 行业"
+        ],
+        "usphone": "'ɪndəstri",
+        "ukphone": "'ɪndəstri"
+    },
+    {
+        "name": "employment",
+        "trans": [
+            "工作； 雇用； 使用 (n.)"
+        ],
+        "usphone": "ɪm'plɔɪmənt",
+        "ukphone": "ɪm'plɔɪmənt"
+    },
+    {
+        "name": "unemployment",
+        "trans": [
+            "失业； 失业人数"
+        ],
+        "usphone": ",ʌnɪm'plɔɪmənt",
+        "ukphone": "ˌʌnɪm'plɔɪmənt"
+    },
+    {
+        "name": "career",
+        "trans": [
+            "生涯， 经历； 职业"
+        ],
+        "usphone": "kə'rɪr",
+        "ukphone": "kə'rɪr"
+    },
+    {
+        "name": "profession",
+        "trans": [
+            "职业； 同行； 专业； 宣称"
+        ],
+        "usphone": "prə'fɛʃən",
+        "ukphone": "prə'feʃn"
+    },
+    {
+        "name": "occupation",
+        "trans": [
+            "占领； 职业； 消遣"
+        ],
+        "usphone": ",ɑkju'peʃən",
+        "ukphone": "ˌɒkju'peɪʃn"
+    },
+    {
+        "name": "salary",
+        "trans": [
+            "薪金， 薪水"
+        ],
+        "usphone": "'sæləri",
+        "ukphone": "'sæləri"
+    },
+    {
+        "name": "wage",
+        "trans": [
+            "工资， 报酬",
+            "进行， 开展"
+        ],
+        "usphone": "wedʒ",
+        "ukphone": "weɪdʒ"
+    },
+    {
+        "name": "income",
+        "trans": [
+            "n. 收入，所得；进款，收益"
+        ],
+        "usphone": "ˈɪnkʌm",
+        "ukphone": "ˈɪnkʌm"
+    },
+    {
+        "name": "poverty",
+        "trans": [
+            "贫穷， 贫困"
+        ],
+        "usphone": "'pɑvɚti",
+        "ukphone": "'pɑːvərti"
+    },
+    {
+        "name": "wealth",
+        "trans": [
+            "财富； 财产； 丰富 (n.)"
+        ],
+        "usphone": "wɛlθ",
+        "ukphone": "welθ"
+    },
+    {
+        "name": "inequality",
+        "trans": [
+            "n. 不平等，不均等；不公平，不公正"
+        ],
+        "usphone": "ˌɪnɪˈkwɑːləti",
+        "ukphone": "ˌɪnɪˈkwɒləti"
+    },
+    {
+        "name": "urbanization",
+        "trans": [
+            "都市化"
+        ],
+        "usphone": ",ɝbənɪ'zeʃən",
+        "ukphone": "ˌɜːrbənaɪ'zeɪʃn"
+    },
+    {
+        "name": "population",
+        "trans": [
+            "人口"
+        ],
+        "usphone": ",pɑpju'leʃən",
+        "ukphone": "ˌpɒpjʊ'leɪʃn"
+    },
+    {
+        "name": "immigration",
+        "trans": [
+            "外来的移民； 移居"
+        ],
+        "usphone": ",ɪmɪ'ɡreʃən",
+        "ukphone": "ˌɪmɪ'greɪʃn"
+    },
+    {
+        "name": "globalization",
+        "trans": [
+            "n.全球化，全球性"
+        ],
+        "usphone": "ˌgloʊbələˈzeɪʃn",
+        "ukphone": "ˌgləʊbəlaɪˈzeɪʃn"
+    },
+    {
+        "name": "culture",
+        "trans": [
+            "文化， 文明； 教养； 培养； 培养菌 (n.)"
+        ],
+        "usphone": "'kʌltʃɚ",
+        "ukphone": "'kʌltʃə"
+    },
+    {
+        "name": "tradition",
+        "trans": [
+            "传统； 惯例"
+        ],
+        "usphone": "trə'dɪʃən",
+        "ukphone": "trə'dɪʃn"
+    },
+    {
+        "name": "custom",
+        "trans": [
+            "n. 习惯，风俗；（顾客的）惯常光顾，（商店的）顾客",
+            "adj. 定做的，定制的"
+        ],
+        "usphone": "ˈkʌstəm",
+        "ukphone": "ˈkʌstəm"
+    },
+    {
+        "name": "heritage",
+        "trans": [
+            "遗产； 传统"
+        ],
+        "usphone": "'hɛrɪtɪdʒ",
+        "ukphone": "'herɪtɪdʒ"
+    },
+    {
+        "name": "generation",
+        "trans": [
+            "一代人； 代； 产生， 发生"
+        ],
+        "usphone": "'dʒɛnə'reʃən",
+        "ukphone": "ˌdʒenə'reɪʃn"
+    },
+    {
+        "name": "individual",
+        "trans": [
+            "单独的；独特的",
+            "个人， 个体"
+        ],
+        "usphone": "ˌɪndəˈvɪdʒʊəl",
+        "ukphone": "ˌɪndɪ'vɪdʒuəl"
+    },
+    {
+        "name": "collective",
+        "trans": [
+            "集体的，共同的",
+            "集体， 共同体"
+        ],
+        "usphone": "kə'lɛktɪv",
+        "ukphone": "kə'lektɪv"
+    },
+    {
+        "name": "cooperation",
+        "trans": [
+            "合作， 协作"
+        ],
+        "usphone": "ko,ɑpə'reʃən",
+        "ukphone": "kouˌɑːpə'reɪʃn"
+    },
+    {
+        "name": "competition",
+        "trans": [
+            "竞争； 比赛"
+        ],
+        "usphone": ",kɑmpə'tɪʃən",
+        "ukphone": "ˌkɒmpə'tɪʃn"
+    },
+    {
+        "name": "responsibility",
+        "trans": [
+            "责任， 责任心； 职责， 任务"
+        ],
+        "usphone": "rɪˌspɑːnsəˈbɪləti",
+        "ukphone": "rɪˌspɒnsə'bɪləti"
+    },
+    {
+        "name": "obligation",
+        "trans": [
+            "义务， 职责， 责任"
+        ],
+        "usphone": ",ɑblɪ'ɡeʃən",
+        "ukphone": "ˌɒblɪ'geɪʃn"
+    },
+    {
+        "name": "freedom",
+        "trans": [
+            "n. 自由，自主；自由权，特权；无拘束，随心所欲；自由度，灵活性"
+        ],
+        "usphone": "ˈfridəm",
+        "ukphone": "ˈfriːdəm"
+    },
+    {
+        "name": "equality",
+        "trans": [
+            "等同； 平等； 相等 (n.)"
+        ],
+        "usphone": "ɪ'kwɑləti",
+        "ukphone": "i'kwɒləti"
+    },
+    {
+        "name": "justice",
+        "trans": [
+            "法官； 司法； 正义， 公正"
+        ],
+        "usphone": "'dʒʌstɪs",
+        "ukphone": "'dʒʌstɪs"
+    },
+    {
+        "name": "crime",
+        "trans": [
+            "犯罪； 罪行"
+        ],
+        "usphone": "kraɪm",
+        "ukphone": "kraɪm"
+    },
+    {
+        "name": "punishment",
+        "trans": [
+            "惩罚， 刑罚； 虐待"
+        ],
+        "usphone": "'pʌnɪʃmənt",
+        "ukphone": "'pʌnɪʃmənt"
+    },
+    {
+        "name": "discrimination",
+        "trans": [
+            "n. 歧视，区别对待；区分，辨别；辨别力，鉴赏力"
+        ],
+        "usphone": "dɪˌskrɪmɪ'neɪʃ(ə)n",
+        "ukphone": "dɪˌskrɪmɪ'neɪʃn"
+    },
+    {
+        "name": "health",
+        "trans": [
+            "n. 健康，身体状况；卫生，保健"
+        ],
+        "usphone": "helθ",
+        "ukphone": "helθ"
+    },
+    {
+        "name": "medical",
+        "trans": [
+            "医学的， 医疗的； 内科的"
+        ],
+        "usphone": "'mɛdɪkl",
+        "ukphone": "'medɪkl"
+    },
+    {
+        "name": "medicine",
+        "trans": [
+            "n. 药，药物；医学，医术；内科学"
+        ],
+        "usphone": "ˈmedɪsn",
+        "ukphone": "ˈmeds(ə)n"
+    },
+    {
+        "name": "disease",
+        "trans": [
+            "疾病； 弊端， 恶疾"
+        ],
+        "usphone": "dɪ'ziz",
+        "ukphone": "dɪ'ziːz"
+    },
+    {
+        "name": "illness",
+        "trans": [
+            "n. 疾病，病；生病"
+        ],
+        "usphone": "ˈɪlnəs",
+        "ukphone": "ˈɪlnəs"
+    },
+    {
+        "name": "symptom",
+        "trans": [
+            "症状； 征兆"
+        ],
+        "usphone": "'sɪmptəm",
+        "ukphone": "'sɪmptəm"
+    },
+    {
+        "name": "treatment",
+        "trans": [
+            "治疗； 对待"
+        ],
+        "usphone": "'tritmənt",
+        "ukphone": "'triːtmənt"
+    },
+    {
+        "name": "therapy",
+        "trans": [
+            "治疗， 疗法"
+        ],
+        "usphone": "'θɛrəpi",
+        "ukphone": "'θerəpi"
+    },
+    {
+        "name": "prevention",
+        "trans": [
+            "n. 预防，防止；阻止，妨碍"
+        ],
+        "usphone": "prɪˈvenʃn",
+        "ukphone": "prɪˈvenʃn"
+    },
+    {
+        "name": "nutrition",
+        "trans": [
+            "营养； 营养学"
+        ],
+        "usphone": "nu'trɪʃən",
+        "ukphone": "nu'trɪʃn"
+    },
+    {
+        "name": "diet",
+        "trans": [
+            "节食",
+            "饮食，食物；规定饮食"
+        ],
+        "usphone": "'daɪət",
+        "ukphone": "'daɪət"
+    },
+    {
+        "name": "obesity",
+        "trans": [
+            "过度肥胖 (n.)"
+        ],
+        "usphone": "o'bisəti",
+        "ukphone": "əu'biːsəti"
+    },
+    {
+        "name": "exercise",
+        "trans": [
+            "n. 锻炼，运动；练习，习题；演习，练习",
+            "v. 锻炼，运动；行使，运用"
+        ],
+        "usphone": "ˈeksərsaɪz",
+        "ukphone": "ˈeksəsaɪz"
+    },
+    {
+        "name": "fitness",
+        "trans": [
+            "健康， 健壮； 适合"
+        ],
+        "usphone": "ˈfɪtnɪs",
+        "ukphone": "'fɪtnəs"
+    },
+    {
+        "name": "mental",
+        "trans": [
+            "精神的； 智力的； 精神健康的"
+        ],
+        "usphone": "'mɛntl",
+        "ukphone": "'mentl"
+    },
+    {
+        "name": "psychological",
+        "trans": [
+            "心理的 (adj.)"
+        ],
+        "usphone": ",saɪkə'lɑdʒɪkl",
+        "ukphone": "ˌsaɪkə'lɒdʒɪkl"
+    },
+    {
+        "name": "anxiety",
+        "trans": [
+            "焦虑， 忧虑； 渴望， 热望 (n.)"
+        ],
+        "usphone": "æŋ'zaɪəti",
+        "ukphone": "æŋ'zaɪəti"
+    },
+    {
+        "name": "depression",
+        "trans": [
+            "n. 抑郁，沮丧；萧条（期），不景气；低气压；凹陷，浅坑；俯角，俯视角"
+        ],
+        "usphone": "dɪ'preʃ(ə)n",
+        "ukphone": "dɪ'preʃn"
+    },
+    {
+        "name": "media",
+        "trans": [
+            "n. 媒体，传播媒介；新闻媒体，新闻界",
+            "adj. 媒体的，传媒的"
+        ],
+        "usphone": "ˈmiːdiə",
+        "ukphone": "ˈmiːdiə"
+    },
+    {
+        "name": "journalism",
+        "trans": [
+            "新闻业， 新闻工作"
+        ],
+        "usphone": "'dʒɝnl'ɪzəm",
+        "ukphone": "'dʒɜːrnəlɪzəm"
+    },
+    {
+        "name": "broadcast",
+        "trans": [
+            "广播，播放",
+            "广播， 广播节目"
+        ],
+        "usphone": "'brɔdkæst",
+        "ukphone": "'brɔːdkæst"
+    },
+    {
+        "name": "advertisement",
+        "trans": [
+            "广告， 公告； 广告活动， 宣传"
+        ],
+        "usphone": ",ædvɚ'taɪzmənt",
+        "ukphone": "əd'vɜːtɪsmənt"
+    },
+    {
+        "name": "publicity",
+        "trans": [
+            "宣传， 宣扬； 公众的注意， 名声"
+        ],
+        "usphone": "pʌb'lɪsəti",
+        "ukphone": "pʌb'lɪsətɪ"
+    },
+    {
+        "name": "propaganda",
+        "trans": [
+            "宣传 (n.)"
+        ],
+        "usphone": "'prɑpə'gændə",
+        "ukphone": "ˌprɒpə'gændə"
+    },
+    {
+        "name": "censorship",
+        "trans": [
+            "n. 审查制度，言论管制"
+        ],
+        "usphone": "ˈsensərʃɪp",
+        "ukphone": "ˈsensəʃɪp"
+    },
+    {
+        "name": "entertainment",
+        "trans": [
+            "招待， 款待； 娱乐； 供消遣的事物"
+        ],
+        "usphone": "ˌɛntɚ'tenmənt",
+        "ukphone": "ˌentə'teɪnmənt"
+    },
+    {
+        "name": "audience",
+        "trans": [
+            "听众； 观众； 读者"
+        ],
+        "usphone": "'ɔdɪəns",
+        "ukphone": "'ɔːdiəns"
+    },
+    {
+        "name": "celebrity",
+        "trans": [
+            "n. 名声，名望；名人，明星"
+        ],
+        "usphone": "sə'lebrəti",
+        "ukphone": "sə'lebrəti"
+    }
+]

--- a/public/dicts/TOEFL_order.json
+++ b/public/dicts/TOEFL_order.json
@@ -1,0 +1,35160 @@
+[
+    {
+        "name": "abandon",
+        "trans": [
+            "离弃，放弃",
+            "放纵， 放任"
+        ],
+        "usphone": "ə'bændən",
+        "ukphone": "ə'bændən"
+    },
+    {
+        "name": "abate",
+        "trans": [
+            "减少， 减轻"
+        ],
+        "usphone": "ə'bet",
+        "ukphone": "ə'beɪt"
+    },
+    {
+        "name": "abbey",
+        "trans": [
+            "修道院； 大教堂"
+        ],
+        "usphone": "'æbi",
+        "ukphone": "'æbi"
+    },
+    {
+        "name": "abbreviate",
+        "trans": [
+            "缩略， 缩写"
+        ],
+        "usphone": "ə'brivɪ'et",
+        "ukphone": "ə'briːvieɪt"
+    },
+    {
+        "name": "aberrant",
+        "trans": [
+            "越轨的； 异常的"
+        ],
+        "usphone": "æ'bɛrənt",
+        "ukphone": "æ'berənt"
+    },
+    {
+        "name": "abhor",
+        "trans": [
+            "憎恨， 厌恶"
+        ],
+        "usphone": "əb'hɔr",
+        "ukphone": "əb'hɔːr"
+    },
+    {
+        "name": "abiding",
+        "trans": [
+            "持久的， 永久的"
+        ],
+        "usphone": "ə'baɪdɪŋ",
+        "ukphone": "ə'baɪdɪŋ"
+    },
+    {
+        "name": "ability",
+        "trans": [
+            "能力， 才干"
+        ],
+        "usphone": "əˈbɪlətɪ",
+        "ukphone": "ə'bɪləti"
+    },
+    {
+        "name": "ablaze",
+        "trans": [
+            "着火的， 燃烧的； 闪耀的； 情绪激动的"
+        ],
+        "usphone": "ə'blez",
+        "ukphone": "ə'bleɪz"
+    },
+    {
+        "name": "abnormal",
+        "trans": [
+            "反常的， 变态的"
+        ],
+        "usphone": "æbˈnɔːrml",
+        "ukphone": "æb'nɔːrml"
+    },
+    {
+        "name": "abolish",
+        "trans": [
+            "废止， 废除"
+        ],
+        "usphone": "ə'bɑlɪʃ",
+        "ukphone": "ə'bɑːlɪʃ"
+    },
+    {
+        "name": "abolition",
+        "trans": [
+            "废除， 废止； 废奴运动"
+        ],
+        "usphone": ",æbə'lɪʃən",
+        "ukphone": "ˌæbə'lɪʃn"
+    },
+    {
+        "name": "aboriginal",
+        "trans": [
+            "原始的；土著的，土生土长的",
+            "土著"
+        ],
+        "usphone": ",æbə'rɪdʒənl",
+        "ukphone": "ˌæbə'rɪdʒənl"
+    },
+    {
+        "name": "abort",
+        "trans": [
+            "夭折， 中止； 使流产"
+        ],
+        "usphone": "ə'bɔrt",
+        "ukphone": "ə'bɔːrt"
+    },
+    {
+        "name": "abortive",
+        "trans": [
+            "落空的， 失败的"
+        ],
+        "usphone": "ə'bɔrtɪv",
+        "ukphone": "ə'bɔːrtɪv"
+    },
+    {
+        "name": "abound",
+        "trans": [
+            "富于； 大量存在； 充满"
+        ],
+        "usphone": "ə'baʊnd",
+        "ukphone": "ə'baund"
+    },
+    {
+        "name": "abrasion",
+        "trans": [
+            "表面磨损"
+        ],
+        "usphone": "ə'breʒən",
+        "ukphone": "ə'breɪʒn"
+    },
+    {
+        "name": "abreast",
+        "trans": [
+            "并列地， 并排地"
+        ],
+        "usphone": "ə'brɛst",
+        "ukphone": "ə'brest"
+    },
+    {
+        "name": "abridge",
+        "trans": [
+            "缩短， 删节， 节略， 精简"
+        ],
+        "usphone": "ə'brɪdʒ",
+        "ukphone": "ə'brɪdʒ"
+    },
+    {
+        "name": "abrupt",
+        "trans": [
+            "突然的， 意外的； 唐突的， 鲁莽的"
+        ],
+        "usphone": "ə'brʌpt",
+        "ukphone": "ə'brʌpt"
+    },
+    {
+        "name": "absence",
+        "trans": [
+            "缺席； 缺乏"
+        ],
+        "usphone": "'æbsns",
+        "ukphone": "'æbsəns"
+    },
+    {
+        "name": "absenteeism",
+        "trans": [
+            "旷课； 旷工"
+        ],
+        "usphone": ",æbsən'tiɪzəm",
+        "ukphone": "ˌæbsən'tiːɪzəm"
+    },
+    {
+        "name": "absolute",
+        "trans": [
+            "完全的， 绝对的； 地道的； 无疑的， 确凿的； 不受限制的， 不受约束的"
+        ],
+        "usphone": "'æbsəlut",
+        "ukphone": "'æbsəluːt"
+    },
+    {
+        "name": "absolve",
+        "trans": [
+            "赦免； 免除； 宽恕"
+        ],
+        "usphone": "əb'zɑlv",
+        "ukphone": "əb'zɑːlv"
+    },
+    {
+        "name": "absorb",
+        "trans": [
+            "吸收； 理解， 掌握； 吸引…的注意， 使全神贯注； 使并入， 同化"
+        ],
+        "usphone": "æbˈsɔrb; æbˈzɔrb; əbˈsɔrb",
+        "ukphone": "əb'sɔːrb"
+    },
+    {
+        "name": "absorption",
+        "trans": [
+            "吸收； 全神贯注， 专心致志"
+        ],
+        "usphone": "əbˈsɔrpʃən, -ˈzɔrp-",
+        "ukphone": "əb'sɔːrpʃn"
+    },
+    {
+        "name": "abstract",
+        "trans": [
+            "抽象的；抽象派的",
+            "摘要， 梗概",
+            "做…的摘要； 提取"
+        ],
+        "usphone": "'æbstrækt",
+        "ukphone": "'æbstrækt"
+    },
+    {
+        "name": "absurd",
+        "trans": [
+            "可笑的， 荒唐的"
+        ],
+        "usphone": "əbˈsɝ​d",
+        "ukphone": "əb'sɜːrd"
+    },
+    {
+        "name": "abundant",
+        "trans": [
+            "大量的， 充足的， 丰富的"
+        ],
+        "usphone": "ə'bʌndənt",
+        "ukphone": "ə'bʌndənt"
+    },
+    {
+        "name": "abut",
+        "trans": [
+            "邻接， 毗邻"
+        ],
+        "usphone": "ə'bʌt",
+        "ukphone": "ə'bʌt"
+    },
+    {
+        "name": "abysmal",
+        "trans": [
+            "深不可测的； 极坏的， 糟透的"
+        ],
+        "usphone": "ə'bɪzməl",
+        "ukphone": "ə'bɪzməl"
+    },
+    {
+        "name": "academic",
+        "trans": [
+            "学术的；学校的，学院的；纯理论的",
+            "大学教师"
+        ],
+        "usphone": ",ækə'dɛmɪk",
+        "ukphone": "ˌækə'demɪk"
+    },
+    {
+        "name": "academy",
+        "trans": [
+            "学会， 研究院； 专科院校"
+        ],
+        "usphone": "ə'kædəmi",
+        "ukphone": "ə'kædəmi"
+    },
+    {
+        "name": "accede",
+        "trans": [
+            "即位， 就任； 同意"
+        ],
+        "usphone": "ək'sid",
+        "ukphone": "ək'siːd"
+    },
+    {
+        "name": "accelerate",
+        "trans": [
+            "加快， 加速"
+        ],
+        "usphone": "əkˈsɛləˌret",
+        "ukphone": "ək'seləreɪt"
+    },
+    {
+        "name": "accent",
+        "trans": [
+            "重音； 口音； 重音符号",
+            "重读"
+        ],
+        "usphone": "'æksɛnt",
+        "ukphone": "'æks(ə)nt; -sent"
+    },
+    {
+        "name": "access",
+        "trans": [
+            "通道；接近，进入；机会",
+            "进入； 使用； 存取"
+        ],
+        "usphone": "'æksɛs",
+        "ukphone": "'ækses"
+    },
+    {
+        "name": "accessible",
+        "trans": [
+            "易接近的； 可得到的； 可进入的"
+        ],
+        "usphone": "ək'sɛsəbl",
+        "ukphone": "ək'sesəbl"
+    },
+    {
+        "name": "accessory",
+        "trans": [
+            "辅助的",
+            "附件，零件；配饰；从犯，同谋"
+        ],
+        "usphone": "ək'sɛsəri",
+        "ukphone": "ək'sesəri"
+    },
+    {
+        "name": "accident",
+        "trans": [
+            "意外事件， 事故"
+        ],
+        "usphone": "'æksədənt",
+        "ukphone": "'æksɪdənt"
+    },
+    {
+        "name": "acclaim",
+        "trans": [
+            "喝彩， 称赞"
+        ],
+        "usphone": "ə'klem",
+        "ukphone": "ə'kleɪm"
+    },
+    {
+        "name": "accommodate",
+        "trans": [
+            "提供； 容纳； 适应， 顺应"
+        ],
+        "usphone": "ə'kɑmədet",
+        "ukphone": "ə'kɑːmədeɪt"
+    },
+    {
+        "name": "accompany",
+        "trans": [
+            "为…伴奏； 陪伴， 陪同； 伴随， 和…一起发生"
+        ],
+        "usphone": "ə'kʌmpəni",
+        "ukphone": "ə'kʌmpəni"
+    },
+    {
+        "name": "accomplish",
+        "trans": [
+            "达到； 完成； 实现"
+        ],
+        "usphone": "ə'kɑmplɪʃ",
+        "ukphone": "ə'kɑːmplɪʃ"
+    },
+    {
+        "name": "accomplishment",
+        "trans": [
+            "成就； 完成； 才艺， 技艺"
+        ],
+        "usphone": "ə'kɑmplɪʃmənt",
+        "ukphone": "ə'kɑːmplɪʃmənt"
+    },
+    {
+        "name": "accord",
+        "trans": [
+            "与…一致， 符合",
+            "协议，条约"
+        ],
+        "usphone": "ə'kɔrd",
+        "ukphone": "ə'kɔːrd"
+    },
+    {
+        "name": "accordion",
+        "trans": [
+            "手风琴"
+        ],
+        "usphone": "ə'kɔrdɪən",
+        "ukphone": "ə'kɔːrdiən"
+    },
+    {
+        "name": "account",
+        "trans": [
+            "说明，解释；占",
+            "解释， 描述， 叙述； 账目； 账户"
+        ],
+        "usphone": "ə'kaʊnt",
+        "ukphone": "ə'kaunt"
+    },
+    {
+        "name": "accounting",
+        "trans": [
+            "会计学； 会计"
+        ],
+        "usphone": "ə'kaʊntɪŋ",
+        "ukphone": "ə'kauntɪŋ"
+    },
+    {
+        "name": "accredit",
+        "trans": [
+            "委任， 授权； 把…归于； 正式认可"
+        ],
+        "usphone": "ə'krɛdɪt",
+        "ukphone": "ə'kredɪt"
+    },
+    {
+        "name": "accumulate",
+        "trans": [
+            "积累， 积聚， 堆积"
+        ],
+        "usphone": "ə'kjumjəlet",
+        "ukphone": "ə'kjuːmjəleɪt"
+    },
+    {
+        "name": "accuracy",
+        "trans": [
+            "准确， 精确"
+        ],
+        "usphone": "'ækjərəsi",
+        "ukphone": "'ækjərəsi"
+    },
+    {
+        "name": "accurate",
+        "trans": [
+            "正确无误的， 精确的"
+        ],
+        "usphone": "'ækjərət",
+        "ukphone": "'ækjərət"
+    },
+    {
+        "name": "accuse",
+        "trans": [
+            "谴责； 指责， 归咎； 指控， 控告"
+        ],
+        "usphone": "ə'kjuz",
+        "ukphone": "ə'kjuːz"
+    },
+    {
+        "name": "accustom",
+        "trans": [
+            "使习惯于"
+        ],
+        "usphone": "ə'kʌstəm",
+        "ukphone": "ə'kʌstəm"
+    },
+    {
+        "name": "acid",
+        "trans": [
+            "酸的， 酸味的； 尖刻的， 刻薄的",
+            "酸，酸性物质"
+        ],
+        "usphone": "'æsɪd",
+        "ukphone": "'æsɪd"
+    },
+    {
+        "name": "acidity",
+        "trans": [
+            "酸度； 酸性"
+        ],
+        "usphone": "ə'sɪdəti",
+        "ukphone": "ə'sɪdəti"
+    },
+    {
+        "name": "acknowledge",
+        "trans": [
+            "承认， 确认； 对…表示感谢"
+        ],
+        "usphone": "ək'nɑlɪdʒ",
+        "ukphone": "ək'nɑːlɪdʒ"
+    },
+    {
+        "name": "acoustic",
+        "trans": [
+            "非电声乐器的， 原声的； 听觉的， 声音的"
+        ],
+        "usphone": "ə'kʊstɪk",
+        "ukphone": "ə'kuːstɪk"
+    },
+    {
+        "name": "acquaint",
+        "trans": [
+            "使认识； 使熟悉"
+        ],
+        "usphone": "ə'kwent",
+        "ukphone": "ə'kweɪnt"
+    },
+    {
+        "name": "acquiesce",
+        "trans": [
+            "默许， 默认"
+        ],
+        "usphone": ",ækwi'es",
+        "ukphone": "ˌækwi'es"
+    },
+    {
+        "name": "acquire",
+        "trans": [
+            "获得， 取得"
+        ],
+        "usphone": "ə'kwaɪr",
+        "ukphone": "ə'kwaɪər"
+    },
+    {
+        "name": "acquisition",
+        "trans": [
+            "习得， 获得； 收购， 购置"
+        ],
+        "usphone": ",ækwɪ'zɪʃən",
+        "ukphone": "ˌækwɪ'zɪʃn"
+    },
+    {
+        "name": "acquit",
+        "trans": [
+            "宣告无罪； 表现"
+        ],
+        "usphone": "ə'kwɪt",
+        "ukphone": "ə'kwɪt"
+    },
+    {
+        "name": "acronym",
+        "trans": [
+            "首字母缩写词"
+        ],
+        "usphone": "'ækrənɪm",
+        "ukphone": "'ækrənɪm"
+    },
+    {
+        "name": "across",
+        "trans": [
+            "横过；到对面，向对面",
+            "穿过， 越过； 在对面"
+        ],
+        "usphone": "ə'krɔs",
+        "ukphone": "ə'krɔːs"
+    },
+    {
+        "name": "acting",
+        "trans": [
+            "代理的",
+            "演戏， 表演"
+        ],
+        "usphone": "'æktɪŋ",
+        "ukphone": "'æktɪŋ"
+    },
+    {
+        "name": "activate",
+        "trans": [
+            "刺激， 使活动"
+        ],
+        "usphone": "'æktə'vet",
+        "ukphone": "'æktɪveɪt"
+    },
+    {
+        "name": "acumen",
+        "trans": [
+            "敏锐， 聪明"
+        ],
+        "usphone": "əˈkjumən",
+        "ukphone": "'ækjəmən"
+    },
+    {
+        "name": "acute",
+        "trans": [
+            "严重的； 极度的， 激烈的； 敏锐的"
+        ],
+        "usphone": "ə'kjut",
+        "ukphone": "ə'kjuːt"
+    },
+    {
+        "name": "adamant",
+        "trans": [
+            "坚定不移的， 坚决的； 固执的"
+        ],
+        "usphone": "'ædəmənt",
+        "ukphone": "'ædəmənt"
+    },
+    {
+        "name": "adapt",
+        "trans": [
+            "适合； 适应； 调整； 改编， 改写"
+        ],
+        "usphone": "ə'dæpt",
+        "ukphone": "ə'dæpt"
+    },
+    {
+        "name": "adaptable",
+        "trans": [
+            "能适应的； 可改编的"
+        ],
+        "usphone": "ə'dæptəbl",
+        "ukphone": "ə'dæptəbl"
+    },
+    {
+        "name": "adaptive",
+        "trans": [
+            "适合的， 有适应性的"
+        ],
+        "usphone": "ə'dæptɪv",
+        "ukphone": "ə'dæptɪv"
+    },
+    {
+        "name": "addictive",
+        "trans": [
+            "使人上瘾的； 使人沉醉的， 醉心的"
+        ],
+        "usphone": "ə'dɪktɪv",
+        "ukphone": "ə'dɪktɪv"
+    },
+    {
+        "name": "addition",
+        "trans": [
+            "加， 加法； 添加， 增加"
+        ],
+        "usphone": "ə'dɪʃən",
+        "ukphone": "ə'dɪʃn"
+    },
+    {
+        "name": "additive",
+        "trans": [
+            "〔食品的〕添加剂，添加物"
+        ],
+        "usphone": "'ædətɪv",
+        "ukphone": "'ædətɪv"
+    },
+    {
+        "name": "address",
+        "trans": [
+            "作讲话； 写姓名地址",
+            "地址；讲话"
+        ],
+        "usphone": "əˈdrɛs;(for n)ˈædres; ædrɛs",
+        "ukphone": "ə'dres"
+    },
+    {
+        "name": "adept",
+        "trans": [
+            "熟练的，精通的，内行的",
+            "行家， 熟手"
+        ],
+        "usphone": "ə'dɛpt",
+        "ukphone": "ə'dept"
+    },
+    {
+        "name": "adequate",
+        "trans": [
+            "适当的； 足够的； 适当的， 胜任的"
+        ],
+        "usphone": "ˈædɪkwət",
+        "ukphone": "'ædɪkwət"
+    },
+    {
+        "name": "adhere",
+        "trans": [
+            "黏附， 附着； 坚持； 遵守"
+        ],
+        "usphone": "əd'hɪr",
+        "ukphone": "əd'hɪr"
+    },
+    {
+        "name": "adhesive",
+        "trans": [
+            "带黏性的",
+            "胶合剂"
+        ],
+        "usphone": "əd'hisɪv",
+        "ukphone": "əd'hiːsɪv"
+    },
+    {
+        "name": "adjacent",
+        "trans": [
+            "邻近的， 毗连的"
+        ],
+        "usphone": "ə'dʒesnt",
+        "ukphone": "ə'dʒeɪsnt"
+    },
+    {
+        "name": "adjoin",
+        "trans": [
+            "贴近， 紧挨， 毗连"
+        ],
+        "usphone": "ə'dʒɔɪn",
+        "ukphone": "ə'dʒɔɪn"
+    },
+    {
+        "name": "adjunct",
+        "trans": [
+            "附加物， 附件； 附加语， 修饰语"
+        ],
+        "usphone": "'ædʒʌŋkt",
+        "ukphone": "'ædʒʌŋkt"
+    },
+    {
+        "name": "adjust",
+        "trans": [
+            "调整， 调节； 适合， 适应； 校正， 校准"
+        ],
+        "usphone": "ə'dʒʌst",
+        "ukphone": "ə'dʒʌst"
+    },
+    {
+        "name": "administer",
+        "trans": [
+            "管理； 执行； 给予， 提供"
+        ],
+        "usphone": "əd'mɪnɪstɚ",
+        "ukphone": "əd'mɪnɪstər"
+    },
+    {
+        "name": "admiration",
+        "trans": [
+            "钦佩， 赞赏， 羡慕"
+        ],
+        "usphone": ",ædmə'reʃən",
+        "ukphone": "ˌædmə'reɪʃn"
+    },
+    {
+        "name": "admire",
+        "trans": [
+            "钦佩， 仰慕； 欣赏"
+        ],
+        "usphone": "ədˈmaɪr",
+        "ukphone": "əd'maɪər"
+    },
+    {
+        "name": "admission",
+        "trans": [
+            "准许进入； 入场费； 承认"
+        ],
+        "usphone": "əd'mɪʃən",
+        "ukphone": "əd'mɪʃn"
+    },
+    {
+        "name": "admit",
+        "trans": [
+            "承认； 准许…进入， 接纳"
+        ],
+        "usphone": "əd'mɪt",
+        "ukphone": "əd'mɪt"
+    },
+    {
+        "name": "adobe",
+        "trans": [
+            "泥砖， 土坯"
+        ],
+        "usphone": "'ədobɪ",
+        "ukphone": "ə'doubi"
+    },
+    {
+        "name": "adolescence",
+        "trans": [
+            "青春"
+        ],
+        "usphone": ",ædə'lɛsns",
+        "ukphone": "ˌædə'lesns"
+    },
+    {
+        "name": "adopt",
+        "trans": [
+            "采用； 收养， 领养； 正式通过， 批准"
+        ],
+        "usphone": "ə'dɑpt",
+        "ukphone": "ə'dɑːpt"
+    },
+    {
+        "name": "adorn",
+        "trans": [
+            "装饰， 装扮"
+        ],
+        "usphone": "ə'dɔrn",
+        "ukphone": "ə'dɔːrn"
+    },
+    {
+        "name": "adroit",
+        "trans": [
+            "精明的， 干练的； 熟练的， 灵巧的"
+        ],
+        "usphone": "ə'drɔɪt",
+        "ukphone": "ə'drɔɪt"
+    },
+    {
+        "name": "advance",
+        "trans": [
+            "前进，向前移动；发展，进步；促进；预付",
+            "预先的； 先头的",
+            "前进；进展；预付"
+        ],
+        "usphone": "əd'væns",
+        "ukphone": "əd'væns"
+    },
+    {
+        "name": "advanced",
+        "trans": [
+            "先进的； 高级的， 高等的； 晚期的， 后期的"
+        ],
+        "usphone": "əd'vænst",
+        "ukphone": "əd'vænst"
+    },
+    {
+        "name": "advantage",
+        "trans": [
+            "优点；优势，有利条件",
+            "有益于"
+        ],
+        "usphone": "əd'væntɪdʒ",
+        "ukphone": "əd'væntɪdʒ"
+    },
+    {
+        "name": "advantageous",
+        "trans": [
+            "有利的"
+        ],
+        "usphone": "'ædvən'tedʒəs",
+        "ukphone": "ˌædvən'teɪdʒəs"
+    },
+    {
+        "name": "advent",
+        "trans": [
+            "到来， 来临； 出现"
+        ],
+        "usphone": "'ædvənt",
+        "ukphone": "'ædvent"
+    },
+    {
+        "name": "adventitious",
+        "trans": [
+            "偶然的， 偶发的"
+        ],
+        "usphone": ",ædvɛn'tɪʃəs",
+        "ukphone": "ˌædven'tɪʃəs"
+    },
+    {
+        "name": "adventure",
+        "trans": [
+            "奇遇； 冒险活动"
+        ],
+        "usphone": "əd'vɛntʃɚ",
+        "ukphone": "əd'ventʃər"
+    },
+    {
+        "name": "adversary",
+        "trans": [
+            "对手， 敌手"
+        ],
+        "usphone": "'ædvɚsɛri",
+        "ukphone": "'ædvərseri"
+    },
+    {
+        "name": "adverse",
+        "trans": [
+            "负面的； 不利的； 逆的"
+        ],
+        "usphone": "ædˈvɚs, ˈædˌvɚs",
+        "ukphone": "'ædvɜːrs"
+    },
+    {
+        "name": "advertise",
+        "trans": [
+            "为…做广告， 宣传； 公告， 公布"
+        ],
+        "usphone": "'ædvɚtaɪz",
+        "ukphone": "'ædvərtaɪz"
+    },
+    {
+        "name": "advisable",
+        "trans": [
+            "可取的， 适当的； 明智的"
+        ],
+        "usphone": "əd'vaɪzəbl",
+        "ukphone": "əd'vaɪzəbl"
+    },
+    {
+        "name": "advisory",
+        "trans": [
+            "顾问的，咨询的；劝告的",
+            "警报"
+        ],
+        "usphone": "əd'vaɪzəri",
+        "ukphone": "əd'vaɪzəri"
+    },
+    {
+        "name": "advocate",
+        "trans": [
+            "提倡",
+            "倡导者"
+        ],
+        "usphone": "ˈædvəkeɪt；-et",
+        "ukphone": "'ædvəkeɪt；-ət"
+    },
+    {
+        "name": "aerial",
+        "trans": [
+            "空中的，地表以上的；从飞行器上的",
+            "天线"
+        ],
+        "usphone": "'ɛrɪəl",
+        "ukphone": "'eriəl"
+    },
+    {
+        "name": "aerobics",
+        "trans": [
+            "有氧运动"
+        ],
+        "usphone": "ɛ'robɪks",
+        "ukphone": "e'roubɪks"
+    },
+    {
+        "name": "aesthetic",
+        "trans": [
+            "审美的， 美学的； 美的， 艺术的"
+        ],
+        "usphone": "esˈθetɪk; ɛsˈθɛtɪk",
+        "ukphone": "es'θetɪk"
+    },
+    {
+        "name": "affable",
+        "trans": [
+            "和蔼可亲的， 易于交谈的， 友善的"
+        ],
+        "usphone": "'æfəbl",
+        "ukphone": "'æfəbl"
+    },
+    {
+        "name": "affect",
+        "trans": [
+            "影响； 感染"
+        ],
+        "usphone": "ə'fɛkt",
+        "ukphone": "ə'fekt"
+    },
+    {
+        "name": "affection",
+        "trans": [
+            "喜爱，钟爱；"
+        ],
+        "usphone": "ə'fɛkʃən",
+        "ukphone": "ə'fekʃn"
+    },
+    {
+        "name": "affiliate",
+        "trans": [
+            "使隶属于",
+            "分公司"
+        ],
+        "usphone": "ə'fɪlɪet",
+        "ukphone": "ə'fɪlɪeɪt"
+    },
+    {
+        "name": "affinity",
+        "trans": [
+            "密切关系； 吸引力； 喜爱"
+        ],
+        "usphone": "ə'fɪnəti",
+        "ukphone": "ə'fɪnəti"
+    },
+    {
+        "name": "affirm",
+        "trans": [
+            "断言， 坚持声称； 证实， 确认"
+        ],
+        "usphone": "ə'fɝm",
+        "ukphone": "ə'fɜːrm"
+    },
+    {
+        "name": "afflict",
+        "trans": [
+            "使苦恼， 折磨"
+        ],
+        "usphone": "ə'flɪkt",
+        "ukphone": "ə'flɪkt"
+    },
+    {
+        "name": "affluent",
+        "trans": [
+            "丰富的； 富裕的"
+        ],
+        "usphone": "'æfluənt",
+        "ukphone": "'æfluənt"
+    },
+    {
+        "name": "afford",
+        "trans": [
+            "买得起， 担负得起； 冒险做； 提供， 给予"
+        ],
+        "usphone": "ə'fɔrd",
+        "ukphone": "ə'fɔːrd"
+    },
+    {
+        "name": "afloat",
+        "trans": [
+            "漂浮地",
+            "漂浮的；有偿债能力的，能维持下去的"
+        ],
+        "usphone": "ə'flot",
+        "ukphone": "ə'flout"
+    },
+    {
+        "name": "afoul",
+        "trans": [
+            "相抵触， 有冲突"
+        ],
+        "usphone": "ə'faʊl",
+        "ukphone": "ə'faul"
+    },
+    {
+        "name": "aftermath",
+        "trans": [
+            "后果， 余波"
+        ],
+        "usphone": "'æftəmæθ",
+        "ukphone": "'æftərmæθ"
+    },
+    {
+        "name": "ageism",
+        "trans": [
+            "年龄歧视"
+        ],
+        "usphone": "'edʒ'ɪzəm",
+        "ukphone": "'eɪdʒɪzəm"
+    },
+    {
+        "name": "agency",
+        "trans": [
+            "代理处， 经销机构； 专门机构"
+        ],
+        "usphone": "'edʒənsi",
+        "ukphone": "'eɪdʒənsi"
+    },
+    {
+        "name": "agenda",
+        "trans": [
+            "议程， 议程表"
+        ],
+        "usphone": "ə'dʒɛndə",
+        "ukphone": "ə'dʒendə"
+    },
+    {
+        "name": "aggravate",
+        "trans": [
+            "恶化， 加重； 激怒"
+        ],
+        "usphone": "'æɡrəvet",
+        "ukphone": "'ægrəveɪt"
+    },
+    {
+        "name": "aggregate",
+        "trans": [
+            "聚集物； 总计",
+            "聚集； 总计"
+        ],
+        "usphone": "'æɡrɪɡət; (for v.) æɡrɪˌɡet",
+        "ukphone": "'ægrɪgət; (for v.) ˈægrɪgeɪt"
+    },
+    {
+        "name": "aggression",
+        "trans": [
+            "侵略； 敌对的情绪或行为"
+        ],
+        "usphone": "ə'ɡrɛʃən",
+        "ukphone": "ə'greʃn"
+    },
+    {
+        "name": "aggressive",
+        "trans": [
+            "侵略的， 挑衅的； 强有力的； 敢作敢为的， 有进取心的"
+        ],
+        "usphone": "ə'ɡrɛsɪv",
+        "ukphone": "ə'gresɪv"
+    },
+    {
+        "name": "agile",
+        "trans": [
+            "敏捷的， 灵活的"
+        ],
+        "usphone": "'ædʒl",
+        "ukphone": "'ædʒl"
+    },
+    {
+        "name": "agitate",
+        "trans": [
+            "鼓动， 煽动； 激怒， 使激动， 使不安； 搅动"
+        ],
+        "usphone": "ˈædʒɪˌteɪt",
+        "ukphone": "'ædʒɪteɪt"
+    },
+    {
+        "name": "agonize",
+        "trans": [
+            "苦苦思索； 焦虑不已"
+        ],
+        "usphone": "'æɡənaɪz",
+        "ukphone": "'ægənaɪz"
+    },
+    {
+        "name": "agreeable",
+        "trans": [
+            "使人愉快的； 欣然同意的"
+        ],
+        "usphone": "ə'ɡriəbl",
+        "ukphone": "ə'griːəbl"
+    },
+    {
+        "name": "ailment",
+        "trans": [
+            "小病"
+        ],
+        "usphone": "'elmənt",
+        "ukphone": "'eɪlmənt"
+    },
+    {
+        "name": "airborne",
+        "trans": [
+            "空气传播的； 空运的"
+        ],
+        "usphone": "'ɛr'bɔrn",
+        "ukphone": "'erbɔːrn"
+    },
+    {
+        "name": "alarm",
+        "trans": [
+            "闹钟；警报",
+            "使惊恐； 使担心"
+        ],
+        "usphone": "ə'lɑrm",
+        "ukphone": "ə'lɑːrm"
+    },
+    {
+        "name": "alchemist",
+        "trans": [
+            "炼金术士"
+        ],
+        "usphone": "'ælkəmɪst",
+        "ukphone": "'ælkəmɪst"
+    },
+    {
+        "name": "alert",
+        "trans": [
+            "警觉的，警惕的",
+            "警告，提醒",
+            "警戒； 警报"
+        ],
+        "usphone": "ə'lɝt",
+        "ukphone": "ə'lɜːrt"
+    },
+    {
+        "name": "alga",
+        "trans": [
+            "水藻"
+        ],
+        "usphone": "'ælgɚ",
+        "ukphone": "'ælgə"
+    },
+    {
+        "name": "algebra",
+        "trans": [
+            "代数"
+        ],
+        "usphone": "'ældʒɪbrə",
+        "ukphone": "'ældʒɪbrə"
+    },
+    {
+        "name": "alien",
+        "trans": [
+            "外星人；组织之外的人；外国人，"
+        ],
+        "usphone": "ˈeliən,ˈeljən",
+        "ukphone": "'eɪliən"
+    },
+    {
+        "name": "alienable",
+        "trans": [
+            "可转让的"
+        ],
+        "usphone": "'elɪənəbl",
+        "ukphone": "'eɪliənəbl"
+    },
+    {
+        "name": "alienate",
+        "trans": [
+            "使疏远， 使不友好； 转让， 让渡"
+        ],
+        "usphone": "'eiljəneit",
+        "ukphone": "'eɪliəneɪt"
+    },
+    {
+        "name": "align",
+        "trans": [
+            "结盟； 排整齐； 校准； 使一致"
+        ],
+        "usphone": "ə'laɪn",
+        "ukphone": "ə'laɪn"
+    },
+    {
+        "name": "alike",
+        "trans": [
+            "一样地，相似地；同样程度地",
+            "相同的， 相似的"
+        ],
+        "usphone": "ə'laɪk",
+        "ukphone": "ə'laɪk"
+    },
+    {
+        "name": "alkali",
+        "trans": [
+            "碱"
+        ],
+        "usphone": "'ælkə'lai",
+        "ukphone": "'ælkəlaɪ"
+    },
+    {
+        "name": "allay",
+        "trans": [
+            "减轻， 减少"
+        ],
+        "usphone": "ə'le",
+        "ukphone": "ə'leɪ"
+    },
+    {
+        "name": "allege",
+        "trans": [
+            "断言， 宣称"
+        ],
+        "usphone": "ə'lɛdʒ",
+        "ukphone": "ə'ledʒ"
+    },
+    {
+        "name": "allegiance",
+        "trans": [
+            "忠诚， 效忠， 拥戴"
+        ],
+        "usphone": "ə'lidʒəns",
+        "ukphone": "ə'liːdʒəns"
+    },
+    {
+        "name": "allergic",
+        "trans": [
+            "过敏的， 变态反应的； 对…讨厌的"
+        ],
+        "usphone": "ə'lɝdʒɪk",
+        "ukphone": "ə'lɜːrdʒɪk"
+    },
+    {
+        "name": "allergy",
+        "trans": [
+            "过敏性反应"
+        ],
+        "usphone": "'ælɚdʒi",
+        "ukphone": "'ælərdʒi"
+    },
+    {
+        "name": "alleviate",
+        "trans": [
+            "减轻， 缓解， 缓和"
+        ],
+        "usphone": "ə'livɪ'et",
+        "ukphone": "ə'liːvieɪt"
+    },
+    {
+        "name": "allocate",
+        "trans": [
+            "分配， 分派， 把…拨给"
+        ],
+        "usphone": "'æləket",
+        "ukphone": "'æləkeɪt"
+    },
+    {
+        "name": "allot",
+        "trans": [
+            "分配， 配给， 拨给"
+        ],
+        "usphone": "ə'lɑt",
+        "ukphone": "ə'lɑːt"
+    },
+    {
+        "name": "alloy",
+        "trans": [
+            "合金",
+            "使成合金"
+        ],
+        "usphone": "'ælɔɪ",
+        "ukphone": "'ælɒɪ"
+    },
+    {
+        "name": "allude",
+        "trans": [
+            "暗指， 影射， 间接提到"
+        ],
+        "usphone": "ə'lʊd",
+        "ukphone": "ə'luːd"
+    },
+    {
+        "name": "allure",
+        "trans": [
+            "诱惑， 吸引"
+        ],
+        "usphone": "əˈlʊr",
+        "ukphone": "ə'lur"
+    },
+    {
+        "name": "ally",
+        "trans": [
+            "结盟",
+            "同盟国； 结盟者， 支持者"
+        ],
+        "usphone": "'ælaɪ",
+        "ukphone": "'ælaɪ"
+    },
+    {
+        "name": "aloft",
+        "trans": [
+            "在高处； 在空中"
+        ],
+        "usphone": "ə'lɔft",
+        "ukphone": "ə'lɔːft"
+    },
+    {
+        "name": "along",
+        "trans": [
+            "向前；一起",
+            "沿着"
+        ],
+        "usphone": "ə'lɔŋ",
+        "ukphone": "ə'lɔːŋ"
+    },
+    {
+        "name": "aloof",
+        "trans": [
+            "远离的； 冷淡的， 冷漠的"
+        ],
+        "usphone": "ə'luf",
+        "ukphone": "ə'luːf"
+    },
+    {
+        "name": "alphabet",
+        "trans": [
+            "字母表"
+        ],
+        "usphone": "'ælfə'bɛt",
+        "ukphone": "'ælfəbet"
+    },
+    {
+        "name": "already",
+        "trans": [
+            "已， 已经"
+        ],
+        "usphone": "ɔl'rɛdi",
+        "ukphone": "ɔːl'redi"
+    },
+    {
+        "name": "alter",
+        "trans": [
+            "改变"
+        ],
+        "usphone": "'ɔltɚ",
+        "ukphone": "'ɔːltər"
+    },
+    {
+        "name": "alternate",
+        "trans": [
+            "轮流， 交替",
+            "交替的， 轮流的； 间隔的"
+        ],
+        "usphone": "ˈɔltɚˌnet;(for adj.)ˈɔ:ltərnət",
+        "ukphone": "ˈɔ:ltəneɪt;(for adj.)ɔ:lˈtɜ:nət"
+    },
+    {
+        "name": "alternative",
+        "trans": [
+            "可供替代的； 非传统的",
+            "可供选择的事物；选择的自由，选择的余地"
+        ],
+        "usphone": "ɔl'tɝnətɪv",
+        "ukphone": "ɔːl'tɜːrnətɪv"
+    },
+    {
+        "name": "altitude",
+        "trans": [
+            "海拔，高度；"
+        ],
+        "usphone": "'æltɪtud",
+        "ukphone": "'æltɪtjuːd"
+    },
+    {
+        "name": "altruistic",
+        "trans": [
+            "利他的， 无私心的， 为他人着想的"
+        ],
+        "usphone": ",æltrʊ'ɪstɪk",
+        "ukphone": "ˌæltru'ɪstɪk"
+    },
+    {
+        "name": "aluminum",
+        "trans": [
+            "铝"
+        ],
+        "usphone": "ə'lʊmɪnəm",
+        "ukphone": "ˌæljə'mɪniəm"
+    },
+    {
+        "name": "alumnus",
+        "trans": [
+            "校友，毕业生"
+        ],
+        "usphone": "ə'lʌmnəs",
+        "ukphone": "ə'lʌmnəs"
+    },
+    {
+        "name": "amalgamation",
+        "trans": [
+            "融合， 合并； 联合， 结合"
+        ],
+        "usphone": "ə,mælgə'meʃən",
+        "ukphone": "əˌmælgə'meɪʃn"
+    },
+    {
+        "name": "amass",
+        "trans": [
+            "积聚"
+        ],
+        "usphone": "ə'mæs",
+        "ukphone": "ə'mæs"
+    },
+    {
+        "name": "amateur",
+        "trans": [
+            "业余爱好的； 业余的",
+            "业余爱好者；外行"
+        ],
+        "usphone": "ˈæmətər",
+        "ukphone": "'æmətər"
+    },
+    {
+        "name": "ambience",
+        "trans": [
+            "周围环境， 气氛"
+        ],
+        "usphone": "'æmbɪəns",
+        "ukphone": "'æmbiəns"
+    },
+    {
+        "name": "ambient",
+        "trans": [
+            "周围的， 周围环境的； 产生轻松氛围的"
+        ],
+        "usphone": "'æmbɪənt",
+        "ukphone": "'æmbiənt"
+    },
+    {
+        "name": "ambiguity",
+        "trans": [
+            "模棱两可的话； 歧义"
+        ],
+        "usphone": ",æmbɪ'ɡjuəti",
+        "ukphone": "ˌæmbɪ'gjuːəti"
+    },
+    {
+        "name": "ambiguous",
+        "trans": [
+            "不明确的， 模棱两可的"
+        ],
+        "usphone": "æm'bɪɡjuəs",
+        "ukphone": "æm'bɪgjuəs"
+    },
+    {
+        "name": "ambitious",
+        "trans": [
+            "有雄心的， 有野心的"
+        ],
+        "usphone": "æm'bɪʃəs",
+        "ukphone": "æm'bɪʃəs"
+    },
+    {
+        "name": "ambivalent",
+        "trans": [
+            "对立的， 感情矛盾的"
+        ],
+        "usphone": "æm'bɪvələnt",
+        "ukphone": "æm'bɪvələnt"
+    },
+    {
+        "name": "amble",
+        "trans": [
+            "缓行， 漫步"
+        ],
+        "usphone": "'æmbl",
+        "ukphone": "'æmbl"
+    },
+    {
+        "name": "ambush",
+        "trans": [
+            "埋伏， 伏击"
+        ],
+        "usphone": "'æmbʊʃ",
+        "ukphone": "'æmbuʃ"
+    },
+    {
+        "name": "amenable",
+        "trans": [
+            "顺从的， 服从劝导的； 有服从义务的"
+        ],
+        "usphone": "ə'minəbl",
+        "ukphone": "ə'miːnəbl"
+    },
+    {
+        "name": "amend",
+        "trans": [
+            "修正， 修订"
+        ],
+        "usphone": "ə'mɛnd",
+        "ukphone": "ə'mend"
+    },
+    {
+        "name": "amenity",
+        "trans": [
+            "生活设施；便利设施"
+        ],
+        "usphone": "ə'mɛnəti",
+        "ukphone": "ə'menəti"
+    },
+    {
+        "name": "amiable",
+        "trans": [
+            "可爱的； 友好的， 和蔼的， 亲切的"
+        ],
+        "usphone": "'emɪəbl",
+        "ukphone": "'eɪmiəbl"
+    },
+    {
+        "name": "amid",
+        "trans": [
+            "在…中， 被…围绕"
+        ],
+        "usphone": "ə'mɪd",
+        "ukphone": "ə'mɪd"
+    },
+    {
+        "name": "amino",
+        "trans": [
+            "氨基的"
+        ],
+        "usphone": "ə'mino",
+        "ukphone": "ə'miːnou"
+    },
+    {
+        "name": "ammonia",
+        "trans": [
+            "氨， 氨水"
+        ],
+        "usphone": "ə'monɪə",
+        "ukphone": "ə'mouniə"
+    },
+    {
+        "name": "amount",
+        "trans": [
+            "总计",
+            "总额"
+        ],
+        "usphone": "ə'maʊnt",
+        "ukphone": "ə'maunt"
+    },
+    {
+        "name": "amphibious",
+        "trans": [
+            "两栖的； 水陆两用的"
+        ],
+        "usphone": "æm'fɪbɪəs",
+        "ukphone": "æm'fɪbiəs"
+    },
+    {
+        "name": "ample",
+        "trans": [
+            "富足的， 充足的， 丰富的； 宽敞的"
+        ],
+        "usphone": "'æmpl",
+        "ukphone": "'æmpl"
+    },
+    {
+        "name": "amplify",
+        "trans": [
+            "放大； 增强； 详述， 充实"
+        ],
+        "usphone": "'æmplɪfaɪ",
+        "ukphone": "'æmplɪfaɪ"
+    },
+    {
+        "name": "amusement",
+        "trans": [
+            "可笑； 娱乐， 消遣"
+        ],
+        "usphone": "ə'mjuzmənt",
+        "ukphone": "ə'mjuːzmənt"
+    },
+    {
+        "name": "analogy",
+        "trans": [
+            "类比， 类推"
+        ],
+        "usphone": "ə'nælədʒi",
+        "ukphone": "ə'nælədʒi"
+    },
+    {
+        "name": "analysis",
+        "trans": [
+            "分析； 分析报告； 分解"
+        ],
+        "usphone": "ə'næləsɪs",
+        "ukphone": "ə'næləsɪs"
+    },
+    {
+        "name": "analyze",
+        "trans": [
+            "分析， 研究"
+        ],
+        "usphone": "'ænə,laɪz",
+        "ukphone": "'ænəlaɪz"
+    },
+    {
+        "name": "anarchist",
+        "trans": [
+            "无政府主义者"
+        ],
+        "usphone": "'ænɚkɪst",
+        "ukphone": "'ænərkɪst"
+    },
+    {
+        "name": "anatomy",
+        "trans": [
+            "解剖； 解剖构造； 剖析"
+        ],
+        "usphone": "ə'nætəmi",
+        "ukphone": "ə'nætəmi"
+    },
+    {
+        "name": "ancestor",
+        "trans": [
+            "祖先， 祖宗； 原种； 原型"
+        ],
+        "usphone": "'ænsɛstɚ",
+        "ukphone": "'ænsestər"
+    },
+    {
+        "name": "anchor",
+        "trans": [
+            "抛锚；使固定；扎根，基于；主持",
+            "锚； 给人安全感的物， 精神支柱"
+        ],
+        "usphone": "'æŋkɚ",
+        "ukphone": "'æŋkər"
+    },
+    {
+        "name": "ancient",
+        "trans": [
+            "古代的； 古老的"
+        ],
+        "usphone": "ˈenʃənt",
+        "ukphone": "'eɪnʃənt"
+    },
+    {
+        "name": "anecdotal",
+        "trans": [
+            "轶话的， 逸闻趣事的"
+        ],
+        "usphone": ",ænɪk'dotl",
+        "ukphone": "ˌænɪk'doutl"
+    },
+    {
+        "name": "anecdote",
+        "trans": [
+            "秘闻； 轶事， 趣闻"
+        ],
+        "usphone": "'ænɪkdot",
+        "ukphone": "'ænɪkdout"
+    },
+    {
+        "name": "angiosperm",
+        "trans": [
+            "被子植物"
+        ],
+        "usphone": "'ændʒɪo,spɝm",
+        "ukphone": "'ændʒiouˌspɜːrm"
+    },
+    {
+        "name": "angle",
+        "trans": [
+            "把…放置成一角度； 使带上倾向性",
+            "角；角度，立场，观点"
+        ],
+        "usphone": "'æŋɡl",
+        "ukphone": "'æŋgl"
+    },
+    {
+        "name": "anguish",
+        "trans": [
+            "极度痛苦",
+            "极度痛苦"
+        ],
+        "usphone": "'æŋɡwɪʃ",
+        "ukphone": "'æŋgwɪʃ"
+    },
+    {
+        "name": "angular",
+        "trans": [
+            "有角的， 尖角的； 消瘦的， 瘦骨嶙峋的"
+        ],
+        "usphone": "'æŋɡjəlɚ",
+        "ukphone": "'æŋgjələr"
+    },
+    {
+        "name": "animate",
+        "trans": [
+            "活的， 有生命的",
+            "赋予生命， 使有活力"
+        ],
+        "usphone": "'ænɪmet",
+        "ukphone": "'ænɪmeɪt"
+    },
+    {
+        "name": "annex",
+        "trans": [
+            "兼并； 附加"
+        ],
+        "usphone": "əˈnɛks; æˈnɛks; (for n.) ˈænˌɛks",
+        "ukphone": "'æneks"
+    },
+    {
+        "name": "annotation",
+        "trans": [
+            "注释， 注解"
+        ],
+        "usphone": "ˌænəˈteʃən",
+        "ukphone": "ˌænə'teɪʃn"
+    },
+    {
+        "name": "announce",
+        "trans": [
+            "宣布； 通知； 声称， 宣称； 广播， 播音"
+        ],
+        "usphone": "ə'naʊns",
+        "ukphone": "ə'nauns"
+    },
+    {
+        "name": "annoyed",
+        "trans": [
+            "生气的"
+        ],
+        "usphone": "ə'nɔɪd",
+        "ukphone": "ə'nɔɪd"
+    },
+    {
+        "name": "annual",
+        "trans": [
+            "每年的，一年一度的",
+            "年报， 年刊， 年鉴； 一年生植物"
+        ],
+        "usphone": "'ænjuəl",
+        "ukphone": "'ænjuəl"
+    },
+    {
+        "name": "annul",
+        "trans": [
+            "宣布无效， 取消， 废除"
+        ],
+        "usphone": "ə'nʌl",
+        "ukphone": "ə'nʌl"
+    },
+    {
+        "name": "anomalous",
+        "trans": [
+            "异常的； 不规则的"
+        ],
+        "usphone": "ə'nɑmələs",
+        "ukphone": "ə'nɑːmələs"
+    },
+    {
+        "name": "anomaly",
+        "trans": [
+            "反常， 异常； 异常的人"
+        ],
+        "usphone": "ə'nɑməli",
+        "ukphone": "ə'nɑːməli"
+    },
+    {
+        "name": "anomie",
+        "trans": [
+            "社会道德沦丧， 失范； 混乱"
+        ],
+        "usphone": "'ænəmi",
+        "ukphone": "'ænəmi"
+    },
+    {
+        "name": "anonymous",
+        "trans": [
+            "匿名的， 不具名的； 无特色的， 无个性特征的"
+        ],
+        "usphone": "ə'nɑnəməs",
+        "ukphone": "ə'nɑːnɪməs"
+    },
+    {
+        "name": "antecede",
+        "trans": [
+            "居先； 高于"
+        ],
+        "usphone": ",ænti'si:d",
+        "ukphone": "ˌæntɪ'sɪːd"
+    },
+    {
+        "name": "antecedent",
+        "trans": [
+            "先行的",
+            "祖先，先辈"
+        ],
+        "usphone": "'æntə'sidnt",
+        "ukphone": "ˌæntɪ'siːdnt"
+    },
+    {
+        "name": "anthropology",
+        "trans": [
+            "人类学"
+        ],
+        "usphone": "'ænθrə'pɑlədʒi",
+        "ukphone": "ˌænθrə'pɑːlədʒi"
+    },
+    {
+        "name": "antibiotic",
+        "trans": [
+            "抗菌的"
+        ],
+        "usphone": ",æntɪbaɪ'ɑtɪk; ˌæntaɪ-",
+        "ukphone": "ˌæntibaɪ'ɑːtɪk"
+    },
+    {
+        "name": "anticipate",
+        "trans": [
+            "预见， 预期； 先于…行动"
+        ],
+        "usphone": "æn'tɪsə'pet",
+        "ukphone": "æn'tɪsɪpeɪt"
+    },
+    {
+        "name": "antique",
+        "trans": [
+            "古物，"
+        ],
+        "usphone": "æn'tik",
+        "ukphone": "æn'tiːk"
+    },
+    {
+        "name": "antonym",
+        "trans": [
+            "反义词"
+        ],
+        "usphone": "'æntənɪm",
+        "ukphone": "'æntənɪm"
+    },
+    {
+        "name": "anxious",
+        "trans": [
+            "渴望的； 担忧的； 令人焦虑的"
+        ],
+        "usphone": "'æŋkʃəs",
+        "ukphone": "'æŋkʃəs"
+    },
+    {
+        "name": "apartment",
+        "trans": [
+            "公寓套房； 房间"
+        ],
+        "usphone": "ə'pɑrtmənt",
+        "ukphone": "ə'pɑːrtmənt"
+    },
+    {
+        "name": "apologize",
+        "trans": [
+            "道歉， 认错； 辩解"
+        ],
+        "usphone": "ə'pɑlədʒaɪz",
+        "ukphone": "ə'pɑːlədʒaɪz"
+    },
+    {
+        "name": "apparatus",
+        "trans": [
+            "器械， 器具， 设备， 装置； 机构， 组织； 器官"
+        ],
+        "usphone": "ˌæpəˈrætəs",
+        "ukphone": "ˌæpə'rætəs"
+    },
+    {
+        "name": "apparent",
+        "trans": [
+            "显然的， 明显的； 表面上的， 貌似的"
+        ],
+        "usphone": "ə'pærənt",
+        "ukphone": "ə'pærənt"
+    },
+    {
+        "name": "appeal",
+        "trans": [
+            "上诉，起诉；呼吁，恳求；吸引",
+            "上诉， 申诉； 呼吁， 恳求； 感染力， 吸引力"
+        ],
+        "usphone": "ə'pil",
+        "ukphone": "ə'piːl"
+    },
+    {
+        "name": "appease",
+        "trans": [
+            "平息； 安抚， 抚慰； 绥靖"
+        ],
+        "usphone": "ə'piz",
+        "ukphone": "ə'piːz"
+    },
+    {
+        "name": "append",
+        "trans": [
+            "附加， 增补"
+        ],
+        "usphone": "ə'pɛnd",
+        "ukphone": "ə'pend"
+    },
+    {
+        "name": "appetite",
+        "trans": [
+            "胃口， 食欲； 欲望"
+        ],
+        "usphone": "'æpəˌtaɪt",
+        "ukphone": "'æpɪtaɪt"
+    },
+    {
+        "name": "applaud",
+        "trans": [
+            "鼓掌， 喝彩； 称赞"
+        ],
+        "usphone": "ə'plɔd",
+        "ukphone": "ə'plɔːd"
+    },
+    {
+        "name": "appliance",
+        "trans": [
+            "用具， 器具； 装置"
+        ],
+        "usphone": "ə'plaɪəns",
+        "ukphone": "ə'plaɪəns"
+    },
+    {
+        "name": "applicable",
+        "trans": [
+            "可应用的， 可实施的； 适当的， 合适的"
+        ],
+        "usphone": "'æplɪkəbl",
+        "ukphone": "ə'plɪkəbl"
+    },
+    {
+        "name": "applicant",
+        "trans": [
+            "申请者"
+        ],
+        "usphone": "'æplɪkənt",
+        "ukphone": "'æplɪkənt"
+    },
+    {
+        "name": "application",
+        "trans": [
+            "请求， 申请； 应用， 运用； 敷用"
+        ],
+        "usphone": "ˌæpləˈkeʃən",
+        "ukphone": "ˌæplɪ'keɪʃn"
+    },
+    {
+        "name": "apply",
+        "trans": [
+            "申请， 请求； 适用； 应用， 运用； 涂， 敷， 施"
+        ],
+        "usphone": "ə'plaɪ",
+        "ukphone": "ə'plaɪ"
+    },
+    {
+        "name": "appointment",
+        "trans": [
+            "约会， 约定； 任命， 委派； 职位"
+        ],
+        "usphone": "ə'pɔɪntmənt",
+        "ukphone": "ə'pɔɪntmənt"
+    },
+    {
+        "name": "apportion",
+        "trans": [
+            "分配； 分派"
+        ],
+        "usphone": "ə'pɔrʃən",
+        "ukphone": "ə'pɔːrʃn"
+    },
+    {
+        "name": "apportionment",
+        "trans": [
+            "分派， 分摊， 分配"
+        ],
+        "usphone": "ə'pɔrʃənmənt; ə'porʃənmənt",
+        "ukphone": "ə'pɔːrʃnmənt"
+    },
+    {
+        "name": "appraise",
+        "trans": [
+            "估价； 估量； 评价， 评定"
+        ],
+        "usphone": "ə'prez",
+        "ukphone": "ə'preɪz"
+    },
+    {
+        "name": "appreciate",
+        "trans": [
+            "赏识； 鉴赏， 欣赏； 感激"
+        ],
+        "usphone": "ə'priʃɪet",
+        "ukphone": "ə'priːʃieɪt"
+    },
+    {
+        "name": "appreciation",
+        "trans": [
+            "欣赏； 理解， 体谅； 感激； 鉴定， 评价"
+        ],
+        "usphone": "ə,priʃɪ'eʃən",
+        "ukphone": "əˌpriːʃi'eɪʃn"
+    },
+    {
+        "name": "apprehend",
+        "trans": [
+            "逮捕； 领会， 理解"
+        ],
+        "usphone": ",æprɪ'hɛnd",
+        "ukphone": "ˌæprɪ'hend"
+    },
+    {
+        "name": "apprenticeship",
+        "trans": [
+            "学徒的身份； 学徒的年限"
+        ],
+        "usphone": "ə'prɛntɪʃɪp",
+        "ukphone": "ə'prentɪʃɪp"
+    },
+    {
+        "name": "apprise",
+        "trans": [
+            "通知， 告诉"
+        ],
+        "usphone": "ə'praiz",
+        "ukphone": "ə'praɪz"
+    },
+    {
+        "name": "approach",
+        "trans": [
+            "接近；"
+        ],
+        "usphone": "ə'protʃ",
+        "ukphone": "ə'proutʃ"
+    },
+    {
+        "name": "appropriate",
+        "trans": [
+            "适当的",
+            "拨款； 占用， 挪用"
+        ],
+        "usphone": "əˈproprɪət;(for v.) əˈproprɪet",
+        "ukphone": "əˈprəʊprɪət;(for v.)əˈprəʊprɪeɪt"
+    },
+    {
+        "name": "approve",
+        "trans": [
+            "批准； 赞成"
+        ],
+        "usphone": "ə'prʊv",
+        "ukphone": "ə'pruːv"
+    },
+    {
+        "name": "approximate",
+        "trans": [
+            "大约的， 近似的",
+            "接近， 近似"
+        ],
+        "usphone": "ə'prɑksɪmət",
+        "ukphone": "ə'prɒksɪmət"
+    },
+    {
+        "name": "approximation",
+        "trans": [
+            "接近； 近似值"
+        ],
+        "usphone": "ə'prɑksə'meʃən",
+        "ukphone": "əˌprɑːksɪ'meɪʃn"
+    },
+    {
+        "name": "aptitude",
+        "trans": [
+            "适合， 恰当； 天资， 才能， 资质"
+        ],
+        "usphone": "ˈæptɪˌtud, -ˌtjud",
+        "ukphone": "'æptɪtjuːd"
+    },
+    {
+        "name": "aquarium",
+        "trans": [
+            "养鱼缸； 水族馆"
+        ],
+        "usphone": "ə'kwɛrɪəm",
+        "ukphone": "ə'kweriəm"
+    },
+    {
+        "name": "aquatic",
+        "trans": [
+            "水生的； 水上的"
+        ],
+        "usphone": "ə'kwætɪk",
+        "ukphone": "ə'kwætɪk"
+    },
+    {
+        "name": "aquifer",
+        "trans": [
+            "含水土层"
+        ],
+        "usphone": "'ækwɪfɚ",
+        "ukphone": "'ækwɪfər"
+    },
+    {
+        "name": "arable",
+        "trans": [
+            "可耕作的，适于耕作的",
+            "可耕地"
+        ],
+        "usphone": "'ærəbl",
+        "ukphone": "'ærəbl"
+    },
+    {
+        "name": "arbitrary",
+        "trans": [
+            "任意的； 专制的， 专断的"
+        ],
+        "usphone": "ˈɑːrbətreri",
+        "ukphone": "'ɑːrbətreri"
+    },
+    {
+        "name": "arboreal",
+        "trans": [
+            "树栖的； 树木的"
+        ],
+        "usphone": "ɑr'bɔrɪəl",
+        "ukphone": "ɑːr'bɔːriəl"
+    },
+    {
+        "name": "archaeology",
+        "trans": [
+            "考古学"
+        ],
+        "usphone": ",ɑrkɪ'ɑlədʒi",
+        "ukphone": "ˌɑːrki'ɑːlədʒi"
+    },
+    {
+        "name": "architect",
+        "trans": [
+            "建筑师； 设计师， 缔造者"
+        ],
+        "usphone": "'ɑrkɪtɛkt",
+        "ukphone": "'ɑːrkɪtekt"
+    },
+    {
+        "name": "archive",
+        "trans": [
+            "档案室",
+            "存档"
+        ],
+        "usphone": "'ɑrkaɪv",
+        "ukphone": "'ɑːrkaɪv"
+    },
+    {
+        "name": "ardent",
+        "trans": [
+            "热心的， 热情洋溢的"
+        ],
+        "usphone": "'ɑrdnt",
+        "ukphone": "'ɑːrdnt"
+    },
+    {
+        "name": "arduous",
+        "trans": [
+            "费力的， 艰巨的"
+        ],
+        "usphone": "'ɑrdʒuəs",
+        "ukphone": "'ɑːrdʒuəs"
+    },
+    {
+        "name": "argue",
+        "trans": [
+            "争论， 辩论； 主张， 论证； 说服， 劝说"
+        ],
+        "usphone": "'ɑrgjʊ",
+        "ukphone": "'ɑːrgjuː"
+    },
+    {
+        "name": "aria",
+        "trans": [
+            "独唱曲， 咏叹调"
+        ],
+        "usphone": "'ɑrɪə",
+        "ukphone": "'ɑːriə"
+    },
+    {
+        "name": "arid",
+        "trans": [
+            "干旱的； 贫瘠的； 无趣的"
+        ],
+        "usphone": "'ærɪd",
+        "ukphone": "'ærɪd"
+    },
+    {
+        "name": "aristocratic",
+        "trans": [
+            "贵族的， 有贵族气派的"
+        ],
+        "usphone": "ə,rɪstə'krætɪk",
+        "ukphone": "əˌrɪstə'krætɪk"
+    },
+    {
+        "name": "arithmetic",
+        "trans": [
+            "算术"
+        ],
+        "usphone": "ə'rɪθmətɪk",
+        "ukphone": "ə'rɪθmətɪk"
+    },
+    {
+        "name": "aroma",
+        "trans": [
+            "芳香， 香味； 气氛， 氛围"
+        ],
+        "usphone": "ə'romə",
+        "ukphone": "ə'roumə"
+    },
+    {
+        "name": "arouse",
+        "trans": [
+            "唤醒， 唤起； 激起， 引起"
+        ],
+        "usphone": "ə'raʊz",
+        "ukphone": "ə'rauz"
+    },
+    {
+        "name": "arrange",
+        "trans": [
+            "布置； 安排， 筹备"
+        ],
+        "usphone": "ə'rendʒ",
+        "ukphone": "ə'reɪndʒ"
+    },
+    {
+        "name": "array",
+        "trans": [
+            "一系列；阵列",
+            "布置， 排列； 部署"
+        ],
+        "usphone": "ə're",
+        "ukphone": "ə'reɪ"
+    },
+    {
+        "name": "arrest",
+        "trans": [
+            "逮捕， 拘留； 停止， 阻止； 吸引"
+        ],
+        "usphone": "ə'rɛst",
+        "ukphone": "ə'rest"
+    },
+    {
+        "name": "arrogant",
+        "trans": [
+            "傲慢的， 自大的"
+        ],
+        "usphone": "'ærəɡənt",
+        "ukphone": "'ærəgənt"
+    },
+    {
+        "name": "artesian",
+        "trans": [
+            "自流水的， 喷水的"
+        ],
+        "usphone": "ɑr'tiʒən",
+        "ukphone": "ɑːr'tiːʒn"
+    },
+    {
+        "name": "arthritis",
+        "trans": [
+            "关节炎"
+        ],
+        "usphone": "ɑr'θraɪtɪs",
+        "ukphone": "ɑːr'θraɪtɪs"
+    },
+    {
+        "name": "articulate",
+        "trans": [
+            "善于表达的； 发音清晰的， 口齿清楚的",
+            "明确表达， 清楚说明； 清晰地吐， 清晰地发； 用关节连接"
+        ],
+        "usphone": "ɑr'tɪkjulet",
+        "ukphone": "ɑ:'tɪkjʊleɪt"
+    },
+    {
+        "name": "artifact",
+        "trans": [
+            "人工制品， 手工艺品"
+        ],
+        "usphone": "'ɑrtə,fækt",
+        "ukphone": "'ɑːrtɪfækt"
+    },
+    {
+        "name": "artifice",
+        "trans": [
+            "诡计， 奸计； 策略"
+        ],
+        "usphone": "'ɑrtɪfɪs",
+        "ukphone": "'ɑːrtɪfɪs"
+    },
+    {
+        "name": "artificial",
+        "trans": [
+            "人工的， 人造的， 假的； 矫揉造作的， 假装"
+        ],
+        "usphone": ",ɑrtɪ'fɪʃl",
+        "ukphone": "ˌɑːrtɪ'fɪʃl"
+    },
+    {
+        "name": "artisan",
+        "trans": [
+            "工匠， 手艺人"
+        ],
+        "usphone": "'ɑrtəzn",
+        "ukphone": "'ɑːrtəzn"
+    },
+    {
+        "name": "artistic",
+        "trans": [
+            "艺术的； 富有艺术性的， 精美的； 有艺术天赋的"
+        ],
+        "usphone": "ɑr'tɪstɪk",
+        "ukphone": "ɑːr'tɪstɪk"
+    },
+    {
+        "name": "ascend",
+        "trans": [
+            "上升， 升高； 攀登"
+        ],
+        "usphone": "ə'sɛnd",
+        "ukphone": "ə'send"
+    },
+    {
+        "name": "ascertain",
+        "trans": [
+            "弄清， 查明"
+        ],
+        "usphone": "'æsɚ'ten",
+        "ukphone": "ˌæsər'teɪn"
+    },
+    {
+        "name": "ascribe",
+        "trans": [
+            "把…归于； 归咎于"
+        ],
+        "usphone": "ə'skraɪb",
+        "ukphone": "ə'skraɪb"
+    },
+    {
+        "name": "aspect",
+        "trans": [
+            "方面； 朝向， 方向； 外表， 外观"
+        ],
+        "usphone": "'æspɛkt",
+        "ukphone": "'æspekt"
+    },
+    {
+        "name": "aspire",
+        "trans": [
+            "有志于； 热望， 向往"
+        ],
+        "usphone": "ə'spaɪr",
+        "ukphone": "ə'spaɪər"
+    },
+    {
+        "name": "assail",
+        "trans": [
+            "抨击， 指责； 猛攻； 困扰"
+        ],
+        "usphone": "ə'sel",
+        "ukphone": "ə'seɪl"
+    },
+    {
+        "name": "assassinate",
+        "trans": [
+            "暗杀， 行刺； 诋毁"
+        ],
+        "usphone": "ə'sæsn'et",
+        "ukphone": "ə'sæsəneɪt"
+    },
+    {
+        "name": "assemble",
+        "trans": [
+            "集合； 装配"
+        ],
+        "usphone": "ə'sɛmbl",
+        "ukphone": "ə'sembl"
+    },
+    {
+        "name": "assembly",
+        "trans": [
+            "集会； 集会者； 装配， 安装； 立法机构， 议会"
+        ],
+        "usphone": "ə'sɛmbli",
+        "ukphone": "ə'sembli"
+    },
+    {
+        "name": "assent",
+        "trans": [
+            "同意， 赞成"
+        ],
+        "usphone": "ə'sɛnt",
+        "ukphone": "ə'sent"
+    },
+    {
+        "name": "assert",
+        "trans": [
+            "断言， 声称"
+        ],
+        "usphone": "ə'sɝt",
+        "ukphone": "ə'sɜːrt"
+    },
+    {
+        "name": "assess",
+        "trans": [
+            "估价； 评定"
+        ],
+        "usphone": "ə'sɛs",
+        "ukphone": "ə'ses"
+    },
+    {
+        "name": "asset",
+        "trans": [
+            "资产， 财产； 有价值的人； 长处， 优点"
+        ],
+        "usphone": "'æsɛt",
+        "ukphone": "'æset"
+    },
+    {
+        "name": "assign",
+        "trans": [
+            "指派； 指定； 分配； 布置"
+        ],
+        "usphone": "ə'saɪn",
+        "ukphone": "ə'saɪn"
+    },
+    {
+        "name": "assimilate",
+        "trans": [
+            "透彻理解， 吸收， 消化； 同化"
+        ],
+        "usphone": "ə'sɪməlet",
+        "ukphone": "ə'sɪməleɪt"
+    },
+    {
+        "name": "assimilation",
+        "trans": [
+            "同化； 吸收"
+        ],
+        "usphone": "əˌsɪməˈleʃən",
+        "ukphone": "əˌsɪmə'leɪʃn"
+    },
+    {
+        "name": "assistance",
+        "trans": [
+            "帮助， 援助"
+        ],
+        "usphone": "ə'sɪstəns",
+        "ukphone": "ə'sɪstəns"
+    },
+    {
+        "name": "assistant",
+        "trans": [
+            "辅助的，助理的；副的",
+            "助手， 助教"
+        ],
+        "usphone": "ə'sɪstənt",
+        "ukphone": "ə'sɪstənt"
+    },
+    {
+        "name": "associate",
+        "trans": [
+            "结交； 关联",
+            "副的；合伙的",
+            "伙伴"
+        ],
+        "usphone": "ə'soʃɪet",
+        "ukphone": "ə'səʊʃɪeɪt; -sɪeɪt"
+    },
+    {
+        "name": "associative",
+        "trans": [
+            "联想的； 结合的； 关联的"
+        ],
+        "usphone": "ə'soʃɪətɪv",
+        "ukphone": "ə'souʃiətɪv"
+    },
+    {
+        "name": "assortment",
+        "trans": [
+            "分类； 各种各样"
+        ],
+        "usphone": "ə'sɔrtmənt",
+        "ukphone": "ə'sɔːrtmənt"
+    },
+    {
+        "name": "assume",
+        "trans": [
+            "假定； 承担"
+        ],
+        "usphone": "ə'sum",
+        "ukphone": "ə'suːm"
+    },
+    {
+        "name": "assure",
+        "trans": [
+            "确保； 使确信"
+        ],
+        "usphone": "ə'ʃʊr",
+        "ukphone": "ə'ʃur"
+    },
+    {
+        "name": "asteroid",
+        "trans": [
+            "小行星"
+        ],
+        "usphone": "'æstərɔɪd",
+        "ukphone": "'æstərɔɪd"
+    },
+    {
+        "name": "asthma",
+        "trans": [
+            "哮喘"
+        ],
+        "usphone": "'æzmə",
+        "ukphone": "'æzmə"
+    },
+    {
+        "name": "astronomical",
+        "trans": [
+            "天文学的； 极大的， 庞大的"
+        ],
+        "usphone": ",æstrə'nɑmɪkl",
+        "ukphone": "ˌæstrə'nɑːmɪkl"
+    },
+    {
+        "name": "astronomy",
+        "trans": [
+            "天文学"
+        ],
+        "usphone": "ə'strɑnəmi",
+        "ukphone": "ə'strɑːnəmi"
+    },
+    {
+        "name": "astute",
+        "trans": [
+            "机敏的， 精明的"
+        ],
+        "usphone": "ə'stut",
+        "ukphone": "ə'stuːt"
+    },
+    {
+        "name": "asymmetrical",
+        "trans": [
+            "不均匀的， 不对称的"
+        ],
+        "usphone": ",esɪ'mɛtrɪkl",
+        "ukphone": "ˌeɪsɪ'metrɪkl"
+    },
+    {
+        "name": "athlete",
+        "trans": [
+            "运动员， 体育家"
+        ],
+        "usphone": "'æθlit",
+        "ukphone": "'æθliːt"
+    },
+    {
+        "name": "atmosphere",
+        "trans": [
+            "大气， 大气层； 空气； 气氛， 氛围"
+        ],
+        "usphone": "'ætməsfɪr",
+        "ukphone": "'ætməsfɪr"
+    },
+    {
+        "name": "atom",
+        "trans": [
+            "原子； 微粒， 微量"
+        ],
+        "usphone": "'ætəm",
+        "ukphone": "'ætəm"
+    },
+    {
+        "name": "atomic",
+        "trans": [
+            "原子的； 原子能的"
+        ],
+        "usphone": "ə'tɑmɪk",
+        "ukphone": "ə'tɑːmɪk"
+    },
+    {
+        "name": "atrophy",
+        "trans": [
+            "萎缩"
+        ],
+        "usphone": "'ætrəfi",
+        "ukphone": "'ætrəfi"
+    },
+    {
+        "name": "attach",
+        "trans": [
+            "连接； 依附于； 系， 贴， 连接； 使依恋， 使喜爱 ； 认为有"
+        ],
+        "usphone": "ə'tætʃ",
+        "ukphone": "ə'tætʃ"
+    },
+    {
+        "name": "attain",
+        "trans": [
+            "达到； 获得"
+        ],
+        "usphone": "ə'ten",
+        "ukphone": "ə'teɪn"
+    },
+    {
+        "name": "attempt",
+        "trans": [
+            "尝试； 努力"
+        ],
+        "usphone": "ə'tɛmpt",
+        "ukphone": "ə'tempt"
+    },
+    {
+        "name": "attend",
+        "trans": [
+            "出席， 参加； 照料， 看管； 专心， 注意； 陪同"
+        ],
+        "usphone": "ə'tɛnd",
+        "ukphone": "ə'tend"
+    },
+    {
+        "name": "attention",
+        "trans": [
+            "注意， 留心； 立正"
+        ],
+        "usphone": "ə'tɛnʃən",
+        "ukphone": "ə'tenʃn"
+    },
+    {
+        "name": "attentive",
+        "trans": [
+            "注意的， 专心的； 关心的"
+        ],
+        "usphone": "ə'tɛntɪv",
+        "ukphone": "ə'tentɪv"
+    },
+    {
+        "name": "attire",
+        "trans": [
+            "穿着，服饰",
+            "给…穿衣， 打扮"
+        ],
+        "usphone": "ə'taiə",
+        "ukphone": "ə'taɪər"
+    },
+    {
+        "name": "attorney",
+        "trans": [
+            "辩护律师； 代理人"
+        ],
+        "usphone": "ə'tɝni",
+        "ukphone": "ə'tɜːrni"
+    },
+    {
+        "name": "attract",
+        "trans": [
+            "吸引"
+        ],
+        "usphone": "ə'trækt",
+        "ukphone": "ə'trækt"
+    },
+    {
+        "name": "attractive",
+        "trans": [
+            "吸引人的， 有魅力的； 引起注意的"
+        ],
+        "usphone": "ə'træktɪv",
+        "ukphone": "ə'træktɪv"
+    },
+    {
+        "name": "attribute",
+        "trans": [
+            "属性， 特征",
+            "把…归于"
+        ],
+        "usphone": "ə'trɪbjut",
+        "ukphone": "ə'trɪbjuːt"
+    },
+    {
+        "name": "auction",
+        "trans": [
+            "拍卖"
+        ],
+        "usphone": "'ɔkʃən",
+        "ukphone": "'ɔːkʃn"
+    },
+    {
+        "name": "audible",
+        "trans": [
+            "听得见的"
+        ],
+        "usphone": "'ɔdəbl",
+        "ukphone": "'ɔːdəbl"
+    },
+    {
+        "name": "audience",
+        "trans": [
+            "听众； 观众； 读者"
+        ],
+        "usphone": "'ɔdɪəns",
+        "ukphone": "'ɔːdiəns"
+    },
+    {
+        "name": "audio",
+        "trans": [
+            "音频的； 声音的"
+        ],
+        "usphone": "'ɔdɪo",
+        "ukphone": "'ɔːdiou"
+    },
+    {
+        "name": "audit",
+        "trans": [
+            "旁听； 审计"
+        ],
+        "usphone": "'ɔdɪt",
+        "ukphone": "'ɔːdɪt"
+    },
+    {
+        "name": "audition",
+        "trans": [
+            "旁听； 试演"
+        ],
+        "usphone": "ɔ'dɪʃən",
+        "ukphone": "ɔː'dɪʃn"
+    },
+    {
+        "name": "auditorium",
+        "trans": [
+            "礼堂； 观众席"
+        ],
+        "usphone": ",ɔdɪ'tɔrɪəm",
+        "ukphone": "ˌɔːdɪ'tɔːriəm"
+    },
+    {
+        "name": "auditory",
+        "trans": [
+            "耳的； 听觉的"
+        ],
+        "usphone": "'ɔdətɔri",
+        "ukphone": "'ɔːdətɔːri"
+    },
+    {
+        "name": "augment",
+        "trans": [
+            "增加， 提高"
+        ],
+        "usphone": "ɔɡ'mɛnt",
+        "ukphone": "ɔːg'ment"
+    },
+    {
+        "name": "aurora",
+        "trans": [
+            "极光"
+        ],
+        "usphone": "ɔ:'rɔ:rə",
+        "ukphone": "ɔː'rɔːrə"
+    },
+    {
+        "name": "auspicious",
+        "trans": [
+            "吉兆的， 吉利的； 幸运的"
+        ],
+        "usphone": "ɔ'spɪʃəs",
+        "ukphone": "ɔː'spɪʃəs"
+    },
+    {
+        "name": "authentic",
+        "trans": [
+            "真正的， 真实的； 逼真的； 可靠的"
+        ],
+        "usphone": "ɔ'θɛntɪk",
+        "ukphone": "ɔː'θentɪk"
+    },
+    {
+        "name": "authoritative",
+        "trans": [
+            "官方的； 权威性的， 可信的； 专断的， 命令式的"
+        ],
+        "usphone": "ə'θɔrətetɪv",
+        "ukphone": "ə'θɔːrəteɪtɪv"
+    },
+    {
+        "name": "authority",
+        "trans": [
+            "权力，管辖权；"
+        ],
+        "usphone": "ə'θɔrəti",
+        "ukphone": "ə'θɔːrəti"
+    },
+    {
+        "name": "authorize",
+        "trans": [
+            "授权； 批准， 许可"
+        ],
+        "usphone": "'ɔθəraɪz",
+        "ukphone": "'ɔːθəraɪz"
+    },
+    {
+        "name": "automatic",
+        "trans": [
+            "自动的；无意识的；必然的，自然的",
+            "自动手枪； 自动换挡汽车"
+        ],
+        "usphone": "'ɔtə'mætɪk",
+        "ukphone": "ˌɔːtə'mætɪk"
+    },
+    {
+        "name": "automobile",
+        "trans": [
+            "汽车， 机动车"
+        ],
+        "usphone": ",ɔtəmə'bil",
+        "ukphone": "'ɔːtəməbiːl"
+    },
+    {
+        "name": "autonomous",
+        "trans": [
+            "自治的； 独立自主的"
+        ],
+        "usphone": "ɔ'tɑnəməs",
+        "ukphone": "ɔː'tɑːnəməs"
+    },
+    {
+        "name": "autonomy",
+        "trans": [
+            "自治， 自治权； 自主， 自主权"
+        ],
+        "usphone": "ɔ'tɑnəmi",
+        "ukphone": "ɔː'tɑːnəmi"
+    },
+    {
+        "name": "auxiliary",
+        "trans": [
+            "辅助的， 补助的， 补充的； 备用的， 后备的"
+        ],
+        "usphone": "ɔːɡ'zɪlɪəri",
+        "ukphone": "ɔːg'zɪliəri"
+    },
+    {
+        "name": "available",
+        "trans": [
+            "可得到的， 可找到的； 有空的"
+        ],
+        "usphone": "ə'veləbl",
+        "ukphone": "ə'veɪləbl"
+    },
+    {
+        "name": "avalanche",
+        "trans": [
+            "雪崩； 山崩"
+        ],
+        "usphone": "'ævəlæntʃ",
+        "ukphone": "'ævəlæntʃ"
+    },
+    {
+        "name": "avenge",
+        "trans": [
+            "复仇， 报仇； 向…报仇"
+        ],
+        "usphone": "ə'vɛndʒ",
+        "ukphone": "ə'vendʒ"
+    },
+    {
+        "name": "avenue",
+        "trans": [
+            "途径， 手段； 大街"
+        ],
+        "usphone": "'ævənu",
+        "ukphone": "'ævənjuː"
+    },
+    {
+        "name": "average",
+        "trans": [
+            "平均的；一般的；平庸的",
+            "平均为",
+            "平均水平；平均数"
+        ],
+        "usphone": "'ævərɪdʒ",
+        "ukphone": "'ævərɪdʒ"
+    },
+    {
+        "name": "avert",
+        "trans": [
+            "避免， 规避； 转移"
+        ],
+        "usphone": "ə'vɝt",
+        "ukphone": "ə'vɜːrt"
+    },
+    {
+        "name": "aviation",
+        "trans": [
+            "航空， 航空学； 飞行"
+        ],
+        "usphone": ",evɪ'eʃən",
+        "ukphone": "ˌeɪvi'eɪʃn"
+    },
+    {
+        "name": "avoid",
+        "trans": [
+            "避免， 规避"
+        ],
+        "usphone": "ə'vɔɪd",
+        "ukphone": "ə'vɔɪd"
+    },
+    {
+        "name": "awake",
+        "trans": [
+            "唤醒；醒；觉醒，醒悟",
+            "醒着的； 警觉的"
+        ],
+        "usphone": "ə'wek",
+        "ukphone": "ə'weɪk"
+    },
+    {
+        "name": "aware",
+        "trans": [
+            "知道的； 意识到的"
+        ],
+        "usphone": "ə'wɛr",
+        "ukphone": "ə'wer"
+    },
+    {
+        "name": "awareness",
+        "trans": [
+            "知道， 意识， 察觉"
+        ],
+        "usphone": "ə'wɛrnəs",
+        "ukphone": "ə'wernəs"
+    },
+    {
+        "name": "awesome",
+        "trans": [
+            "使人敬畏的； 使人恐惧的"
+        ],
+        "usphone": "'ɔsəm",
+        "ukphone": "'ɔːsəm"
+    },
+    {
+        "name": "awful",
+        "trans": [
+            "不舒服的； 糟糕的； 可怕的； 非常的"
+        ],
+        "usphone": "'ɔfl",
+        "ukphone": "'ɔːfl"
+    },
+    {
+        "name": "awkward",
+        "trans": [
+            "别扭的； 笨拙的； 难处理的， 棘手的； 难操纵的"
+        ],
+        "usphone": "'ɔkwɚd",
+        "ukphone": "'ɔːkwərd"
+    },
+    {
+        "name": "axis",
+        "trans": [
+            "轴； 轴线， 中心线"
+        ],
+        "usphone": "'æksɪs",
+        "ukphone": "'æksɪs"
+    },
+    {
+        "name": "babble",
+        "trans": [
+            "胡言乱语； 含糊不清地说； 喋喋不休"
+        ],
+        "usphone": "'bæbl",
+        "ukphone": "'bæbl"
+    },
+    {
+        "name": "Babylonian",
+        "trans": [
+            "巴比伦的；奢华的",
+            "巴比伦人"
+        ],
+        "usphone": ",bæbi'ləunjən",
+        "ukphone": "ˌbæbɪ'ləunɪən"
+    },
+    {
+        "name": "backhand",
+        "trans": [
+            "反手击球"
+        ],
+        "usphone": "'bæk'hænd",
+        "ukphone": "'bækhænd"
+    },
+    {
+        "name": "backlighting",
+        "trans": [
+            "逆光"
+        ],
+        "usphone": "'bæk,laitiŋ",
+        "ukphone": "bæk'laɪtɪŋ"
+    },
+    {
+        "name": "backup",
+        "trans": [
+            "后援，增援；"
+        ],
+        "usphone": "'bæk,ʌp",
+        "ukphone": "'bækʌp"
+    },
+    {
+        "name": "bacon",
+        "trans": [
+            "咸肉， 熏肉"
+        ],
+        "usphone": "'bekən",
+        "ukphone": "'beɪkən"
+    },
+    {
+        "name": "bacteria",
+        "trans": [
+            "细菌"
+        ],
+        "usphone": "bæk'tɪrɪə",
+        "ukphone": "bæk'tɪriə"
+    },
+    {
+        "name": "baffle",
+        "trans": [
+            "使困惑， 难住"
+        ],
+        "usphone": "'bæfl",
+        "ukphone": "'bæfl"
+    },
+    {
+        "name": "bagel",
+        "trans": [
+            "硬面包圈"
+        ],
+        "usphone": "'beɡl",
+        "ukphone": "'beɪgl"
+    },
+    {
+        "name": "bait",
+        "trans": [
+            "鱼饵，诱饵",
+            "下诱饵； 激怒"
+        ],
+        "usphone": "bet",
+        "ukphone": "beɪt"
+    },
+    {
+        "name": "bake",
+        "trans": [
+            "烘， 烤， 焙"
+        ],
+        "usphone": "bek",
+        "ukphone": "beɪk"
+    },
+    {
+        "name": "balance",
+        "trans": [
+            "使平衡，使均衡",
+            "天平， 秤； 平衡； 差额； 余款"
+        ],
+        "usphone": "'bæləns",
+        "ukphone": "'bæləns"
+    },
+    {
+        "name": "balcony",
+        "trans": [
+            "阳台； 楼厅， 楼座"
+        ],
+        "usphone": "'bælkənɪ",
+        "ukphone": "'bælkəni"
+    },
+    {
+        "name": "bald",
+        "trans": [
+            "光秃的， 秃头的； 简单的， 单调的"
+        ],
+        "usphone": "bɔld",
+        "ukphone": "bɔːld"
+    },
+    {
+        "name": "balk",
+        "trans": [
+            "畏缩； 阻止； 妨碍",
+            "障碍"
+        ],
+        "usphone": "bɔk",
+        "ukphone": "bɔːk"
+    },
+    {
+        "name": "balm",
+        "trans": [
+            "香脂油， 药膏； 镇痛剂， 安慰剂"
+        ],
+        "usphone": "bɑm",
+        "ukphone": "bɑːm"
+    },
+    {
+        "name": "band",
+        "trans": [
+            "联合，集合",
+            "乐队； 群， 伙； 带； 波段， 频带"
+        ],
+        "usphone": "bænd",
+        "ukphone": "bænd"
+    },
+    {
+        "name": "bandanna",
+        "trans": [
+            "色彩鲜艳的围巾"
+        ],
+        "usphone": "bæn'dænə",
+        "ukphone": "bæn'dænə"
+    },
+    {
+        "name": "banner",
+        "trans": [
+            "横幅"
+        ],
+        "usphone": "'bænɚ",
+        "ukphone": "'bænər"
+    },
+    {
+        "name": "barb",
+        "trans": [
+            "鱼钩， 倒钩； 挖苦的话"
+        ],
+        "usphone": "bɑrb",
+        "ukphone": "bɑːrb"
+    },
+    {
+        "name": "barbecue",
+        "trans": [
+            "在烤架上烧烤",
+            "烧烤野餐；金属烤架"
+        ],
+        "usphone": "'bɑrbɪkju",
+        "ukphone": "'bɑːrbɪkjuː"
+    },
+    {
+        "name": "barber",
+        "trans": [
+            "为…理发； 当理发师",
+            "理发师"
+        ],
+        "usphone": "'bɑrbɚ",
+        "ukphone": "'bɑːrbər"
+    },
+    {
+        "name": "bare",
+        "trans": [
+            "赤裸的；光秃的，无遮盖的；最基本的",
+            "脱掉； 显露"
+        ],
+        "usphone": "bɛr",
+        "ukphone": "ber"
+    },
+    {
+        "name": "bargain",
+        "trans": [
+            "讨价还价",
+            "特价商品，廉价货；协议；交易"
+        ],
+        "usphone": "ˈbɑrɡɪn",
+        "ukphone": "'bɑːrgən"
+    },
+    {
+        "name": "barge",
+        "trans": [
+            "冲撞，乱闯",
+            "驳船"
+        ],
+        "usphone": "bɑrdʒ",
+        "ukphone": "bɑːrdʒ"
+    },
+    {
+        "name": "bark",
+        "trans": [
+            "吠叫； 厉声质问",
+            "树皮；犬吠声"
+        ],
+        "usphone": "bɑrk",
+        "ukphone": "bɑːrk"
+    },
+    {
+        "name": "barn",
+        "trans": [
+            "谷仓； 牲口棚"
+        ],
+        "usphone": "bɑrn",
+        "ukphone": "bɑːrn"
+    },
+    {
+        "name": "barrel",
+        "trans": [
+            "桶"
+        ],
+        "usphone": "'bærəl",
+        "ukphone": "'bærəl"
+    },
+    {
+        "name": "barren",
+        "trans": [
+            "贫瘠的， 荒芜的； 不结果实的， 不育的"
+        ],
+        "usphone": "'bærən",
+        "ukphone": "'bærən"
+    },
+    {
+        "name": "barrier",
+        "trans": [
+            "屏障， 障碍物； 检票口； 障碍， 阻力； 隔阂"
+        ],
+        "usphone": "'bærɪɚ",
+        "ukphone": "'bæriər"
+    },
+    {
+        "name": "barter",
+        "trans": [
+            "实物交易， 以物易物"
+        ],
+        "usphone": "'bɑrtɚ",
+        "ukphone": "'bɑːrtər"
+    },
+    {
+        "name": "base",
+        "trans": [
+            "卑鄙的， 不道德的",
+            "把设在；"
+        ],
+        "usphone": "bes",
+        "ukphone": "beɪs"
+    },
+    {
+        "name": "basement",
+        "trans": [
+            "地下室， 地窖； 建筑物的底部"
+        ],
+        "usphone": "'besmənt",
+        "ukphone": "'beɪsmənt"
+    },
+    {
+        "name": "basic",
+        "trans": [
+            "基本的， 基础的； 初步的， 初级的"
+        ],
+        "usphone": "'besɪk",
+        "ukphone": "'beɪsɪk"
+    },
+    {
+        "name": "basin",
+        "trans": [
+            "盆， 脸盆； 盆地； 流域"
+        ],
+        "usphone": "'besn",
+        "ukphone": "'beɪsn"
+    },
+    {
+        "name": "batch",
+        "trans": [
+            "分批处理",
+            "一批，一组，一群；一批生产的量"
+        ],
+        "usphone": "bætʃ",
+        "ukphone": "bætʃ"
+    },
+    {
+        "name": "batter",
+        "trans": [
+            "连续猛击",
+            "击球手； 面糊"
+        ],
+        "usphone": "'bætɚ",
+        "ukphone": "'bætər"
+    },
+    {
+        "name": "battery",
+        "trans": [
+            "电池； 排炮； 一系列， 一批"
+        ],
+        "usphone": "'bæt(ə)rɪ",
+        "ukphone": "'bætri"
+    },
+    {
+        "name": "beach",
+        "trans": [
+            "海滩， 湖滩， 河滩"
+        ],
+        "usphone": "bitʃ",
+        "ukphone": "biːtʃ"
+    },
+    {
+        "name": "bead",
+        "trans": [
+            "珠子； 小滴"
+        ],
+        "usphone": "bid",
+        "ukphone": "biːd"
+    },
+    {
+        "name": "beak",
+        "trans": [
+            "鸟嘴， 喙"
+        ],
+        "usphone": "bik",
+        "ukphone": "biːk"
+    },
+    {
+        "name": "beam",
+        "trans": [
+            "面露喜色；发射，播送；照射",
+            "束， 波束， 光线； 梁； 笑容， 喜色"
+        ],
+        "usphone": "bim",
+        "ukphone": "biːm"
+    },
+    {
+        "name": "beat",
+        "trans": [
+            "打拍子，指挥；敲打；打败，胜过；跳动",
+            "疲惫的",
+            "跳动；节拍，节奏；有规律的敲击"
+        ],
+        "usphone": "bit",
+        "ukphone": "biːt"
+    },
+    {
+        "name": "beaver",
+        "trans": [
+            "忙于",
+            "海狸； 海狸毛皮"
+        ],
+        "usphone": "'bivɚ",
+        "ukphone": "'biːvər"
+    },
+    {
+        "name": "bedrock",
+        "trans": [
+            "基础， 根基； 基岩"
+        ],
+        "usphone": "'bɛdrɑk",
+        "ukphone": "'bedrɑːk"
+    },
+    {
+        "name": "behave",
+        "trans": [
+            "行为， 表现； 表现得体， 有礼貌； 作出反应"
+        ],
+        "usphone": "bɪ'hev",
+        "ukphone": "bɪ'heɪv"
+    },
+    {
+        "name": "behaviorism",
+        "trans": [
+            "行为主义"
+        ],
+        "usphone": "bɪ'hevjɚ,ɪzəm",
+        "ukphone": "bɪ'heɪvjərɪzəm"
+    },
+    {
+        "name": "belie",
+        "trans": [
+            "给人以错觉； 掩饰； 证明…不正确"
+        ],
+        "usphone": "bɪ'laɪ",
+        "ukphone": "bɪ'laɪ"
+    },
+    {
+        "name": "bellows",
+        "trans": [
+            "风箱"
+        ],
+        "usphone": "'bɛloz",
+        "ukphone": "'belouz"
+    },
+    {
+        "name": "belt",
+        "trans": [
+            "地带， 地区； 腰带， 皮带； 带状物"
+        ],
+        "usphone": "bɛlt",
+        "ukphone": "belt"
+    },
+    {
+        "name": "beneficent",
+        "trans": [
+            "有益的； 行善的， 慈善的"
+        ],
+        "usphone": "bɪ'nɛfɪsnt",
+        "ukphone": "bɪ'nefɪsnt"
+    },
+    {
+        "name": "beneficial",
+        "trans": [
+            "有益的， 有利的"
+        ],
+        "usphone": ",bɛnɪ'fɪʃl",
+        "ukphone": "ˌbenɪ'fɪʃl"
+    },
+    {
+        "name": "benefit",
+        "trans": [
+            "受益； 得益于",
+            "益处，好处；恩惠；津贴"
+        ],
+        "usphone": "'bɛnɪfɪt",
+        "ukphone": "'benɪfɪt"
+    },
+    {
+        "name": "benevolent",
+        "trans": [
+            "慈善的； 善心的"
+        ],
+        "usphone": "bə'nɛvələnt",
+        "ukphone": "bə'nevələnt"
+    },
+    {
+        "name": "benign",
+        "trans": [
+            "良性的； 有利的； 善良的， 和蔼的"
+        ],
+        "usphone": "bɪ'naɪn",
+        "ukphone": "bɪ'naɪn"
+    },
+    {
+        "name": "bequeath",
+        "trans": [
+            "遗赠； 流传"
+        ],
+        "usphone": "bɪ'kwið",
+        "ukphone": "bɪ'kwiːð"
+    },
+    {
+        "name": "besides",
+        "trans": [
+            "而且， 还有",
+            "除…之外"
+        ],
+        "usphone": "bɪ'saɪdz",
+        "ukphone": "bɪ'saɪdz"
+    },
+    {
+        "name": "besiege",
+        "trans": [
+            "包围； 使应接不暇"
+        ],
+        "usphone": "bɪ'sidʒ",
+        "ukphone": "bɪ'siːdʒ"
+    },
+    {
+        "name": "bestow",
+        "trans": [
+            "赠与， 授予， 献给"
+        ],
+        "usphone": "bɪ'sto",
+        "ukphone": "bɪ'stou"
+    },
+    {
+        "name": "bet",
+        "trans": [
+            "打赌； 敢说， 确信",
+            "打赌；赌注"
+        ],
+        "usphone": "bɛt",
+        "ukphone": "bet"
+    },
+    {
+        "name": "betray",
+        "trans": [
+            "出卖， 泄露； 辜负， 对…不忠； 流露情感"
+        ],
+        "usphone": "bɪ'tre",
+        "ukphone": "bɪ'treɪ"
+    },
+    {
+        "name": "beverage",
+        "trans": [
+            "饮料"
+        ],
+        "usphone": "'bɛvərɪdʒ",
+        "ukphone": "'bevərɪdʒ"
+    },
+    {
+        "name": "bewilder",
+        "trans": [
+            "使迷惑， 使不知所措"
+        ],
+        "usphone": "bɪ'wɪldɚ",
+        "ukphone": "bɪ'wɪldər"
+    },
+    {
+        "name": "biannual",
+        "trans": [
+            "一年两次的"
+        ],
+        "usphone": "baɪ'ænjuəl",
+        "ukphone": "baɪ'ænjuəl"
+    },
+    {
+        "name": "bias",
+        "trans": [
+            "偏见，偏心",
+            "使有偏见， 使偏心"
+        ],
+        "usphone": "'baɪəs",
+        "ukphone": "'baɪəs"
+    },
+    {
+        "name": "bicameral",
+        "trans": [
+            "两院制的， 有两个议院的"
+        ],
+        "usphone": ",baɪ'kæmərəl",
+        "ukphone": "ˌbaɪ'kæmərəl"
+    },
+    {
+        "name": "bilateral",
+        "trans": [
+            "有两边的； 双边的"
+        ],
+        "usphone": ",baɪ'lætərəl",
+        "ukphone": "ˌbaɪ'lætərəl"
+    },
+    {
+        "name": "bilingualism",
+        "trans": [
+            "双语现象"
+        ],
+        "usphone": "baɪ'lɪŋgwəlɪzəm",
+        "ukphone": "ˌbaɪ'lɪŋgwəlɪzəm"
+    },
+    {
+        "name": "bill",
+        "trans": [
+            "账单；纸币，钞票；议案，法案；节目单；招贴，海报",
+            "用招贴宣布； 给…开账单"
+        ],
+        "usphone": "bɪl",
+        "ukphone": "bɪl"
+    },
+    {
+        "name": "binary",
+        "trans": [
+            "二进制的； 二元的； 由两部分组成的"
+        ],
+        "usphone": "'baɪnəri",
+        "ukphone": "'baɪnəri"
+    },
+    {
+        "name": "biochemical",
+        "trans": [
+            "生物化学的， 生化的"
+        ],
+        "usphone": "'baɪo'kɛmɪkl",
+        "ukphone": "ˌbaɪou'kemɪkl"
+    },
+    {
+        "name": "biography",
+        "trans": [
+            "传记"
+        ],
+        "usphone": "baɪ'ɑɡrəfi",
+        "ukphone": "baɪ'ɑːgrəfi"
+    },
+    {
+        "name": "biologist",
+        "trans": [
+            "生物学家"
+        ],
+        "usphone": "baɪ'ɑlədʒɪst",
+        "ukphone": "baɪ'ɑːlədʒɪst"
+    },
+    {
+        "name": "bisect",
+        "trans": [
+            "把…二等分， 对半分"
+        ],
+        "usphone": "baɪ'sɛkt",
+        "ukphone": "baɪ'sekt"
+    },
+    {
+        "name": "bison",
+        "trans": [
+            "美洲野牛"
+        ],
+        "usphone": "'baɪsn",
+        "ukphone": "'baɪsn"
+    },
+    {
+        "name": "bizarre",
+        "trans": [
+            "奇形怪状的， 古怪可笑的， 怪诞的"
+        ],
+        "usphone": "bɪ'zɑr",
+        "ukphone": "bɪ'zɑːr"
+    },
+    {
+        "name": "blade",
+        "trans": [
+            "刀刃， 刀片； 叶片； 草叶； 桨叶"
+        ],
+        "usphone": "bled",
+        "ukphone": "bleɪd"
+    },
+    {
+        "name": "blame",
+        "trans": [
+            "谴责，责备",
+            "过失， 责备； 责任"
+        ],
+        "usphone": "blem",
+        "ukphone": "bleɪm"
+    },
+    {
+        "name": "bland",
+        "trans": [
+            "平淡的， 乏味的； 清淡的； 沉稳的"
+        ],
+        "usphone": "blænd",
+        "ukphone": "blænd"
+    },
+    {
+        "name": "blanket",
+        "trans": [
+            "毯子； 覆盖物"
+        ],
+        "usphone": "'blæŋkɪt",
+        "ukphone": "'blæŋkɪt"
+    },
+    {
+        "name": "blast",
+        "trans": [
+            "爆炸；发出尖响；猛烈抨击",
+            "一阵； 爆炸； 冲击波； 响声"
+        ],
+        "usphone": "blæst",
+        "ukphone": "blæst"
+    },
+    {
+        "name": "blaze",
+        "trans": [
+            "燃烧， 着火； 发光， 放光彩； 怒视",
+            "火焰；光辉，强烈的光；迸发"
+        ],
+        "usphone": "blez",
+        "ukphone": "bleɪz"
+    },
+    {
+        "name": "bleach",
+        "trans": [
+            "变白， 漂白",
+            "漂白剂"
+        ],
+        "usphone": "blitʃ",
+        "ukphone": "bliːtʃ"
+    },
+    {
+        "name": "bleak",
+        "trans": [
+            "阴冷的； 无望的， 令人沮丧的； 乏味的； 荒凉的"
+        ],
+        "usphone": "blik",
+        "ukphone": "bliːk"
+    },
+    {
+        "name": "blend",
+        "trans": [
+            "混合，混杂",
+            "混合； 混合物"
+        ],
+        "usphone": "blɛnd",
+        "ukphone": "blend"
+    },
+    {
+        "name": "blink",
+        "trans": [
+            "眨眼睛；闪亮，闪烁",
+            "眨眼睛"
+        ],
+        "usphone": "blɪŋk",
+        "ukphone": "blɪŋk"
+    },
+    {
+        "name": "blizzard",
+        "trans": [
+            "暴风雪， 大风雪"
+        ],
+        "usphone": "'blɪzɚd",
+        "ukphone": "'blɪzərd"
+    },
+    {
+        "name": "block",
+        "trans": [
+            "阻塞；阻碍，妨碍",
+            "大块； 街区； 障碍物"
+        ],
+        "usphone": "blɑk",
+        "ukphone": "blɑːk"
+    },
+    {
+        "name": "bloom",
+        "trans": [
+            "开花",
+            "花；开花；青春焕发"
+        ],
+        "usphone": "blum",
+        "ukphone": "bluːm"
+    },
+    {
+        "name": "blossom",
+        "trans": [
+            "开花； 长成",
+            "花"
+        ],
+        "usphone": "'blɑsəm",
+        "ukphone": "'blɑːsəm"
+    },
+    {
+        "name": "blues",
+        "trans": [
+            "布鲁斯音乐， 蓝调"
+        ],
+        "usphone": "bluz",
+        "ukphone": "bluːz"
+    },
+    {
+        "name": "bluff",
+        "trans": [
+            "虚张声势，吓唬",
+            "直率的， 坦率的",
+            "悬崖，峭壁；虚张声势，唬人"
+        ],
+        "usphone": "blʌf",
+        "ukphone": "blʌf"
+    },
+    {
+        "name": "blunt",
+        "trans": [
+            "钝的；不敏感的；直率的",
+            "使迟钝； 使减弱"
+        ],
+        "usphone": "blʌnt",
+        "ukphone": "blʌnt"
+    },
+    {
+        "name": "blur",
+        "trans": [
+            "变模糊，难以区分；玷污",
+            "模糊形状； 模糊的记忆； 污点"
+        ],
+        "usphone": "blɝ",
+        "ukphone": "blɜːr"
+    },
+    {
+        "name": "blurt",
+        "trans": [
+            "脱口而出"
+        ],
+        "usphone": "blɝt",
+        "ukphone": "blɜːrt"
+    },
+    {
+        "name": "blush",
+        "trans": [
+            "脸红；羞愧",
+            "脸上泛起的红晕"
+        ],
+        "usphone": "blʌʃ",
+        "ukphone": "blʌʃ"
+    },
+    {
+        "name": "bluster",
+        "trans": [
+            "虚张声势地恫吓； 猛刮"
+        ],
+        "usphone": "'blʌstɚ",
+        "ukphone": "'blʌstər"
+    },
+    {
+        "name": "board",
+        "trans": [
+            "登机， 上船； 搭伙， 寄宿",
+            "膳食费用；委员会，董事会；板，木板"
+        ],
+        "usphone": "bɔrd",
+        "ukphone": "bɔːrd"
+    },
+    {
+        "name": "boast",
+        "trans": [
+            "自我夸耀"
+        ],
+        "usphone": "bost",
+        "ukphone": "boust"
+    },
+    {
+        "name": "bode",
+        "trans": [
+            "预示"
+        ],
+        "usphone": "bəud",
+        "ukphone": "boud"
+    },
+    {
+        "name": "bold",
+        "trans": [
+            "大胆的； 冒失的； 粗体的； 醒目的"
+        ],
+        "usphone": "bold",
+        "ukphone": "bould"
+    },
+    {
+        "name": "bolster",
+        "trans": [
+            "支持；改善",
+            "垫子， 枕垫"
+        ],
+        "usphone": "'bolstɚ",
+        "ukphone": "'boulstər"
+    },
+    {
+        "name": "bolt",
+        "trans": [
+            "逃跑；闩上",
+            "插销， 门闩； 闪电"
+        ],
+        "usphone": "bolt",
+        "ukphone": "boult"
+    },
+    {
+        "name": "bonanza",
+        "trans": [
+            "富矿带； 带来好运的事； 兴盛， 繁荣"
+        ],
+        "usphone": "bə'nænzə",
+        "ukphone": "bə'nænzə"
+    },
+    {
+        "name": "bond",
+        "trans": [
+            "黏合， 结合",
+            "联结，黏结；债券；黏合剂；契约，合同"
+        ],
+        "usphone": "bɑnd",
+        "ukphone": "bɑːnd"
+    },
+    {
+        "name": "bony",
+        "trans": [
+            "瘦骨嶙峋的； 似骨的； 多骨的"
+        ],
+        "usphone": "'boni",
+        "ukphone": "'bouni"
+    },
+    {
+        "name": "bookstore",
+        "trans": [
+            "书店"
+        ],
+        "usphone": "bʊkstɔr",
+        "ukphone": "'bukstɔːr"
+    },
+    {
+        "name": "boom",
+        "trans": [
+            "迅速发展，激增；发出低沉有力的声音",
+            "激增， 繁荣； 繁荣昌盛期"
+        ],
+        "usphone": "buːm",
+        "ukphone": "buːm"
+    },
+    {
+        "name": "boon",
+        "trans": [
+            "恩惠， 恩赐； 益处"
+        ],
+        "usphone": "bʊn",
+        "ukphone": "buːn"
+    },
+    {
+        "name": "boost",
+        "trans": [
+            "提高，推进；替…做广告，宣扬",
+            "增加， 帮助"
+        ],
+        "usphone": "bʊst",
+        "ukphone": "buːst"
+    },
+    {
+        "name": "bosom",
+        "trans": [
+            "胸部， 乳房； 胸怀， 内心"
+        ],
+        "usphone": "'bʊzəm",
+        "ukphone": "'buzəm"
+    },
+    {
+        "name": "botany",
+        "trans": [
+            "植物学； 植物"
+        ],
+        "usphone": "'bɑtəni",
+        "ukphone": "'bɑːtəni"
+    },
+    {
+        "name": "boulder",
+        "trans": [
+            "巨石， 巨砾"
+        ],
+        "usphone": "'boldɚ",
+        "ukphone": "'bouldər"
+    },
+    {
+        "name": "bounce",
+        "trans": [
+            "弹起，反弹",
+            "弹跳； 反弹力"
+        ],
+        "usphone": "baʊns",
+        "ukphone": "bauns"
+    },
+    {
+        "name": "bound",
+        "trans": [
+            "被束缚的，有义务的",
+            "跳跃； 弹回； 形成…的界线， 给…划界"
+        ],
+        "usphone": "baʊnd",
+        "ukphone": "baund"
+    },
+    {
+        "name": "boundary",
+        "trans": [
+            "分界线； 边界"
+        ],
+        "usphone": "'baʊndri",
+        "ukphone": "'baundri"
+    },
+    {
+        "name": "bountiful",
+        "trans": [
+            "慷慨的； 大量的， 充足的"
+        ],
+        "usphone": "'baʊntɪfl",
+        "ukphone": "'bauntɪfl"
+    },
+    {
+        "name": "bouquet",
+        "trans": [
+            "花束； 香味， 芬芳"
+        ],
+        "usphone": "bu'ke",
+        "ukphone": "bu'keɪ"
+    },
+    {
+        "name": "boycott",
+        "trans": [
+            "联合抵制， 拒绝购买"
+        ],
+        "usphone": "'bɔɪkɑt",
+        "ukphone": "'bɔɪkɑːt"
+    },
+    {
+        "name": "brace",
+        "trans": [
+            "绷紧肌肉；使顶住；使防备；加强，加固",
+            "支架， 托架"
+        ],
+        "usphone": "bres",
+        "ukphone": "breɪs"
+    },
+    {
+        "name": "brag",
+        "trans": [
+            "吹嘘， 自夸， 自吹自擂"
+        ],
+        "usphone": "bræɡ",
+        "ukphone": "bræg"
+    },
+    {
+        "name": "braid",
+        "trans": [
+            "穗带，饰带；发辫",
+            "编织； 编成辫子"
+        ],
+        "usphone": "bred",
+        "ukphone": "breɪd"
+    },
+    {
+        "name": "brand",
+        "trans": [
+            "铭刻；打烙印于；丑化，败坏名声",
+            "商标， 品牌； 类型； 烙印"
+        ],
+        "usphone": "brænd",
+        "ukphone": "brænd"
+    },
+    {
+        "name": "brass",
+        "trans": [
+            "铜管乐器； 黄铜"
+        ],
+        "usphone": "bræs",
+        "ukphone": "bræs"
+    },
+    {
+        "name": "breach",
+        "trans": [
+            "违背；破裂；缺口",
+            "打破； 违反"
+        ],
+        "usphone": "britʃ",
+        "ukphone": "briːtʃ"
+    },
+    {
+        "name": "break",
+        "trans": [
+            "破，裂，碎；使中止，打断，断绝；损坏，弄坏；违犯；打破；破晓",
+            "打断， 中止； 休息时间； 破裂"
+        ],
+        "usphone": "brek",
+        "ukphone": "breɪk"
+    },
+    {
+        "name": "breakthrough",
+        "trans": [
+            "突破， 重大进展"
+        ],
+        "usphone": "'brek'θrʊ",
+        "ukphone": "'breɪkθruː"
+    },
+    {
+        "name": "breathing",
+        "trans": [
+            "呼吸"
+        ],
+        "usphone": "'briðɪŋ",
+        "ukphone": "'briːðɪŋ"
+    },
+    {
+        "name": "breed",
+        "trans": [
+            "〔动物〕交配繁殖",
+            "〔宠物或牲畜的〕品种"
+        ],
+        "usphone": "brid",
+        "ukphone": "briːd"
+    },
+    {
+        "name": "breeze",
+        "trans": [
+            "飘然移动",
+            "微风，和风"
+        ],
+        "usphone": "briz",
+        "ukphone": "briːz"
+    },
+    {
+        "name": "brew",
+        "trans": [
+            "酿造；冲泡；酝酿，行将发生",
+            "冲泡的饮料； 啤酒"
+        ],
+        "usphone": "brʊ",
+        "ukphone": "bruː"
+    },
+    {
+        "name": "brief",
+        "trans": [
+            "简短的，短暂的；简洁的"
+        ],
+        "usphone": "brif",
+        "ukphone": "briːf"
+    },
+    {
+        "name": "brighten",
+        "trans": [
+            "更明亮； 快活起来； 有希望"
+        ],
+        "usphone": "'braɪtn",
+        "ukphone": "'braɪtn"
+    },
+    {
+        "name": "brilliant",
+        "trans": [
+            "给人印象深刻的； 闪耀的； 杰出的， 卓越的"
+        ],
+        "usphone": "'brɪljənt",
+        "ukphone": "'brɪliənt"
+    },
+    {
+        "name": "brisk",
+        "trans": [
+            "清新的； 敏捷的， 活泼的"
+        ],
+        "usphone": "brɪsk",
+        "ukphone": "brɪsk"
+    },
+    {
+        "name": "brittle",
+        "trans": [
+            "易碎的； 脆弱的； 尖利的"
+        ],
+        "usphone": "'brɪtl",
+        "ukphone": "'brɪtl"
+    },
+    {
+        "name": "broadcast",
+        "trans": [
+            "广播，播放",
+            "广播， 广播节目"
+        ],
+        "usphone": "'brɔdkæst",
+        "ukphone": "'brɔːdkæst"
+    },
+    {
+        "name": "brochure",
+        "trans": [
+            "小册子， 说明书"
+        ],
+        "usphone": "bro'ʃʊr",
+        "ukphone": "brou'ʃur"
+    },
+    {
+        "name": "bronze",
+        "trans": [
+            "青铜色的",
+            "青铜；青铜色；青铜制品；铜牌"
+        ],
+        "usphone": "brɑnz",
+        "ukphone": "brɑːnz"
+    },
+    {
+        "name": "browse",
+        "trans": [
+            "吃嫩叶或草；浏览",
+            "嫩叶； 浏览"
+        ],
+        "usphone": "braʊz",
+        "ukphone": "brauz"
+    },
+    {
+        "name": "bruise",
+        "trans": [
+            "出现伤痕；挫伤",
+            "伤痕， 擦痕， 青肿"
+        ],
+        "usphone": "bruz",
+        "ukphone": "bruːz"
+    },
+    {
+        "name": "brush",
+        "trans": [
+            "刷，拂；轻碰",
+            "画笔； 刷子； 轻碰； 小冲突"
+        ],
+        "usphone": "brʌʃ",
+        "ukphone": "brʌʃ"
+    },
+    {
+        "name": "bubble",
+        "trans": [
+            "泡；"
+        ],
+        "usphone": "'bʌbl",
+        "ukphone": "'bʌbl"
+    },
+    {
+        "name": "buck",
+        "trans": [
+            "猛然弓背跃起；猛然震荡；抵制，反抗",
+            "美元； 雄鹿"
+        ],
+        "usphone": "",
+        "ukphone": "bʌk"
+    },
+    {
+        "name": "buckle",
+        "trans": [
+            "扣紧； 变形， 弯曲",
+            "皮带扣环"
+        ],
+        "usphone": "",
+        "ukphone": "'bʌkl"
+    },
+    {
+        "name": "bud",
+        "trans": [
+            "发芽， 萌芽",
+            "芽；蓓蕾"
+        ],
+        "usphone": "bʌd",
+        "ukphone": "bʌd"
+    },
+    {
+        "name": "buddy",
+        "trans": [
+            "密友； 搭档， 伙伴"
+        ],
+        "usphone": "'bʌdi",
+        "ukphone": "'bʌdi"
+    },
+    {
+        "name": "budget",
+        "trans": [
+            "做预算",
+            "价格低廉的",
+            "预算"
+        ],
+        "usphone": "'bʌdʒɪt",
+        "ukphone": "'bʌdʒɪt"
+    },
+    {
+        "name": "buffalo",
+        "trans": [
+            "水牛； 野牛"
+        ],
+        "usphone": "'bʌfəlo",
+        "ukphone": "'bʌfəlou"
+    },
+    {
+        "name": "bulb",
+        "trans": [
+            "鳞茎； 鳞茎状物； 灯泡"
+        ],
+        "usphone": "bʌlb",
+        "ukphone": "bʌlb"
+    },
+    {
+        "name": "bulk",
+        "trans": [
+            "容积， 体积； 主体， 大部分"
+        ],
+        "usphone": "bʌlk",
+        "ukphone": "bʌlk"
+    },
+    {
+        "name": "bulletin",
+        "trans": [
+            "新闻简报； 公告， 布告； 简报"
+        ],
+        "usphone": "'bʊlətɪn",
+        "ukphone": "'bulətɪn"
+    },
+    {
+        "name": "bump",
+        "trans": [
+            "碰撞",
+            "肿块；撞击；碰撞声"
+        ],
+        "usphone": "bʌmp",
+        "ukphone": "bʌmp"
+    },
+    {
+        "name": "bunch",
+        "trans": [
+            "捆成一束； 聚集",
+            "簇，束，捆；帮，伙"
+        ],
+        "usphone": "bʌntʃ",
+        "ukphone": "bʌntʃ"
+    },
+    {
+        "name": "bundle",
+        "trans": [
+            "捆，束；包袱",
+            "收集， 归拢； 把…塞入"
+        ],
+        "usphone": "'bʌndl",
+        "ukphone": "'bʌndl"
+    },
+    {
+        "name": "buoyant",
+        "trans": [
+            "有浮力的， 漂浮的； 轻快的， 快乐的； 繁荣的； 看涨的"
+        ],
+        "usphone": "'bujənt",
+        "ukphone": "'bɔɪənt"
+    },
+    {
+        "name": "bureau",
+        "trans": [
+            "局， 署； 办公室； 机构"
+        ],
+        "usphone": "'bjʊro",
+        "ukphone": "'bjurou"
+    },
+    {
+        "name": "bureaucracy",
+        "trans": [
+            "官僚主义， 官僚作风； 政府机构， 官僚机构"
+        ],
+        "usphone": "bjʊ'rɑkrəsi",
+        "ukphone": "bju'rɑːkrəsi"
+    },
+    {
+        "name": "burgeon",
+        "trans": [
+            "迅速成长， 发展"
+        ],
+        "usphone": "'bɝdʒən",
+        "ukphone": "'bɜːrdʒən"
+    },
+    {
+        "name": "burrow",
+        "trans": [
+            "挖掘，挖地洞；寻找，"
+        ],
+        "usphone": "'bɝro",
+        "ukphone": "'bɜːrou"
+    },
+    {
+        "name": "bush",
+        "trans": [
+            "灌木； 荒野"
+        ],
+        "usphone": "",
+        "ukphone": "buʃ"
+    },
+    {
+        "name": "bustle",
+        "trans": [
+            "奔忙， 匆匆忙忙",
+            "忙乱嘈杂，喧嚣"
+        ],
+        "usphone": "'bʌsl",
+        "ukphone": "'bʌsl"
+    },
+    {
+        "name": "butter",
+        "trans": [
+            "黄油",
+            "涂黄油于"
+        ],
+        "usphone": "'bʌtɚ",
+        "ukphone": "'bʌtər"
+    },
+    {
+        "name": "by-product",
+        "trans": [
+            "副产品； 副作用， 意外结果"
+        ],
+        "usphone": "'baɪ,prɑdəkt",
+        "ukphone": "'baɪˌprɑːdʌkt"
+    },
+    {
+        "name": "cabin",
+        "trans": [
+            "小屋； 机舱， 船舱"
+        ],
+        "usphone": "'kæbɪn",
+        "ukphone": "'kæbɪn"
+    },
+    {
+        "name": "cabinet",
+        "trans": [
+            "内阁； 储藏柜， 陈列柜"
+        ],
+        "usphone": "'kæbɪnət",
+        "ukphone": "'kæbɪnət"
+    },
+    {
+        "name": "cable",
+        "trans": [
+            "给…发电报， 用电报传送",
+            "缆绳，钢索；电缆；电报"
+        ],
+        "usphone": "'kebl",
+        "ukphone": "'keɪbl"
+    },
+    {
+        "name": "cactus",
+        "trans": [
+            "仙人掌"
+        ],
+        "usphone": "'kæktəs",
+        "ukphone": "'kæktəs"
+    },
+    {
+        "name": "cafeteria",
+        "trans": [
+            "自助餐厅， 自助食堂"
+        ],
+        "usphone": ",kæfə'tɪrɪə",
+        "ukphone": "ˌkæfə'tɪriə"
+    },
+    {
+        "name": "calamitous",
+        "trans": [
+            "灾难性的"
+        ],
+        "usphone": "kə'læmɪtəs",
+        "ukphone": "kə'læmɪtəs"
+    },
+    {
+        "name": "calculable",
+        "trans": [
+            "可计算的； 能预测的； 可信的"
+        ],
+        "usphone": "'kælkjələbl",
+        "ukphone": "'kælkjələbl"
+    },
+    {
+        "name": "calculate",
+        "trans": [
+            "计算， 核算； 估计， 推测； 计划， 打算"
+        ],
+        "usphone": "'kælkjulet",
+        "ukphone": "'kælkjuleɪt"
+    },
+    {
+        "name": "calculus",
+        "trans": [
+            "微积分； 结石"
+        ],
+        "usphone": "'kælkjələs",
+        "ukphone": "'kælkjələs"
+    },
+    {
+        "name": "calendar",
+        "trans": [
+            "日历， 挂历， 月历； 日程表"
+        ],
+        "usphone": "'kæləndɚ",
+        "ukphone": "'kælɪndər"
+    },
+    {
+        "name": "calm",
+        "trans": [
+            "平静的；镇静的，沉着的",
+            "使平静， 使镇定， 平息"
+        ],
+        "usphone": "kɑm",
+        "ukphone": "kɑːm"
+    },
+    {
+        "name": "camouflage",
+        "trans": [
+            "掩饰， 伪装"
+        ],
+        "usphone": "'kæmə'flɑʒ",
+        "ukphone": "'kæməflɑːʒ"
+    },
+    {
+        "name": "campaign",
+        "trans": [
+            "竞选；参加战斗",
+            "竞选活动； 活动； 战役"
+        ],
+        "usphone": "kæm'pen",
+        "ukphone": "kæm'peɪn"
+    },
+    {
+        "name": "campus",
+        "trans": [
+            "校园"
+        ],
+        "usphone": "'kæmpəs",
+        "ukphone": "'kæmpəs"
+    },
+    {
+        "name": "canal",
+        "trans": [
+            "运河，沟渠",
+            "开运河"
+        ],
+        "usphone": "kə'næl",
+        "ukphone": "kə'næl"
+    },
+    {
+        "name": "cancel",
+        "trans": [
+            "取消， 废除； 删去， 删除； 抵消"
+        ],
+        "usphone": "'kænsl",
+        "ukphone": "'kænsl"
+    },
+    {
+        "name": "candid",
+        "trans": [
+            "坦白的， 直率的， 直言不讳的"
+        ],
+        "usphone": "'kændɪd",
+        "ukphone": "'kændɪd"
+    },
+    {
+        "name": "candidate",
+        "trans": [
+            "候选人； 投考者"
+        ],
+        "usphone": "ˈkændɪˌdet, -dɪt",
+        "ukphone": "'kændɪdət"
+    },
+    {
+        "name": "cannibalism",
+        "trans": [
+            "嗜食同类"
+        ],
+        "usphone": "'kænəbl,ɪzəm",
+        "ukphone": "'kænɪbəlɪzəm"
+    },
+    {
+        "name": "canoe",
+        "trans": [
+            "乘独木舟，划独木舟",
+            "独木舟"
+        ],
+        "usphone": "kə'nu",
+        "ukphone": "kə'nuː"
+    },
+    {
+        "name": "canopy",
+        "trans": [
+            "天篷； 罩盖， 遮篷； 天蓬似的树阴"
+        ],
+        "usphone": "'kænəpi",
+        "ukphone": "'kænəpi"
+    },
+    {
+        "name": "canvas",
+        "trans": [
+            "画布； 油画； 帆布"
+        ],
+        "usphone": "'kænvəs",
+        "ukphone": "'kænvəs"
+    },
+    {
+        "name": "canvass",
+        "trans": [
+            "游说， 拉选票； 细查"
+        ],
+        "usphone": "'kænvəs",
+        "ukphone": "'kænvəs"
+    },
+    {
+        "name": "canyon",
+        "trans": [
+            "峡谷"
+        ],
+        "usphone": "'kænjən",
+        "ukphone": "'kænjən"
+    },
+    {
+        "name": "capability",
+        "trans": [
+            "能力； 性能； 容量； 潜质"
+        ],
+        "usphone": "ˌkepəˈbɪlətɪ",
+        "ukphone": "ˌkeɪpə'bɪləti"
+    },
+    {
+        "name": "capacity",
+        "trans": [
+            "能力； 容量； 职责， 职位； 生产力"
+        ],
+        "usphone": "kə'pæsəti",
+        "ukphone": "kə'pæsəti"
+    },
+    {
+        "name": "cape",
+        "trans": [
+            "海角， 岬； 斗篷， 披肩"
+        ],
+        "usphone": "kep",
+        "ukphone": "keɪp"
+    },
+    {
+        "name": "capillary",
+        "trans": [
+            "毛状的； 毛细血管的",
+            "毛细血管"
+        ],
+        "usphone": "'kæpəlɛri",
+        "ukphone": "'kæpəleri"
+    },
+    {
+        "name": "caption",
+        "trans": [
+            "说明文字；标题；字幕",
+            "给加说明文字"
+        ],
+        "usphone": "'kæpʃən",
+        "ukphone": "'kæpʃn"
+    },
+    {
+        "name": "captive",
+        "trans": [
+            "被监禁的，被困住的；受控制的",
+            "俘虏， 战俘"
+        ],
+        "usphone": "'kæptɪv",
+        "ukphone": "'kæptɪv"
+    },
+    {
+        "name": "captivity",
+        "trans": [
+            "囚禁， 拘留"
+        ],
+        "usphone": "kæp'tɪvəti",
+        "ukphone": "kæp'tɪvəti"
+    },
+    {
+        "name": "carbohydrate",
+        "trans": [
+            "碳水化合物"
+        ],
+        "usphone": ",kɑrbo'haɪdret",
+        "ukphone": "ˌkɑːrbou'haɪdreɪt"
+    },
+    {
+        "name": "carbon",
+        "trans": [
+            "碳"
+        ],
+        "usphone": "'kɑrbən",
+        "ukphone": "'kɑːrbən"
+    },
+    {
+        "name": "cardiac",
+        "trans": [
+            "心脏的； 心脏病的"
+        ],
+        "usphone": "'kɑrdɪæk",
+        "ukphone": "'kɑːrdiæk"
+    },
+    {
+        "name": "cardinal",
+        "trans": [
+            "主要的，最重要的",
+            "红衣凤头鸟"
+        ],
+        "usphone": "'kɑrdɪnl",
+        "ukphone": "'kɑːrdɪnl"
+    },
+    {
+        "name": "care",
+        "trans": [
+            "关心， 关怀； 介意； 担忧",
+            "小心，谨慎；照看，照料；忧虑，焦虑"
+        ],
+        "usphone": "kɛr",
+        "ukphone": "ker"
+    },
+    {
+        "name": "career",
+        "trans": [
+            "生涯， 经历； 职业"
+        ],
+        "usphone": "kə'rɪr",
+        "ukphone": "kə'rɪr"
+    },
+    {
+        "name": "careless",
+        "trans": [
+            "粗心的， 疏忽的； 无忧无虑的； 不关心的， 冷漠的"
+        ],
+        "usphone": "'kɛrləs",
+        "ukphone": "'kerləs"
+    },
+    {
+        "name": "cargo",
+        "trans": [
+            "货物"
+        ],
+        "usphone": "'kɑrɡo",
+        "ukphone": "'kɑːrgou"
+    },
+    {
+        "name": "caribou",
+        "trans": [
+            "北美驯鹿"
+        ],
+        "usphone": "'kærɪbu",
+        "ukphone": "'kærɪbuː"
+    },
+    {
+        "name": "carnivore",
+        "trans": [
+            "食肉动物"
+        ],
+        "usphone": "'kɑrnɪvɔr",
+        "ukphone": "'kɑːrnɪvɔːr"
+    },
+    {
+        "name": "cart",
+        "trans": [
+            "运货马车；手推车",
+            "用车装运"
+        ],
+        "usphone": "kɑrt",
+        "ukphone": "kɑːrt"
+    },
+    {
+        "name": "cartilage",
+        "trans": [
+            "软骨"
+        ],
+        "usphone": "'kɑrtɪlɪdʒ",
+        "ukphone": "'kɑːrtɪlɪdʒ"
+    },
+    {
+        "name": "carve",
+        "trans": [
+            "雕刻； 切"
+        ],
+        "usphone": "kɑrv",
+        "ukphone": "kɑːrv"
+    },
+    {
+        "name": "cascade",
+        "trans": [
+            "倾泻，流注",
+            "小瀑布； 倾泻"
+        ],
+        "usphone": "kæ'sked",
+        "ukphone": "kæ'skeɪd"
+    },
+    {
+        "name": "cascara",
+        "trans": [
+            "缓泻剂"
+        ],
+        "usphone": "kæ'skɑ:rə",
+        "ukphone": "kæs'kɑːrə"
+    },
+    {
+        "name": "cashier",
+        "trans": [
+            "收银员， 出纳员"
+        ],
+        "usphone": "kæ'ʃɪr",
+        "ukphone": "kæ'ʃɪr"
+    },
+    {
+        "name": "cassette",
+        "trans": [
+            "盒式录音带"
+        ],
+        "usphone": "kə'sɛt",
+        "ukphone": "kə'set"
+    },
+    {
+        "name": "cast",
+        "trans": [
+            "浇铸；投掷；投射；蜕",
+            "铸件； 演员表， 全体演员； 投， 抛"
+        ],
+        "usphone": "kæst",
+        "ukphone": "kæst"
+    },
+    {
+        "name": "casual",
+        "trans": [
+            "非正式的， 随便的； 漫不经心的； 漠不关心的， 冷淡的； 偶然的， 碰巧的； 临时的"
+        ],
+        "usphone": "'kæʒʊəl",
+        "ukphone": "'kæʒuəl"
+    },
+    {
+        "name": "casualty",
+        "trans": [
+            "伤亡事故； 伤亡"
+        ],
+        "usphone": "'kæʒuəlti",
+        "ukphone": "'kæʒuəlti"
+    },
+    {
+        "name": "catalog",
+        "trans": [
+            "目录"
+        ],
+        "usphone": "'kætəlɔg",
+        "ukphone": "'kætəlɔːg"
+    },
+    {
+        "name": "catalyst",
+        "trans": [
+            "催化剂， 触媒； 促使变化的人"
+        ],
+        "usphone": "'kætəlɪst",
+        "ukphone": "'kætəlɪst"
+    },
+    {
+        "name": "catastrophe",
+        "trans": [
+            "灾难， 灾祸； 困难"
+        ],
+        "usphone": "kə'tæstrəfi",
+        "ukphone": "kə'tæstrəfi"
+    },
+    {
+        "name": "categorize",
+        "trans": [
+            "将…分类， 把…加以分类"
+        ],
+        "usphone": "'kætəgə'raɪz",
+        "ukphone": "'kætəgəraɪz"
+    },
+    {
+        "name": "category",
+        "trans": [
+            "种类； 范畴"
+        ],
+        "usphone": "'kætəɡɔri",
+        "ukphone": "'kætəgɔːri"
+    },
+    {
+        "name": "cater",
+        "trans": [
+            "迎合； 提供饮食"
+        ],
+        "usphone": "'ketɚ",
+        "ukphone": "'keɪtər"
+    },
+    {
+        "name": "caterpillar",
+        "trans": [
+            "毛毛虫"
+        ],
+        "usphone": "'kætɚpɪlɚ",
+        "ukphone": "'kætərpɪlər"
+    },
+    {
+        "name": "catholic",
+        "trans": [
+            "广泛的，包罗万象的；[C-]天主教的",
+            "[C-]天主教"
+        ],
+        "usphone": "kæθəlɪk",
+        "ukphone": "'kæθlɪk"
+    },
+    {
+        "name": "causal",
+        "trans": [
+            "原因的， 因果关系的"
+        ],
+        "usphone": "'kɔzl",
+        "ukphone": "'kɔːzl"
+    },
+    {
+        "name": "cautious",
+        "trans": [
+            "小心的， 谨慎的"
+        ],
+        "usphone": "'kɔʃəs",
+        "ukphone": "'kɔːʃəs"
+    },
+    {
+        "name": "cavern",
+        "trans": [
+            "大洞穴， 大山洞"
+        ],
+        "usphone": "'kævɚn",
+        "ukphone": "'kævərn"
+    },
+    {
+        "name": "cavity",
+        "trans": [
+            "腔； 洞， 穴， 窟窿； 龋洞"
+        ],
+        "usphone": "'kævəti",
+        "ukphone": "'kævəti"
+    },
+    {
+        "name": "cease",
+        "trans": [
+            "结束， 终止， 停止"
+        ],
+        "usphone": "sis",
+        "ukphone": "siːs"
+    },
+    {
+        "name": "celebrate",
+        "trans": [
+            "赞美； 庆祝"
+        ],
+        "usphone": "sɛləˌbret",
+        "ukphone": "'selɪbreɪt"
+    },
+    {
+        "name": "celestial",
+        "trans": [
+            "天空的， 天上的"
+        ],
+        "usphone": "sə'lɛstʃəl",
+        "ukphone": "sə'lestʃl"
+    },
+    {
+        "name": "cell",
+        "trans": [
+            "细胞； 基层组织； 单人房间； 电池"
+        ],
+        "usphone": "sɛl",
+        "ukphone": "sel"
+    },
+    {
+        "name": "cellist",
+        "trans": [
+            "大提琴演奏家"
+        ],
+        "usphone": "'tʃɛlɪst",
+        "ukphone": "'tʃelɪst"
+    },
+    {
+        "name": "cement",
+        "trans": [
+            "水泥；胶合剂",
+            "巩固； 使团结"
+        ],
+        "usphone": "sə'mɛnt",
+        "ukphone": "sɪ'ment"
+    },
+    {
+        "name": "censor",
+        "trans": [
+            "审查员",
+            "审查， 检查"
+        ],
+        "usphone": "'sɛnsɚ",
+        "ukphone": "'sensər"
+    },
+    {
+        "name": "census",
+        "trans": [
+            "人口普查， 人口统计"
+        ],
+        "usphone": "'sɛnsəs",
+        "ukphone": "'sensəs"
+    },
+    {
+        "name": "centennial",
+        "trans": [
+            "百年纪念"
+        ],
+        "usphone": "sɛn'tɛnɪəl",
+        "ukphone": "sen'teniəl"
+    },
+    {
+        "name": "centigrade",
+        "trans": [
+            "百分度的； 摄氏温度的"
+        ],
+        "usphone": "'sɛntɪɡred",
+        "ukphone": "'sentɪgreɪd"
+    },
+    {
+        "name": "centric",
+        "trans": [
+            "以…为中心的"
+        ],
+        "usphone": "'sɛntrɪk",
+        "ukphone": "'sentrɪk"
+    },
+    {
+        "name": "ceramic",
+        "trans": [
+            "陶器的， 瓷器的"
+        ],
+        "usphone": "sə'ræmɪk",
+        "ukphone": "sə'ræmɪk"
+    },
+    {
+        "name": "cereal",
+        "trans": [
+            "谷物； 谷类食物"
+        ],
+        "usphone": "'sɪrɪəl",
+        "ukphone": "'sɪriəl"
+    },
+    {
+        "name": "cerebral",
+        "trans": [
+            "大脑的； 理智的"
+        ],
+        "usphone": "sə'ribrəl",
+        "ukphone": "sə'riːbrəl"
+    },
+    {
+        "name": "ceremonial",
+        "trans": [
+            "礼仪的，礼节的",
+            "礼仪， 礼节"
+        ],
+        "usphone": ",sɛrɪ'monɪəl",
+        "ukphone": "ˌserɪ'mouniəl"
+    },
+    {
+        "name": "ceremony",
+        "trans": [
+            "典礼， 仪式； 礼节"
+        ],
+        "usphone": "ˈsɛrəˌmoʊni",
+        "ukphone": "'serəmouni"
+    },
+    {
+        "name": "certificate",
+        "trans": [
+            "证书， 证明书； 文凭， 结业证书"
+        ],
+        "usphone": "sɚˈtɪfɪkɪt; (for v.,) sɚˈtɪfɪˌket",
+        "ukphone": "sər'tɪfɪkət"
+    },
+    {
+        "name": "certitude",
+        "trans": [
+            "确定， 确信； 必然性"
+        ],
+        "usphone": "'sə:titju:d",
+        "ukphone": "'sɜːrtɪtuːd"
+    },
+    {
+        "name": "chafe",
+        "trans": [
+            "擦破， 擦痛； 恼怒， 焦躁"
+        ],
+        "usphone": "tʃef",
+        "ukphone": "tʃeɪf"
+    },
+    {
+        "name": "chagrin",
+        "trans": [
+            "懊恼， 失望"
+        ],
+        "usphone": "ʃə'ɡrɪn",
+        "ukphone": "ʃə'grɪn"
+    },
+    {
+        "name": "chain",
+        "trans": [
+            "链；",
+            "用链条拴住； 联号， 连锁店"
+        ],
+        "usphone": "tʃen",
+        "ukphone": "tʃeɪn"
+    },
+    {
+        "name": "challenge",
+        "trans": [
+            "挑战；艰巨任务，难题；质疑，质问",
+            "向…挑战； 公然反抗； 对…质疑"
+        ],
+        "usphone": "'tʃælɪndʒ",
+        "ukphone": "'tʃælɪndʒ"
+    },
+    {
+        "name": "chamber",
+        "trans": [
+            "会议厅； 议院； 洞穴； 腔， 室； 房间"
+        ],
+        "usphone": "ˈtʃeɪmbər",
+        "ukphone": "'tʃeɪmbər"
+    },
+    {
+        "name": "champion",
+        "trans": [
+            "冠军；拥护者",
+            "声援"
+        ],
+        "usphone": "'tʃæmpɪən",
+        "ukphone": "'tʃæmpiən"
+    },
+    {
+        "name": "championship",
+        "trans": [
+            "锦标赛，冠军赛"
+        ],
+        "usphone": "'tʃæmpɪənʃɪp",
+        "ukphone": "'tʃæmpiənʃɪp"
+    },
+    {
+        "name": "chance",
+        "trans": [
+            "碰巧， 偶然发生； 冒…的险",
+            "机会；可能性，偶然性；偶然的事"
+        ],
+        "usphone": "tʃæns",
+        "ukphone": "tʃæns"
+    },
+    {
+        "name": "channel",
+        "trans": [
+            "频道； 渠道， 途径； 通道； 海峡； 水道， 航道"
+        ],
+        "usphone": "'tʃænl",
+        "ukphone": "'tʃænl"
+    },
+    {
+        "name": "chant",
+        "trans": [
+            "唱圣歌； 反复呼喊",
+            "圣歌；单调的吟唱；反复呼喊的话语"
+        ],
+        "usphone": "tʃænt",
+        "ukphone": "tʃænt"
+    },
+    {
+        "name": "chaos",
+        "trans": [
+            "混乱"
+        ],
+        "usphone": "'keɑs",
+        "ukphone": "'keɪɑːs"
+    },
+    {
+        "name": "chaotic",
+        "trans": [
+            "混乱的， 无秩序的"
+        ],
+        "usphone": "ke'ɑtɪk",
+        "ukphone": "keɪ'ɑːtɪk"
+    },
+    {
+        "name": "chapel",
+        "trans": [
+            "教堂； 祈祷室"
+        ],
+        "usphone": "'tʃæpl",
+        "ukphone": "'tʃæpl"
+    },
+    {
+        "name": "characteristic",
+        "trans": [
+            "特有的； 典型的",
+            "特性，特征"
+        ],
+        "usphone": ",kærəktə'rɪstɪk",
+        "ukphone": "ˌkærəktə'rɪstɪk"
+    },
+    {
+        "name": "characterize",
+        "trans": [
+            "以…为特征； 刻画； 描述"
+        ],
+        "usphone": "'kærəktə'raɪz",
+        "ukphone": "'kærəktəraɪz"
+    },
+    {
+        "name": "charcoal",
+        "trans": [
+            "木炭"
+        ],
+        "usphone": "'tʃɑrkol",
+        "ukphone": "'tʃɑːrkoul"
+    },
+    {
+        "name": "charisma",
+        "trans": [
+            "超凡魅力； 感召力； 号召力"
+        ],
+        "usphone": "kə'rɪzmə",
+        "ukphone": "kə'rɪzmə"
+    },
+    {
+        "name": "charismatic",
+        "trans": [
+            "蒙受神恩的； 有超凡魅力的"
+        ],
+        "usphone": ",kærɪz'mætɪk",
+        "ukphone": "ˌkærɪz'mætɪk"
+    },
+    {
+        "name": "chart",
+        "trans": [
+            "用图说明；制图；记录，跟踪；计划",
+            "图表； 航海图"
+        ],
+        "usphone": "tʃɑrt",
+        "ukphone": "tʃɑːrt"
+    },
+    {
+        "name": "charter",
+        "trans": [
+            "特许设立，给予特权；包租",
+            "纲领， 宣言； 宪章； 特许状"
+        ],
+        "usphone": "'tʃɑrtɚ",
+        "ukphone": "'tʃɑːrtər"
+    },
+    {
+        "name": "chaste",
+        "trans": [
+            "贞洁的； 简朴的， 朴实的"
+        ],
+        "usphone": "tʃest",
+        "ukphone": "tʃeɪst"
+    },
+    {
+        "name": "check",
+        "trans": [
+            "支票；账单；"
+        ],
+        "usphone": "tʃɛk",
+        "ukphone": "tʃek"
+    },
+    {
+        "name": "checked",
+        "trans": [
+            "格子花纹的； 棋盘状的"
+        ],
+        "usphone": "tʃɛkt",
+        "ukphone": "tʃekt"
+    },
+    {
+        "name": "cherish",
+        "trans": [
+            "爱护， 珍爱； 怀有， 抱有"
+        ],
+        "usphone": "'tʃɛrɪʃ",
+        "ukphone": "'tʃerɪʃ"
+    },
+    {
+        "name": "chew",
+        "trans": [
+            "咀嚼； 思量， 熟思"
+        ],
+        "usphone": "tʃʊ",
+        "ukphone": "tʃuː"
+    },
+    {
+        "name": "chief",
+        "trans": [
+            "主要的；总的；首席的",
+            "首领； 酋长， 族长"
+        ],
+        "usphone": "tʃif",
+        "ukphone": "tʃiːf"
+    },
+    {
+        "name": "chill",
+        "trans": [
+            "寒冷的",
+            "变冷， 冷却",
+            "寒冷，寒意"
+        ],
+        "usphone": "tʃɪl",
+        "ukphone": "tʃɪl"
+    },
+    {
+        "name": "chilly",
+        "trans": [
+            "寒冷的； 冷淡的， 不友好的"
+        ],
+        "usphone": "'tʃɪli",
+        "ukphone": "'tʃɪli"
+    },
+    {
+        "name": "chimpanzee",
+        "trans": [
+            "黑猩猩"
+        ],
+        "usphone": ",tʃɪmpæn'zi",
+        "ukphone": "ˌtʃɪmpæn'ziː"
+    },
+    {
+        "name": "chip",
+        "trans": [
+            "削下",
+            "碎片； 芯片"
+        ],
+        "usphone": "tʃɪp",
+        "ukphone": "tʃɪp"
+    },
+    {
+        "name": "chivalrous",
+        "trans": [
+            "有骑士精神的； 彬彬有礼的， 殷勤的"
+        ],
+        "usphone": "'ʃɪvəlrəs",
+        "ukphone": "'ʃɪvlrəs"
+    },
+    {
+        "name": "chlorine",
+        "trans": [
+            "氯"
+        ],
+        "usphone": "'klɔrin",
+        "ukphone": "'klɔːriːn"
+    },
+    {
+        "name": "choir",
+        "trans": [
+            "合唱",
+            "唱诗班，合唱队"
+        ],
+        "usphone": "'kwaɪɚ",
+        "ukphone": "'kwaɪər"
+    },
+    {
+        "name": "cholesterol",
+        "trans": [
+            "胆固醇"
+        ],
+        "usphone": "kə'lɛstərɔl",
+        "ukphone": "kə'lestərɔːl"
+    },
+    {
+        "name": "choppy",
+        "trans": [
+            "波浪起伏的， 不平静的； 不连贯的， 支离破碎的"
+        ],
+        "usphone": "'tʃɑpi",
+        "ukphone": "'tʃɑːpi"
+    },
+    {
+        "name": "choreograph",
+        "trans": [
+            "设计舞蹈动作， 编舞"
+        ],
+        "usphone": "'kɔriəɡrɑ:f",
+        "ukphone": "'kɔːriəgræf"
+    },
+    {
+        "name": "chorus",
+        "trans": [
+            "合唱曲；合唱队；副歌，叠句；齐声，"
+        ],
+        "usphone": "'kɔrəs",
+        "ukphone": "'kɔːrəs"
+    },
+    {
+        "name": "chromosome",
+        "trans": [
+            "染色体"
+        ],
+        "usphone": "'kroməsom",
+        "ukphone": "'krouməsoum"
+    },
+    {
+        "name": "chronical",
+        "trans": [
+            "慢性的， 延续很长的"
+        ],
+        "usphone": "'krɔnikəl",
+        "ukphone": "'krɑːnɪkl"
+    },
+    {
+        "name": "chronicle",
+        "trans": [
+            "把…载入编年史",
+            "编年史， 年代记"
+        ],
+        "usphone": "'krɑnɪkl",
+        "ukphone": "'krɑːnɪkl"
+    },
+    {
+        "name": "chronological",
+        "trans": [
+            "按年代顺序排列的， 年代学的"
+        ],
+        "usphone": ",krɑnə'lɑdʒɪkl",
+        "ukphone": "ˌkrɑːnə'lɑːdʒɪkl"
+    },
+    {
+        "name": "chubby",
+        "trans": [
+            "丰满的， 圆胖的"
+        ],
+        "usphone": "'tʃʌbi",
+        "ukphone": "'tʃʌbi"
+    },
+    {
+        "name": "chunk",
+        "trans": [
+            "厚片， 大块； 相当大的部分； 矮胖的人"
+        ],
+        "usphone": "tʃʌŋk",
+        "ukphone": "tʃʌŋk"
+    },
+    {
+        "name": "cider",
+        "trans": [
+            "苹果酒； 苹果汁"
+        ],
+        "usphone": "'saɪdɚ",
+        "ukphone": "'saɪdər"
+    },
+    {
+        "name": "cipher",
+        "trans": [
+            "密码， 暗号"
+        ],
+        "usphone": "'saɪfɚ",
+        "ukphone": "'saɪfər"
+    },
+    {
+        "name": "circuit",
+        "trans": [
+            "电路； 线路； 巡回； 环行； 环行路线"
+        ],
+        "usphone": "'sɝkɪt",
+        "ukphone": "'sɜːrkɪt"
+    },
+    {
+        "name": "circular",
+        "trans": [
+            "圆形的， 环形的； 循环的； 绕行的"
+        ],
+        "usphone": "'sɝkjəlɚ",
+        "ukphone": "'sɜːrkjələr"
+    },
+    {
+        "name": "circulate",
+        "trans": [
+            "循环； 流通； 传播， 流传"
+        ],
+        "usphone": "'sɝkjəlet",
+        "ukphone": "'sɜːrkjəleɪt"
+    },
+    {
+        "name": "circumference",
+        "trans": [
+            "周围， 周边； 圆周； 周长"
+        ],
+        "usphone": "sɚ'kʌmfərəns",
+        "ukphone": "sər'kʌmfərəns"
+    },
+    {
+        "name": "circumstance",
+        "trans": [
+            "环境， 条件； 境况， 经济状况"
+        ],
+        "usphone": "ˈsɝ​kəmˌstəns",
+        "ukphone": "'sɜːrkəmstæns"
+    },
+    {
+        "name": "citadel",
+        "trans": [
+            "堡垒， 要塞"
+        ],
+        "usphone": "ˈsɪtədəl",
+        "ukphone": "'sɪtədəl"
+    },
+    {
+        "name": "cite",
+        "trans": [
+            "引用， 引证； 传唤， 传讯； 表彰， 嘉奖"
+        ],
+        "usphone": "saɪt",
+        "ukphone": "saɪt"
+    },
+    {
+        "name": "civil",
+        "trans": [
+            "市民的， 公民的， 平民的； 民事的； 国家的， 政府的； 文明的， 有教养的"
+        ],
+        "usphone": "'sɪvl",
+        "ukphone": "'sɪvl"
+    },
+    {
+        "name": "claim",
+        "trans": [
+            "声称， 断言； 要求； 索赔"
+        ],
+        "usphone": "klem",
+        "ukphone": "kleɪm"
+    },
+    {
+        "name": "clam",
+        "trans": [
+            "蛤， 蛤肉； 〈口〉守口如瓶的人， 寡言的人"
+        ],
+        "usphone": "klæm",
+        "ukphone": "klæm"
+    },
+    {
+        "name": "clamor",
+        "trans": [
+            "吵闹， 喧哗"
+        ],
+        "usphone": "'klæmə",
+        "ukphone": "'klæmər"
+    },
+    {
+        "name": "clan",
+        "trans": [
+            "家族， 宗族， 氏族； 帮派"
+        ],
+        "usphone": "klæn",
+        "ukphone": "klæn"
+    },
+    {
+        "name": "clarify",
+        "trans": [
+            "澄清， 阐明"
+        ],
+        "usphone": "'klærəfaɪ",
+        "ukphone": "'klærəfaɪ"
+    },
+    {
+        "name": "clasp",
+        "trans": [
+            "搭扣，扣环；紧抱；紧握",
+            "握紧； 抱紧； 扣住， 扣牢"
+        ],
+        "usphone": "klæsp",
+        "ukphone": "klæsp"
+    },
+    {
+        "name": "classic",
+        "trans": [
+            "经典的；典型的",
+            "经典作品；"
+        ],
+        "usphone": "'klæsɪk",
+        "ukphone": "'klæsɪk"
+    },
+    {
+        "name": "classical",
+        "trans": [
+            "经典的， 古典的"
+        ],
+        "usphone": "'klæsɪkl",
+        "ukphone": "'klæsɪkl"
+    },
+    {
+        "name": "classify",
+        "trans": [
+            "分类； 分等"
+        ],
+        "usphone": "'klæsɪfaɪ",
+        "ukphone": "'klæsɪfaɪ"
+    },
+    {
+        "name": "clay",
+        "trans": [
+            "泥土， 黏土"
+        ],
+        "usphone": "kle",
+        "ukphone": "kleɪ"
+    },
+    {
+        "name": "clench",
+        "trans": [
+            "握紧， 抓牢； 咬紧"
+        ],
+        "usphone": "klɛntʃ",
+        "ukphone": "klentʃ"
+    },
+    {
+        "name": "client",
+        "trans": [
+            "委托人， 当事人； 顾客"
+        ],
+        "usphone": "'klaɪənt",
+        "ukphone": "'klaɪənt"
+    },
+    {
+        "name": "cliff",
+        "trans": [
+            "悬崖， 峭壁"
+        ],
+        "usphone": "klɪf",
+        "ukphone": "klɪf"
+    },
+    {
+        "name": "climate",
+        "trans": [
+            "气候； 气候区， 地带； 风气， 氛围； 思潮"
+        ],
+        "usphone": "ˈklaɪmɪt",
+        "ukphone": "'klaɪmət"
+    },
+    {
+        "name": "cling",
+        "trans": [
+            "附着， 黏住； 紧紧抓住； 挨近"
+        ],
+        "usphone": "klɪŋ",
+        "ukphone": "klɪŋ"
+    },
+    {
+        "name": "clinic",
+        "trans": [
+            "门诊部， 诊所"
+        ],
+        "usphone": "'klɪnɪk",
+        "ukphone": "'klɪnɪk"
+    },
+    {
+        "name": "clip",
+        "trans": [
+            "夹住，扣住；修剪；剪下",
+            "夹子， 回形针， 别针； 弹夹， 弹仓； 电影片段， 剪报"
+        ],
+        "usphone": "klɪp",
+        "ukphone": "klɪp"
+    },
+    {
+        "name": "clipper",
+        "trans": [
+            "快速帆船； 剪刀"
+        ],
+        "usphone": "'klɪpɚ",
+        "ukphone": "'klɪpər"
+    },
+    {
+        "name": "clog",
+        "trans": [
+            "堵塞，阻塞",
+            "障碍"
+        ],
+        "usphone": "klɑg",
+        "ukphone": "klɑːg"
+    },
+    {
+        "name": "clone",
+        "trans": [
+            "克隆动物，无性繁殖动物；复制品，翻版",
+            "克隆， 以无性繁殖技术复制"
+        ],
+        "usphone": "klon",
+        "ukphone": "kloun"
+    },
+    {
+        "name": "closet",
+        "trans": [
+            "隐蔽的； 私下的， 秘密的",
+            "把…关在房间里",
+            "橱，壁橱"
+        ],
+        "usphone": "'klɑzət",
+        "ukphone": "'klɑːzət"
+    },
+    {
+        "name": "clue",
+        "trans": [
+            "线索； 提示"
+        ],
+        "usphone": "klʊ",
+        "ukphone": "kluː"
+    },
+    {
+        "name": "clump",
+        "trans": [
+            "聚集， 成群； 以沉重的脚步行走",
+            "丛，簇，束；块，团；群，组"
+        ],
+        "usphone": "klʌmp",
+        "ukphone": "klʌmp"
+    },
+    {
+        "name": "clumsy",
+        "trans": [
+            "笨拙的； 不得体的， 冒犯人的； 复杂难懂的， 难处理的"
+        ],
+        "usphone": "'klʌmzi",
+        "ukphone": "'klʌmzi"
+    },
+    {
+        "name": "cluster",
+        "trans": [
+            "成群， 成串； 丛生； 群集",
+            "簇，团，串，丛；群"
+        ],
+        "usphone": "'klʌstɚ",
+        "ukphone": "'klʌstər"
+    },
+    {
+        "name": "clutch",
+        "trans": [
+            "企图抓住， 抓紧",
+            "一次所孵的卵；离合器；掌握，控制；把握，抓紧"
+        ],
+        "usphone": "klʌtʃ",
+        "ukphone": "klʌtʃ"
+    },
+    {
+        "name": "coalition",
+        "trans": [
+            "联盟， 同盟； 结合， 联合"
+        ],
+        "usphone": "ˌkoʊəˈlɪʃn",
+        "ukphone": "ˌkouə'lɪʃn"
+    },
+    {
+        "name": "coarse",
+        "trans": [
+            "粗糙的； 粗俗的"
+        ],
+        "usphone": "kɔrs",
+        "ukphone": "kɔːrs"
+    },
+    {
+        "name": "code",
+        "trans": [
+            "编纂；把…编码",
+            "法典， 法规； 密码， 代码"
+        ],
+        "usphone": "kod",
+        "ukphone": "koud"
+    },
+    {
+        "name": "codify",
+        "trans": [
+            "把…编成法典， 使法律成文化； 整理， 系统化"
+        ],
+        "usphone": "'kɔdifai",
+        "ukphone": "'koudɪfaɪ"
+    },
+    {
+        "name": "coefficient",
+        "trans": [
+            "系数"
+        ],
+        "usphone": ",koɪ'fɪʃnt",
+        "ukphone": "ˌkouɪ'fɪʃnt"
+    },
+    {
+        "name": "coexist",
+        "trans": [
+            "共存"
+        ],
+        "usphone": ",koɪɡ'zɪst",
+        "ukphone": "ˌkouɪg'zɪst"
+    },
+    {
+        "name": "cognition",
+        "trans": [
+            "感知， 认知， 认识"
+        ],
+        "usphone": "kɑɡ'nɪʃən",
+        "ukphone": "kɑːg'nɪʃn"
+    },
+    {
+        "name": "cognitive",
+        "trans": [
+            "认识的； 认知的， 有感知的"
+        ],
+        "usphone": "'kɑɡnətɪv",
+        "ukphone": "'kɑːgnətɪv"
+    },
+    {
+        "name": "cohabitation",
+        "trans": [
+            "同居， 同住"
+        ],
+        "usphone": "ko,hæbə'teʃən",
+        "ukphone": "ˌkouˌhæbɪ'teɪʃn"
+    },
+    {
+        "name": "cohere",
+        "trans": [
+            "连贯， 一致； 黏合； 齐心协力， 团结一致"
+        ],
+        "usphone": "ko'hɪr",
+        "ukphone": "kou'hɪr"
+    },
+    {
+        "name": "coherent",
+        "trans": [
+            "条理清楚的， 连贯的； 有表达能力的"
+        ],
+        "usphone": "ko'hɪrənt",
+        "ukphone": "kou'hɪrənt"
+    },
+    {
+        "name": "cohesion",
+        "trans": [
+            "内聚力； 凝聚力； 团结， 结合"
+        ],
+        "usphone": "ko'hiʒən",
+        "ukphone": "kou'hiːʒn"
+    },
+    {
+        "name": "cohesive",
+        "trans": [
+            "黏着的； 使凝结的， 使内聚的"
+        ],
+        "usphone": "ko'hisɪv",
+        "ukphone": "kou'hiːsɪv"
+    },
+    {
+        "name": "coil",
+        "trans": [
+            "盘绕，卷",
+            "卷； 线圈"
+        ],
+        "usphone": "kɔɪl",
+        "ukphone": "kɔɪl"
+    },
+    {
+        "name": "coincide",
+        "trans": [
+            "同时发生； 一致， 相符； 重合"
+        ],
+        "usphone": ",koɪn'saɪd",
+        "ukphone": "ˌkouɪn'saɪd"
+    },
+    {
+        "name": "collaborate",
+        "trans": [
+            "协作， 合作； 勾结， 通敌"
+        ],
+        "usphone": "kə'læbəret",
+        "ukphone": "kə'læbəreɪt"
+    },
+    {
+        "name": "collaborative",
+        "trans": [
+            "合作的， 协作的"
+        ],
+        "usphone": "kə'læbəretɪv",
+        "ukphone": "kə'læbəreɪtɪv"
+    },
+    {
+        "name": "collaborator",
+        "trans": [
+            "合作者， 协作者； 通敌者"
+        ],
+        "usphone": "kə'læbə'retɚ",
+        "ukphone": "kə'læbəreɪtər"
+    },
+    {
+        "name": "collapse",
+        "trans": [
+            "崩溃， 倒塌； 虚脱"
+        ],
+        "usphone": "kə'læps",
+        "ukphone": "kə'læps"
+    },
+    {
+        "name": "colleague",
+        "trans": [
+            "同事， 同僚"
+        ],
+        "usphone": "'kɑliɡ",
+        "ukphone": "'kɑːliːg"
+    },
+    {
+        "name": "collective",
+        "trans": [
+            "集体的，共同的",
+            "集体， 共同体"
+        ],
+        "usphone": "kə'lɛktɪv",
+        "ukphone": "kə'lektɪv"
+    },
+    {
+        "name": "collide",
+        "trans": [
+            "碰撞， 互撞； 冲突， 抵触"
+        ],
+        "usphone": "kə'laɪd",
+        "ukphone": "kə'laɪd"
+    },
+    {
+        "name": "collision",
+        "trans": [
+            "碰撞； 冲突， 抵触"
+        ],
+        "usphone": "kə'lɪʒən",
+        "ukphone": "kə'lɪʒn"
+    },
+    {
+        "name": "colonial",
+        "trans": [
+            "殖民的； 殖民国家的"
+        ],
+        "usphone": "kə'lonɪəl",
+        "ukphone": "kə'louniəl"
+    },
+    {
+        "name": "colonization",
+        "trans": [
+            "殖民地化"
+        ],
+        "usphone": ",kɑlənɪ'zeʃən",
+        "ukphone": "ˌkɑːlənə'zeɪʃn"
+    },
+    {
+        "name": "colonize",
+        "trans": [
+            "聚居于， 大批生长于； 开拓殖民地， 移居于"
+        ],
+        "usphone": "'kɑlənaɪz",
+        "ukphone": "'kɑːlənaɪz"
+    },
+    {
+        "name": "colony",
+        "trans": [
+            "群， 群体； 殖民地； 聚居地"
+        ],
+        "usphone": "'kɑləni",
+        "ukphone": "'kɑːləni"
+    },
+    {
+        "name": "column",
+        "trans": [
+            "专栏； 圆柱， 支柱； 纵队"
+        ],
+        "usphone": "'kɑləm",
+        "ukphone": "'kɑːləm"
+    },
+    {
+        "name": "combat",
+        "trans": [
+            "战斗， 格斗"
+        ],
+        "usphone": "'kɑmbæt",
+        "ukphone": "'kɑːmbæt"
+    },
+    {
+        "name": "combination",
+        "trans": [
+            "结合， 混合； 化合； 组合"
+        ],
+        "usphone": ",kɑmbɪ'neʃən",
+        "ukphone": "ˌkɑːmbɪ'neɪʃn"
+    },
+    {
+        "name": "combine",
+        "trans": [
+            "联合， 结合"
+        ],
+        "usphone": "kəm'baɪn",
+        "ukphone": "kəm'baɪn"
+    },
+    {
+        "name": "combustible",
+        "trans": [
+            "可燃的， 易燃的"
+        ],
+        "usphone": "kəm'bʌstəbl",
+        "ukphone": "kəm'bʌstəbl"
+    },
+    {
+        "name": "comedy",
+        "trans": [
+            "喜剧； 喜剧性， 滑稽， 幽默"
+        ],
+        "usphone": "'kɑmədi",
+        "ukphone": "'kɑːmədi"
+    },
+    {
+        "name": "comet",
+        "trans": [
+            "彗星"
+        ],
+        "usphone": "'kɑmət",
+        "ukphone": "'kɑːmət"
+    },
+    {
+        "name": "comic",
+        "trans": [
+            "可笑的，滑稽的；喜剧的",
+            "喜剧演员"
+        ],
+        "usphone": "'kɑmɪk",
+        "ukphone": "'kɑːmɪk"
+    },
+    {
+        "name": "command",
+        "trans": [
+            "命令； 指挥， 统率"
+        ],
+        "usphone": "kə'mænd",
+        "ukphone": "kə'mænd"
+    },
+    {
+        "name": "commemorate",
+        "trans": [
+            "庆祝， 纪念"
+        ],
+        "usphone": "kə'mɛməret",
+        "ukphone": "kə'meməreɪt"
+    },
+    {
+        "name": "comment",
+        "trans": [
+            "评论； 注释"
+        ],
+        "usphone": "'kɑmɛnt",
+        "ukphone": "'kɑːment"
+    },
+    {
+        "name": "commentary",
+        "trans": [
+            "评论， 注释； 实况报道， 现场解说"
+        ],
+        "usphone": "'kɑməntɛri",
+        "ukphone": "'kɑːmənteri"
+    },
+    {
+        "name": "commerce",
+        "trans": [
+            "贸易， 商业； 交往， 交流"
+        ],
+        "usphone": "'kɑmɝs",
+        "ukphone": "'kɑːmɜːrs"
+    },
+    {
+        "name": "commission",
+        "trans": [
+            "授权，委任；委员会；佣金，回扣",
+            "委托， 授权"
+        ],
+        "usphone": "kə'mɪʃən",
+        "ukphone": "kə'mɪʃn"
+    },
+    {
+        "name": "commit",
+        "trans": [
+            "承诺； 犯错； 犯罪； 忠于"
+        ],
+        "usphone": "kə'mɪt",
+        "ukphone": "kə'mɪt"
+    },
+    {
+        "name": "committee",
+        "trans": [
+            "委员会"
+        ],
+        "usphone": "kə'mɪti",
+        "ukphone": "kə'mɪti"
+    },
+    {
+        "name": "commodity",
+        "trans": [
+            "商品； 日用品"
+        ],
+        "usphone": "kə'mɑdəti",
+        "ukphone": "kə'mɑːdəti"
+    },
+    {
+        "name": "commonplace",
+        "trans": [
+            "普通的， 平凡的",
+            "平凡的事；老生常谈"
+        ],
+        "usphone": "'kɑmən'ples",
+        "ukphone": "'kɑːmənpleɪs"
+    },
+    {
+        "name": "communal",
+        "trans": [
+            "公共的， 共享的； 社区的"
+        ],
+        "usphone": "kəˈmjunəl",
+        "ukphone": "kə'mjuːnl"
+    },
+    {
+        "name": "commune",
+        "trans": [
+            "与…亲密地交谈",
+            "群体， 公社"
+        ],
+        "usphone": "kə'mju:n, 'kɔmju:n",
+        "ukphone": "'kɒmjuːn"
+    },
+    {
+        "name": "communicate",
+        "trans": [
+            "交流， 沟通； 传达， 传播； 通信"
+        ],
+        "usphone": "kə'mjunɪket",
+        "ukphone": "kə'mjuːnɪkeɪt"
+    },
+    {
+        "name": "community",
+        "trans": [
+            "社会； 社团； 群落； 共同体"
+        ],
+        "usphone": "kəˈmjunətɪ",
+        "ukphone": "kə'mjuːnəti"
+    },
+    {
+        "name": "commute",
+        "trans": [
+            "上下班往返， 经常往返； 代偿； 减刑"
+        ],
+        "usphone": "kə'mjʊt",
+        "ukphone": "kə'mjuːt"
+    },
+    {
+        "name": "compact",
+        "trans": [
+            "紧凑的；简洁的",
+            "压缩"
+        ],
+        "usphone": "'kɑmpækt",
+        "ukphone": "kəm'pækt"
+    },
+    {
+        "name": "companion",
+        "trans": [
+            "同伴， 共事者"
+        ],
+        "usphone": "kəm'pænɪən",
+        "ukphone": "kəm'pæniən"
+    },
+    {
+        "name": "comparable",
+        "trans": [
+            "可比较的， 类似的； 比得上的"
+        ],
+        "usphone": "'kɑmpərəbl",
+        "ukphone": "'kɑːmpərəbl"
+    },
+    {
+        "name": "comparative",
+        "trans": [
+            "比较的；比较级的；相对的",
+            "比较级"
+        ],
+        "usphone": "kəm'pærətɪv",
+        "ukphone": "kəm'pærətɪv"
+    },
+    {
+        "name": "compare",
+        "trans": [
+            "比较， 相比， 对比"
+        ],
+        "usphone": "kəm'pɛr",
+        "ukphone": "kəm'per"
+    },
+    {
+        "name": "comparison",
+        "trans": [
+            "比较， 对比； 比拟， 比喻"
+        ],
+        "usphone": "kəm'pærɪsn",
+        "ukphone": "kəm'pærɪsn"
+    },
+    {
+        "name": "compass",
+        "trans": [
+            "罗盘，罗盘仪；"
+        ],
+        "usphone": "'kʌmpəs",
+        "ukphone": "'kʌmpəs"
+    },
+    {
+        "name": "compatible",
+        "trans": [
+            "协调的， 一致的； 兼容的； 能和睦相处的"
+        ],
+        "usphone": "kəm'pætəbl",
+        "ukphone": "kəm'pætəbl"
+    },
+    {
+        "name": "compel",
+        "trans": [
+            "驱使， 强迫"
+        ],
+        "usphone": "kəm'pɛl",
+        "ukphone": "kəm'pel"
+    },
+    {
+        "name": "compensate",
+        "trans": [
+            "赔偿， 弥补"
+        ],
+        "usphone": "'kɑmpɛnset",
+        "ukphone": "'kɑːmpenseɪt"
+    },
+    {
+        "name": "compensation",
+        "trans": [
+            "补偿， 赔偿； 赔偿金"
+        ],
+        "usphone": ",kɑmpɛn'seʃən",
+        "ukphone": "ˌkɑːmpen'seɪʃn"
+    },
+    {
+        "name": "competence",
+        "trans": [
+            "能力， 胜任； 权限； 技能"
+        ],
+        "usphone": "'kɑmpɪtəns",
+        "ukphone": "'kɑːmpɪtəns"
+    },
+    {
+        "name": "compile",
+        "trans": [
+            "汇编； 编辑， 编纂"
+        ],
+        "usphone": "kəm'paɪl",
+        "ukphone": "kəm'paɪl"
+    },
+    {
+        "name": "complacence",
+        "trans": [
+            "自满， 满足"
+        ],
+        "usphone": "kəm'plesns",
+        "ukphone": "kəm'pleɪsns"
+    },
+    {
+        "name": "complain",
+        "trans": [
+            "诉苦， 抱怨； 投诉； 控告"
+        ],
+        "usphone": "kəm'plen",
+        "ukphone": "kəm'pleɪn"
+    },
+    {
+        "name": "complaint",
+        "trans": [
+            "诉苦， 抱怨； 投诉； 控告"
+        ],
+        "usphone": "kəm'plent",
+        "ukphone": "kəm'pleɪnt"
+    },
+    {
+        "name": "complement",
+        "trans": [
+            "补充， 补足， 使完善； 与…相配",
+            "补充物， 补足物； 足数， 足额； 补足语"
+        ],
+        "usphone": "ˈkɑːmplɪment",
+        "ukphone": "'kɒmplɪm(ə)nt"
+    },
+    {
+        "name": "complementary",
+        "trans": [
+            "补充的； 互补的"
+        ],
+        "usphone": "'kɑmplə'mɛntri",
+        "ukphone": "ˌkɑːmplɪ'mentri"
+    },
+    {
+        "name": "completion",
+        "trans": [
+            "完成， 实现； 结束"
+        ],
+        "usphone": "kəm'pliʃən",
+        "ukphone": "kəm'pliːʃn"
+    },
+    {
+        "name": "complex",
+        "trans": [
+            "合成的， 综合的； 复杂的， 错综的， 难以理解的",
+            "建筑群； 综合体， 集合体； 情结"
+        ],
+        "usphone": "ˈkɑmplɛks;kəmˈplɛks",
+        "ukphone": "'kɒmpleks"
+    },
+    {
+        "name": "complicated",
+        "trans": [
+            "难懂的， 复杂的"
+        ],
+        "usphone": "'kɑmplɪketɪd",
+        "ukphone": "'kɑːmplɪkeɪtɪd"
+    },
+    {
+        "name": "compliment",
+        "trans": [
+            "赞美， 称赞",
+            "赞美；"
+        ],
+        "usphone": "ˈkɑːmplɪmənt",
+        "ukphone": "'kɒmplɪm(ə)nt"
+    },
+    {
+        "name": "comply",
+        "trans": [
+            "服从； 遵守"
+        ],
+        "usphone": "kəm'plaɪ",
+        "ukphone": "kəm'plaɪ"
+    },
+    {
+        "name": "component",
+        "trans": [
+            "组成的， 构成的",
+            "成分，组成部分"
+        ],
+        "usphone": "kəm'ponənt",
+        "ukphone": "kəm'pounənt"
+    },
+    {
+        "name": "compose",
+        "trans": [
+            "创作； 组成； 使安定"
+        ],
+        "usphone": "kəm'poz",
+        "ukphone": "kəm'pouz"
+    },
+    {
+        "name": "composer",
+        "trans": [
+            "作曲家， 作曲者"
+        ],
+        "usphone": "kəm'pozɚ",
+        "ukphone": "kəm'pouzər"
+    },
+    {
+        "name": "compound",
+        "trans": [
+            "化合物，",
+            "使恶化， 使加重； 混合"
+        ],
+        "usphone": "'kɑmpaʊnd",
+        "ukphone": "'kɒmpaʊnd"
+    },
+    {
+        "name": "comprehend",
+        "trans": [
+            "理解， 领会； 包括， 由…组成"
+        ],
+        "usphone": ",kɑmprɪ'hɛnd",
+        "ukphone": "ˌkɑːmprɪ'hend"
+    },
+    {
+        "name": "comprehensible",
+        "trans": [
+            "可理解的， 能懂的， 能充分理解的"
+        ],
+        "usphone": "'kɑmprɪ'hɛnsəbl",
+        "ukphone": "ˌkɑːmprɪ'hensəbl"
+    },
+    {
+        "name": "comprehensive",
+        "trans": [
+            "全面的； 综合的"
+        ],
+        "usphone": "ˌkɑːmprɪˈhensɪv",
+        "ukphone": "ˌkɑːmprɪ'hensɪv"
+    },
+    {
+        "name": "compress",
+        "trans": [
+            "压缩； 缩短； 浓缩"
+        ],
+        "usphone": "kəm'prɛs",
+        "ukphone": "kəm'pres"
+    },
+    {
+        "name": "compressible",
+        "trans": [
+            "可压缩的"
+        ],
+        "usphone": "kəm'presəbl",
+        "ukphone": "kəm'presbl"
+    },
+    {
+        "name": "comprise",
+        "trans": [
+            "包含； 由…组成"
+        ],
+        "usphone": "kəm'praɪz",
+        "ukphone": "kəm'praɪz"
+    },
+    {
+        "name": "compromise",
+        "trans": [
+            "妥协， 折中"
+        ],
+        "usphone": "'kɑmprəmaɪz",
+        "ukphone": "'kɑːmprəmaɪz"
+    },
+    {
+        "name": "compulsory",
+        "trans": [
+            "必须做的， 义务的； 强制性的； 必修的"
+        ],
+        "usphone": "kəmˈpʌlsərɪ",
+        "ukphone": "kəm'pʌlsəri"
+    },
+    {
+        "name": "compute",
+        "trans": [
+            "计算， 估算"
+        ],
+        "usphone": "kəm'pjʊt",
+        "ukphone": "kəm'pjuːt"
+    },
+    {
+        "name": "concave",
+        "trans": [
+            "凹的"
+        ],
+        "usphone": "kɑn'kev",
+        "ukphone": "kɑːn'keɪv"
+    },
+    {
+        "name": "conceal",
+        "trans": [
+            "隐蔽； 隐瞒； 覆盖"
+        ],
+        "usphone": "kən'sil",
+        "ukphone": "kən'siːl"
+    },
+    {
+        "name": "concede",
+        "trans": [
+            "承认； 让步； 允许"
+        ],
+        "usphone": "kən'sid",
+        "ukphone": "kən'siːd"
+    },
+    {
+        "name": "conceit",
+        "trans": [
+            "自负， 自大"
+        ],
+        "usphone": "kən'sit",
+        "ukphone": "kən'siːt"
+    },
+    {
+        "name": "conceivable",
+        "trans": [
+            "可能的； 可信的， 可想象的"
+        ],
+        "usphone": "kən'sivəbl",
+        "ukphone": "kən'siːvəbl"
+    },
+    {
+        "name": "conceive",
+        "trans": [
+            "构思， 构想， 设想； 怀孕"
+        ],
+        "usphone": "kən'siv",
+        "ukphone": "kən'siːv"
+    },
+    {
+        "name": "concentrate",
+        "trans": [
+            "集中，专心；"
+        ],
+        "usphone": "'kɑnsn'tret",
+        "ukphone": "'kɑːnsntreɪt"
+    },
+    {
+        "name": "concentration",
+        "trans": [
+            "专注， 专心； 浓度， 含量； 集中， 聚集"
+        ],
+        "usphone": "'kɑnsn'treʃən",
+        "ukphone": "ˌkɑːnsn'treɪʃn"
+    },
+    {
+        "name": "concentric",
+        "trans": [
+            "同心的"
+        ],
+        "usphone": "kən'sɛntrɪk",
+        "ukphone": "kən'sentrɪk"
+    },
+    {
+        "name": "concept",
+        "trans": [
+            "概念， 观念； 设想"
+        ],
+        "usphone": "'kɑnsɛpt",
+        "ukphone": "'kɑːnsept"
+    },
+    {
+        "name": "concern",
+        "trans": [
+            "涉及，关系到；使关心，使担忧",
+            "关心， 挂念； 关系； 有关的事， 负责的事； 公司， 企业"
+        ],
+        "usphone": "kən'sɝn",
+        "ukphone": "kən'sɜːrn"
+    },
+    {
+        "name": "concert",
+        "trans": [
+            "音乐会， 演奏会； 一致"
+        ],
+        "usphone": "'kɑnsɚt",
+        "ukphone": "'kɑːnsərt"
+    },
+    {
+        "name": "conciliate",
+        "trans": [
+            "安抚， 抚慰； 调和"
+        ],
+        "usphone": "kən'sɪlɪet",
+        "ukphone": "kən'sɪlieɪt"
+    },
+    {
+        "name": "concise",
+        "trans": [
+            "简明的， 简练的"
+        ],
+        "usphone": "kən'saɪs",
+        "ukphone": "kən'saɪs"
+    },
+    {
+        "name": "conclusive",
+        "trans": [
+            "确定的， 确凿的， 不容置疑的； 结论性的"
+        ],
+        "usphone": "kən'klusɪv",
+        "ukphone": "kən'kluːsɪv"
+    },
+    {
+        "name": "concomitant",
+        "trans": [
+            "伴随的",
+            "伴随物"
+        ],
+        "usphone": "kən'kɑmətənt",
+        "ukphone": "kən'kɑːmɪtənt"
+    },
+    {
+        "name": "concord",
+        "trans": [
+            "和睦； 公约"
+        ],
+        "usphone": "'kɑŋkɔrd",
+        "ukphone": "'kɑːŋkɔːrd"
+    },
+    {
+        "name": "concrete",
+        "trans": [
+            "混凝土制的；具体的；确凿的",
+            "混凝土"
+        ],
+        "usphone": "'kɑŋkrit",
+        "ukphone": "'kɑːŋkriːt"
+    },
+    {
+        "name": "concur",
+        "trans": [
+            "同时发生； 意见一致"
+        ],
+        "usphone": "kən'kɝ",
+        "ukphone": "kən'kɜːr"
+    },
+    {
+        "name": "condense",
+        "trans": [
+            "压缩； 凝结"
+        ],
+        "usphone": "kən'dɛns",
+        "ukphone": "kən'dens"
+    },
+    {
+        "name": "condiment",
+        "trans": [
+            "调味品"
+        ],
+        "usphone": "'kɑndɪmənt",
+        "ukphone": "'kɑːndɪmənt"
+    },
+    {
+        "name": "condole",
+        "trans": [
+            "向…吊唁； 慰问"
+        ],
+        "usphone": "kən'dəul",
+        "ukphone": "kən'doul"
+    },
+    {
+        "name": "conducive",
+        "trans": [
+            "有助于…的， 有益于…的"
+        ],
+        "usphone": "kən'dusɪv",
+        "ukphone": "kən'duːsɪv"
+    },
+    {
+        "name": "conduct",
+        "trans": [
+            "引导； 传导； 进行； 管理， 指挥； 表现",
+            "行为； 管理， 实施"
+        ],
+        "usphone": "kən'dʌkt",
+        "ukphone": "'kɒndʌkt"
+    },
+    {
+        "name": "conductivity",
+        "trans": [
+            "传导性； 传导率"
+        ],
+        "usphone": ",kɑndʌk'tɪvəti",
+        "ukphone": "ˌkɑːndʌk'tɪvəti"
+    },
+    {
+        "name": "confederacy",
+        "trans": [
+            "联盟， 同盟， 联邦； 私党"
+        ],
+        "usphone": "kən'fɛdərəsi",
+        "ukphone": "kən'fedərəsi"
+    },
+    {
+        "name": "confer",
+        "trans": [
+            "授予； 协商， 商讨"
+        ],
+        "usphone": "kən'fɝ",
+        "ukphone": "kən'fɜːr"
+    },
+    {
+        "name": "confession",
+        "trans": [
+            "供认， 招供， 坦白； 供词； 承认"
+        ],
+        "usphone": "kən'fɛʃən",
+        "ukphone": "kən'feʃn"
+    },
+    {
+        "name": "confidant",
+        "trans": [
+            "知己， 密友"
+        ],
+        "usphone": "'kɑnfɪdænt",
+        "ukphone": "'kɑːnfɪdænt"
+    },
+    {
+        "name": "confidence",
+        "trans": [
+            "信任； 信心"
+        ],
+        "usphone": "'kɑnfɪdəns",
+        "ukphone": "'kɑːnfɪdəns"
+    },
+    {
+        "name": "configuration",
+        "trans": [
+            "布局， 格局； 结构， 构造， 形状； 配置"
+        ],
+        "usphone": "kən,fɪɡjə'reʃən",
+        "ukphone": "kənˌfɪgjə'reɪʃn"
+    },
+    {
+        "name": "confine",
+        "trans": [
+            "限制； 禁闭"
+        ],
+        "usphone": "kən'faɪn",
+        "ukphone": "kən'faɪn"
+    },
+    {
+        "name": "confirm",
+        "trans": [
+            "证实； 使巩固； 批准"
+        ],
+        "usphone": "kən'fɝm",
+        "ukphone": "kən'fɜːrm"
+    },
+    {
+        "name": "confiscate",
+        "trans": [
+            "没收， 充公， 征用"
+        ],
+        "usphone": "'kɑnfɪsket",
+        "ukphone": "'kɑːnfɪskeɪt"
+    },
+    {
+        "name": "conflict",
+        "trans": [
+            "冲突； 不一致； 争论",
+            "冲突； 争论"
+        ],
+        "usphone": "'kɑnflɪkt",
+        "ukphone": "'kɒnflɪkt"
+    },
+    {
+        "name": "conform",
+        "trans": [
+            "遵守， 服从； 符合； 适应"
+        ],
+        "usphone": "kən'fɔrm",
+        "ukphone": "kən'fɔːrm"
+    },
+    {
+        "name": "confront",
+        "trans": [
+            "使面临， 使遭遇； 对抗"
+        ],
+        "usphone": "kən'frʌnt",
+        "ukphone": "kən'frʌnt"
+    },
+    {
+        "name": "confusion",
+        "trans": [
+            "困惑； 混乱， 混淆"
+        ],
+        "usphone": "kən'fjʊʒən",
+        "ukphone": "kən'fjuːʒn"
+    },
+    {
+        "name": "congenial",
+        "trans": [
+            "情投意合的； 相宜的， 适宜的； 适当的， 合适的"
+        ],
+        "usphone": "kən'dʒinɪəl",
+        "ukphone": "kən'dʒiːniəl"
+    },
+    {
+        "name": "congest",
+        "trans": [
+            "充满， 拥塞； 充血"
+        ],
+        "usphone": "kən'dʒɛst",
+        "ukphone": "kən'dʒest"
+    },
+    {
+        "name": "congratulation",
+        "trans": [
+            "祝贺， 道喜"
+        ],
+        "usphone": "kən,ɡrætʃu'leʃən",
+        "ukphone": "kənˌgrætʃu'leɪʃn"
+    },
+    {
+        "name": "congress",
+        "trans": [
+            "[C-] 议会， 国会； 大会"
+        ],
+        "usphone": "'kɑŋɡrəs",
+        "ukphone": "'kɑːŋgrəs"
+    },
+    {
+        "name": "congressional",
+        "trans": [
+            "立法机构的； 代表大会的； 国会的"
+        ],
+        "usphone": "kən'ɡrɛʃənl",
+        "ukphone": "kən'greʃənl"
+    },
+    {
+        "name": "conjure",
+        "trans": [
+            "变魔术， 变戏法； 召唤"
+        ],
+        "usphone": "'kʌndʒɚ",
+        "ukphone": "'kʌndʒər"
+    },
+    {
+        "name": "connote",
+        "trans": [
+            "意味着； 暗示"
+        ],
+        "usphone": "kə'not",
+        "ukphone": "kə'nout"
+    },
+    {
+        "name": "conquer",
+        "trans": [
+            "战胜， 征服； 克服"
+        ],
+        "usphone": "'kɑŋkɚ",
+        "ukphone": "'kɑːŋkər"
+    },
+    {
+        "name": "conscientious",
+        "trans": [
+            "凭良心的； 认真谨慎的， 一丝不苟的"
+        ],
+        "usphone": "'kɑnʃɪ'ɛnʃəs",
+        "ukphone": "ˌkɑːnʃi'enʃəs"
+    },
+    {
+        "name": "conscious",
+        "trans": [
+            "自觉的， 意识到的； 有知觉的， 有意识的； 有意的， 刻意的"
+        ],
+        "usphone": "'kɑnʃəs",
+        "ukphone": "'kɑːnʃəs"
+    },
+    {
+        "name": "consecutive",
+        "trans": [
+            "连续不断的， 连贯的"
+        ],
+        "usphone": "kən'sɛkjətɪv",
+        "ukphone": "kən'sekjətɪv"
+    },
+    {
+        "name": "consensus",
+        "trans": [
+            "共识， 一致同意； 舆论"
+        ],
+        "usphone": "kən'sɛnsəs",
+        "ukphone": "kən'sensəs"
+    },
+    {
+        "name": "consent",
+        "trans": [
+            "同意， 赞成， 准许"
+        ],
+        "usphone": "kən'sɛnt",
+        "ukphone": "kən'sent"
+    },
+    {
+        "name": "consequence",
+        "trans": [
+            "结果； 影响； 推理； 重要， 重大"
+        ],
+        "usphone": "'kɑnsəkwɛns",
+        "ukphone": "'kɑːnsəkwens"
+    },
+    {
+        "name": "conservation",
+        "trans": [
+            "守恒； 保存； 保护"
+        ],
+        "usphone": ",kɑnsɚ'veʃən",
+        "ukphone": "ˌkɑːnsər'veɪʃn"
+    },
+    {
+        "name": "conservationist",
+        "trans": [
+            "自然环境保护论者"
+        ],
+        "usphone": ",kɑnsɚ'veʃənɪst",
+        "ukphone": "ˌkɑːnsər'veɪʃənɪst"
+    },
+    {
+        "name": "conservative",
+        "trans": [
+            "保守的，守旧的；不时新的，传统的",
+            "保守派"
+        ],
+        "usphone": "kən'sɝvətɪv",
+        "ukphone": "kən'sɜːrvətɪv"
+    },
+    {
+        "name": "conserve",
+        "trans": [
+            "保存， 保藏"
+        ],
+        "usphone": "kən'sɝv",
+        "ukphone": "kən'sɜːrv"
+    },
+    {
+        "name": "considerate",
+        "trans": [
+            "考虑周到的， 体贴的， 体谅的"
+        ],
+        "usphone": "kənˈsɪdərɪt",
+        "ukphone": "kən'sɪdərət"
+    },
+    {
+        "name": "consideration",
+        "trans": [
+            "考虑， 思考； 体谅， 照顾； 考虑因素， 理由； 报酬"
+        ],
+        "usphone": "kən,sɪdə'reʃən",
+        "ukphone": "kənˌsɪdə'reɪʃn"
+    },
+    {
+        "name": "consist",
+        "trans": [
+            "在于， 存在于； 由…组成， 由…构成"
+        ],
+        "usphone": "kən'sɪst",
+        "ukphone": "kən'sɪst"
+    },
+    {
+        "name": "consistency",
+        "trans": [
+            "浓度， 密度； 一致性， 协调； 连接， 结合"
+        ],
+        "usphone": "kən'sɪstənsi",
+        "ukphone": "kən'sɪstənsi"
+    },
+    {
+        "name": "consistent",
+        "trans": [
+            "一致的； 稳定的； 调和的； 始终如一的"
+        ],
+        "usphone": "kən'sɪstənt",
+        "ukphone": "kən'sɪstənt"
+    },
+    {
+        "name": "console",
+        "trans": [
+            "安慰， 抚慰"
+        ],
+        "usphone": "'kɑnsol",
+        "ukphone": "kən'soul"
+    },
+    {
+        "name": "consolidate",
+        "trans": [
+            "巩固； 合并"
+        ],
+        "usphone": "kən'sɑlɪdet",
+        "ukphone": "kən'sɑːlɪdeɪt"
+    },
+    {
+        "name": "consonant",
+        "trans": [
+            "和谐的，协调的，符合的",
+            "辅音"
+        ],
+        "usphone": "'kɑnsənənt",
+        "ukphone": "'kɑːnsənənt"
+    },
+    {
+        "name": "consort",
+        "trans": [
+            "结交； 鬼混",
+            "配偶； 团伙"
+        ],
+        "usphone": "'kɑn,sɔrt",
+        "ukphone": "'kɒnsɔːt"
+    },
+    {
+        "name": "conspicuous",
+        "trans": [
+            "显眼的， 明显的"
+        ],
+        "usphone": "kən'spɪkjʊəs",
+        "ukphone": "kən'spɪkjuəs"
+    },
+    {
+        "name": "conspiracy",
+        "trans": [
+            "密谋； 阴谋"
+        ],
+        "usphone": "kən'spɪrəsi",
+        "ukphone": "kən'spɪrəsi"
+    },
+    {
+        "name": "constant",
+        "trans": [
+            "坚定的；稳定的；不变的，持续的",
+            "常数， 恒量"
+        ],
+        "usphone": "'kɑnstənt",
+        "ukphone": "'kɑːnstənt"
+    },
+    {
+        "name": "constituent",
+        "trans": [
+            "有宪法制定或修改权的； 组成的， 构成的",
+            "选民；要素，成分"
+        ],
+        "usphone": "kən'stɪtʃuənt",
+        "ukphone": "kən'stɪtʃuənt"
+    },
+    {
+        "name": "constitute",
+        "trans": [
+            "组成； 设立； 制定"
+        ],
+        "usphone": "'kɑnstətut",
+        "ukphone": "'kɑːnstətjuːt"
+    },
+    {
+        "name": "constitution",
+        "trans": [
+            "宪法， 章程； 体质； 构成"
+        ],
+        "usphone": "'kɑnstə'tʊʃən",
+        "ukphone": "ˌkɑːnstə'tuːʃn"
+    },
+    {
+        "name": "constrain",
+        "trans": [
+            "束缚， 限制"
+        ],
+        "usphone": "kən'stren",
+        "ukphone": "kən'streɪn"
+    },
+    {
+        "name": "constricted",
+        "trans": [
+            "狭窄的； 收缩的； 抑制的， 约束的"
+        ],
+        "usphone": "kən'striktid",
+        "ukphone": "kən'strɪktɪd"
+    },
+    {
+        "name": "construct",
+        "trans": [
+            "建造； 创立",
+            "构想， 观念"
+        ],
+        "usphone": "kən'strʌkt",
+        "ukphone": "kən'strʌkt"
+    },
+    {
+        "name": "construction",
+        "trans": [
+            "构造， 结构； 建筑物"
+        ],
+        "usphone": "kən'strʌkʃən",
+        "ukphone": "kən'strʌkʃn"
+    },
+    {
+        "name": "consult",
+        "trans": [
+            "请教； 商议； 参考， 翻阅"
+        ],
+        "usphone": "kən'sʌlt",
+        "ukphone": "kən'sʌlt"
+    },
+    {
+        "name": "consume",
+        "trans": [
+            "消耗， 损耗； 消费； 吃， 喝； 使充满； 烧毁， 毁灭"
+        ],
+        "usphone": "kənˈsum",
+        "ukphone": "kən'suːm"
+    },
+    {
+        "name": "consumption",
+        "trans": [
+            "消耗； 消费； 食用"
+        ],
+        "usphone": "kən'sʌmpʃən",
+        "ukphone": "kən'sʌmpʃn"
+    },
+    {
+        "name": "contagious",
+        "trans": [
+            "传染性的； 有感染力的"
+        ],
+        "usphone": "kən'tedʒəs",
+        "ukphone": "kən'teɪdʒəs"
+    },
+    {
+        "name": "contain",
+        "trans": [
+            "包含， 容纳； 控制； 防止…蔓延"
+        ],
+        "usphone": "kən'ten",
+        "ukphone": "kən'teɪn"
+    },
+    {
+        "name": "contaminate",
+        "trans": [
+            "污染"
+        ],
+        "usphone": "kən'tæmɪnet",
+        "ukphone": "kən'tæmɪneɪt"
+    },
+    {
+        "name": "contamination",
+        "trans": [
+            "污染； 玷污"
+        ],
+        "usphone": "kən,tæmi'neiʃən",
+        "ukphone": "kənˌtæmɪ'neɪʃn"
+    },
+    {
+        "name": "contemplate",
+        "trans": [
+            "思量， 考虑， 思忖； 注视， 凝视； 打算"
+        ],
+        "usphone": "'kɑntəmplet",
+        "ukphone": "'kɑːntəmpleɪt"
+    },
+    {
+        "name": "contemporary",
+        "trans": [
+            "当代的；"
+        ],
+        "usphone": "kən'tɛmpərɛri",
+        "ukphone": "kən'tempəreri"
+    },
+    {
+        "name": "contempt",
+        "trans": [
+            "轻视， 鄙视， 轻蔑"
+        ],
+        "usphone": "kən'tɛmpt",
+        "ukphone": "kən'tempt"
+    },
+    {
+        "name": "contender",
+        "trans": [
+            "竞争者， 争夺者， 对手"
+        ],
+        "usphone": "kən'tɛndɚ",
+        "ukphone": "kən'tendər"
+    },
+    {
+        "name": "contest",
+        "trans": [
+            "竞争； 争辩， 就…提出异议",
+            "竞赛； 辩论； 争夺"
+        ],
+        "usphone": "kən'tɛst",
+        "ukphone": "'kɒntest"
+    },
+    {
+        "name": "context",
+        "trans": [
+            "上下文； 背景； 环境"
+        ],
+        "usphone": "'kɑntɛkst",
+        "ukphone": "'kɑːntekst"
+    },
+    {
+        "name": "contiguous",
+        "trans": [
+            "接壤的， 毗邻的； 不间断的"
+        ],
+        "usphone": "kən'tɪɡjuəs",
+        "ukphone": "kən'tɪgjuəs"
+    },
+    {
+        "name": "continent",
+        "trans": [
+            "大陆， 陆地； 洲"
+        ],
+        "usphone": "'kɑntɪnənt",
+        "ukphone": "'kɑːntɪnənt"
+    },
+    {
+        "name": "continuation",
+        "trans": [
+            "延长， 延续， 持续； 延长物， 扩建物； 延续部分"
+        ],
+        "usphone": "kən'tɪnjʊ'eʃən",
+        "ukphone": "kənˌtɪnju'eɪʃn"
+    },
+    {
+        "name": "continuity",
+        "trans": [
+            "连贯性， 连续性"
+        ],
+        "usphone": "'kɑntə'nʊəti",
+        "ukphone": "ˌkɑːntə'njuːəti"
+    },
+    {
+        "name": "continuum",
+        "trans": [
+            "统一体"
+        ],
+        "usphone": "kən'tɪnjuəm",
+        "ukphone": "kən'tɪnjuəm"
+    },
+    {
+        "name": "contour",
+        "trans": [
+            "等高线； 轮廓"
+        ],
+        "usphone": "'kɑntʊr",
+        "ukphone": "'kɑːntur"
+    },
+    {
+        "name": "contract",
+        "trans": [
+            "订合同； 收缩； 感染， 染上",
+            "合同， 契约"
+        ],
+        "usphone": "'kɑntrækt",
+        "ukphone": "'kɒntrækt"
+    },
+    {
+        "name": "contradict",
+        "trans": [
+            "反驳； 同…矛盾， 相抵触"
+        ],
+        "usphone": "'kɑntrə'dɪkt",
+        "ukphone": "ˌkɑːntrə'dɪkt"
+    },
+    {
+        "name": "contradictory",
+        "trans": [
+            "对立的，矛盾的；反驳的",
+            "对立物； 矛盾因素"
+        ],
+        "usphone": ",kɑntrə'dɪktəri",
+        "ukphone": "ˌkɑːntrə'dɪktəri"
+    },
+    {
+        "name": "contrary",
+        "trans": [
+            "相反的，逆的",
+            "相反， 反面"
+        ],
+        "usphone": "'kɑntrɛri",
+        "ukphone": "'kɑːntreri"
+    },
+    {
+        "name": "contrast",
+        "trans": [
+            "对比， 对照",
+            "对比， 对照"
+        ],
+        "usphone": "'kɑntræst",
+        "ukphone": "'kɒntrɑːst"
+    },
+    {
+        "name": "contribute",
+        "trans": [
+            "贡献， 捐赠； 有助于； 投稿"
+        ],
+        "usphone": "kən'trɪbjut",
+        "ukphone": "kən'trɪbjuːt"
+    },
+    {
+        "name": "contributor",
+        "trans": [
+            "投稿者； 贡献者， 捐助者； 促成物"
+        ],
+        "usphone": "kən'trɪbjətɚ",
+        "ukphone": "kən'trɪbjətər"
+    },
+    {
+        "name": "contributory",
+        "trans": [
+            "贡献的； 捐助的； 促进的"
+        ],
+        "usphone": "kən'trɪbjətɔri",
+        "ukphone": "kən'trɪbjətɔːri"
+    },
+    {
+        "name": "controversial",
+        "trans": [
+            "引起争论的， 有争议的"
+        ],
+        "usphone": ",kɑntrə'vɝʃl",
+        "ukphone": "ˌkɑːntrə'vɜːrʃl"
+    },
+    {
+        "name": "controversy",
+        "trans": [
+            "争论， 辩论"
+        ],
+        "usphone": "ˈkɑntrəvɝ​sɪ",
+        "ukphone": "'kɑːntrəvɜːrsi"
+    },
+    {
+        "name": "convection",
+        "trans": [
+            "对流； 传送"
+        ],
+        "usphone": "kən'vɛkʃən",
+        "ukphone": "kən'vekʃn"
+    },
+    {
+        "name": "convene",
+        "trans": [
+            "召集， 召开； 聚集， 集合"
+        ],
+        "usphone": "kən'vin",
+        "ukphone": "kən'viːn"
+    },
+    {
+        "name": "convenience",
+        "trans": [
+            "便利； 便利设施"
+        ],
+        "usphone": "kən'vinɪəns",
+        "ukphone": "kən'viːniəns"
+    },
+    {
+        "name": "convention",
+        "trans": [
+            "会议； 习俗， 惯例； 公约"
+        ],
+        "usphone": "kən'vɛnʃən",
+        "ukphone": "kən'venʃn"
+    },
+    {
+        "name": "converge",
+        "trans": [
+            "汇聚， 聚集， 聚合； 相交， 会合； 趋于一致"
+        ],
+        "usphone": "kən'vɝdʒ",
+        "ukphone": "kən'vɜːrdʒ"
+    },
+    {
+        "name": "conversation",
+        "trans": [
+            "交谈， 会话"
+        ],
+        "usphone": ",kɑnvɚ'seʃən",
+        "ukphone": "ˌkɑːnvər'seɪʃn"
+    },
+    {
+        "name": "converse",
+        "trans": [
+            "交谈，会话",
+            "逆向的，相反的",
+            "相反的事物； 反面"
+        ],
+        "usphone": "kən'vəʳs",
+        "ukphone": "kən'vɜːrs"
+    },
+    {
+        "name": "conversion",
+        "trans": [
+            "转变， 变换； 改变信仰， 皈依"
+        ],
+        "usphone": "kən'vɝʒn",
+        "ukphone": "kən'vɜːrʒn"
+    },
+    {
+        "name": "convert",
+        "trans": [
+            "改变； 转变， 转化"
+        ],
+        "usphone": "kən'vɝt",
+        "ukphone": "kən'vɜːrt"
+    },
+    {
+        "name": "convex",
+        "trans": [
+            "凸出的"
+        ],
+        "usphone": "'kɑnvɛks",
+        "ukphone": "'kɑːnveks"
+    },
+    {
+        "name": "convey",
+        "trans": [
+            "运送， 运输； 传达， 表达"
+        ],
+        "usphone": "kən've",
+        "ukphone": "kən'veɪ"
+    },
+    {
+        "name": "convict",
+        "trans": [
+            "定罪，宣告…有罪",
+            "服刑囚犯"
+        ],
+        "usphone": "kən'vɪkt",
+        "ukphone": "kən'vɪkt"
+    },
+    {
+        "name": "convince",
+        "trans": [
+            "使确信， 说服"
+        ],
+        "usphone": "kən'vɪns",
+        "ukphone": "kən'vɪns"
+    },
+    {
+        "name": "cookout",
+        "trans": [
+            "野外烧烤宴会"
+        ],
+        "usphone": "'kuk,aut",
+        "ukphone": "'kukaut"
+    },
+    {
+        "name": "cooperation",
+        "trans": [
+            "合作， 协作"
+        ],
+        "usphone": "ko,ɑpə'reʃən",
+        "ukphone": "kouˌɑːpə'reɪʃn"
+    },
+    {
+        "name": "cooperative",
+        "trans": [
+            "合作的，协作的；配合的",
+            "合作企业"
+        ],
+        "usphone": "ko'ɑpərətɪv",
+        "ukphone": "kou'ɑːpərətɪv"
+    },
+    {
+        "name": "coordinate",
+        "trans": [
+            "协调， 相配合",
+            "同等物； 坐标"
+        ],
+        "usphone": "ko'ɔrdɪnet",
+        "ukphone": "kəʊ'ɔ:dɪneɪt"
+    },
+    {
+        "name": "copilot",
+        "trans": [
+            "副驾驶员"
+        ],
+        "usphone": "'ko,paɪlət",
+        "ukphone": "'kouˌpaɪlət"
+    },
+    {
+        "name": "copious",
+        "trans": [
+            "丰富的， 富饶的"
+        ],
+        "usphone": "'kopɪəs",
+        "ukphone": "'koupiəs"
+    },
+    {
+        "name": "copper",
+        "trans": [
+            "铜； 铜币"
+        ],
+        "usphone": "'kɑpɚ",
+        "ukphone": "'kɑːpər"
+    },
+    {
+        "name": "coral",
+        "trans": [
+            "珊瑚色的， 红色的",
+            "珊瑚"
+        ],
+        "usphone": "'kɔrəl",
+        "ukphone": "'kɔːrəl"
+    },
+    {
+        "name": "cordial",
+        "trans": [
+            "亲切的， 热诚的"
+        ],
+        "usphone": "'kɔrdʒəl",
+        "ukphone": "'kɔːrdʒəl"
+    },
+    {
+        "name": "core",
+        "trans": [
+            "地核；果心，核心；要点，精髓",
+            "去掉…的中心部分"
+        ],
+        "usphone": "kɔr",
+        "ukphone": "kɔːr"
+    },
+    {
+        "name": "cornerstone",
+        "trans": [
+            "墙角石， 奠基石； 基础"
+        ],
+        "usphone": "'kɔrnɚston",
+        "ukphone": "'kɔːrnərstoun"
+    },
+    {
+        "name": "corollary",
+        "trans": [
+            "必然的结果； 推断"
+        ],
+        "usphone": "'kɔrəlɛri",
+        "ukphone": "'kɔːrəleri"
+    },
+    {
+        "name": "corona",
+        "trans": [
+            "日冕， 日华； 光环"
+        ],
+        "usphone": "kə'ronə",
+        "ukphone": "kə'rounə"
+    },
+    {
+        "name": "corporate",
+        "trans": [
+            "法人的， 公司的； 共同的， 全体的"
+        ],
+        "usphone": "ˈkɔːrpərət",
+        "ukphone": "'kɔːrpərət"
+    },
+    {
+        "name": "corporeal",
+        "trans": [
+            "肉体的， 身体的； 物质的； 实体的"
+        ],
+        "usphone": "kɔr'pɔrɪəl",
+        "ukphone": "kɔːr'pɔːriəl"
+    },
+    {
+        "name": "corps",
+        "trans": [
+            "军团， 兵团； 特种部队； 一群人， 一组人"
+        ],
+        "usphone": "kɔrz",
+        "ukphone": "kɔːr"
+    },
+    {
+        "name": "corpus",
+        "trans": [
+            "文集， 文献， 汇编； 语料库"
+        ],
+        "usphone": "'kɔrpəs",
+        "ukphone": "'kɔːrpəs"
+    },
+    {
+        "name": "correspond",
+        "trans": [
+            "相一致， 符合； 相当于； 通信"
+        ],
+        "usphone": ",kɔrə'spɑnd",
+        "ukphone": "ˌkɔːrə'spɑːnd"
+    },
+    {
+        "name": "correspondent",
+        "trans": [
+            "报道者， 记者； 通信者"
+        ],
+        "usphone": ",kɔrə'spɑndənt",
+        "ukphone": "ˌkɔːrə'spɑːndənt"
+    },
+    {
+        "name": "corrosion",
+        "trans": [
+            "腐蚀， 侵蚀"
+        ],
+        "usphone": "kə'roʒən",
+        "ukphone": "kə'rouʒn"
+    },
+    {
+        "name": "corrosive",
+        "trans": [
+            "腐蚀的"
+        ],
+        "usphone": "kə'rosɪv",
+        "ukphone": "kə'rousɪv"
+    },
+    {
+        "name": "corrupt",
+        "trans": [
+            "堕落的，腐化的；腐败的，"
+        ],
+        "usphone": "kə'rʌpt",
+        "ukphone": "kə'rʌpt"
+    },
+    {
+        "name": "cortex",
+        "trans": [
+            "皮层， 皮质"
+        ],
+        "usphone": "'kɔrtɛks",
+        "ukphone": "'kɔːrteks"
+    },
+    {
+        "name": "cosmic",
+        "trans": [
+            "宇宙的； 无限的"
+        ],
+        "usphone": "'kɑzmɪk",
+        "ukphone": "'kɑːzmɪk"
+    },
+    {
+        "name": "cosmos",
+        "trans": [
+            "宇宙"
+        ],
+        "usphone": "'kɑzmos",
+        "ukphone": "'kɑːzmous"
+    },
+    {
+        "name": "costume",
+        "trans": [
+            "服饰； 服装， 装束； 戏装"
+        ],
+        "usphone": "ˈkɑsˌtum",
+        "ukphone": "'kɑːstjuːm"
+    },
+    {
+        "name": "council",
+        "trans": [
+            "委员会； 地方议会"
+        ],
+        "usphone": "'kaʊnsl",
+        "ukphone": "'kaunsl"
+    },
+    {
+        "name": "counseling",
+        "trans": [
+            "咨询； 辅导"
+        ],
+        "usphone": "'kaʊnslɪŋ",
+        "ukphone": "'kaunsəlɪŋ"
+    },
+    {
+        "name": "counselor",
+        "trans": [
+            "顾问； 律师"
+        ],
+        "usphone": "'kaʊnslɚ",
+        "ukphone": "'kaunsələr"
+    },
+    {
+        "name": "count",
+        "trans": [
+            "数，计算；算入；看做，认为；值得考虑，有重要意义",
+            "计数， 计算； 总数； 罪状"
+        ],
+        "usphone": "kaʊnt",
+        "ukphone": "kaunt"
+    },
+    {
+        "name": "counter",
+        "trans": [
+            "相反地",
+            "相反的",
+            "柜台；"
+        ],
+        "usphone": "'kaʊntɚ",
+        "ukphone": "'kauntər"
+    },
+    {
+        "name": "counteract",
+        "trans": [
+            "消除； 抵消"
+        ],
+        "usphone": ",kaʊntɚ'ækt",
+        "ukphone": "ˌkauntər'ækt"
+    },
+    {
+        "name": "counterfeit",
+        "trans": [
+            "伪造的，假冒的",
+            "赝品",
+            "伪造， 仿造"
+        ],
+        "usphone": "'kaʊntɚ'fɪt",
+        "ukphone": "'kauntərfɪt"
+    },
+    {
+        "name": "counterpart",
+        "trans": [
+            "相对物； 职位相当的人； 副本"
+        ],
+        "usphone": "'kaʊntɚpɑrt",
+        "ukphone": "'kauntərpɑːrt"
+    },
+    {
+        "name": "couple",
+        "trans": [
+            "对，双；夫妇，情侣；几个人，几件事",
+            "连接， 结合"
+        ],
+        "usphone": "'kʌpl",
+        "ukphone": "'kʌpl"
+    },
+    {
+        "name": "coupon",
+        "trans": [
+            "礼券， 优惠券； 配给券， 票证"
+        ],
+        "usphone": "'kupɑn",
+        "ukphone": "'kuːpɑːn"
+    },
+    {
+        "name": "courageous",
+        "trans": [
+            "勇敢的， 有胆量的"
+        ],
+        "usphone": "kə'redʒəs",
+        "ukphone": "kə'reɪdʒəs"
+    },
+    {
+        "name": "courier",
+        "trans": [
+            "送急件的人， 信使； 旅游服务员"
+        ],
+        "usphone": "'kʊrɪɚ",
+        "ukphone": "'kuriər"
+    },
+    {
+        "name": "course",
+        "trans": [
+            "课程， 教程； 过程， 进程； 路线； 一道菜"
+        ],
+        "usphone": "kɔrs",
+        "ukphone": "kɔːrs"
+    },
+    {
+        "name": "court",
+        "trans": [
+            "法院，法庭；宫廷，朝廷；球场",
+            "献殷勤， 讨好； 招致； 求爱"
+        ],
+        "usphone": "kɔrt",
+        "ukphone": "kɔːrt"
+    },
+    {
+        "name": "courteous",
+        "trans": [
+            "谦恭的， 有礼貌的"
+        ],
+        "usphone": "'kɝtɪəs",
+        "ukphone": "'kɜːrtiəs"
+    },
+    {
+        "name": "cousin",
+        "trans": [
+            "堂兄弟， 堂姐妹"
+        ],
+        "usphone": "'kʌzn",
+        "ukphone": "'kʌzn"
+    },
+    {
+        "name": "coverage",
+        "trans": [
+            "新闻报道； 覆盖范围"
+        ],
+        "usphone": "'kʌvərɪdʒ",
+        "ukphone": "'kʌvərɪdʒ"
+    },
+    {
+        "name": "cowhand",
+        "trans": [
+            "牛仔， 牧牛工"
+        ],
+        "usphone": "'kaʊhænd",
+        "ukphone": "'kauhænd"
+    },
+    {
+        "name": "crab",
+        "trans": [
+            "蟹， 螃蟹"
+        ],
+        "usphone": "kræb",
+        "ukphone": "kræb"
+    },
+    {
+        "name": "crack",
+        "trans": [
+            "破裂，断裂；发出爆裂声；重击，猛击；崩溃，"
+        ],
+        "usphone": "kræk",
+        "ukphone": "kræk"
+    },
+    {
+        "name": "cradle",
+        "trans": [
+            "摇篮； 发源地"
+        ],
+        "usphone": "'kredl",
+        "ukphone": "'kreɪdl"
+    },
+    {
+        "name": "craft",
+        "trans": [
+            "手工制作",
+            "手艺，工艺"
+        ],
+        "usphone": "kræft",
+        "ukphone": "kræft"
+    },
+    {
+        "name": "craftsman",
+        "trans": [
+            "能工巧匠， 手艺人， 工艺师"
+        ],
+        "usphone": "'kræftsmən",
+        "ukphone": "'kræftsmən"
+    },
+    {
+        "name": "cram",
+        "trans": [
+            "填塞， 塞满； 匆忙准备， 临时死记硬背"
+        ],
+        "usphone": "kræm",
+        "ukphone": "kræm"
+    },
+    {
+        "name": "cramp",
+        "trans": [
+            "痉挛，抽筋；",
+            "阻碍， 阻止"
+        ],
+        "usphone": "kræmp",
+        "ukphone": "kræmp"
+    },
+    {
+        "name": "cramped",
+        "trans": [
+            "狭小的， 狭窄的； 受限制的； 密小难认的"
+        ],
+        "usphone": "kræmpt",
+        "ukphone": "kræmpt"
+    },
+    {
+        "name": "cranial",
+        "trans": [
+            "头盖骨的， 颅骨的"
+        ],
+        "usphone": "'krenɪəl",
+        "ukphone": "'kreɪniəl"
+    },
+    {
+        "name": "crater",
+        "trans": [
+            "火山口； 坑"
+        ],
+        "usphone": "'kretɚ",
+        "ukphone": "'kreɪtər"
+    },
+    {
+        "name": "crawl",
+        "trans": [
+            "缓慢行进；爬行",
+            "缓慢的速度"
+        ],
+        "usphone": "krɔl",
+        "ukphone": "krɔːl"
+    },
+    {
+        "name": "crazy",
+        "trans": [
+            "疯狂的， 不理智的； 狂热的， 热衷的； 精神失常的"
+        ],
+        "usphone": "'krezi",
+        "ukphone": "'kreɪzi"
+    },
+    {
+        "name": "creative",
+        "trans": [
+            "有创造力的， 创造性的"
+        ],
+        "usphone": "krɪ'etɪv",
+        "ukphone": "kri'eɪtɪv"
+    },
+    {
+        "name": "creativity",
+        "trans": [
+            "创造力， 创造性"
+        ],
+        "usphone": ",krie'tɪvəti",
+        "ukphone": "ˌkriːeɪ'tɪvəti"
+    },
+    {
+        "name": "credence",
+        "trans": [
+            "可信性， 真实性； 信任； 信念"
+        ],
+        "usphone": "'kridns",
+        "ukphone": "'kriːdns"
+    },
+    {
+        "name": "credential",
+        "trans": [
+            "证书； 文凭； 资格"
+        ],
+        "usphone": "krə'dɛnʃl",
+        "ukphone": "krə'denʃl"
+    },
+    {
+        "name": "credentialism",
+        "trans": [
+            "文凭主义"
+        ],
+        "usphone": "krɪ'dɛnʃə,lɪzəm",
+        "ukphone": "krə'denʃəlɪzəm"
+    },
+    {
+        "name": "credit",
+        "trans": [
+            "把…归于",
+            "荣誉； 学分； 信用； 贷款"
+        ],
+        "usphone": "'krɛdɪt",
+        "ukphone": "'kredɪt"
+    },
+    {
+        "name": "creep",
+        "trans": [
+            "缓慢行进； 爬行； 悄悄地移动"
+        ],
+        "usphone": "krip",
+        "ukphone": "kriːp"
+    },
+    {
+        "name": "crescent",
+        "trans": [
+            "新月形的；逐渐增强的",
+            "新月； 新月形， 月牙形"
+        ],
+        "usphone": "'krɛsnt",
+        "ukphone": "'kresnt"
+    },
+    {
+        "name": "crest",
+        "trans": [
+            "达到顶点",
+            "顶峰，顶点；浪尖；羽冠"
+        ],
+        "usphone": "krɛst",
+        "ukphone": "krest"
+    },
+    {
+        "name": "crevice",
+        "trans": [
+            "缺口， 裂缝"
+        ],
+        "usphone": "'krɛvɪs",
+        "ukphone": "'krevɪs"
+    },
+    {
+        "name": "crew",
+        "trans": [
+            "全体船员； 全体工作人员"
+        ],
+        "usphone": "krʊ",
+        "ukphone": "kruː"
+    },
+    {
+        "name": "crime",
+        "trans": [
+            "犯罪； 罪行"
+        ],
+        "usphone": "kraɪm",
+        "ukphone": "kraɪm"
+    },
+    {
+        "name": "crippling",
+        "trans": [
+            "令人震惊的； 严重损害身体的； 极其有害的"
+        ],
+        "usphone": "'krɪplɪŋ",
+        "ukphone": "'krɪplɪŋ"
+    },
+    {
+        "name": "criss-cross",
+        "trans": [
+            "构成十字形图案；交叉往来",
+            "纵横交错的"
+        ],
+        "usphone": "'kris krɔs",
+        "ukphone": "'krɪsˌkrɔːs"
+    },
+    {
+        "name": "criteria",
+        "trans": [
+            "[criterion的复数形式]标准， 准则"
+        ],
+        "usphone": "kraɪ'tɪrɪə",
+        "ukphone": "kraɪ'tɪriə"
+    },
+    {
+        "name": "criterion",
+        "trans": [
+            "〔判断、决定的〕标准，准则"
+        ],
+        "usphone": "kraɪˈtɪriən",
+        "ukphone": "kraɪ'tɪriən"
+    },
+    {
+        "name": "critic",
+        "trans": [
+            "评论家， 批评家； 吹毛求疵者"
+        ],
+        "usphone": "'krɪtɪk",
+        "ukphone": "'krɪtɪk"
+    },
+    {
+        "name": "criticize",
+        "trans": [
+            "批评； 吹毛求疵， 非难； 评论"
+        ],
+        "usphone": "'krɪtə'saɪz",
+        "ukphone": "'krɪtɪsaɪz"
+    },
+    {
+        "name": "critique",
+        "trans": [
+            "批评，评论",
+            "写评论"
+        ],
+        "usphone": "krɪ'tik",
+        "ukphone": "krɪ'tiːk"
+    },
+    {
+        "name": "crooked",
+        "trans": [
+            "不诚实的； 欺诈的； 弯曲的"
+        ],
+        "usphone": "'krʊkɪd",
+        "ukphone": "'krukɪd"
+    },
+    {
+        "name": "crossing",
+        "trans": [
+            "十字路口， 人行横道； 过境处； 交叉点； 穿越， 横渡"
+        ],
+        "usphone": "'krɔsɪŋ",
+        "ukphone": "'krɔːsɪŋ"
+    },
+    {
+        "name": "crow",
+        "trans": [
+            "啼叫， 打鸣； 得意洋洋",
+            "乌鸦"
+        ],
+        "usphone": "kro",
+        "ukphone": "krou"
+    },
+    {
+        "name": "crown",
+        "trans": [
+            "加冕； 使圆满， 使完美",
+            "王冠；花冠"
+        ],
+        "usphone": "kraʊn",
+        "ukphone": "kraun"
+    },
+    {
+        "name": "crucial",
+        "trans": [
+            "至关重要的， 决定性的"
+        ],
+        "usphone": "'krʊʃəl",
+        "ukphone": "'kruːʃl"
+    },
+    {
+        "name": "crude",
+        "trans": [
+            "天然的， 未提炼的； 粗糙的； 粗俗的"
+        ],
+        "usphone": "krud",
+        "ukphone": "krud"
+    },
+    {
+        "name": "crumple",
+        "trans": [
+            "变皱， 起皱； 破裂； 崩溃， 垮台"
+        ],
+        "usphone": "'krʌmpl",
+        "ukphone": "'krʌmpl"
+    },
+    {
+        "name": "crusade",
+        "trans": [
+            "加入十字军， 投身正义运动",
+            "十字军；斗争，运动"
+        ],
+        "usphone": "kru'sed",
+        "ukphone": "kruː'seɪd"
+    },
+    {
+        "name": "crush",
+        "trans": [
+            "碾碎； 使变形； 镇压"
+        ],
+        "usphone": "krʌʃ",
+        "ukphone": "krʌʃ"
+    },
+    {
+        "name": "crust",
+        "trans": [
+            "地壳； 外壳； 硬的表面； 面包片"
+        ],
+        "usphone": "krʌst",
+        "ukphone": "krʌst"
+    },
+    {
+        "name": "crustacean",
+        "trans": [
+            "甲壳类的",
+            "甲壳类动物"
+        ],
+        "usphone": "krʌ'steʃən",
+        "ukphone": "krʌ'steɪʃn"
+    },
+    {
+        "name": "crustal",
+        "trans": [
+            "外壳的， 地壳的"
+        ],
+        "usphone": "'krʌstl",
+        "ukphone": "'krʌstl"
+    },
+    {
+        "name": "crystal",
+        "trans": [
+            "水晶；晶体，"
+        ],
+        "usphone": "'krɪstl",
+        "ukphone": "'krɪstl"
+    },
+    {
+        "name": "crystallize",
+        "trans": [
+            "结晶； 明确"
+        ],
+        "usphone": "'krɪstə'laɪz",
+        "ukphone": "'krɪstəlaɪz"
+    },
+    {
+        "name": "cube",
+        "trans": [
+            "立方体； 立方形的东西； 立方"
+        ],
+        "usphone": "kjʊb",
+        "ukphone": "kjuːb"
+    },
+    {
+        "name": "cubism",
+        "trans": [
+            "立体派； 立体主义"
+        ],
+        "usphone": "'kjubɪzəm",
+        "ukphone": "'kjuːbɪzəm"
+    },
+    {
+        "name": "cue",
+        "trans": [
+            "暗示， 提示"
+        ],
+        "usphone": "kju",
+        "ukphone": "kjuː"
+    },
+    {
+        "name": "cuisine",
+        "trans": [
+            "烹饪； 烹调法， 烹调风格"
+        ],
+        "usphone": "kwɪ'zin",
+        "ukphone": "kwɪ'ziːn"
+    },
+    {
+        "name": "culminate",
+        "trans": [
+            "达到顶点； 告终； 【天】到中天"
+        ],
+        "usphone": "'kʌlmɪnet",
+        "ukphone": "'kʌlmɪneɪt"
+    },
+    {
+        "name": "culpable",
+        "trans": [
+            "有罪的； 该谴责的， 难辞其咎的"
+        ],
+        "usphone": "'kʌlpəbl",
+        "ukphone": "'kʌlpəb"
+    },
+    {
+        "name": "cultivate",
+        "trans": [
+            "耕种； 培养"
+        ],
+        "usphone": "'kʌltɪvet",
+        "ukphone": "'kʌltɪveɪt"
+    },
+    {
+        "name": "cumbersome",
+        "trans": [
+            "笨重的； 麻烦的； 累赘的， 冗长的"
+        ],
+        "usphone": "'kʌmbəsəm",
+        "ukphone": "'kʌmbərsəm"
+    },
+    {
+        "name": "cuneiform",
+        "trans": [
+            "〔古代美索不达米亚人使用的〕楔形文字的"
+        ],
+        "usphone": "'kjʊnɪə,fɔrm",
+        "ukphone": "'kjuːnɪfɔːrm"
+    },
+    {
+        "name": "curative",
+        "trans": [
+            "有助于治疗的，有疗效的",
+            "药物"
+        ],
+        "usphone": "'kjʊrətɪv",
+        "ukphone": "'kjurətɪv"
+    },
+    {
+        "name": "curiosity",
+        "trans": [
+            "好奇心， 求知欲； 罕见而有趣之物， 珍品"
+        ],
+        "usphone": ",kjʊrɪ'ɑsəti",
+        "ukphone": "ˌkjuri'ɑːsəti"
+    },
+    {
+        "name": "curl",
+        "trans": [
+            "卷曲，蜷缩",
+            "卷发； 卷曲状； 卷曲物"
+        ],
+        "usphone": "kɝl",
+        "ukphone": "kɜːrl"
+    },
+    {
+        "name": "current",
+        "trans": [
+            "现行的， 当前的； 流通的； 最近的",
+            "流；潮流，趋势"
+        ],
+        "usphone": "kɝ​ənt",
+        "ukphone": "'kɜːrənt"
+    },
+    {
+        "name": "curriculum",
+        "trans": [
+            "课程"
+        ],
+        "usphone": "kə'rɪkjələm",
+        "ukphone": "kə'rɪkjələm"
+    },
+    {
+        "name": "curtail",
+        "trans": [
+            "缩短， 缩减， 削减"
+        ],
+        "usphone": "kɚ'tel",
+        "ukphone": "kɜːr'teɪl"
+    },
+    {
+        "name": "curtsy",
+        "trans": [
+            "行屈膝礼",
+            "屈膝礼"
+        ],
+        "usphone": "'kɝtsi",
+        "ukphone": "'kɜːrtsi"
+    },
+    {
+        "name": "curve",
+        "trans": [
+            "弄弯，成曲线形",
+            "曲线； 曲线图； 弯曲"
+        ],
+        "usphone": "kɝv",
+        "ukphone": "kɜːrv"
+    },
+    {
+        "name": "cushion",
+        "trans": [
+            "起缓冲作用",
+            "垫子"
+        ],
+        "usphone": "'kʊʃən",
+        "ukphone": "'kuʃn"
+    },
+    {
+        "name": "customs",
+        "trans": [
+            "关税， 进口税； 海关"
+        ],
+        "usphone": "'kʌstəmz",
+        "ukphone": "'kʌstəmz"
+    },
+    {
+        "name": "cylinder",
+        "trans": [
+            "圆筒， 圆柱体； 气缸"
+        ],
+        "usphone": "'sɪlɪndɚ",
+        "ukphone": "'sɪlɪndər"
+    },
+    {
+        "name": "cynical",
+        "trans": [
+            "愤世嫉俗的， 冷嘲热讽的"
+        ],
+        "usphone": "'sɪnɪkl",
+        "ukphone": "'sɪnɪkl"
+    },
+    {
+        "name": "dairy",
+        "trans": [
+            "乳品的",
+            "牛奶场；乳品店；奶制品"
+        ],
+        "usphone": "'dɛri",
+        "ukphone": "'deri"
+    },
+    {
+        "name": "daisy",
+        "trans": [
+            "雏菊； 一流的人物"
+        ],
+        "usphone": "'dezi",
+        "ukphone": "'deɪzi"
+    },
+    {
+        "name": "dam",
+        "trans": [
+            "坝，堤",
+            "筑坝； 控制"
+        ],
+        "usphone": "dæm",
+        "ukphone": "dæm"
+    },
+    {
+        "name": "damp",
+        "trans": [
+            "潮湿的",
+            "潮湿；湿气",
+            "弄湿； 减弱， 抑制"
+        ],
+        "usphone": "dæmp",
+        "ukphone": "dæmp"
+    },
+    {
+        "name": "database",
+        "trans": [
+            "数据库"
+        ],
+        "usphone": "'detəbes",
+        "ukphone": "'deɪtəbeɪs"
+    },
+    {
+        "name": "date",
+        "trans": [
+            "日期，日子；时期，年代；约会；"
+        ],
+        "usphone": "det",
+        "ukphone": "deɪt"
+    },
+    {
+        "name": "dateline",
+        "trans": [
+            "日期栏； 国际日期变更线"
+        ],
+        "usphone": "'det,laɪn",
+        "ukphone": "'deɪtlaɪn"
+    },
+    {
+        "name": "dawn",
+        "trans": [
+            "破晓， 黎明； 开始， 发端"
+        ],
+        "usphone": "dɔn",
+        "ukphone": "dɔːn"
+    },
+    {
+        "name": "daylight",
+        "trans": [
+            "日光； 白昼"
+        ],
+        "usphone": "'delaɪt",
+        "ukphone": "'deɪlaɪt"
+    },
+    {
+        "name": "dazzling",
+        "trans": [
+            "令人眼花缭乱的， 耀眼的"
+        ],
+        "usphone": "'dæzliŋ",
+        "ukphone": "'dæzlɪŋ"
+    },
+    {
+        "name": "deadline",
+        "trans": [
+            "最后期限， 截止时间"
+        ],
+        "usphone": "ˈdedlaɪn",
+        "ukphone": "'dedlaɪn"
+    },
+    {
+        "name": "deal",
+        "trans": [
+            "处理， 对付； 给予； 做买卖， 经营",
+            "交易，买卖；协议"
+        ],
+        "usphone": "dil",
+        "ukphone": "diːl"
+    },
+    {
+        "name": "dearth",
+        "trans": [
+            "缺乏， 短缺"
+        ],
+        "usphone": "də:θ",
+        "ukphone": "dɜːrθ"
+    },
+    {
+        "name": "debatable",
+        "trans": [
+            "有争议的"
+        ],
+        "usphone": "dɪ'betəbəl",
+        "ukphone": "dɪ'beɪtəbl"
+    },
+    {
+        "name": "debate",
+        "trans": [
+            "辩论； 讨论， 争论"
+        ],
+        "usphone": "dɪ'bet",
+        "ukphone": "dɪ'beɪt"
+    },
+    {
+        "name": "debris",
+        "trans": [
+            "岩屑； 残骸； 碎屑"
+        ],
+        "usphone": "dəˈbri",
+        "ukphone": "də'briː"
+    },
+    {
+        "name": "debt",
+        "trans": [
+            "债务； 负债情况； 罪过"
+        ],
+        "usphone": "dɛt",
+        "ukphone": "det"
+    },
+    {
+        "name": "debut",
+        "trans": [
+            "首次演出； 初次亮相"
+        ],
+        "usphone": "de'bju",
+        "ukphone": "deɪ'bjuː"
+    },
+    {
+        "name": "decade",
+        "trans": [
+            "十年， 十年期"
+        ],
+        "usphone": "'dɛked",
+        "ukphone": "'dekeɪd"
+    },
+    {
+        "name": "decadent",
+        "trans": [
+            "堕落的， 颓废的"
+        ],
+        "usphone": "'dɛkədənt",
+        "ukphone": "'dekədənt"
+    },
+    {
+        "name": "decay",
+        "trans": [
+            "腐烂， 腐朽； 衰退， 衰落"
+        ],
+        "usphone": "dɪ'ke",
+        "ukphone": "dɪ'keɪ"
+    },
+    {
+        "name": "deceitful",
+        "trans": [
+            "欺诈的， 惯于欺骗的， 不诚实的"
+        ],
+        "usphone": "dɪ'sitfl",
+        "ukphone": "dɪ'siːtfl"
+    },
+    {
+        "name": "deceive",
+        "trans": [
+            "欺骗"
+        ],
+        "usphone": "dɪ'siv",
+        "ukphone": "dɪ'siːv"
+    },
+    {
+        "name": "decent",
+        "trans": [
+            "体面的； 适当的， 得体的； 令人满意的； 正派的"
+        ],
+        "usphone": "'disnt",
+        "ukphone": "'diːsnt"
+    },
+    {
+        "name": "deception",
+        "trans": [
+            "骗局； 诡计； 欺骗， 欺诈"
+        ],
+        "usphone": "dɪ'sɛpʃən",
+        "ukphone": "dɪ'sepʃn"
+    },
+    {
+        "name": "deceptive",
+        "trans": [
+            "欺骗性的， 导致误解的"
+        ],
+        "usphone": "dɪ'sɛptɪv",
+        "ukphone": "dɪ'septɪv"
+    },
+    {
+        "name": "deciduous",
+        "trans": [
+            "落叶的； 非永久的， 短暂的"
+        ],
+        "usphone": "dɪ'sɪdʒuəs",
+        "ukphone": "dɪ'sɪdʒuəs"
+    },
+    {
+        "name": "decimal",
+        "trans": [
+            "十进位的，小数的",
+            "小数"
+        ],
+        "usphone": "'dɛsɪml",
+        "ukphone": "'desɪml"
+    },
+    {
+        "name": "decipher",
+        "trans": [
+            "破译"
+        ],
+        "usphone": "dɪ'saɪfɚ",
+        "ukphone": "dɪ'saɪfər"
+    },
+    {
+        "name": "decisive",
+        "trans": [
+            "决定性的； 果断的"
+        ],
+        "usphone": "dɪ'saɪsɪv",
+        "ukphone": "dɪ'saɪsɪv"
+    },
+    {
+        "name": "declare",
+        "trans": [
+            "表明； 断言， 声称； 申报"
+        ],
+        "usphone": "dɪ'klɛr",
+        "ukphone": "dɪ'kler"
+    },
+    {
+        "name": "decline",
+        "trans": [
+            "下降； 衰退； 拒绝， 谢绝"
+        ],
+        "usphone": "dɪ'klaɪn",
+        "ukphone": "dɪ'klaɪn"
+    },
+    {
+        "name": "decode",
+        "trans": [
+            "译， 解， 破译"
+        ],
+        "usphone": "",
+        "ukphone": "ˌdiː'koud"
+    },
+    {
+        "name": "decompose",
+        "trans": [
+            "分解； 腐烂"
+        ],
+        "usphone": ",dikəm'poz",
+        "ukphone": "ˌdiːkəm'pouz"
+    },
+    {
+        "name": "decorate",
+        "trans": [
+            "装饰， 布置"
+        ],
+        "usphone": "'dɛkəret",
+        "ukphone": "'dekəreɪt"
+    },
+    {
+        "name": "decorative",
+        "trans": [
+            "装饰性的， 做装饰用的"
+        ],
+        "usphone": "'dɛkəretɪv",
+        "ukphone": "'dekəreɪtɪv"
+    },
+    {
+        "name": "decrease",
+        "trans": [
+            "减少",
+            "减少"
+        ],
+        "usphone": "dɪ'kris",
+        "ukphone": "dɪ'kriːs"
+    },
+    {
+        "name": "decree",
+        "trans": [
+            "判决； 颁布",
+            "政令，法令；裁定，判决"
+        ],
+        "usphone": "dɪ'kri",
+        "ukphone": "dɪ'kriː"
+    },
+    {
+        "name": "dedicate",
+        "trans": [
+            "致力于， 奉献给； 题献词于上"
+        ],
+        "usphone": "'dɛdɪket",
+        "ukphone": "'dedɪkeɪt"
+    },
+    {
+        "name": "dedication",
+        "trans": [
+            "献身， 奉献； 献词； 奉献仪式"
+        ],
+        "usphone": ",dɛdɪ'keʃən",
+        "ukphone": "ˌdedɪ'keɪʃn"
+    },
+    {
+        "name": "deduct",
+        "trans": [
+            "扣除， 减去； 推论， 演绎"
+        ],
+        "usphone": "dɪ'dʌkt",
+        "ukphone": "dɪ'dʌkt"
+    },
+    {
+        "name": "deductive",
+        "trans": [
+            "演绎的， 推论的"
+        ],
+        "usphone": "dɪ'dʌktɪv",
+        "ukphone": "dɪ'dʌktɪv"
+    },
+    {
+        "name": "deem",
+        "trans": [
+            "认为， 相信"
+        ],
+        "usphone": "dim",
+        "ukphone": "diːm"
+    },
+    {
+        "name": "default",
+        "trans": [
+            "不履行义务， 违约",
+            "违约；弃权；缺省"
+        ],
+        "usphone": "dɪ'fɔlt",
+        "ukphone": "dɪ'fɔːlt"
+    },
+    {
+        "name": "defecate",
+        "trans": [
+            "排便； 澄清"
+        ],
+        "usphone": "'dɛfəket",
+        "ukphone": "'defəkeɪt"
+    },
+    {
+        "name": "defect",
+        "trans": [
+            "变节， 叛变",
+            "瑕疵， 缺陷； 过失"
+        ],
+        "usphone": "‘dɪfɛkt",
+        "ukphone": "'diːfekt; dɪ'fekt"
+    },
+    {
+        "name": "defense",
+        "trans": [
+            "防御， 防卫"
+        ],
+        "usphone": "dɪ'fɛns",
+        "ukphone": "dɪ'fens"
+    },
+    {
+        "name": "defer",
+        "trans": [
+            "推迟， 延期"
+        ],
+        "usphone": "dɪ'fɝ",
+        "ukphone": "dɪ'fɜːr"
+    },
+    {
+        "name": "defiant",
+        "trans": [
+            "反叛的， 挑衅的， 公然违抗的"
+        ],
+        "usphone": "dɪ'faɪənt",
+        "ukphone": "dɪ'faɪənt"
+    },
+    {
+        "name": "deficiency",
+        "trans": [
+            "不足， 缺乏"
+        ],
+        "usphone": "dɪ'fɪʃənsi",
+        "ukphone": "dɪ'fɪʃnsi"
+    },
+    {
+        "name": "deficient",
+        "trans": [
+            "不足的， 缺乏的； 有缺陷的， 不完善的"
+        ],
+        "usphone": "dɪ'fɪʃnt",
+        "ukphone": "dɪ'fɪʃnt"
+    },
+    {
+        "name": "deficit",
+        "trans": [
+            "不足额； 赤字， 逆差"
+        ],
+        "usphone": "'dɛfəsɪt",
+        "ukphone": "'defɪsɪt"
+    },
+    {
+        "name": "define",
+        "trans": [
+            "定义， 解释； 限定"
+        ],
+        "usphone": "dɪ'faɪn",
+        "ukphone": "dɪ'faɪn"
+    },
+    {
+        "name": "definite",
+        "trans": [
+            "清楚的， 确切的； 肯定的"
+        ],
+        "usphone": "'dɛfɪnət",
+        "ukphone": "'defɪnət"
+    },
+    {
+        "name": "definitive",
+        "trans": [
+            "确定的，最后的，决定性的；"
+        ],
+        "usphone": "dɪ'fɪnətɪv",
+        "ukphone": "dɪ'fɪnətɪv"
+    },
+    {
+        "name": "deflect",
+        "trans": [
+            "偏斜， 转向"
+        ],
+        "usphone": "dɪ'flɛkt",
+        "ukphone": "dɪ'flekt"
+    },
+    {
+        "name": "deform",
+        "trans": [
+            "变形"
+        ],
+        "usphone": "dɪ'fɔrm",
+        "ukphone": "dɪ'fɔːrm"
+    },
+    {
+        "name": "degenerate",
+        "trans": [
+            "退化， 衰退",
+            "堕落的； 退化的"
+        ],
+        "usphone": "dɪ'dʒɛnəret",
+        "ukphone": "dɪ'dʒen(ə)rət"
+    },
+    {
+        "name": "degenerative",
+        "trans": [
+            "衰退的， 堕落的； 变性的"
+        ],
+        "usphone": "dɪ'dʒɛnərətɪv",
+        "ukphone": "dɪ'dʒenərətɪv"
+    },
+    {
+        "name": "degree",
+        "trans": [
+            "程度； 度数； 学位； 等级"
+        ],
+        "usphone": "dɪ'ɡri",
+        "ukphone": "dɪ'griː"
+    },
+    {
+        "name": "dehydrate",
+        "trans": [
+            "脱水"
+        ],
+        "usphone": "di'haɪdret",
+        "ukphone": "diː'haɪdreɪt"
+    },
+    {
+        "name": "delay",
+        "trans": [
+            "耽搁，延迟",
+            "耽搁， 延迟"
+        ],
+        "usphone": "dɪ'le",
+        "ukphone": "dɪ'leɪ"
+    },
+    {
+        "name": "delectable",
+        "trans": [
+            "美味可口的； 有吸引力的； 令人喜爱的， 赏心悦目的"
+        ],
+        "usphone": "dɪ'lɛktəbl",
+        "ukphone": "dɪ'lektəbl"
+    },
+    {
+        "name": "delegate",
+        "trans": [
+            "代表",
+            "委派…为代表， 授权"
+        ],
+        "usphone": "ˈdɛləgɪt; (for v.,) ˈdɛləˌgeɪt",
+        "ukphone": "ˈdɛlɪˌɡeɪt; -ɡɪt; (for v.,) ˈdɛlɪˌɡeɪt"
+    },
+    {
+        "name": "deliberate",
+        "trans": [
+            "故意的， 蓄意的； 审慎的， 深思熟虑的",
+            "深思熟虑"
+        ],
+        "usphone": "dɪ'lɪbərət",
+        "ukphone": "dɪ'lɪb(ə)rət"
+    },
+    {
+        "name": "delicate",
+        "trans": [
+            "易损的； 微妙的； 精巧的； 娇弱的， 纤细的"
+        ],
+        "usphone": "ˈdɛlɪkɪt",
+        "ukphone": "'delɪkət"
+    },
+    {
+        "name": "delight",
+        "trans": [
+            "愉快，高兴",
+            "快乐， 高兴； 令人高兴的事， 乐趣"
+        ],
+        "usphone": "dɪ'laɪt",
+        "ukphone": "dɪ'laɪt"
+    },
+    {
+        "name": "delineate",
+        "trans": [
+            "描绘， 描述； 解释"
+        ],
+        "usphone": "dɪ'lɪnɪet",
+        "ukphone": "dɪ'lɪnieɪt"
+    },
+    {
+        "name": "delinquency",
+        "trans": [
+            "行为不良； 过失， 失职"
+        ],
+        "usphone": "dɪ'lɪŋkwənsi",
+        "ukphone": "dɪ'lɪŋkwənsi"
+    },
+    {
+        "name": "delirium",
+        "trans": [
+            "精神错乱， 神志失常"
+        ],
+        "usphone": "dɪ'lɪrɪəm",
+        "ukphone": "dɪ'lɪriəm"
+    },
+    {
+        "name": "deliver",
+        "trans": [
+            "传送， 传递； 发表， 宣布； 履行诺言； 移交， 交出； 接生"
+        ],
+        "usphone": "dɪ'lɪvɚ",
+        "ukphone": "dɪ'lɪvər"
+    },
+    {
+        "name": "delta",
+        "trans": [
+            "三角洲； 希腊字母表的第四个字母"
+        ],
+        "usphone": "'dɛltə",
+        "ukphone": "'deltə"
+    },
+    {
+        "name": "demanding",
+        "trans": [
+            "苛求的， 难满足的； 需要高的， 费力的"
+        ],
+        "usphone": "dɪ'mændɪŋ",
+        "ukphone": "dɪ'mændɪŋ"
+    },
+    {
+        "name": "demobilize",
+        "trans": [
+            "遣散； 使复员"
+        ],
+        "usphone": "di'mobəlaɪz",
+        "ukphone": "diː'moubəlaɪz"
+    },
+    {
+        "name": "democracy",
+        "trans": [
+            "民主政体， 民主制度； 民主国家； 民主精神"
+        ],
+        "usphone": "dɪˈmɑkrəsi",
+        "ukphone": "dɪ'mɑːkrəsi"
+    },
+    {
+        "name": "democrat",
+        "trans": [
+            "民主主义者； [D-]民主党人"
+        ],
+        "usphone": "'dɛməkræt",
+        "ukphone": "'deməkræt"
+    },
+    {
+        "name": "demolish",
+        "trans": [
+            "拆除； 破坏； 驳倒， 推翻"
+        ],
+        "usphone": "dɪ'mɑlɪʃ",
+        "ukphone": "dɪ'mɑːlɪʃ"
+    },
+    {
+        "name": "demonstrate",
+        "trans": [
+            "论证， 证明； 表现， 显露； 示范， 演示； 游行示威"
+        ],
+        "usphone": "'dɛmən'stret",
+        "ukphone": "'demənstreɪt"
+    },
+    {
+        "name": "denote",
+        "trans": [
+            "表示， 意指； 标示， 预示， 象征"
+        ],
+        "usphone": "dɪ'not",
+        "ukphone": "dɪ'nout"
+    },
+    {
+        "name": "denounce",
+        "trans": [
+            "谴责， 公开指责， 抨击； 告发"
+        ],
+        "usphone": "dɪ'naʊns",
+        "ukphone": "dɪ'nauns"
+    },
+    {
+        "name": "dent",
+        "trans": [
+            "使凹下；挫伤，损害",
+            "缺口， 凹痕"
+        ],
+        "usphone": "dɛnt",
+        "ukphone": "dent"
+    },
+    {
+        "name": "deny",
+        "trans": [
+            "否认； 拒绝承认； 拒绝给予"
+        ],
+        "usphone": "dɪ'nai",
+        "ukphone": "dɪ'naɪ"
+    },
+    {
+        "name": "depart",
+        "trans": [
+            "离开； 背离"
+        ],
+        "usphone": "dɪ'pɑrt",
+        "ukphone": "dɪ'pɑːrt"
+    },
+    {
+        "name": "depend",
+        "trans": [
+            "依靠， 依赖； 取决于"
+        ],
+        "usphone": "dɪ'pɛnd",
+        "ukphone": "dɪ'pend"
+    },
+    {
+        "name": "depict",
+        "trans": [
+            "描写， 描述， 描绘"
+        ],
+        "usphone": "dɪ'pɪkt",
+        "ukphone": "dɪ'pɪkt"
+    },
+    {
+        "name": "deplete",
+        "trans": [
+            "使枯竭， 耗尽"
+        ],
+        "usphone": "dɪ'plit",
+        "ukphone": "dɪ'pliːt"
+    },
+    {
+        "name": "deplore",
+        "trans": [
+            "悲叹， 哀叹， 公开谴责"
+        ],
+        "usphone": "dɪ'plɔr",
+        "ukphone": "dɪ'plɔːr"
+    },
+    {
+        "name": "deploy",
+        "trans": [
+            "部署， 调度； 利用"
+        ],
+        "usphone": "dɪ'plɔɪ",
+        "ukphone": "dɪ'plɔɪ"
+    },
+    {
+        "name": "deport",
+        "trans": [
+            "驱逐出境"
+        ],
+        "usphone": "dɪ'pɔrt",
+        "ukphone": "dɪ'pɔːrt"
+    },
+    {
+        "name": "depose",
+        "trans": [
+            "革除， 罢免， 废黜"
+        ],
+        "usphone": "dɪ'poz",
+        "ukphone": "dɪ'pouz"
+    },
+    {
+        "name": "deposit",
+        "trans": [
+            "沉淀；堆积；储蓄；"
+        ],
+        "usphone": "dɪ'pɑzɪt",
+        "ukphone": "dɪ'pɑːzɪt"
+    },
+    {
+        "name": "depot",
+        "trans": [
+            "库房， 仓库； 公共汽车站， 火车站"
+        ],
+        "usphone": "'dipo",
+        "ukphone": "'diːpou"
+    },
+    {
+        "name": "depredation",
+        "trans": [
+            "劫掠， 掠夺， 破坏"
+        ],
+        "usphone": ",dɛprə'deʃən",
+        "ukphone": "ˌdeprə'deɪʃn"
+    },
+    {
+        "name": "depress",
+        "trans": [
+            "降低， 削弱； 使沮丧； 使萧条"
+        ],
+        "usphone": "dɪ'prɛs",
+        "ukphone": "dɪ'pres"
+    },
+    {
+        "name": "deprive",
+        "trans": [
+            "使失去， 剥夺"
+        ],
+        "usphone": "dɪ'praɪv",
+        "ukphone": "dɪ'praɪv"
+    },
+    {
+        "name": "derivation",
+        "trans": [
+            "起源， 发源； 派生"
+        ],
+        "usphone": "'dɛrə'veʃən",
+        "ukphone": "ˌderɪ'veɪʃn"
+    },
+    {
+        "name": "derivative",
+        "trans": [
+            "派生的，引出的；无创意的",
+            "派生词， 衍生词； 派生物"
+        ],
+        "usphone": "də'rɪvətɪv",
+        "ukphone": "dɪ'rɪvətɪv"
+    },
+    {
+        "name": "derive",
+        "trans": [
+            "取得； 起源"
+        ],
+        "usphone": "dɪ'raɪv",
+        "ukphone": "dɪ'raɪv"
+    },
+    {
+        "name": "descend",
+        "trans": [
+            "遗传； 下降； 起源； 降临， 来临"
+        ],
+        "usphone": "dɪ'sɛnd",
+        "ukphone": "dɪ'send"
+    },
+    {
+        "name": "descent",
+        "trans": [
+            "血统， 世系； 下降"
+        ],
+        "usphone": "dɪ'sɛnt",
+        "ukphone": "dɪ'sent"
+    },
+    {
+        "name": "descriptive",
+        "trans": [
+            "描述性的， 叙述的"
+        ],
+        "usphone": "dɪ'skrɪptɪv",
+        "ukphone": "dɪ'skrɪptɪv"
+    },
+    {
+        "name": "desegregate",
+        "trans": [
+            "废除种族隔离"
+        ],
+        "usphone": ",di'sɛɡrɪɡet",
+        "ukphone": "ˌdiː'segrɪgeɪt"
+    },
+    {
+        "name": "deserted",
+        "trans": [
+            "荒废的， 空无一人的； 被离弃的， 被遗弃的"
+        ],
+        "usphone": "dɪ'zɝtɪd",
+        "ukphone": "dɪ'zɜːrtɪd"
+    },
+    {
+        "name": "deserve",
+        "trans": [
+            "应得， 值得"
+        ],
+        "usphone": "dɪ'zɝv",
+        "ukphone": "dɪ'zɜːrv"
+    },
+    {
+        "name": "designate",
+        "trans": [
+            "已任命但尚未就职的",
+            "命名；任命；指明，标示"
+        ],
+        "usphone": "'dɛzɪɡnet",
+        "ukphone": "'dezɪgneɪt"
+    },
+    {
+        "name": "desolate",
+        "trans": [
+            "荒凉的， 无人烟的； 不幸的， 忧伤的",
+            "使感到悲惨， 使感到凄凉； 使荒芜"
+        ],
+        "usphone": "'dɛsələt",
+        "ukphone": "'des(ə)lət"
+    },
+    {
+        "name": "desperate",
+        "trans": [
+            "绝望的； 不顾死活的， 拼命的； 极度渴望的"
+        ],
+        "usphone": "'dɛspərət",
+        "ukphone": "'despərət"
+    },
+    {
+        "name": "despise",
+        "trans": [
+            "鄙视， 看不起"
+        ],
+        "usphone": "dɪ'spaɪz",
+        "ukphone": "dɪ'spaɪz"
+    },
+    {
+        "name": "despoil",
+        "trans": [
+            "夺取， 掠夺； 蹂躏"
+        ],
+        "usphone": "dɪ'spɔɪl",
+        "ukphone": "dɪ'spɔɪl"
+    },
+    {
+        "name": "despondent",
+        "trans": [
+            "垂头丧气的， 沮丧的"
+        ],
+        "usphone": "dɪ'spɑndənt",
+        "ukphone": "dɪ'spɑːndənt"
+    },
+    {
+        "name": "destination",
+        "trans": [
+            "目的地， 终点"
+        ],
+        "usphone": ",dɛstɪ'neʃən",
+        "ukphone": "ˌdestɪ'neɪʃn"
+    },
+    {
+        "name": "destined",
+        "trans": [
+            "注定的； 以…为目的地的"
+        ],
+        "usphone": "'dɛstɪnd",
+        "ukphone": "'destɪnd"
+    },
+    {
+        "name": "destruction",
+        "trans": [
+            "毁坏， 毁灭"
+        ],
+        "usphone": "dɪ'strʌkʃən",
+        "ukphone": "dɪ'strʌkʃn"
+    },
+    {
+        "name": "destructive",
+        "trans": [
+            "破坏性的， 毁灭性的"
+        ],
+        "usphone": "dɪ'strʌktɪv",
+        "ukphone": "dɪ'strʌktɪv"
+    },
+    {
+        "name": "detect",
+        "trans": [
+            "发现， 察觉； 探测； 查明"
+        ],
+        "usphone": "dɪ'tɛkt",
+        "ukphone": "dɪ'tekt"
+    },
+    {
+        "name": "detectable",
+        "trans": [
+            "可发觉的， 可察觉的"
+        ],
+        "usphone": "dɪ'tɛktəbl",
+        "ukphone": "dɪ'tektəbl"
+    },
+    {
+        "name": "detective",
+        "trans": [
+            "侦探的",
+            "侦探，私人侦探"
+        ],
+        "usphone": "dɪ'tɛktɪv",
+        "ukphone": "dɪ'tektɪv"
+    },
+    {
+        "name": "deter",
+        "trans": [
+            "威慑， 阻止"
+        ],
+        "usphone": "dɪ'tɝ",
+        "ukphone": "dɪ'tɜːr"
+    },
+    {
+        "name": "detergent",
+        "trans": [
+            "净化的， 清洁的",
+            "清洁剂"
+        ],
+        "usphone": "dɪ'tɝdʒənt",
+        "ukphone": "dɪ'tɜːrdʒənt"
+    },
+    {
+        "name": "deteriorate",
+        "trans": [
+            "变坏， 恶化； 变质"
+        ],
+        "usphone": "dɪ'tɪrɪəret",
+        "ukphone": "dɪ'tɪriəreɪt"
+    },
+    {
+        "name": "determine",
+        "trans": [
+            "查明， 确定； 决心， 决定； 支配， 影响"
+        ],
+        "usphone": "dɪ'tɝmɪn",
+        "ukphone": "dɪ'tɜːrmɪn"
+    },
+    {
+        "name": "detest",
+        "trans": [
+            "憎恶"
+        ],
+        "usphone": "dɪ'tɛst",
+        "ukphone": "dɪ'test"
+    },
+    {
+        "name": "detract",
+        "trans": [
+            "减损； 贬低， 诋毁"
+        ],
+        "usphone": "dɪ'trækt",
+        "ukphone": "dɪ'trækt"
+    },
+    {
+        "name": "devastate",
+        "trans": [
+            "破坏， 毁坏； 令人震惊， 使难以承受"
+        ],
+        "usphone": "'dɛvəstet",
+        "ukphone": "'devəsteɪt"
+    },
+    {
+        "name": "deviant",
+        "trans": [
+            "不正常的，越出常规的",
+            "不正常的人"
+        ],
+        "usphone": "'divɪənt",
+        "ukphone": "'diːviənt"
+    },
+    {
+        "name": "device",
+        "trans": [
+            "装置， 设备； 手法， 策略"
+        ],
+        "usphone": "dɪ'vaɪs",
+        "ukphone": "dɪ'vaɪs"
+    },
+    {
+        "name": "devise",
+        "trans": [
+            "设计； 发明； 想出； 策划， 图谋"
+        ],
+        "usphone": "dɪ'vaɪz",
+        "ukphone": "dɪ'vaɪz"
+    },
+    {
+        "name": "devoid",
+        "trans": [
+            "全无的"
+        ],
+        "usphone": "dɪ'vɔɪd",
+        "ukphone": "dɪ'vɔɪd"
+    },
+    {
+        "name": "devote",
+        "trans": [
+            "为…付出； 献身于"
+        ],
+        "usphone": "dɪ'vot",
+        "ukphone": "dɪ'vout"
+    },
+    {
+        "name": "devour",
+        "trans": [
+            "狼吞虎咽地吃， 吞食； 吞没， 吞噬； 如饥似渴地读"
+        ],
+        "usphone": "dɪ'vaʊɚ",
+        "ukphone": "dɪ'vauər"
+    },
+    {
+        "name": "devout",
+        "trans": [
+            "虔敬的； 诚恳的"
+        ],
+        "usphone": "dɪ'vaʊt",
+        "ukphone": "dɪ'vaut"
+    },
+    {
+        "name": "dexterous",
+        "trans": [
+            "惯用右手的； 灵巧的， 熟练的"
+        ],
+        "usphone": "'dɛkstrəs",
+        "ukphone": "'dekstrəs"
+    },
+    {
+        "name": "diagnose",
+        "trans": [
+            "诊断； 判断"
+        ],
+        "usphone": ",daɪəɡ'nos",
+        "ukphone": "ˌdaɪəg'nous"
+    },
+    {
+        "name": "diagonal",
+        "trans": [
+            "斜线的，"
+        ],
+        "usphone": "daɪ'æɡənl",
+        "ukphone": "daɪ'ægənl"
+    },
+    {
+        "name": "diagram",
+        "trans": [
+            "图表； 图解"
+        ],
+        "usphone": "'daɪəɡræm",
+        "ukphone": "'daɪəgræm"
+    },
+    {
+        "name": "dialect",
+        "trans": [
+            "方言， 土话"
+        ],
+        "usphone": "'daɪə'lɛkt",
+        "ukphone": "'daɪəlekt"
+    },
+    {
+        "name": "diameter",
+        "trans": [
+            "直径"
+        ],
+        "usphone": "daɪ'æmɪtɚ",
+        "ukphone": "daɪ'æmɪtər"
+    },
+    {
+        "name": "dictate",
+        "trans": [
+            "规定；决定；口述；支配",
+            "命令， 规定"
+        ],
+        "usphone": "'dɪktet",
+        "ukphone": "'dɪkteɪt"
+    },
+    {
+        "name": "diction",
+        "trans": [
+            "措辞， 用语"
+        ],
+        "usphone": "'dɪkʃən",
+        "ukphone": "'dɪkʃn"
+    },
+    {
+        "name": "diet",
+        "trans": [
+            "节食",
+            "饮食，食物；规定饮食"
+        ],
+        "usphone": "'daɪət",
+        "ukphone": "'daɪət"
+    },
+    {
+        "name": "differential",
+        "trans": [
+            "差别的，有区别的；微分的",
+            "差别， 差异； 微分"
+        ],
+        "usphone": "'dɪfə'rɛnʃəl",
+        "ukphone": "ˌdɪfə'renʃl"
+    },
+    {
+        "name": "differentiate",
+        "trans": [
+            "不同， 区别"
+        ],
+        "usphone": ",dɪfə'rɛnʃɪet",
+        "ukphone": "ˌdɪfə'renʃieɪt "
+    },
+    {
+        "name": "diffuse",
+        "trans": [
+            "散播， 传播； 漫射， 扩散",
+            "扩散的， 漫射的； 冗长的"
+        ],
+        "usphone": "dɪ'fjus",
+        "ukphone": "dɪ'fjuːz"
+    },
+    {
+        "name": "diffusion",
+        "trans": [
+            "散布， 扩散； 传播"
+        ],
+        "usphone": "dɪ'fjʊʒən",
+        "ukphone": "dɪ'fjuːʒn"
+    },
+    {
+        "name": "digest",
+        "trans": [
+            "消化， 吸收； 领悟",
+            "摘要， 概要"
+        ],
+        "usphone": "daɪ'dʒɛst",
+        "ukphone": "daɪ'dʒest; dɪ-"
+    },
+    {
+        "name": "digitize",
+        "trans": [
+            "数字化"
+        ],
+        "usphone": "'dɪdʒɪtaɪz",
+        "ukphone": "'dɪdʒɪtaɪz"
+    },
+    {
+        "name": "dignify",
+        "trans": [
+            "使有尊严， 使高贵； 美化"
+        ],
+        "usphone": "'dɪɡnɪfaɪ",
+        "ukphone": "'dɪgnɪfaɪ"
+    },
+    {
+        "name": "dignity",
+        "trans": [
+            "尊严， 庄严； 高贵， 尊贵； 自尊， 自重"
+        ],
+        "usphone": "'dɪɡnəti",
+        "ukphone": "'dɪgnəti"
+    },
+    {
+        "name": "digression",
+        "trans": [
+            "离题， 扯到枝节上； 题外话， 枝节内容"
+        ],
+        "usphone": "daɪ'grɛʃən",
+        "ukphone": "daɪ'greʃn"
+    },
+    {
+        "name": "dilate",
+        "trans": [
+            "膨胀， 扩大； 详述"
+        ],
+        "usphone": "daɪˈlet",
+        "ukphone": "daɪ'leɪt"
+    },
+    {
+        "name": "dilemma",
+        "trans": [
+            "困境， 进退两难的局面"
+        ],
+        "usphone": "dəˈlɛmə, daɪ-",
+        "ukphone": "dɪ'lemə"
+    },
+    {
+        "name": "diligent",
+        "trans": [
+            "勤奋的， 刻苦的， 勤勉的"
+        ],
+        "usphone": "'dɪlɪdʒənt",
+        "ukphone": "'dɪlɪdʒənt"
+    },
+    {
+        "name": "dilute",
+        "trans": [
+            "冲淡的，稀释的",
+            "冲淡， 稀释； 淡化， 削弱"
+        ],
+        "usphone": "daɪ'l(j)ut",
+        "ukphone": "daɪ'luːt"
+    },
+    {
+        "name": "dim",
+        "trans": [
+            "模糊的；暗淡的；朦胧的；不乐观的",
+            "变暗淡； 变冷漠"
+        ],
+        "usphone": "dɪm",
+        "ukphone": "dɪm"
+    },
+    {
+        "name": "dimension",
+        "trans": [
+            "维，元；尺寸；方面；特点；"
+        ],
+        "usphone": "dəˈmɛnʃən, daɪ-",
+        "ukphone": "dɪ'menʃn"
+    },
+    {
+        "name": "dimensional",
+        "trans": [
+            "…度空间的"
+        ],
+        "usphone": "dɪ'menʃənəl",
+        "ukphone": "daɪ'menʃənl"
+    },
+    {
+        "name": "diminish",
+        "trans": [
+            "降低， 贬低； 减少， 减弱"
+        ],
+        "usphone": "dɪ'mɪnɪʃ",
+        "ukphone": "dɪ'mɪnɪʃ"
+    },
+    {
+        "name": "diminution",
+        "trans": [
+            "减少， 缩减"
+        ],
+        "usphone": "ˌdɪmɪˈnuːʃn",
+        "ukphone": "ˌdɪmɪ'nuːʃn"
+    },
+    {
+        "name": "dinosaur",
+        "trans": [
+            "恐龙"
+        ],
+        "usphone": "ˈdaɪnəˌsɔr",
+        "ukphone": "'daɪnəsɔːr"
+    },
+    {
+        "name": "dioxide",
+        "trans": [
+            "二氧化物"
+        ],
+        "usphone": "daɪ'ɑksaɪd",
+        "ukphone": "daɪ'ɑːksaɪd"
+    },
+    {
+        "name": "diplomat",
+        "trans": [
+            "外交官； 有手腕的人"
+        ],
+        "usphone": "'dɪpləmæt",
+        "ukphone": "'dɪpləmæt"
+    },
+    {
+        "name": "diplomatic",
+        "trans": [
+            "外交的， 从事外交的； 有策略的， 有手腕的， 老练的"
+        ],
+        "usphone": ",dɪplə'mætɪk",
+        "ukphone": "ˌdɪplə'mætɪk"
+    },
+    {
+        "name": "directory",
+        "trans": [
+            "人名地址录， 电话号码簿； 目录"
+        ],
+        "usphone": "dəˈrɛktəri; (also) daɪˈrɛktəri",
+        "ukphone": "də'rektəri"
+    },
+    {
+        "name": "disadvantage",
+        "trans": [
+            "缺点， 障碍， 不利之处"
+        ],
+        "usphone": ",dɪsəd'væntɪdʒ",
+        "ukphone": "ˌdɪsəd'væntɪdʒ"
+    },
+    {
+        "name": "disappoint",
+        "trans": [
+            "失望， 扫兴"
+        ],
+        "usphone": "'dɪsə'pɔɪnt",
+        "ukphone": "ˌdɪsə'pɔɪnt"
+    },
+    {
+        "name": "disarm",
+        "trans": [
+            "解除武装； 裁军； 消除， 消解"
+        ],
+        "usphone": "dɪs'ɑrm",
+        "ukphone": "dɪs'ɑːrm"
+    },
+    {
+        "name": "disaster",
+        "trans": [
+            "灾难； 彻底的失败"
+        ],
+        "usphone": "dɪ'zæstɚ",
+        "ukphone": "dɪ'zæstər"
+    },
+    {
+        "name": "disastrous",
+        "trans": [
+            "灾难性的"
+        ],
+        "usphone": "dɪ'zæstrəs",
+        "ukphone": "dɪ'zæstrəs"
+    },
+    {
+        "name": "discard",
+        "trans": [
+            "丢弃"
+        ],
+        "usphone": "dɪsˈkɑːrd",
+        "ukphone": "dɪs'kɑːrd"
+    },
+    {
+        "name": "discern",
+        "trans": [
+            "洞悉； 识别"
+        ],
+        "usphone": "dɪ'sɝn",
+        "ukphone": "dɪ'sɜːrn"
+    },
+    {
+        "name": "discharge",
+        "trans": [
+            "释放； 放； 解雇； 清偿； 履行",
+            "流出物； 放电"
+        ],
+        "usphone": "dɪs'tʃɑrdʒ",
+        "ukphone": "dɪs'tʃɑːdʒ"
+    },
+    {
+        "name": "disciple",
+        "trans": [
+            "门徒， 弟子， 追随者"
+        ],
+        "usphone": "dɪ'saɪpl",
+        "ukphone": "dɪ'saɪpl"
+    },
+    {
+        "name": "discipline",
+        "trans": [
+            "训练；惩罚",
+            "纪律； 学科"
+        ],
+        "usphone": "'dɪsəplɪn",
+        "ukphone": "'dɪsəplɪn"
+    },
+    {
+        "name": "disclose",
+        "trans": [
+            "泄露， 透露； 揭发"
+        ],
+        "usphone": "dɪs'kloz",
+        "ukphone": "dɪs'klouz"
+    },
+    {
+        "name": "disconcert",
+        "trans": [
+            "使惊慌， 使不安； 使困惑"
+        ],
+        "usphone": "'dɪskən'sɝt",
+        "ukphone": "ˌdɪskən'sɜːrt"
+    },
+    {
+        "name": "discord",
+        "trans": [
+            "不一致； 不和， 纷争； 不和谐"
+        ],
+        "usphone": "'dɪskɔrd",
+        "ukphone": "'dɪskɔːrd"
+    },
+    {
+        "name": "discount",
+        "trans": [
+            "折扣",
+            "把…打折扣； 不全信， 漠视， 低估"
+        ],
+        "usphone": "dɪs'kaʊnt",
+        "ukphone": "'dɪskaʊnt"
+    },
+    {
+        "name": "discourage",
+        "trans": [
+            "使泄气， 使灰心； 阻止， 劝阻"
+        ],
+        "usphone": "dɪs'kɝɪdʒ",
+        "ukphone": "dɪs'kɜːrɪdʒ"
+    },
+    {
+        "name": "discourse",
+        "trans": [
+            "讲述， 论述",
+            "演讲； 论文； 话语"
+        ],
+        "usphone": "'dɪskɔrs",
+        "ukphone": "'dɪskɔːs; -'kɔːs"
+    },
+    {
+        "name": "discredit",
+        "trans": [
+            "使丧失声誉；使怀疑",
+            "名誉丧失"
+        ],
+        "usphone": "dɪs'krɛdɪt",
+        "ukphone": "dɪs'kredɪt"
+    },
+    {
+        "name": "discrete",
+        "trans": [
+            "分离的， 个别的； 离散的"
+        ],
+        "usphone": "dɪ'skrit",
+        "ukphone": "dɪ'skriːt"
+    },
+    {
+        "name": "discriminate",
+        "trans": [
+            "区别； 歧视"
+        ],
+        "usphone": "dɪ'skrɪmɪnet",
+        "ukphone": "dɪ'skrɪmɪneɪt"
+    },
+    {
+        "name": "disease",
+        "trans": [
+            "疾病； 弊端， 恶疾"
+        ],
+        "usphone": "dɪ'ziz",
+        "ukphone": "dɪ'ziːz"
+    },
+    {
+        "name": "disguise",
+        "trans": [
+            "掩饰； 伪装， 假装"
+        ],
+        "usphone": "dɪs'ɡaɪz",
+        "ukphone": "dɪs'gaɪz"
+    },
+    {
+        "name": "disgust",
+        "trans": [
+            "厌恶， 嫌恶"
+        ],
+        "usphone": "dɪs'ɡʌst",
+        "ukphone": "dɪs'gʌst"
+    },
+    {
+        "name": "disintegrate",
+        "trans": [
+            "瓦解； 碎裂"
+        ],
+        "usphone": "dɪs'ɪntɪɡret",
+        "ukphone": "dɪs'ɪntɪgreɪt"
+    },
+    {
+        "name": "disinterest",
+        "trans": [
+            "无兴趣， 冷漠； 客观， 公正"
+        ],
+        "usphone": "dɪs'ɪntrəst",
+        "ukphone": "dɪs'ɪntrəst"
+    },
+    {
+        "name": "disinterested",
+        "trans": [
+            "客观的， 无私的， 公正的； 无兴趣的， 不关心的"
+        ],
+        "usphone": "dɪs'ɪntərɪsɪd",
+        "ukphone": "dɪs'ɪntrəstɪd"
+    },
+    {
+        "name": "dismal",
+        "trans": [
+            "阴沉的， 阴郁的； 忧郁的， 沮丧的； 差劲的"
+        ],
+        "usphone": "'dɪzməl",
+        "ukphone": "'dɪzməl"
+    },
+    {
+        "name": "dismay",
+        "trans": [
+            "使气馁，使沮丧；使诧异",
+            "灰心， 气馁； 诧异"
+        ],
+        "usphone": "dɪs'me",
+        "ukphone": "dɪs'meɪ"
+    },
+    {
+        "name": "dismiss",
+        "trans": [
+            "不再考虑， 不接受； 消除， 摒除； 免职， 解雇； 解散， 遣散； 驳回， 不受理"
+        ],
+        "usphone": "dɪs'mɪs",
+        "ukphone": "dɪs'mɪs"
+    },
+    {
+        "name": "disorder",
+        "trans": [
+            "混乱， 凌乱； 动乱， 骚乱； 失调， 紊乱"
+        ],
+        "usphone": "dɪs'ɔrdɚ",
+        "ukphone": "dɪs'ɔːrdər"
+    },
+    {
+        "name": "disparate",
+        "trans": [
+            "迥然不同的"
+        ],
+        "usphone": "'dɪspərət",
+        "ukphone": "'dɪspərət"
+    },
+    {
+        "name": "dispatch",
+        "trans": [
+            "分派， 派遣； 发送"
+        ],
+        "usphone": "dɪ'spætʃ",
+        "ukphone": "dɪ'spætʃ"
+    },
+    {
+        "name": "dispel",
+        "trans": [
+            "驱散， 驱逐； 消除"
+        ],
+        "usphone": "dɪ'spɛl",
+        "ukphone": "dɪ'spel"
+    },
+    {
+        "name": "dispersal",
+        "trans": [
+            "疏散； 散布， 散开"
+        ],
+        "usphone": "dɪ'spɝsl",
+        "ukphone": "dɪ'spɜːrsl"
+    },
+    {
+        "name": "disperse",
+        "trans": [
+            "分散， 散开； 疏散； 散布"
+        ],
+        "usphone": "dɪ'spɝs",
+        "ukphone": "dɪ'spɜːrs"
+    },
+    {
+        "name": "displace",
+        "trans": [
+            "取代； 撤职； 迫使…离开家园"
+        ],
+        "usphone": "dɪs'ples",
+        "ukphone": "dɪs'pleɪs"
+    },
+    {
+        "name": "display",
+        "trans": [
+            "陈列； 展示； 显示"
+        ],
+        "usphone": "dɪ'sple",
+        "ukphone": "dɪ'spleɪ"
+    },
+    {
+        "name": "disposal",
+        "trans": [
+            "清除， 外理， 处置； 变卖"
+        ],
+        "usphone": "dɪ'spozl",
+        "ukphone": "dɪ'spouzl"
+    },
+    {
+        "name": "dispose",
+        "trans": [
+            "安排， 布置； 使倾向于"
+        ],
+        "usphone": "dɪ'spoz",
+        "ukphone": "dɪ'spouz"
+    },
+    {
+        "name": "disproportionate",
+        "trans": [
+            "不成比例的"
+        ],
+        "usphone": "disprə'pɔ:ʃənət",
+        "ukphone": "ˌdɪsprə'pɔːrʃənət"
+    },
+    {
+        "name": "disprove",
+        "trans": [
+            "证明…不成立， 证明…是错误的"
+        ],
+        "usphone": ",dɪs'pruv",
+        "ukphone": "ˌdɪs'pruːv"
+    },
+    {
+        "name": "dispute",
+        "trans": [
+            "争论； 对…表示异议",
+            "争论；纠纷"
+        ],
+        "usphone": "'dɪs'pjʊt",
+        "ukphone": "dɪ'spjuːt"
+    },
+    {
+        "name": "disquiet",
+        "trans": [
+            "不安，忧虑",
+            "不安， 忧虑"
+        ],
+        "usphone": "dɪs'kwaɪət",
+        "ukphone": "dɪs'kwaɪət"
+    },
+    {
+        "name": "disrepute",
+        "trans": [
+            "坏名声， 不光彩"
+        ],
+        "usphone": ",dɪsrɪ'pjut",
+        "ukphone": "ˌdɪsrɪ'pjuːt"
+    },
+    {
+        "name": "disrupt",
+        "trans": [
+            "使中断； 扰乱； 使分裂， 使瓦解"
+        ],
+        "usphone": "dɪs'rʌpt",
+        "ukphone": "dɪs'rʌpt"
+    },
+    {
+        "name": "disseminate",
+        "trans": [
+            "散布， 传播"
+        ],
+        "usphone": "dɪ'sɛmɪnet",
+        "ukphone": "dɪ'semɪneɪt"
+    },
+    {
+        "name": "dissent",
+        "trans": [
+            "不同意，持异议",
+            "不同意见， 异议"
+        ],
+        "usphone": "dɪ'sɛnt",
+        "ukphone": "dɪ'sent"
+    },
+    {
+        "name": "dissenter",
+        "trans": [
+            "不同意者， 反对者"
+        ],
+        "usphone": "di'sentə",
+        "ukphone": "dɪ'sentər"
+    },
+    {
+        "name": "dissimulate",
+        "trans": [
+            "掩盖， 掩饰， 假装"
+        ],
+        "usphone": "di'simjuleit",
+        "ukphone": "dɪ'sɪmjuleɪt"
+    },
+    {
+        "name": "dissipate",
+        "trans": [
+            "消散， 消失； 挥霍， 浪费"
+        ],
+        "usphone": "'dɪsɪpet",
+        "ukphone": "'dɪsɪpeɪt"
+    },
+    {
+        "name": "dissolute",
+        "trans": [
+            "放荡的， 放纵的， 道德沦丧的"
+        ],
+        "usphone": "'dɪsəlut",
+        "ukphone": "'dɪsəluːt"
+    },
+    {
+        "name": "dissolve",
+        "trans": [
+            "溶解； 清除； 解散， 结束"
+        ],
+        "usphone": "dɪ'zɑlv",
+        "ukphone": "dɪ'zɑːlv"
+    },
+    {
+        "name": "dissuade",
+        "trans": [
+            "劝阻， 阻止"
+        ],
+        "usphone": "dɪ'swed",
+        "ukphone": "dɪ'sweɪd"
+    },
+    {
+        "name": "distant",
+        "trans": [
+            "远离的， 遥远的； 疏远的， 冷淡的； 久远的； 不同的"
+        ],
+        "usphone": "'dɪstənt",
+        "ukphone": "'dɪstənt"
+    },
+    {
+        "name": "distasteful",
+        "trans": [
+            "令人反感的， 讨厌的； 味道不佳的"
+        ],
+        "usphone": "dɪs'testfl",
+        "ukphone": "dɪs'teɪstfl"
+    },
+    {
+        "name": "distinct",
+        "trans": [
+            "明显的， 清楚的； 确实的； 截然不同的"
+        ],
+        "usphone": "dɪ'stɪŋkt",
+        "ukphone": "dɪ'stɪŋkt"
+    },
+    {
+        "name": "distinctive",
+        "trans": [
+            "出众的， 有特色的"
+        ],
+        "usphone": "dɪ'stɪŋktɪv",
+        "ukphone": "dɪ'stɪŋktɪv"
+    },
+    {
+        "name": "distinguish",
+        "trans": [
+            "区别， 辨别； 使有别于， 成为…的特征； 看清， 听出； 使杰出， 使著名"
+        ],
+        "usphone": "dɪ'stɪŋɡwɪʃ",
+        "ukphone": "dɪ'stɪŋgwɪʃ"
+    },
+    {
+        "name": "distort",
+        "trans": [
+            "弄歪； 扭曲， 歪曲"
+        ],
+        "usphone": "dɪ'stɔrt",
+        "ukphone": "dɪ'stɔːrt"
+    },
+    {
+        "name": "distract",
+        "trans": [
+            "分散注意力， 使分心"
+        ],
+        "usphone": "dɪ'strækt",
+        "ukphone": "dɪ'strækt"
+    },
+    {
+        "name": "distress",
+        "trans": [
+            "痛苦，忧伤；贫困，窘迫；遇难",
+            "使痛苦， 使悲伤， 使忧虑"
+        ],
+        "usphone": "dɪ'strɛs",
+        "ukphone": "dɪ'stres"
+    },
+    {
+        "name": "distribute",
+        "trans": [
+            "分配， 分发； 散布"
+        ],
+        "usphone": "dɪ'strɪbjut",
+        "ukphone": "dɪ'strɪbjuːt"
+    },
+    {
+        "name": "district",
+        "trans": [
+            "地区， 区域； 管区， 行政区"
+        ],
+        "usphone": "'dɪstrɪkt",
+        "ukphone": "'dɪstrɪkt"
+    },
+    {
+        "name": "disturb",
+        "trans": [
+            "打扰； 搅乱， 弄乱； 使烦恼， 使不安"
+        ],
+        "usphone": "dɪ'stɝb",
+        "ukphone": "dɪ'stɜːrb"
+    },
+    {
+        "name": "disturbance",
+        "trans": [
+            "打扰； 骚动； 心神不安， 烦恼"
+        ],
+        "usphone": "dɪ'stɝbəns",
+        "ukphone": "dɪ'stɜːrbəns"
+    },
+    {
+        "name": "dive",
+        "trans": [
+            "跳水； 潜水"
+        ],
+        "usphone": "daɪv",
+        "ukphone": "daɪv"
+    },
+    {
+        "name": "diverge",
+        "trans": [
+            "分开， 叉开； 分歧； 偏离"
+        ],
+        "usphone": "daɪ'vɝdʒ",
+        "ukphone": "daɪ'vɜːrdʒ"
+    },
+    {
+        "name": "diverse",
+        "trans": [
+            "不同的； 多样的"
+        ],
+        "usphone": "daɪ'vɝs",
+        "ukphone": "daɪ'vɜːrs"
+    },
+    {
+        "name": "diversify",
+        "trans": [
+            "多样化， 不同"
+        ],
+        "usphone": "daɪˈvɜrsəˌfaɪ",
+        "ukphone": "daɪ'vɜːrsɪfaɪ"
+    },
+    {
+        "name": "diversion",
+        "trans": [
+            "消遣， 娱乐； 转移， 转换"
+        ],
+        "usphone": "dəˈvɝʒən; dəˈvɝʃən; daɪˈvɝʒən; daɪˈvɝʃən",
+        "ukphone": "daɪ'vɜːrʒn"
+    },
+    {
+        "name": "diversity",
+        "trans": [
+            "多样性"
+        ],
+        "usphone": "dɪˈvəsɪti",
+        "ukphone": "dɪ'vɜːrsəti"
+    },
+    {
+        "name": "divert",
+        "trans": [
+            "转移…的注意力， 使分心； 使娱乐； 使转向， 使改道"
+        ],
+        "usphone": "dɪˈvɚt",
+        "ukphone": "daɪ'vɜːrt"
+    },
+    {
+        "name": "dividend",
+        "trans": [
+            "红利， 股息； 回报， 效益； 被除数"
+        ],
+        "usphone": "'dɪvɪdɛnd",
+        "ukphone": "'dɪvɪdend"
+    },
+    {
+        "name": "divine",
+        "trans": [
+            "神的，神圣的；非凡的，超人的；极好的，"
+        ],
+        "usphone": "dɪ'vaɪn",
+        "ukphone": "dɪ'vaɪn"
+    },
+    {
+        "name": "division",
+        "trans": [
+            "除， 除法； 分开， 分隔； 分配； 部分； 分歧， 分裂； 部门"
+        ],
+        "usphone": "də'vɪʒən",
+        "ukphone": "dɪ'vɪʒn"
+    },
+    {
+        "name": "divorce",
+        "trans": [
+            "与…离婚； 使分离， 使脱离",
+            "离婚；分离，脱离"
+        ],
+        "usphone": "dɪ'vɔrs",
+        "ukphone": "dɪ'vɔːrs"
+    },
+    {
+        "name": "doctrine",
+        "trans": [
+            "教条， 教义； 学说"
+        ],
+        "usphone": "'dɑktrɪn",
+        "ukphone": "'dɑːktrɪn"
+    },
+    {
+        "name": "documentary",
+        "trans": [
+            "文件的，文献的；记录的，纪实的",
+            "纪录片"
+        ],
+        "usphone": "'dɑkjə'mɛntri",
+        "ukphone": "ˌdɑːkju'mentri"
+    },
+    {
+        "name": "documentation",
+        "trans": [
+            "文件； 归档， 文献记录"
+        ],
+        "usphone": "'dɑkjəmɛn'teʃən",
+        "ukphone": "ˌdɑːkjumen'teɪʃn"
+    },
+    {
+        "name": "dogged",
+        "trans": [
+            "顽强的， 坚持不懈的； 顽固的， 固执的"
+        ],
+        "usphone": "'dɔɡɪd",
+        "ukphone": "'dɔːgɪd"
+    },
+    {
+        "name": "dolphin",
+        "trans": [
+            "海豚"
+        ],
+        "usphone": "'dɑlfɪn",
+        "ukphone": "'dɑːlfɪn"
+    },
+    {
+        "name": "domain",
+        "trans": [
+            "领土； 领域"
+        ],
+        "usphone": "do'men",
+        "ukphone": "dou'meɪn"
+    },
+    {
+        "name": "domestic",
+        "trans": [
+            "国内的； 家庭的； 驯养的"
+        ],
+        "usphone": "də'mɛstɪk",
+        "ukphone": "də'mestɪk"
+    },
+    {
+        "name": "domesticate",
+        "trans": [
+            "驯养， 驯化； 使精于家务， 使喜爱家居"
+        ],
+        "usphone": "də'mɛstɪket",
+        "ukphone": "də'mestɪkeɪt"
+    },
+    {
+        "name": "domicile",
+        "trans": [
+            "住处， 住所"
+        ],
+        "usphone": "'dɑmɪsaɪl",
+        "ukphone": "'dɑːmɪsaɪl"
+    },
+    {
+        "name": "dominant",
+        "trans": [
+            "统治的， 支配的， 占优势的； 有统治权的"
+        ],
+        "usphone": "'dɑmɪnənt",
+        "ukphone": "'dɑːmɪnənt"
+    },
+    {
+        "name": "dominate",
+        "trans": [
+            "支配， 统治； 控制； 盛行"
+        ],
+        "usphone": "'dɑmɪnet",
+        "ukphone": "'dɑːmɪneɪt"
+    },
+    {
+        "name": "donate",
+        "trans": [
+            "捐赠； 赠送"
+        ],
+        "usphone": "'donet",
+        "ukphone": "'douneɪt"
+    },
+    {
+        "name": "doodle",
+        "trans": [
+            "乱涂， 胡画"
+        ],
+        "usphone": "'dudl",
+        "ukphone": "'duːdl"
+    },
+    {
+        "name": "dormancy",
+        "trans": [
+            "休眠； 催眠状态； 隐匿"
+        ],
+        "usphone": "'dɔrmənsi",
+        "ukphone": "'dɔːrmənsɪ"
+    },
+    {
+        "name": "dormant",
+        "trans": [
+            "静止的； 休眠的； 隐匿的"
+        ],
+        "usphone": "'dɔrmənt",
+        "ukphone": "'dɔːrmənt"
+    },
+    {
+        "name": "dormitory",
+        "trans": [
+            "宿舍"
+        ],
+        "usphone": "'dɔrmətɔri",
+        "ukphone": "'dɔːrmətɔːri"
+    },
+    {
+        "name": "dorsal",
+        "trans": [
+            "背部的， 背脊的"
+        ],
+        "usphone": "'dɔrsl",
+        "ukphone": "'dɔːrsl"
+    },
+    {
+        "name": "dosage",
+        "trans": [
+            "剂量"
+        ],
+        "usphone": "'dosɪdʒ",
+        "ukphone": "'dousɪdʒ"
+    },
+    {
+        "name": "dot",
+        "trans": [
+            "星罗棋布于；打点于；点缀",
+            "点， 圆点； 小数点"
+        ],
+        "usphone": "dɑt",
+        "ukphone": "dɑːt"
+    },
+    {
+        "name": "dote",
+        "trans": [
+            "溺爱"
+        ],
+        "usphone": "dot",
+        "ukphone": "dout"
+    },
+    {
+        "name": "downside",
+        "trans": [
+            "缺点， 负面； 底侧； 下降趋势"
+        ],
+        "usphone": "'daʊnsaɪd",
+        "ukphone": "'daunsaɪd"
+    },
+    {
+        "name": "downtown",
+        "trans": [
+            "在市中心； 往市中心",
+            "市中心的"
+        ],
+        "usphone": "'daʊn'taʊn",
+        "ukphone": "ˌdaun'taun"
+    },
+    {
+        "name": "downward",
+        "trans": [
+            "向下，往下",
+            "向下的"
+        ],
+        "usphone": "'daʊnwɚd",
+        "ukphone": "'daunwərd"
+    },
+    {
+        "name": "dozen",
+        "trans": [
+            "一打， 十二个"
+        ],
+        "usphone": "'dʌzn",
+        "ukphone": "'dʌzn"
+    },
+    {
+        "name": "draft",
+        "trans": [
+            "供役使的",
+            "草图，草稿；汇票；气流",
+            "起草；征募，选派"
+        ],
+        "usphone": "dræft",
+        "ukphone": "dræft"
+    },
+    {
+        "name": "drag",
+        "trans": [
+            "拖动；缓慢而费力地移动；拖沓地进行，拖延",
+            "累赘， 障碍； 一吸， 一抽， 一饮"
+        ],
+        "usphone": "dræg",
+        "ukphone": "dræg"
+    },
+    {
+        "name": "dragonfly",
+        "trans": [
+            "蜻蜓"
+        ],
+        "usphone": "ˈdrægənˌflaɪ",
+        "ukphone": "'drægənflaɪ"
+    },
+    {
+        "name": "drain",
+        "trans": [
+            "流走，流出；使耗尽",
+            "下水道， 排水沟； 排放； 消耗"
+        ],
+        "usphone": "dren",
+        "ukphone": "dreɪn"
+    },
+    {
+        "name": "dramatic",
+        "trans": [
+            "戏剧的； 引人注目的； 突然的， 巨大的； 戏剧性的"
+        ],
+        "usphone": "drə'mætɪk",
+        "ukphone": "drə'mætɪk"
+    },
+    {
+        "name": "dramatize",
+        "trans": [
+            "改编成戏剧； 戏剧化， 戏剧性地表现"
+        ],
+        "usphone": "'dræmətaɪz",
+        "ukphone": "'dræmətaɪz"
+    },
+    {
+        "name": "drastic",
+        "trans": [
+            "剧烈的， 猛烈的， 激烈的"
+        ],
+        "usphone": "'dræstɪk",
+        "ukphone": "'dræstɪk"
+    },
+    {
+        "name": "draw",
+        "trans": [
+            "吸引，招引；画，描绘；拖，拉；引起，激起；拨出，抽出；提取，支取；推断出；打成平局",
+            "平局， 和局； 抽签"
+        ],
+        "usphone": "drɔ",
+        "ukphone": "drɔː"
+    },
+    {
+        "name": "drawback",
+        "trans": [
+            "缺点， 障碍， 不利条件； 退款， 退税"
+        ],
+        "usphone": "'drɔbæk",
+        "ukphone": "'drɔːbæk"
+    },
+    {
+        "name": "drench",
+        "trans": [
+            "使湿透"
+        ],
+        "usphone": "drɛntʃ",
+        "ukphone": "drentʃ"
+    },
+    {
+        "name": "drift",
+        "trans": [
+            "漂流，漂移；漂泊，游荡",
+            "漂流； 漂泊； 大意， 主旨； 倾向， 趋势"
+        ],
+        "usphone": "drɪft",
+        "ukphone": "drɪft"
+    },
+    {
+        "name": "drill",
+        "trans": [
+            "钻，打眼；训练",
+            "钻； 训练"
+        ],
+        "usphone": "drɪl",
+        "ukphone": "drɪl"
+    },
+    {
+        "name": "drought",
+        "trans": [
+            "干旱， 旱灾"
+        ],
+        "usphone": "draʊt",
+        "ukphone": "draut"
+    },
+    {
+        "name": "drowsy",
+        "trans": [
+            "昏昏欲睡的； 催眠的"
+        ],
+        "usphone": "'draʊzi",
+        "ukphone": "'drauzi"
+    },
+    {
+        "name": "dual",
+        "trans": [
+            "双的， 二重的"
+        ],
+        "usphone": "'dʊəl",
+        "ukphone": "'duːəl"
+    },
+    {
+        "name": "dubious",
+        "trans": [
+            "怀疑的， 拿不准的； 可疑的， 靠不住的"
+        ],
+        "usphone": "'dubɪəs",
+        "ukphone": "'duːbiəs"
+    },
+    {
+        "name": "ductile",
+        "trans": [
+            "有延性的， 韧性的； 易引导的， 易受影响的"
+        ],
+        "usphone": "'dʌktaɪl",
+        "ukphone": "'dʌktaɪl"
+    },
+    {
+        "name": "due",
+        "trans": [
+            "到期的； 预期的； 应得的； 恰当的， 适当的； 应支付的"
+        ],
+        "usphone": "du",
+        "ukphone": "duː"
+    },
+    {
+        "name": "dull",
+        "trans": [
+            "乏味的， 单调的； 迟钝的； 无光泽的； 萧条的； 阴沉的， 昏暗的"
+        ],
+        "usphone": "dʌl",
+        "ukphone": "dʌl"
+    },
+    {
+        "name": "dump",
+        "trans": [
+            "丢弃，倾倒；抛弃；推卸；倾销",
+            "垃圾场"
+        ],
+        "usphone": "dʌmp",
+        "ukphone": "dʌmp"
+    },
+    {
+        "name": "dupe",
+        "trans": [
+            "上当者",
+            "欺骗， 愚弄"
+        ],
+        "usphone": "dju:p",
+        "ukphone": "duːp"
+    },
+    {
+        "name": "duplicate",
+        "trans": [
+            "完全相同的；副本的",
+            "复制品； 副本",
+            "复写； 复制； 使加倍"
+        ],
+        "usphone": "'duplɪket",
+        "ukphone": "ˈdjuːplɪkeɪt"
+    },
+    {
+        "name": "durable",
+        "trans": [
+            "持久的， 耐用的"
+        ],
+        "usphone": "'dʊrəbl",
+        "ukphone": "'durəbl"
+    },
+    {
+        "name": "dwarf",
+        "trans": [
+            "矮小的",
+            "使显得矮小，使相形见绌",
+            "侏儒， 矮人"
+        ],
+        "usphone": "dwɔrf",
+        "ukphone": "dwɔːrf"
+    },
+    {
+        "name": "dwindle",
+        "trans": [
+            "减少； 缩小"
+        ],
+        "usphone": "'dwɪndl",
+        "ukphone": "'dwɪndl"
+    },
+    {
+        "name": "dye",
+        "trans": [
+            "染色",
+            "颜料，染料"
+        ],
+        "usphone": "daɪ",
+        "ukphone": "daɪ"
+    },
+    {
+        "name": "dynamical",
+        "trans": [
+            "动态的； 动力的； 充满活力的"
+        ],
+        "usphone": "dai'næmikəl",
+        "ukphone": "daɪ'næmɪkl"
+    },
+    {
+        "name": "eager",
+        "trans": [
+            "渴望的， 热切的"
+        ],
+        "usphone": "'igɚ",
+        "ukphone": "'iːgər"
+    },
+    {
+        "name": "earnest",
+        "trans": [
+            "认真的；真诚的",
+            "诚挚； 认真"
+        ],
+        "usphone": "",
+        "ukphone": "'ɜːrnɪst"
+    },
+    {
+        "name": "ease",
+        "trans": [
+            "缓和， 减轻",
+            "不费力，容易；悠闲，自在"
+        ],
+        "usphone": "iz",
+        "ukphone": "iːz"
+    },
+    {
+        "name": "Easter",
+        "trans": [
+            "复活节"
+        ],
+        "usphone": "istəʳ",
+        "ukphone": "'iːstər"
+    },
+    {
+        "name": "eccentric",
+        "trans": [
+            "古怪的， 反常的",
+            "古怪的人"
+        ],
+        "usphone": "ɪk'sɛntrɪk",
+        "ukphone": "ɪk'sentrɪk"
+    },
+    {
+        "name": "eclecticism",
+        "trans": [
+            "折中主义"
+        ],
+        "usphone": "",
+        "ukphone": "ɪ'klektɪsɪzəm"
+    },
+    {
+        "name": "eclipse",
+        "trans": [
+            "遮住光；使相形见绌",
+            "日食， 月食"
+        ],
+        "usphone": "ɪ'klɪps",
+        "ukphone": "ɪ'klɪps"
+    },
+    {
+        "name": "ecological",
+        "trans": [
+            "生态的"
+        ],
+        "usphone": "'ikə'lɑdʒɪkl",
+        "ukphone": "ˌiːkə'lɑːdʒɪkl"
+    },
+    {
+        "name": "ecology",
+        "trans": [
+            "生态； 生态学； 生态环境"
+        ],
+        "usphone": "ɪ'kɑlədʒi",
+        "ukphone": "i'kɑːlədʒi"
+    },
+    {
+        "name": "economic",
+        "trans": [
+            "经济的； 经济上的； 经济学的； 合算的"
+        ],
+        "usphone": "ˌikəˈnɑmɪk, ˌɛkəˈ-nɑmɪk",
+        "ukphone": "ˌiːkə'nɑːmɪk"
+    },
+    {
+        "name": "economical",
+        "trans": [
+            "经济的， 实惠的； 节俭的， 节约的； 精打细算的"
+        ],
+        "usphone": ",ɛkə'nɑmɪkl",
+        "ukphone": "ˌiːkə'nɑːmɪkl"
+    },
+    {
+        "name": "ecosystem",
+        "trans": [
+            "生态系统"
+        ],
+        "usphone": "'ɛko,sɪstəm",
+        "ukphone": "'iːkousɪstəm"
+    },
+    {
+        "name": "edge",
+        "trans": [
+            "徐徐移动； 略为增加； 给…加边",
+            "边，边缘；刀口，刃；优势"
+        ],
+        "usphone": "ɛdʒ",
+        "ukphone": "edʒ"
+    },
+    {
+        "name": "edible",
+        "trans": [
+            "可食用的"
+        ],
+        "usphone": "'ɛdəbl",
+        "ukphone": "'edəbl"
+    },
+    {
+        "name": "edifice",
+        "trans": [
+            "大厦， 宏伟的建筑物"
+        ],
+        "usphone": "'ɛdɪfɪs",
+        "ukphone": "'edɪfɪs"
+    },
+    {
+        "name": "editorial",
+        "trans": [
+            "社论的； 编辑的",
+            "社论，重要评论"
+        ],
+        "usphone": ",ɛdɪ'tɔrɪəl",
+        "ukphone": "ˌedɪ'tɔːriəl"
+    },
+    {
+        "name": "educated",
+        "trans": [
+            "受过教育的， 有教养的"
+        ],
+        "usphone": "'ɛdʒə'ketɪd",
+        "ukphone": "'edʒukeɪtɪd"
+    },
+    {
+        "name": "effective",
+        "trans": [
+            "有效的， 生效的； 显著的； 实际的， 事实上的"
+        ],
+        "usphone": "ɪ'fɛktɪv",
+        "ukphone": "ɪ'fektɪv"
+    },
+    {
+        "name": "efficiency",
+        "trans": [
+            "效率， 功效"
+        ],
+        "usphone": "ɪˈfɪʃənsɪ",
+        "ukphone": "ɪ'fɪʃnsi"
+    },
+    {
+        "name": "efficient",
+        "trans": [
+            "有效的， 有效率的； 有能力的， 能胜任的"
+        ],
+        "usphone": "ɪ'fɪʃnt",
+        "ukphone": "ɪ'fɪʃnt"
+    },
+    {
+        "name": "effluent",
+        "trans": [
+            "流出物， 废水， 污水"
+        ],
+        "usphone": "'ɛflʊənt",
+        "ukphone": "'efluənt"
+    },
+    {
+        "name": "eject",
+        "trans": [
+            "逐出， 驱赶； 喷出， 喷射； 弹出"
+        ],
+        "usphone": "ɪ'dʒɛkt",
+        "ukphone": "i'dʒekt"
+    },
+    {
+        "name": "elaborate",
+        "trans": [
+            "精心制作的， 复杂精美的",
+            "详述； 详细制订， 精心制作"
+        ],
+        "usphone": "ɪ'læbəret",
+        "ukphone": "ɪ'læb(ə)rət"
+    },
+    {
+        "name": "elapse",
+        "trans": [
+            "消逝， 流逝"
+        ],
+        "usphone": "ɪ'læps",
+        "ukphone": "ɪ'læps"
+    },
+    {
+        "name": "elasticity",
+        "trans": [
+            "弹力； 弹性"
+        ],
+        "usphone": ",ilæ'stɪsəti",
+        "ukphone": "ˌiːlæ'stɪsəti"
+    },
+    {
+        "name": "elective",
+        "trans": [
+            "选举的； 可选择的； 选修的"
+        ],
+        "usphone": "ɪ'lɛktɪv",
+        "ukphone": "ɪ'lektɪv"
+    },
+    {
+        "name": "electricity",
+        "trans": [
+            "电； 电流"
+        ],
+        "usphone": "ɪ'lɛk'trɪsəti",
+        "ukphone": "ɪˌlek'trɪsəti"
+    },
+    {
+        "name": "electrode",
+        "trans": [
+            "电极"
+        ],
+        "usphone": "ɪ'lɛktrod",
+        "ukphone": "ɪ'lektroud"
+    },
+    {
+        "name": "electrolysis",
+        "trans": [
+            "电解作用； 电解术"
+        ],
+        "usphone": "ɪ,lɛk'trɑləsɪs",
+        "ukphone": "ɪˌlek'trɑːləsɪs"
+    },
+    {
+        "name": "electron",
+        "trans": [
+            "电子"
+        ],
+        "usphone": "ɪ'lɛktrɑn",
+        "ukphone": "ɪ'lektrɑːn"
+    },
+    {
+        "name": "elegant",
+        "trans": [
+            "优美的， 高雅的； 雅致的， 精美的； 简练的， 简洁的"
+        ],
+        "usphone": "'ɛləgənt",
+        "ukphone": "'elɪgənt"
+    },
+    {
+        "name": "element",
+        "trans": [
+            "元素，要素，组成部分；"
+        ],
+        "usphone": "'ɛləmənt",
+        "ukphone": "'elɪmənt"
+    },
+    {
+        "name": "elementary",
+        "trans": [
+            "初级的， 基础的； 基本的； 简单的"
+        ],
+        "usphone": ",ɛlɪ'mɛntri",
+        "ukphone": "ˌelɪ'mentri"
+    },
+    {
+        "name": "elevate",
+        "trans": [
+            "举起， 抬高； 提升职位； 使情绪高昂， 使兴高采烈"
+        ],
+        "usphone": "'ɛlɪvet",
+        "ukphone": "'elɪveɪt"
+    },
+    {
+        "name": "elicit",
+        "trans": [
+            "得出， 引出； 诱出"
+        ],
+        "usphone": "ɪ'lɪsɪt",
+        "ukphone": "i'lɪsɪt"
+    },
+    {
+        "name": "eligible",
+        "trans": [
+            "符合条件的， 合格的； 适合的"
+        ],
+        "usphone": "'ɛlɪdʒəbl",
+        "ukphone": "'elɪdʒəbl"
+    },
+    {
+        "name": "eliminate",
+        "trans": [
+            "消除； 淘汰"
+        ],
+        "usphone": "ɪ'lɪmɪnet",
+        "ukphone": "ɪ'lɪmɪneɪt"
+    },
+    {
+        "name": "elite",
+        "trans": [
+            "卓越的，精锐的",
+            "精英"
+        ],
+        "usphone": "ɪˈliːt",
+        "ukphone": "ɪ'liːt"
+    },
+    {
+        "name": "ellipse",
+        "trans": [
+            "椭圆， 椭圆形"
+        ],
+        "usphone": "ɪ'lɪps",
+        "ukphone": "ɪ'lɪps"
+    },
+    {
+        "name": "elliptical",
+        "trans": [
+            "椭圆的； 隐晦的； 省略的， 简略的"
+        ],
+        "usphone": "ɪ'lɪptɪkl",
+        "ukphone": "ɪ'lɪptɪkl"
+    },
+    {
+        "name": "elm",
+        "trans": [
+            "榆树"
+        ],
+        "usphone": "ɛlm",
+        "ukphone": "elm"
+    },
+    {
+        "name": "elongate",
+        "trans": [
+            "延长， 伸长"
+        ],
+        "usphone": "ɪ'lɔŋɡet",
+        "ukphone": "ɪ'lɔːŋgeɪt"
+    },
+    {
+        "name": "eloquent",
+        "trans": [
+            "雄辩的 ； 动人的"
+        ],
+        "usphone": "'ɛləkwənt",
+        "ukphone": "'eləkwənt"
+    },
+    {
+        "name": "elusive",
+        "trans": [
+            "难以理解的， 难懂的； 难捕捉的； 逃避的"
+        ],
+        "usphone": "ɪ'lusɪv",
+        "ukphone": "i'luːsɪv"
+    },
+    {
+        "name": "emanate",
+        "trans": [
+            "散发； 表现， 显示"
+        ],
+        "usphone": "ˈɛməˌneɪt",
+        "ukphone": "'eməneɪt"
+    },
+    {
+        "name": "emancipate",
+        "trans": [
+            "解放， 解除"
+        ],
+        "usphone": "ɪ'mænsɪpet",
+        "ukphone": "ɪ'mænsɪpeɪt"
+    },
+    {
+        "name": "embargo",
+        "trans": [
+            "禁止贸易令；"
+        ],
+        "usphone": "ɪm'bɑrɡo",
+        "ukphone": "ɪm'bɑːrgou"
+    },
+    {
+        "name": "embark",
+        "trans": [
+            "上船"
+        ],
+        "usphone": "ɪm'bɑrk",
+        "ukphone": "ɪm'bɑːrk"
+    },
+    {
+        "name": "embarrass",
+        "trans": [
+            "使尴尬， 使困窘； 使困惑"
+        ],
+        "usphone": "ɪm'bærəs",
+        "ukphone": "ɪm'bærəs"
+    },
+    {
+        "name": "embed",
+        "trans": [
+            "把…嵌入； 使深留脑中"
+        ],
+        "usphone": "ɪm'bɛd",
+        "ukphone": "ɪm'bed"
+    },
+    {
+        "name": "embellish",
+        "trans": [
+            "装饰； 对…添枝加叶， 渲染"
+        ],
+        "usphone": "im'beliʃ",
+        "ukphone": "ɪm'belɪʃ"
+    },
+    {
+        "name": "emblem",
+        "trans": [
+            "徽章； 标记， 象征"
+        ],
+        "usphone": "'ɛmbləm",
+        "ukphone": "'embləm"
+    },
+    {
+        "name": "embody",
+        "trans": [
+            "表达， 体现； 含有"
+        ],
+        "usphone": "ɪm'bɑdi",
+        "ukphone": "ɪm'bɑːdi"
+    },
+    {
+        "name": "embrace",
+        "trans": [
+            "拥抱；包含；欣然接受",
+            "拥抱"
+        ],
+        "usphone": "ɪm'bres",
+        "ukphone": "ɪm'breɪs"
+    },
+    {
+        "name": "embryo",
+        "trans": [
+            "胚， 胚胎； 雏形"
+        ],
+        "usphone": "'ɛmbrɪo",
+        "ukphone": "'embriou"
+    },
+    {
+        "name": "emerald",
+        "trans": [
+            "祖母绿， 绿宝石； 翡翠绿"
+        ],
+        "usphone": "'ɛmərəld",
+        "ukphone": "'emərəld"
+    },
+    {
+        "name": "emerge",
+        "trans": [
+            "显露， 暴露； 出来， 现出"
+        ],
+        "usphone": "ɪ'mɝdʒ",
+        "ukphone": "i'mɜːrdʒ"
+    },
+    {
+        "name": "emergent",
+        "trans": [
+            "突现的； 新兴的； 紧急的"
+        ],
+        "usphone": "ɪ'mɝdʒənt",
+        "ukphone": "i'mɜːrdʒənt"
+    },
+    {
+        "name": "emigrate",
+        "trans": [
+            "移民， 移居国外"
+        ],
+        "usphone": "'ɛmɪɡret",
+        "ukphone": "'emɪgreɪt"
+    },
+    {
+        "name": "eminent",
+        "trans": [
+            "显著的， 杰出的"
+        ],
+        "usphone": "'ɛmɪnənt",
+        "ukphone": "'emɪnənt"
+    },
+    {
+        "name": "emission",
+        "trans": [
+            "散发物， 排放物； 发射， 排放"
+        ],
+        "usphone": "ɪ'mɪʃən",
+        "ukphone": "i'mɪʃn"
+    },
+    {
+        "name": "emit",
+        "trans": [
+            "发出； 放射； 排放"
+        ],
+        "usphone": "ɪ'mɪt",
+        "ukphone": "i'mɪt"
+    },
+    {
+        "name": "emotion",
+        "trans": [
+            "感情， 激情， 情绪"
+        ],
+        "usphone": "ɪ'moʃən",
+        "ukphone": "ɪ'mouʃn"
+    },
+    {
+        "name": "emotional",
+        "trans": [
+            "感情的， 情绪的； 引起情感的； 易动感情的"
+        ],
+        "usphone": "ɪ'moʃənl",
+        "ukphone": "ɪ'mouʃənl"
+    },
+    {
+        "name": "emphasize",
+        "trans": [
+            "强调， 着重"
+        ],
+        "usphone": "'ɛmfəsaɪz",
+        "ukphone": "'emfəsaɪz"
+    },
+    {
+        "name": "empiricism",
+        "trans": [
+            "经验论， 经验主义"
+        ],
+        "usphone": "ɛm'pɪrə'sɪzəm",
+        "ukphone": "ɪm'pɪrɪsɪzəm"
+    },
+    {
+        "name": "employ",
+        "trans": [
+            "用，使用；雇用",
+            "受雇， 雇用"
+        ],
+        "usphone": "ɪm'plɔɪ",
+        "ukphone": "ɪm'plɔɪ"
+    },
+    {
+        "name": "empower",
+        "trans": [
+            "授权， 准许； 使控制局势"
+        ],
+        "usphone": "ɪm'paʊɚ",
+        "ukphone": "ɪm'pauər"
+    },
+    {
+        "name": "empress",
+        "trans": [
+            "女皇， 皇后"
+        ],
+        "usphone": "'ɛmprəs",
+        "ukphone": "'emprəs"
+    },
+    {
+        "name": "enact",
+        "trans": [
+            "制定法律， 颁布； 扮演"
+        ],
+        "usphone": "ɪ'nækt",
+        "ukphone": "ɪ'nækt"
+    },
+    {
+        "name": "enactment",
+        "trans": [
+            "制订， 颁布； 法律， 法规"
+        ],
+        "usphone": "ɪ'næktmənt",
+        "ukphone": "ɪ'næktmənt"
+    },
+    {
+        "name": "encase",
+        "trans": [
+            "包住"
+        ],
+        "usphone": "ɪn'kes",
+        "ukphone": "ɪn'keɪs"
+    },
+    {
+        "name": "enclose",
+        "trans": [
+            "围住； 把…装入"
+        ],
+        "usphone": "ɪn'kloz",
+        "ukphone": "ɪn'klouz"
+    },
+    {
+        "name": "encompass",
+        "trans": [
+            "包含； 环绕"
+        ],
+        "usphone": "ɪn'kʌmpəs",
+        "ukphone": "ɪn'kʌmpəs"
+    },
+    {
+        "name": "encounter",
+        "trans": [
+            "偶然碰到； 遭遇"
+        ],
+        "usphone": "ɪn'kaʊntɚ",
+        "ukphone": "ɪn'kauntər"
+    },
+    {
+        "name": "encourage",
+        "trans": [
+            "鼓励， 激励； 促进， 激发"
+        ],
+        "usphone": "ɪn'kɝrɪdʒ",
+        "ukphone": "ɪn'kɜːrɪdʒ"
+    },
+    {
+        "name": "encroach",
+        "trans": [
+            "侵占； 侵蚀， 蚕食"
+        ],
+        "usphone": "ɪn'krotʃ",
+        "ukphone": "ɪn'kroutʃ"
+    },
+    {
+        "name": "encrust",
+        "trans": [
+            "在表面形成硬壳， 结壳； 用…装饰外层"
+        ],
+        "usphone": "",
+        "ukphone": "ɪn'krʌst"
+    },
+    {
+        "name": "endanger",
+        "trans": [
+            "危及， 危害"
+        ],
+        "usphone": "ɪn'dendʒɚ",
+        "ukphone": "ɪn'deɪndʒər"
+    },
+    {
+        "name": "endangered",
+        "trans": [
+            "濒危的， 将要灭绝的"
+        ],
+        "usphone": "ɪn'dendʒɚd",
+        "ukphone": "ɪn'deɪndʒərd"
+    },
+    {
+        "name": "endeavor",
+        "trans": [
+            "努力， 尽力"
+        ],
+        "usphone": "ɪn'dɛvɚ",
+        "ukphone": "ɪn'devər"
+    },
+    {
+        "name": "endless",
+        "trans": [
+            "无止境的， 无穷尽的"
+        ],
+        "usphone": "ˈɛndlɪs",
+        "ukphone": "'endləs"
+    },
+    {
+        "name": "endorse",
+        "trans": [
+            "签名； 宣传， 代言； 签署； 赞同， 支持"
+        ],
+        "usphone": "ɪn'dɔrs",
+        "ukphone": "ɪn'dɔːrs"
+    },
+    {
+        "name": "endow",
+        "trans": [
+            "使天生具有， 赋予； 资助， 捐赠"
+        ],
+        "usphone": "ɪn'daʊ",
+        "ukphone": "ɪn'dau"
+    },
+    {
+        "name": "endure",
+        "trans": [
+            "忍受， 忍耐； 持久， 持续"
+        ],
+        "usphone": "ɪn'dʊr",
+        "ukphone": "ɪn'dur"
+    },
+    {
+        "name": "energetic",
+        "trans": [
+            "精力充沛的， 积极的"
+        ],
+        "usphone": ",ɛnɚ'dʒɛtɪk",
+        "ukphone": "ˌenər'dʒetɪk"
+    },
+    {
+        "name": "enforce",
+        "trans": [
+            "实施， 生效， 执行； 强迫， 迫使"
+        ],
+        "usphone": "ɪn'fɔrs",
+        "ukphone": "ɪn'fɔːrs"
+    },
+    {
+        "name": "engage",
+        "trans": [
+            "从事于， 忙于； 吸引； 订婚； 聘用"
+        ],
+        "usphone": "ɪn'ɡedʒ",
+        "ukphone": "ɪn'geɪdʒ"
+    },
+    {
+        "name": "engaging",
+        "trans": [
+            "迷人的"
+        ],
+        "usphone": "ɪn'ɡedʒɪŋ",
+        "ukphone": "ɪn'geɪdʒɪŋ"
+    },
+    {
+        "name": "engineering",
+        "trans": [
+            "工程； 工程学"
+        ],
+        "usphone": "'ɛndʒə'nɪrɪŋ",
+        "ukphone": "ˌendʒɪ'nɪrɪŋ"
+    },
+    {
+        "name": "engrave",
+        "trans": [
+            "雕刻； 铭刻"
+        ],
+        "usphone": "ɪn'ɡrev",
+        "ukphone": "ɪn'greɪv"
+    },
+    {
+        "name": "engraving",
+        "trans": [
+            "雕刻术， 刻版术； 版画"
+        ],
+        "usphone": "ɪn'ɡrevɪŋ",
+        "ukphone": "ɪn'greɪvɪŋ"
+    },
+    {
+        "name": "engulf",
+        "trans": [
+            "吞没"
+        ],
+        "usphone": "ɛnˈɡʌlf",
+        "ukphone": "ɪn'gʌlf"
+    },
+    {
+        "name": "enhance",
+        "trans": [
+            "提高； 增强"
+        ],
+        "usphone": "ɪn'hæns",
+        "ukphone": "ɪn'hæns"
+    },
+    {
+        "name": "enlighten",
+        "trans": [
+            "启发， 启迪； 开导； 阐明"
+        ],
+        "usphone": "ɪn'laɪtn",
+        "ukphone": "ɪn'laɪtn"
+    },
+    {
+        "name": "enlightenment",
+        "trans": [
+            "启发， 教化， 启迪； [the E-]启蒙运动"
+        ],
+        "usphone": "ɪn'laɪtnmənt",
+        "ukphone": "ɪn'laɪtnmənt"
+    },
+    {
+        "name": "enlist",
+        "trans": [
+            "征募； 从军， 参军； 谋取"
+        ],
+        "usphone": "ɪn'lɪst",
+        "ukphone": "ɪn'lɪst"
+    },
+    {
+        "name": "enormous",
+        "trans": [
+            "巨大的， 极大的"
+        ],
+        "usphone": "ɪ'nɔrməs",
+        "ukphone": "ɪ'nɔːrməs"
+    },
+    {
+        "name": "enrich",
+        "trans": [
+            "使充实； 使肥沃； 使富裕， 使富有"
+        ],
+        "usphone": "ɪn'rɪtʃ",
+        "ukphone": "ɪn'rɪtʃ"
+    },
+    {
+        "name": "enroll",
+        "trans": [
+            "登记， 注册； 招收"
+        ],
+        "usphone": "ɪn'rol",
+        "ukphone": "ɪn'roul"
+    },
+    {
+        "name": "enrollment",
+        "trans": [
+            "登记， 注册； 入学"
+        ],
+        "usphone": "ɪn'rolmənt",
+        "ukphone": "ɪn'roulmənt"
+    },
+    {
+        "name": "ensconce",
+        "trans": [
+            "使安顿， 安置， 使安坐"
+        ],
+        "usphone": "in'skɔns",
+        "ukphone": "ɪn'skɑːns"
+    },
+    {
+        "name": "enslave",
+        "trans": [
+            "奴役"
+        ],
+        "usphone": "ɪn'slev",
+        "ukphone": "ɪn'sleɪv"
+    },
+    {
+        "name": "ensue",
+        "trans": [
+            "继而发生， 接着发生"
+        ],
+        "usphone": "ɪn'su",
+        "ukphone": "ɪn'suː"
+    },
+    {
+        "name": "ensure",
+        "trans": [
+            "确保， 担保， 保证"
+        ],
+        "usphone": "ɪn'ʃʊr",
+        "ukphone": "ɪn'ʃur"
+    },
+    {
+        "name": "entail",
+        "trans": [
+            "牵涉； 使必要， 需要"
+        ],
+        "usphone": "ɪn'tel",
+        "ukphone": "ɪn'teɪl"
+    },
+    {
+        "name": "enterprise",
+        "trans": [
+            "企业， 公司； 事业"
+        ],
+        "usphone": "'ɛntɚ'praɪz",
+        "ukphone": "'entərpraɪz"
+    },
+    {
+        "name": "entertain",
+        "trans": [
+            "招待， 款待； 使快乐， 娱乐"
+        ],
+        "usphone": ",ɛntɚ'ten",
+        "ukphone": "ˌentər'teɪn"
+    },
+    {
+        "name": "enthusiasm",
+        "trans": [
+            "热情； 积极性； 热衷的事物"
+        ],
+        "usphone": "ɪn'θuzɪæzəm",
+        "ukphone": "ɪn'θuːziæzəm"
+    },
+    {
+        "name": "enthusiastic",
+        "trans": [
+            "热情的， 热心的"
+        ],
+        "usphone": "ɪn,θuzɪ'æstɪk",
+        "ukphone": "ɪnˌθuːzi'æstɪk"
+    },
+    {
+        "name": "entitle",
+        "trans": [
+            "使…有权； 给题名"
+        ],
+        "usphone": "ɪn'taɪtl",
+        "ukphone": "ɪn'taɪtl"
+    },
+    {
+        "name": "entity",
+        "trans": [
+            "实体， 独立存在物"
+        ],
+        "usphone": "'ɛntəti",
+        "ukphone": "'entəti"
+    },
+    {
+        "name": "entourage",
+        "trans": [
+            "〈总称〉随从， 随行人员"
+        ],
+        "usphone": "'ɑnturɑʒ",
+        "ukphone": "'ɑːnturɑːʒ"
+    },
+    {
+        "name": "entreat",
+        "trans": [
+            "乞求， 恳求， 请求"
+        ],
+        "usphone": "ɪn'trit",
+        "ukphone": "ɪn'triːt"
+    },
+    {
+        "name": "entrench",
+        "trans": [
+            "使根深蒂固， 牢固确立"
+        ],
+        "usphone": "ɪn'trɛntʃ",
+        "ukphone": "ɪn'trentʃ"
+    },
+    {
+        "name": "entrepreneur",
+        "trans": [
+            "企业家； 承包人"
+        ],
+        "usphone": "ˌɑntrəprəˈnɝ​",
+        "ukphone": "ˌɑːntrəprə'nɜːr"
+    },
+    {
+        "name": "enunciate",
+        "trans": [
+            "清晰地发音； 表达， 阐明"
+        ],
+        "usphone": "ɪ'nʌnsɪet",
+        "ukphone": "ɪ'nʌnsieɪt"
+    },
+    {
+        "name": "envelop",
+        "trans": [
+            "包围"
+        ],
+        "usphone": "ɪn'vɛləp",
+        "ukphone": "ɪn'veləp"
+    },
+    {
+        "name": "envelope",
+        "trans": [
+            "信封"
+        ],
+        "usphone": "",
+        "ukphone": "'envəloup"
+    },
+    {
+        "name": "environmental",
+        "trans": [
+            "有关环境的， 自然环境的， 生态环境的； 环境的"
+        ],
+        "usphone": "ɪn,vaɪrən'mɛntl",
+        "ukphone": "ɪnˌvaɪrən'mentl"
+    },
+    {
+        "name": "envision",
+        "trans": [
+            "想象， 展望， 预想"
+        ],
+        "usphone": "ɪn'vɪʒn",
+        "ukphone": "ɪn'vɪʒn"
+    },
+    {
+        "name": "enzyme",
+        "trans": [
+            "酶， 酵素"
+        ],
+        "usphone": "'ɛnzaɪm",
+        "ukphone": "'enzaɪm"
+    },
+    {
+        "name": "ephemeral",
+        "trans": [
+            "短暂的， 转瞬即逝的"
+        ],
+        "usphone": "ə'fɛmərəl",
+        "ukphone": "ɪ'femərəl"
+    },
+    {
+        "name": "epic",
+        "trans": [
+            "史诗般的； 艰苦卓绝的； 壮丽的， 宏大的",
+            "史诗；史诗般的电影；壮举"
+        ],
+        "usphone": "'ɛpɪk",
+        "ukphone": "'epɪk"
+    },
+    {
+        "name": "epidemic",
+        "trans": [
+            "流行性的， 传染性的",
+            "流行；流行病"
+        ],
+        "usphone": ",ɛpɪ'dɛmɪk",
+        "ukphone": "ˌepɪ'demɪk"
+    },
+    {
+        "name": "episode",
+        "trans": [
+            "一段时期； 片段， 插曲； 一集"
+        ],
+        "usphone": "'ɛpɪsod",
+        "ukphone": "'epɪsoud"
+    },
+    {
+        "name": "epitome",
+        "trans": [
+            "摘要， 梗概； 典型， 典范"
+        ],
+        "usphone": "ɪ'pɪtəmi",
+        "ukphone": "ɪ'pɪtəmi"
+    },
+    {
+        "name": "epitomize",
+        "trans": [
+            "成为…的缩影； 摘要， 概括， 缩写"
+        ],
+        "usphone": "ɪ'pɪtəmaɪz",
+        "ukphone": "ɪ'pɪtəmaɪz"
+    },
+    {
+        "name": "epoch",
+        "trans": [
+            "新纪元， 时代"
+        ],
+        "usphone": "'ɛpək",
+        "ukphone": "'iːpɑːk"
+    },
+    {
+        "name": "equal",
+        "trans": [
+            "相同的",
+            "等于；相当于",
+            "同等的人； 相等的事物"
+        ],
+        "usphone": "'ikwəl",
+        "ukphone": "'iːkwəl"
+    },
+    {
+        "name": "equation",
+        "trans": [
+            "等式， 方程式； 等同， 相等； 均衡"
+        ],
+        "usphone": "ɪ'kweʒn",
+        "ukphone": "ɪ'kweɪʒn"
+    },
+    {
+        "name": "equator",
+        "trans": [
+            "赤道"
+        ],
+        "usphone": "ɪ'kwetɚ",
+        "ukphone": "ɪ'kweɪtər"
+    },
+    {
+        "name": "equitable",
+        "trans": [
+            "公平的， 公正的"
+        ],
+        "usphone": "'ekwitəbl",
+        "ukphone": "'ekwɪtəbl"
+    },
+    {
+        "name": "equivalent",
+        "trans": [
+            "相同的； 相当的",
+            "对等物；等价物"
+        ],
+        "usphone": "ɪ'kwɪvələnt",
+        "ukphone": "ɪ'kwɪvələnt"
+    },
+    {
+        "name": "era",
+        "trans": [
+            "纪元， 年代， 时代； 代"
+        ],
+        "usphone": "'ɪrə",
+        "ukphone": "'ɪrə"
+    },
+    {
+        "name": "eradicate",
+        "trans": [
+            "根除， 灭绝"
+        ],
+        "usphone": "ɪ'rædɪket",
+        "ukphone": "ɪ'rædɪkeɪt"
+    },
+    {
+        "name": "erect",
+        "trans": [
+            "直立的",
+            "建立； 竖立"
+        ],
+        "usphone": "ɪ'rɛkt",
+        "ukphone": "ɪ'rekt"
+    },
+    {
+        "name": "erode",
+        "trans": [
+            "侵蚀， 腐蚀"
+        ],
+        "usphone": "ɪ'rod",
+        "ukphone": "ɪ'roud"
+    },
+    {
+        "name": "erosion",
+        "trans": [
+            "腐蚀， 侵蚀； 削弱， 减少"
+        ],
+        "usphone": "ɪ'roʒən",
+        "ukphone": "ɪ'rouʒn"
+    },
+    {
+        "name": "errand",
+        "trans": [
+            "差事， 差使"
+        ],
+        "usphone": "'ɛrənd",
+        "ukphone": "'erənd"
+    },
+    {
+        "name": "erratic",
+        "trans": [
+            "古怪的， 反复无常的； 不规则的； 不稳定的"
+        ],
+        "usphone": "ɪ'rætɪk",
+        "ukphone": "ɪ'rætɪk"
+    },
+    {
+        "name": "erupt",
+        "trans": [
+            "突然发生， 爆发； 喷出"
+        ],
+        "usphone": "ɪ'rʌpt",
+        "ukphone": "ɪ'rʌpt"
+    },
+    {
+        "name": "eschew",
+        "trans": [
+            "避开， 戒除， 回避"
+        ],
+        "usphone": "ɪsˈtʃuː",
+        "ukphone": "ɪs'tʃuː"
+    },
+    {
+        "name": "espouse",
+        "trans": [
+            "支持， 拥护， 赞成"
+        ],
+        "usphone": "ɪ'spaʊz",
+        "ukphone": "ɪ'spauz"
+    },
+    {
+        "name": "essay",
+        "trans": [
+            "散文， 随笔； 短文； 评论"
+        ],
+        "usphone": "'ɛse",
+        "ukphone": "'eseɪ"
+    },
+    {
+        "name": "essence",
+        "trans": [
+            "本质， 精髓"
+        ],
+        "usphone": "'ɛsns",
+        "ukphone": "'esns"
+    },
+    {
+        "name": "essential",
+        "trans": [
+            "基本的，本质的；极其重要的，必不可少的",
+            "要素， 实质； 必需品"
+        ],
+        "usphone": "ɪ'sɛnʃl",
+        "ukphone": "ɪ'senʃl"
+    },
+    {
+        "name": "establish",
+        "trans": [
+            "建立， 设立； 安置， 使定居； 确定， 证实"
+        ],
+        "usphone": "ɪˈstæblɪʃ",
+        "ukphone": "ɪ'stæblɪʃ"
+    },
+    {
+        "name": "estate",
+        "trans": [
+            "地产； 庄园； 个人财产， 遗产"
+        ],
+        "usphone": "ɪ'stet",
+        "ukphone": "ɪ'steɪt"
+    },
+    {
+        "name": "esteem",
+        "trans": [
+            "尊重， 敬重"
+        ],
+        "usphone": "ɪ'stim",
+        "ukphone": "ɪ'stiːm"
+    },
+    {
+        "name": "estimate",
+        "trans": [
+            "评估， 估计； 估价",
+            "估计； 估价； 评价， 看法"
+        ],
+        "usphone": "'ɛstə,met",
+        "ukphone": "'estɪmeɪt"
+    },
+    {
+        "name": "eternal",
+        "trans": [
+            "永恒的， 不朽的"
+        ],
+        "usphone": "ɪ'tɝnl",
+        "ukphone": "ɪ'tɜːrnl"
+    },
+    {
+        "name": "ethic",
+        "trans": [
+            "伦理；道德体系"
+        ],
+        "usphone": "'ɛθɪk",
+        "ukphone": "'eθɪk"
+    },
+    {
+        "name": "ethical",
+        "trans": [
+            "道德的"
+        ],
+        "usphone": "'ɛθɪkl",
+        "ukphone": "'eθɪkl"
+    },
+    {
+        "name": "ethnic",
+        "trans": [
+            "种族的； 民族的"
+        ],
+        "usphone": "'ɛθnɪk",
+        "ukphone": "'eθnɪk"
+    },
+    {
+        "name": "ethnology",
+        "trans": [
+            "民族学， 文化人类学"
+        ],
+        "usphone": "",
+        "ukphone": "eθ'nɑːlədʒi"
+    },
+    {
+        "name": "etiquette",
+        "trans": [
+            "礼节， 礼仪"
+        ],
+        "usphone": "'ɛtɪkɛt",
+        "ukphone": "'etɪket"
+    },
+    {
+        "name": "evacuate",
+        "trans": [
+            "疏散， 撤离； 排空"
+        ],
+        "usphone": "ɪ'vækjuet",
+        "ukphone": "ɪ'vækjueɪt"
+    },
+    {
+        "name": "evacuation",
+        "trans": [
+            "撤离"
+        ],
+        "usphone": "ɪ,vækjʊ'eʃən",
+        "ukphone": "ɪˌvækju'eɪʃn"
+    },
+    {
+        "name": "evade",
+        "trans": [
+            "逃避， 回避； 躲开， 避开"
+        ],
+        "usphone": "ɪ'ved",
+        "ukphone": "ɪ'veɪd"
+    },
+    {
+        "name": "evaluate",
+        "trans": [
+            "评价， 估计"
+        ],
+        "usphone": "ɪ'væljʊ'et",
+        "ukphone": "ɪ'væljueɪt"
+    },
+    {
+        "name": "evaporate",
+        "trans": [
+            "蒸发； 消失， 不复存在"
+        ],
+        "usphone": "ɪ'væpəret",
+        "ukphone": "ɪ'væpəreɪt"
+    },
+    {
+        "name": "evaporation",
+        "trans": [
+            "蒸发； 消失， 不存在"
+        ],
+        "usphone": "ɪ,væpə'reʃən",
+        "ukphone": "ɪˌvæpə'reɪʃn"
+    },
+    {
+        "name": "even",
+        "trans": [
+            "甚至，连；甚至可以说",
+            "平滑的，平坦的；平稳的，均匀的；均衡的；平均的；偶数的",
+            "平坦； 相等"
+        ],
+        "usphone": "'ivən",
+        "ukphone": "'iːvn"
+    },
+    {
+        "name": "evergreen",
+        "trans": [
+            "常绿的",
+            "常绿树， 常青树"
+        ],
+        "usphone": "'ɛvɚɡrin",
+        "ukphone": "'evərgriːn"
+    },
+    {
+        "name": "evidence",
+        "trans": [
+            "证明",
+            "证据； 迹象； 根据"
+        ],
+        "usphone": "'ɛvɪdəns",
+        "ukphone": "'evɪdəns"
+    },
+    {
+        "name": "eviscerate",
+        "trans": [
+            "取出内脏； 除去主要部分"
+        ],
+        "usphone": "ɪ'vɪsəret",
+        "ukphone": "ɪ'vɪsəreɪt"
+    },
+    {
+        "name": "evoke",
+        "trans": [
+            "唤起， 引起， 激起"
+        ],
+        "usphone": "ɪ'vok",
+        "ukphone": "ɪ'vouk"
+    },
+    {
+        "name": "evolution",
+        "trans": [
+            "发展； 演变， 进化， 进化论"
+        ],
+        "usphone": "ˌɛvəˈluʃən; (occas.) ˌ ivəˈluʃən",
+        "ukphone": "ˌiːvə'luːʃn"
+    },
+    {
+        "name": "evolve",
+        "trans": [
+            "发展； 进化"
+        ],
+        "usphone": "ɪ'vɑlv",
+        "ukphone": "i'vɑːlv"
+    },
+    {
+        "name": "exact",
+        "trans": [
+            "精确的，准确的；严谨的，严格的；"
+        ],
+        "usphone": "ɪɡ'zækt",
+        "ukphone": "ɪg'zækt"
+    },
+    {
+        "name": "exaggerate",
+        "trans": [
+            "夸张， 夸大"
+        ],
+        "usphone": "ɪɡ'zædʒəret",
+        "ukphone": "ɪg'zædʒəreɪt"
+    },
+    {
+        "name": "exalt",
+        "trans": [
+            "高度赞扬， 褒扬； 提升， 提拔"
+        ],
+        "usphone": "ɪɡ'zɔlt",
+        "ukphone": "ɪg'zɔːlt"
+    },
+    {
+        "name": "exalted",
+        "trans": [
+            "崇高的， 高贵的， 显赫的"
+        ],
+        "usphone": "ɪg'zɔltɪd",
+        "ukphone": "ɪg'zɔːltɪd"
+    },
+    {
+        "name": "excavate",
+        "trans": [
+            "挖掘； 掘出"
+        ],
+        "usphone": "'ɛkskə'vet",
+        "ukphone": "'ekskəveɪt"
+    },
+    {
+        "name": "excavation",
+        "trans": [
+            "挖掘， 发掘； 出土文物； 挖掘现场"
+        ],
+        "usphone": ",ɛkskə'veʃən",
+        "ukphone": "ˌekskə'veɪʃn"
+    },
+    {
+        "name": "exceed",
+        "trans": [
+            "超过， 超出"
+        ],
+        "usphone": "ɪk'sid",
+        "ukphone": "ɪk'siːd"
+    },
+    {
+        "name": "exception",
+        "trans": [
+            "除外， 例外"
+        ],
+        "usphone": "ɪk'sɛpʃən",
+        "ukphone": "ɪk'sepʃn"
+    },
+    {
+        "name": "excess",
+        "trans": [
+            "过量的； 额外的",
+            "过度， 超过"
+        ],
+        "usphone": "'ɛk'sɛs",
+        "ukphone": "ɪk'ses; ek-; 'ekses"
+    },
+    {
+        "name": "exchange",
+        "trans": [
+            "兑换；交易；调换，交换；交流",
+            "交易； 兑换； 交换； 交流"
+        ],
+        "usphone": "ɪks'tʃendʒ",
+        "ukphone": "ɪks'tʃeɪndʒ"
+    },
+    {
+        "name": "excise",
+        "trans": [
+            "切除； 删去"
+        ],
+        "usphone": "ɛk'saɪz",
+        "ukphone": "'eksaɪz"
+    },
+    {
+        "name": "exclaim",
+        "trans": [
+            "惊叫， 呼喊"
+        ],
+        "usphone": "ɪk'sklem",
+        "ukphone": "ɪk'skleɪm"
+    },
+    {
+        "name": "exclude",
+        "trans": [
+            "把…排除在外"
+        ],
+        "usphone": "ɪk'sklʊd",
+        "ukphone": "ɪk'skluːd"
+    },
+    {
+        "name": "exclusive",
+        "trans": [
+            "独占的；除外的，排他的；奢华的",
+            "独家新闻"
+        ],
+        "usphone": "ɪk'sklusɪv",
+        "ukphone": "ɪk'skluːsɪv"
+    },
+    {
+        "name": "excursion",
+        "trans": [
+            "远足， 短途旅游"
+        ],
+        "usphone": "ɪk'skɝʒn",
+        "ukphone": "ɪk'skɜːrʒn"
+    },
+    {
+        "name": "execute",
+        "trans": [
+            "执行， 履行， 实施； 将…处死， 处决； 完成"
+        ],
+        "usphone": "'ɛksɪkjut",
+        "ukphone": "'eksɪkjuːt"
+    },
+    {
+        "name": "executive",
+        "trans": [
+            "执行的， 实施的； 行政的",
+            "执行者；管理人员；行政负责人"
+        ],
+        "usphone": "ɪɡ'zɛkjətɪv",
+        "ukphone": "ɪg'zekjətɪv"
+    },
+    {
+        "name": "exemplary",
+        "trans": [
+            "模范的； 典型的"
+        ],
+        "usphone": "ɪɡ'zɛmpləri",
+        "ukphone": "ɪg'zempləri"
+    },
+    {
+        "name": "exemplify",
+        "trans": [
+            "是…的典型； 例示， 举例证明"
+        ],
+        "usphone": "ɪɡ'zɛmplɪfaɪ",
+        "ukphone": "ɪg'zemplɪfaɪ"
+    },
+    {
+        "name": "exempt",
+        "trans": [
+            "被免除的，被豁免的",
+            "免除， 豁免"
+        ],
+        "usphone": "ɪg'zɛmpt",
+        "ukphone": "ɪg'zempt"
+    },
+    {
+        "name": "exert",
+        "trans": [
+            "运用， 行使； 施加； 努力， 竭力"
+        ],
+        "usphone": "ɪɡ'zɝt",
+        "ukphone": "ɪg'zɜːrt"
+    },
+    {
+        "name": "exhale",
+        "trans": [
+            "呼出； 散发"
+        ],
+        "usphone": "ɛks'hel",
+        "ukphone": "eks'heɪl"
+    },
+    {
+        "name": "exhaust",
+        "trans": [
+            "废气；排气管",
+            "用尽， 耗尽； 使非常疲倦； 详尽讨论"
+        ],
+        "usphone": "ɪɡ'zɔst",
+        "ukphone": "ɪg'zɔːst"
+    },
+    {
+        "name": "exhibit",
+        "trans": [
+            "陈列，展览；显示，表现",
+            "展览， 陈列"
+        ],
+        "usphone": "ɪɡ'zɪbɪt",
+        "ukphone": "ɪg'zɪbɪt"
+    },
+    {
+        "name": "exhilarating",
+        "trans": [
+            "令人高兴的， 使人兴奋的"
+        ],
+        "usphone": "ɪɡ'zɪləretɪŋ",
+        "ukphone": "ɪg'zɪləreɪtɪŋ"
+    },
+    {
+        "name": "exhort",
+        "trans": [
+            "劝告， 规劝， 告诫"
+        ],
+        "usphone": "ɪɡ'zɔrt",
+        "ukphone": "ɪg'zɔːrt"
+    },
+    {
+        "name": "existence",
+        "trans": [
+            "存在， 实在； 生存， 生活"
+        ],
+        "usphone": "ɪɡ'zɪstəns",
+        "ukphone": "ɪg'zɪstəns"
+    },
+    {
+        "name": "exodus",
+        "trans": [
+            "大批离去， 成群外出"
+        ],
+        "usphone": "'ɛksədəs",
+        "ukphone": "'eksədəs"
+    },
+    {
+        "name": "exorbitant",
+        "trans": [
+            "过高的， 不合理的"
+        ],
+        "usphone": "ɪɡ'zɔrbɪtənt",
+        "ukphone": "ɪg'zɔːrbɪtənt"
+    },
+    {
+        "name": "exotic",
+        "trans": [
+            "外来的， 来自异国的； 奇异的"
+        ],
+        "usphone": "ɪɡ'zɑtɪk",
+        "ukphone": "ɪg'zɑːtɪk"
+    },
+    {
+        "name": "expand",
+        "trans": [
+            "扩张； 膨胀； 伸展， 伸开"
+        ],
+        "usphone": "ɪk'spænd",
+        "ukphone": "ɪk'spænd"
+    },
+    {
+        "name": "expansion",
+        "trans": [
+            "扩张； 膨胀"
+        ],
+        "usphone": "ɪk'spænʃən",
+        "ukphone": "ɪk'spænʃn"
+    },
+    {
+        "name": "expect",
+        "trans": [
+            "预期， 期望， 指望"
+        ],
+        "usphone": "ɪk'spɛkt",
+        "ukphone": "ɪk'spekt"
+    },
+    {
+        "name": "expedient",
+        "trans": [
+            "得当的， 可取的",
+            "权宜之计，应急办法，临时手段"
+        ],
+        "usphone": "ɪk'spidɪənt",
+        "ukphone": "ɪk'spiːdiənt"
+    },
+    {
+        "name": "expedition",
+        "trans": [
+            "远征； 探险"
+        ],
+        "usphone": ",ɛkspə'dɪʃən",
+        "ukphone": "ˌekspə'dɪʃn"
+    },
+    {
+        "name": "expeditious",
+        "trans": [
+            "迅速而有效的， 迅速完成的"
+        ],
+        "usphone": ",ɛkspə'dɪʃəs",
+        "ukphone": "ˌekspə'dɪʃəs"
+    },
+    {
+        "name": "expel",
+        "trans": [
+            "开除； 驱逐； 排出"
+        ],
+        "usphone": "ɪk'spɛl",
+        "ukphone": "ɪk'spel"
+    },
+    {
+        "name": "expenditure",
+        "trans": [
+            "花费， 支出"
+        ],
+        "usphone": "ɪk'spɛndɪtʃɚ",
+        "ukphone": "ek'spendɪtʃər"
+    },
+    {
+        "name": "experimental",
+        "trans": [
+            "实验的， 用于实验的"
+        ],
+        "usphone": "ɛk'spɛrɪ'mɛntəl",
+        "ukphone": "ɪkˌsperɪ'mentl"
+    },
+    {
+        "name": "expertise",
+        "trans": [
+            "专门知识， 专长"
+        ],
+        "usphone": "'ɛkspɝ'tiz",
+        "ukphone": "ˌekspɜːr'tiːz"
+    },
+    {
+        "name": "expire",
+        "trans": [
+            "到期， 期满， 失效； 断气， 去世"
+        ],
+        "usphone": "ɪk'spaɪɚ",
+        "ukphone": "ɪk'spaɪər"
+    },
+    {
+        "name": "explicit",
+        "trans": [
+            "清楚的； 直率的"
+        ],
+        "usphone": "ɪk'splɪsɪt",
+        "ukphone": "ɪk'splɪsɪt"
+    },
+    {
+        "name": "explode",
+        "trans": [
+            "爆炸； 激增； 冲动， 发怒"
+        ],
+        "usphone": "ɪk'splod",
+        "ukphone": "ɪk'sploud"
+    },
+    {
+        "name": "exploit",
+        "trans": [
+            "开发； 利用； 剥削",
+            "英勇行为， 业绩， 功绩"
+        ],
+        "usphone": "ɛksplɔɪt; ɪkˈsplɔɪt",
+        "ukphone": "ˈeksplɔɪt;ɪkˈsplɔɪt"
+    },
+    {
+        "name": "explore",
+        "trans": [
+            "探索， 勘探； 探险； 探究"
+        ],
+        "usphone": "ɪk'splɔr",
+        "ukphone": "ɪk'splɔːr"
+    },
+    {
+        "name": "explosion",
+        "trans": [
+            "爆炸； 爆发； 激增"
+        ],
+        "usphone": "ɪk'sploʒən",
+        "ukphone": "ɪk'splouʒn"
+    },
+    {
+        "name": "explosive",
+        "trans": [
+            "爆炸的，爆发的；使人冲动的",
+            "炸药"
+        ],
+        "usphone": "ɪk'splosɪv; ɪk'splozɪv",
+        "ukphone": "ɪk'splousɪv"
+    },
+    {
+        "name": "exponent",
+        "trans": [
+            "解释者； 倡导者， 拥护者； 指数， 幂"
+        ],
+        "usphone": "ɪk'sponənt",
+        "ukphone": "ɪk'spounənt"
+    },
+    {
+        "name": "expose",
+        "trans": [
+            "暴露， 显露； 揭露， 揭穿； 使接触， 使面临"
+        ],
+        "usphone": "ɪk'spoz；ek-",
+        "ukphone": "ɪk'spouz"
+    },
+    {
+        "name": "exposition",
+        "trans": [
+            "展览会， 博览会； 阐释"
+        ],
+        "usphone": ",ɛkspə'zɪʃən",
+        "ukphone": "ˌekspə'zɪʃn"
+    },
+    {
+        "name": "exposure",
+        "trans": [
+            "暴露， 显露； 揭露； 曝光； 面临， 遭受"
+        ],
+        "usphone": "ɪk'spoʒɚ",
+        "ukphone": "ɪk'spouʒər"
+    },
+    {
+        "name": "expressive",
+        "trans": [
+            "有表现力的， 富有表情的； 表示…的， 表现…的"
+        ],
+        "usphone": "ɪk'sprɛsɪv",
+        "ukphone": "ɪk'spresɪv"
+    },
+    {
+        "name": "expropriate",
+        "trans": [
+            "征用， 没收"
+        ],
+        "usphone": "ɛks'proprɪet",
+        "ukphone": "eks'prouprieɪt"
+    },
+    {
+        "name": "extend",
+        "trans": [
+            "延长， 延伸； 扩大…的范围； 舒展"
+        ],
+        "usphone": "ɪk'stɛnd",
+        "ukphone": "ɪk'stend"
+    },
+    {
+        "name": "extension",
+        "trans": [
+            "延长； 延伸； 电话分机， 分机号码"
+        ],
+        "usphone": "ɪk'stɛnʃən",
+        "ukphone": "ɪk'stenʃn"
+    },
+    {
+        "name": "extensive",
+        "trans": [
+            "广大的， 广阔的； 广泛的， 大量的"
+        ],
+        "usphone": "ɪk'stɛnsɪv",
+        "ukphone": "ɪk'stensɪv"
+    },
+    {
+        "name": "extent",
+        "trans": [
+            "程度， 范围"
+        ],
+        "usphone": "ɪk'stɛnt",
+        "ukphone": "ɪk'stent"
+    },
+    {
+        "name": "exterior",
+        "trans": [
+            "外部的，外表的",
+            "外部， 外表"
+        ],
+        "usphone": "ɪk'stɪrɪɚ",
+        "ukphone": "ɪk'stɪriər"
+    },
+    {
+        "name": "external",
+        "trans": [
+            "外部的， 外面的； 外来的； 对外的"
+        ],
+        "usphone": "ɪk'stɝnl",
+        "ukphone": "ɪk'stɜːrnl"
+    },
+    {
+        "name": "externality",
+        "trans": [
+            "外部性， 外界效应"
+        ],
+        "usphone": ",ɛkstɚ'næləti",
+        "ukphone": "ˌekstɜːr'næləti"
+    },
+    {
+        "name": "extinct",
+        "trans": [
+            "灭绝的， 不存在的； 不再活跃的"
+        ],
+        "usphone": "ɪk'stɪŋkt",
+        "ukphone": "ɪk'stɪŋkt"
+    },
+    {
+        "name": "extinguish",
+        "trans": [
+            "熄灭， 扑灭； 消灭， 毁灭， 使破灭"
+        ],
+        "usphone": "ɪk'stɪŋɡwɪʃ",
+        "ukphone": "ɪk'stɪŋgwɪʃ"
+    },
+    {
+        "name": "extol",
+        "trans": [
+            "赞美， 颂扬"
+        ],
+        "usphone": "ɪk'stol",
+        "ukphone": "ɪk'stoul"
+    },
+    {
+        "name": "extort",
+        "trans": [
+            "勒索， 敲诈， 强夺"
+        ],
+        "usphone": "ɪk'stɔrt",
+        "ukphone": "ɪk'stɔːrt"
+    },
+    {
+        "name": "extract",
+        "trans": [
+            "取出； 提取， 榨取",
+            "提出物； 摘录， 选段； 精， 汁"
+        ],
+        "usphone": "'ɛkstrækt",
+        "ukphone": "ˈekstrækt"
+    },
+    {
+        "name": "extraordinary",
+        "trans": [
+            "特别的； 非凡的"
+        ],
+        "usphone": "ɪkˈstrɔrdənerɪ; ɪkˈstrɔrdnˌɛrɪ",
+        "ukphone": "ɪk'strɔːrdəneri"
+    },
+    {
+        "name": "extrapolate",
+        "trans": [
+            "外推； 推断， 推知"
+        ],
+        "usphone": "ɪk'stræpə'let",
+        "ukphone": "ɪk'stræpəleɪt"
+    },
+    {
+        "name": "extravagant",
+        "trans": [
+            "放肆的， 过分的； 奢侈的， 铺张的"
+        ],
+        "usphone": "ɪk'strævəgənt",
+        "ukphone": "ɪk'strævəgənt"
+    },
+    {
+        "name": "extreme",
+        "trans": [
+            "极度的；极端的",
+            "极端"
+        ],
+        "usphone": "ɪk'strim",
+        "ukphone": "ɪk'striːm"
+    },
+    {
+        "name": "extremity",
+        "trans": [
+            "末端； 极端， 极度"
+        ],
+        "usphone": "ɪk'strɛməti",
+        "ukphone": "ɪk'streməti"
+    },
+    {
+        "name": "extrinsic",
+        "trans": [
+            "外来的， 外在的， 非本质的"
+        ],
+        "usphone": "ɛks'trɪnsɪk",
+        "ukphone": "eks'trɪnsɪk"
+    },
+    {
+        "name": "fable",
+        "trans": [
+            "寓言； 谎言"
+        ],
+        "usphone": "'febl",
+        "ukphone": "'feɪbl"
+    },
+    {
+        "name": "fabric",
+        "trans": [
+            "布料， 织品； 构造， 结构"
+        ],
+        "usphone": "'fæbrɪk",
+        "ukphone": "'fæbrɪk"
+    },
+    {
+        "name": "fabricate",
+        "trans": [
+            "编造； 制造"
+        ],
+        "usphone": "'fæbrɪket",
+        "ukphone": "'fæbrɪkeɪt"
+    },
+    {
+        "name": "fabulous",
+        "trans": [
+            "寓言式的； 难以置信的； 极好的"
+        ],
+        "usphone": "'fæbjələs",
+        "ukphone": "'fæbjələs"
+    },
+    {
+        "name": "facade",
+        "trans": [
+            "正面； 表面"
+        ],
+        "usphone": "",
+        "ukphone": "fə'sɑːd"
+    },
+    {
+        "name": "facet",
+        "trans": [
+            "小平面； 方面"
+        ],
+        "usphone": "'fæsɪt",
+        "ukphone": "'fæsɪt"
+    },
+    {
+        "name": "facial",
+        "trans": [
+            "面部的； 面部用的"
+        ],
+        "usphone": "'feʃl",
+        "ukphone": "'feɪʃl"
+    },
+    {
+        "name": "facilitate",
+        "trans": [
+            "推动， 促进"
+        ],
+        "usphone": "fə'sɪlə'tet",
+        "ukphone": "fə'sɪlɪteɪt"
+    },
+    {
+        "name": "facility",
+        "trans": [
+            "设施；设备；容易；灵巧"
+        ],
+        "usphone": "fə'sɪləti",
+        "ukphone": "fə'sɪləti"
+    },
+    {
+        "name": "faction",
+        "trans": [
+            "派别， 派系， 小集团； 派系斗争"
+        ],
+        "usphone": "'fækʃən",
+        "ukphone": "'fækʃn"
+    },
+    {
+        "name": "factor",
+        "trans": [
+            "要素， 因素； 因数； 系数"
+        ],
+        "usphone": "'fæktɚ",
+        "ukphone": "'fæktər"
+    },
+    {
+        "name": "factual",
+        "trans": [
+            "实际的， 真实的， 事实的"
+        ],
+        "usphone": "'fæktʃuəl",
+        "ukphone": "'fæktʃuəl"
+    },
+    {
+        "name": "faculty",
+        "trans": [
+            "学院； 全体教职员工； 能力"
+        ],
+        "usphone": "'fæklti",
+        "ukphone": "'fæklti"
+    },
+    {
+        "name": "fade",
+        "trans": [
+            "褪色； 凋谢； 逐渐消失"
+        ],
+        "usphone": "fed",
+        "ukphone": "feɪd"
+    },
+    {
+        "name": "Fahrenheit",
+        "trans": [
+            "华氏温度的",
+            "华氏温度计"
+        ],
+        "usphone": "'færən'haɪt",
+        "ukphone": "'færənhaɪt"
+    },
+    {
+        "name": "faint",
+        "trans": [
+            "昏厥，晕倒",
+            "模糊的，不清楚的；无力的，虚弱的；眩晕的",
+            "昏厥"
+        ],
+        "usphone": "fent",
+        "ukphone": "feɪnt"
+    },
+    {
+        "name": "fake",
+        "trans": [
+            "伪造； 伪装"
+        ],
+        "usphone": "feɪk",
+        "ukphone": "feɪk"
+    },
+    {
+        "name": "falcon",
+        "trans": [
+            "猎鹰， 隼"
+        ],
+        "usphone": "'fælkən",
+        "ukphone": "'fælkən"
+    },
+    {
+        "name": "falter",
+        "trans": [
+            "衰退， 衰落； 发抖， 结巴地说； 蹒跚"
+        ],
+        "usphone": "'fɔltɚ",
+        "ukphone": "'fɔːltər"
+    },
+    {
+        "name": "familiarize",
+        "trans": [
+            "使熟悉"
+        ],
+        "usphone": "fə'mɪlɪəraɪz",
+        "ukphone": "fə'mɪliəraɪz"
+    },
+    {
+        "name": "famish",
+        "trans": [
+            "饥饿"
+        ],
+        "usphone": "'fæmɪʃ",
+        "ukphone": "'fæmɪʃ"
+    },
+    {
+        "name": "fantastic",
+        "trans": [
+            "荒诞的， 奇异的； 极好的； 极大的"
+        ],
+        "usphone": "fæn'tæstɪk",
+        "ukphone": "fæn'tæstɪk"
+    },
+    {
+        "name": "fantasy",
+        "trans": [
+            "想象， 幻想"
+        ],
+        "usphone": "'fæntəsi",
+        "ukphone": "'fæntəsi"
+    },
+    {
+        "name": "far-fetched",
+        "trans": [
+            "牵强的"
+        ],
+        "usphone": "'fɑ:'fetʃt",
+        "ukphone": "fɑːr'fetʃt"
+    },
+    {
+        "name": "farce",
+        "trans": [
+            "笑剧， 滑稽剧； 闹剧"
+        ],
+        "usphone": "fɑrs",
+        "ukphone": "fɑːrs"
+    },
+    {
+        "name": "fare",
+        "trans": [
+            "进展",
+            "费用"
+        ],
+        "usphone": "fɛr",
+        "ukphone": "fer"
+    },
+    {
+        "name": "fascinate",
+        "trans": [
+            "深深吸引， 迷住"
+        ],
+        "usphone": "'fæsə'net",
+        "ukphone": "'fæsɪneɪt"
+    },
+    {
+        "name": "fascinating",
+        "trans": [
+            "迷人的， 醉人的"
+        ],
+        "usphone": "'fæsɪnetɪŋ",
+        "ukphone": "'fæsɪneɪtɪŋ"
+    },
+    {
+        "name": "fasten",
+        "trans": [
+            "使固定； 系牢， 扎牢； 握住， 抓牢"
+        ],
+        "usphone": "'fæsən",
+        "ukphone": "'fæsn"
+    },
+    {
+        "name": "fatal",
+        "trans": [
+            "致命的； 毁灭性的； 命中注定的"
+        ],
+        "usphone": "'fetl",
+        "ukphone": "'feɪtl"
+    },
+    {
+        "name": "fatigue",
+        "trans": [
+            "劳累； 疲劳"
+        ],
+        "usphone": "fə'tig",
+        "ukphone": "fə'tiːg"
+    },
+    {
+        "name": "faucet",
+        "trans": [
+            "龙头， 旋塞"
+        ],
+        "usphone": "'fɔsɪt",
+        "ukphone": "'fɔːsɪt"
+    },
+    {
+        "name": "fault",
+        "trans": [
+            "过错， 过失； 缺点， 弱点； 断层"
+        ],
+        "usphone": "fɔlt",
+        "ukphone": "fɔːlt"
+    },
+    {
+        "name": "fauna",
+        "trans": [
+            "动物群"
+        ],
+        "usphone": "'fɔnə",
+        "ukphone": "'fɔːnə"
+    },
+    {
+        "name": "favor",
+        "trans": [
+            "帮助； 赞同， 支持； 偏爱"
+        ],
+        "usphone": "'fevɚ",
+        "ukphone": "'feɪvər"
+    },
+    {
+        "name": "feasible",
+        "trans": [
+            "可行的， 行得通的"
+        ],
+        "usphone": "'fizəbl",
+        "ukphone": "'fiːzəbl"
+    },
+    {
+        "name": "feast",
+        "trans": [
+            "尽情享用",
+            "节日；盛宴，宴会"
+        ],
+        "usphone": "fist",
+        "ukphone": "fiːst"
+    },
+    {
+        "name": "feat",
+        "trans": [
+            "功绩， 壮举"
+        ],
+        "usphone": "fit",
+        "ukphone": "fiːt"
+    },
+    {
+        "name": "federal",
+        "trans": [
+            "联邦的； 联邦制的； 联邦政府的"
+        ],
+        "usphone": "'fɛdərəl",
+        "ukphone": "'fedərəl"
+    },
+    {
+        "name": "feeble",
+        "trans": [
+            "虚弱的， 衰弱的， 无力的"
+        ],
+        "usphone": "'fibl",
+        "ukphone": "'fiːbl"
+    },
+    {
+        "name": "feedback",
+        "trans": [
+            "反馈； 反馈信息"
+        ],
+        "usphone": "'fidbæk",
+        "ukphone": "'fiːdbæk"
+    },
+    {
+        "name": "feign",
+        "trans": [
+            "装作， 假装； 伪造"
+        ],
+        "usphone": "fen",
+        "ukphone": "feɪn"
+    },
+    {
+        "name": "fellowship",
+        "trans": [
+            "友谊； 奖学金； 团体， 协会"
+        ],
+        "usphone": "'fɛloʃɪp",
+        "ukphone": "'felouʃɪp"
+    },
+    {
+        "name": "feminist",
+        "trans": [
+            "女权主义者"
+        ],
+        "usphone": "'fɛmənɪst",
+        "ukphone": "'femənɪst"
+    },
+    {
+        "name": "ferment",
+        "trans": [
+            "发酵； 骚动",
+            "发酵； 动乱， 骚动"
+        ],
+        "usphone": "fɚ'mɛnt",
+        "ukphone": "fə'ment"
+    },
+    {
+        "name": "fertile",
+        "trans": [
+            "肥沃的， 富饶的； 能结果的， 能繁殖的； 想象力丰富的"
+        ],
+        "usphone": "ˈfɝtəl; (canadian) ˈfɝˌtaɪl",
+        "ukphone": "'fɜːrtl"
+    },
+    {
+        "name": "fervor",
+        "trans": [
+            "热情， 热烈"
+        ],
+        "usphone": "'fə:və",
+        "ukphone": "'fɜːrvər"
+    },
+    {
+        "name": "feudal",
+        "trans": [
+            "封建的"
+        ],
+        "usphone": "'fjudl",
+        "ukphone": "'fjuːdl"
+    },
+    {
+        "name": "fiber",
+        "trans": [
+            "纤维素； 纤维制品； 纤维"
+        ],
+        "usphone": "'faɪbɚ",
+        "ukphone": "'faɪbər"
+    },
+    {
+        "name": "fibrous",
+        "trans": [
+            "含纤维的； 纤维状的"
+        ],
+        "usphone": "'faɪbrəs",
+        "ukphone": "'faɪbrəs"
+    },
+    {
+        "name": "fiction",
+        "trans": [
+            "小说； 虚构， 编造"
+        ],
+        "usphone": "'fɪkʃən",
+        "ukphone": "'fɪkʃn"
+    },
+    {
+        "name": "fictitious",
+        "trans": [
+            "虚构的； 假的； 假装的， 虚伪的"
+        ],
+        "usphone": "fɪk'tɪʃəs",
+        "ukphone": "fɪk'tɪʃəs"
+    },
+    {
+        "name": "fidelity",
+        "trans": [
+            "忠诚， 忠实； 精确， 逼真"
+        ],
+        "usphone": "fɪ'dɛləti",
+        "ukphone": "fɪ'deləti"
+    },
+    {
+        "name": "fierce",
+        "trans": [
+            "凶猛的， 残忍的； 狂热的， 强烈的； 激烈的， 猛烈的"
+        ],
+        "usphone": "fɪrs",
+        "ukphone": "fɪrs"
+    },
+    {
+        "name": "fiery",
+        "trans": [
+            "似火的； 易怒的， 暴躁的"
+        ],
+        "usphone": "'faɪəri",
+        "ukphone": "'faɪəri"
+    },
+    {
+        "name": "figurative",
+        "trans": [
+            "比喻的， 借喻的， 象征的； 形象的"
+        ],
+        "usphone": "'fɪgərətɪv",
+        "ukphone": "'fɪgərətɪv"
+    },
+    {
+        "name": "figure",
+        "trans": [
+            "身材，体形；轮廓；数字；图形，图表；人物，"
+        ],
+        "usphone": "'fɪɡjɚ",
+        "ukphone": "'fɪgjər"
+    },
+    {
+        "name": "filament",
+        "trans": [
+            "灯丝； 细丝"
+        ],
+        "usphone": "'fɪləmənt",
+        "ukphone": "'fɪləmənt"
+    },
+    {
+        "name": "filial",
+        "trans": [
+            "子女的； 子孙后代的"
+        ],
+        "usphone": "'fɪlɪəl",
+        "ukphone": "'fɪliəl"
+    },
+    {
+        "name": "filter",
+        "trans": [
+            "过滤；筛选；走漏；渗入，透过",
+            "过滤器； 筛选"
+        ],
+        "usphone": "'fɪltɚ",
+        "ukphone": "'fɪltər"
+    },
+    {
+        "name": "fin",
+        "trans": [
+            "鳍； 鳍状物； 翼"
+        ],
+        "usphone": "fɪn",
+        "ukphone": "fɪn"
+    },
+    {
+        "name": "finalize",
+        "trans": [
+            "使完成； 把…最后定下来； 定稿"
+        ],
+        "usphone": "'faɪnəlaɪz",
+        "ukphone": "'faɪnəlaɪz"
+    },
+    {
+        "name": "finance",
+        "trans": [
+            "给…提供资金",
+            "财政，金融；"
+        ],
+        "usphone": "'faɪnæns",
+        "ukphone": "'faɪnæns"
+    },
+    {
+        "name": "financial",
+        "trans": [
+            "财政的， 财务的， 金融的"
+        ],
+        "usphone": "faɪˈnænʃəl;fəˈnæ-",
+        "ukphone": "faɪ'nænʃl"
+    },
+    {
+        "name": "finch",
+        "trans": [
+            "雀类"
+        ],
+        "usphone": "fɪntʃ",
+        "ukphone": "fɪntʃ"
+    },
+    {
+        "name": "firm",
+        "trans": [
+            "结实的； 坚定的， 坚决的",
+            "公司"
+        ],
+        "usphone": "fɝm",
+        "ukphone": "fɜːrm"
+    },
+    {
+        "name": "fitness",
+        "trans": [
+            "健康， 健壮； 适合"
+        ],
+        "usphone": "ˈfɪtnɪs",
+        "ukphone": "'fɪtnəs"
+    },
+    {
+        "name": "fix",
+        "trans": [
+            "修理；使固定，安装；安排；找到，确定",
+            "解决方法； 困境， 窘境"
+        ],
+        "usphone": "fɪks",
+        "ukphone": "fɪks"
+    },
+    {
+        "name": "flag",
+        "trans": [
+            "标记",
+            "旗帜；标记"
+        ],
+        "usphone": "flæg",
+        "ukphone": "flæg"
+    },
+    {
+        "name": "flagellum",
+        "trans": [
+            "[昆] 鞭毛；鞭子；鞭状匍匐枝"
+        ],
+        "usphone": "flə'dʒɛləm",
+        "ukphone": "flə'dʒeləm"
+    },
+    {
+        "name": "flair",
+        "trans": [
+            "才能， 本领； 天资"
+        ],
+        "usphone": "flɛr",
+        "ukphone": "fler"
+    },
+    {
+        "name": "flake",
+        "trans": [
+            "使成薄片；雪片般落下",
+            "薄片"
+        ],
+        "usphone": "flek",
+        "ukphone": "fleɪk"
+    },
+    {
+        "name": "flamboyant",
+        "trans": [
+            "艳丽的， 绚丽夺目的； 炫耀的"
+        ],
+        "usphone": "flæm'bɔɪənt",
+        "ukphone": "flæm'bɔɪənt"
+    },
+    {
+        "name": "flame",
+        "trans": [
+            "燃烧； 闪耀",
+            "火舌，火焰；光芒，光辉；强烈的感情"
+        ],
+        "usphone": "flem",
+        "ukphone": "fleɪm"
+    },
+    {
+        "name": "flank",
+        "trans": [
+            "肋腹；侧面；侧翼",
+            "位于…的侧面"
+        ],
+        "usphone": "flæŋk",
+        "ukphone": "flæŋk"
+    },
+    {
+        "name": "flap",
+        "trans": [
+            "拍打；振翅；封盖，"
+        ],
+        "usphone": "flæp",
+        "ukphone": "flæp"
+    },
+    {
+        "name": "flash",
+        "trans": [
+            "闪光； 反射",
+            "闪光；闪现"
+        ],
+        "usphone": "flæʃ",
+        "ukphone": "flæʃ"
+    },
+    {
+        "name": "flask",
+        "trans": [
+            "细颈瓶； 烧瓶"
+        ],
+        "usphone": "flæsk",
+        "ukphone": "flɑːrsk"
+    },
+    {
+        "name": "flavor",
+        "trans": [
+            "风味，滋味；调味品",
+            "给…调味"
+        ],
+        "usphone": "'flevɚ",
+        "ukphone": "'fleɪvər"
+    },
+    {
+        "name": "flexibility",
+        "trans": [
+            "灵活性； 弹性， 韧性； 适应性"
+        ],
+        "usphone": ",flɛksə'bɪləti",
+        "ukphone": "ˌfleksə'bɪlətɪ"
+    },
+    {
+        "name": "flexible",
+        "trans": [
+            "易弯曲的； 柔韧的； 灵活的， 可变通的"
+        ],
+        "usphone": "'flɛksəbl",
+        "ukphone": "'fleksəbl"
+    },
+    {
+        "name": "flick",
+        "trans": [
+            "轻拍；移动",
+            "轻拍； 浏览"
+        ],
+        "usphone": "flɪk",
+        "ukphone": "flɪk"
+    },
+    {
+        "name": "flint",
+        "trans": [
+            "燧石， 打火石"
+        ],
+        "usphone": "flɪnt",
+        "ukphone": "flɪnt"
+    },
+    {
+        "name": "float",
+        "trans": [
+            "漂浮， 浮动； 飘动"
+        ],
+        "usphone": "flot",
+        "ukphone": "flout"
+    },
+    {
+        "name": "flock",
+        "trans": [
+            "聚结，成群",
+            "群； 一群； 大量"
+        ],
+        "usphone": "flɑk",
+        "ukphone": "flɑːk"
+    },
+    {
+        "name": "flora",
+        "trans": [
+            "植物群"
+        ],
+        "usphone": "'flɔrə",
+        "ukphone": "'flɔːrə"
+    },
+    {
+        "name": "floral",
+        "trans": [
+            "花的， 像花的； 饰以花的， 绘有花的"
+        ],
+        "usphone": "'flɔrəl",
+        "ukphone": "'flɔːrəl"
+    },
+    {
+        "name": "flourish",
+        "trans": [
+            "繁荣， 茂盛； 挥舞， 挥动"
+        ],
+        "usphone": "ˈflɜːrɪʃ",
+        "ukphone": "'flɜːrɪʃ"
+    },
+    {
+        "name": "flu",
+        "trans": [
+            "流行性感冒"
+        ],
+        "usphone": "flu",
+        "ukphone": "fluː"
+    },
+    {
+        "name": "fluctuate",
+        "trans": [
+            "波动； 变化"
+        ],
+        "usphone": "'flʌktʃʊ'et",
+        "ukphone": "'flʌktʃueɪt"
+    },
+    {
+        "name": "fluctuation",
+        "trans": [
+            "波动， 起伏"
+        ],
+        "usphone": ",flʌktʃʊ'eʃən",
+        "ukphone": "ˌflʌktʃu'eɪʃn"
+    },
+    {
+        "name": "fluid",
+        "trans": [
+            "液体的； 流动的",
+            "液体，流体"
+        ],
+        "usphone": "'fluɪd",
+        "ukphone": "'fluːɪd"
+    },
+    {
+        "name": "flux",
+        "trans": [
+            "变迁， 不断的变动"
+        ],
+        "usphone": "flʌks",
+        "ukphone": "flʌks"
+    },
+    {
+        "name": "focal",
+        "trans": [
+            "焦点的； 很重要的"
+        ],
+        "usphone": "'fokl",
+        "ukphone": "'foukl"
+    },
+    {
+        "name": "focalize",
+        "trans": [
+            "调节焦距； 使聚焦； 使集中"
+        ],
+        "usphone": "'fokəlaɪz",
+        "ukphone": "'foukəlaɪz"
+    },
+    {
+        "name": "focus",
+        "trans": [
+            "集中； 聚焦",
+            "焦点，焦距；中心"
+        ],
+        "usphone": "'fokəs",
+        "ukphone": "'foukəs"
+    },
+    {
+        "name": "fold",
+        "trans": [
+            "褶，褶层；褶皱；褶痕，褶缝；羊栏，"
+        ],
+        "usphone": "fold",
+        "ukphone": "fould"
+    },
+    {
+        "name": "foliage",
+        "trans": [
+            "叶"
+        ],
+        "usphone": "'folɪɪdʒ",
+        "ukphone": "'fouliɪdʒ"
+    },
+    {
+        "name": "folklore",
+        "trans": [
+            "民间传说； 民俗学"
+        ],
+        "usphone": "'foklɔr",
+        "ukphone": "'fouklɔːr"
+    },
+    {
+        "name": "folkway",
+        "trans": [
+            "社会风俗"
+        ],
+        "usphone": "'fəukwei",
+        "ukphone": "'foukˌweɪ"
+    },
+    {
+        "name": "foment",
+        "trans": [
+            "煽动， 挑起， 激起"
+        ],
+        "usphone": "",
+        "ukphone": "fou'ment"
+    },
+    {
+        "name": "forage",
+        "trans": [
+            "觅食；搜寻",
+            "草料， 饲料"
+        ],
+        "usphone": "'fɔrɪdʒ",
+        "ukphone": "'fɔːrɪdʒ"
+    },
+    {
+        "name": "forecast",
+        "trans": [
+            "预报； 预测， 预料"
+        ],
+        "usphone": "'fɔrkæst",
+        "ukphone": "'fɔːrkæst"
+    },
+    {
+        "name": "forefront",
+        "trans": [
+            "最前沿， 最前线； 中心"
+        ],
+        "usphone": "'fɔrfrʌnt",
+        "ukphone": "'fɔːrfrʌnt"
+    },
+    {
+        "name": "foremost",
+        "trans": [
+            "最先的； 最著名的， 最重要的"
+        ],
+        "usphone": "'fɔr'most",
+        "ukphone": "'fɔːrmoust"
+    },
+    {
+        "name": "forerunner",
+        "trans": [
+            "先驱者， 开路人； 先兆， 预兆"
+        ],
+        "usphone": "'fɔr'rʌnɚ",
+        "ukphone": "'fɔːrʌnər"
+    },
+    {
+        "name": "foreshorten",
+        "trans": [
+            "用透视法缩小； 缩短， 节略"
+        ],
+        "usphone": "",
+        "ukphone": "fɔːr'ʃɔːrtn"
+    },
+    {
+        "name": "forestall",
+        "trans": [
+            "预防， 预先阻止； 先发制人"
+        ],
+        "usphone": "",
+        "ukphone": "fɔːr'stɔːl"
+    },
+    {
+        "name": "forfeit",
+        "trans": [
+            "被没收，丧失",
+            "罚款； 没收物"
+        ],
+        "usphone": "'fɔrfət",
+        "ukphone": "'fɔːrfət"
+    },
+    {
+        "name": "formal",
+        "trans": [
+            "正规的， 正式的； 形式的"
+        ],
+        "usphone": "'fɔrml",
+        "ukphone": "'fɔːrml"
+    },
+    {
+        "name": "format",
+        "trans": [
+            "设计，安排；格式，样式",
+            "使格式化"
+        ],
+        "usphone": "'fɔrmæt",
+        "ukphone": "'fɔːrmæt"
+    },
+    {
+        "name": "formation",
+        "trans": [
+            "形成， 构成； 形成物； 编队"
+        ],
+        "usphone": "fɔr'meʃən",
+        "ukphone": "fɔːr'meɪʃn"
+    },
+    {
+        "name": "former",
+        "trans": [
+            "从前的",
+            "前者"
+        ],
+        "usphone": "'fɔrmɚ",
+        "ukphone": "'fɔːrmər"
+    },
+    {
+        "name": "formidable",
+        "trans": [
+            "难对付的； 强大的； 令人敬畏的"
+        ],
+        "usphone": "'fɔrmɪdəbl",
+        "ukphone": "'fɔːmɪdəb(ə)l; fɔː'mɪd-"
+    },
+    {
+        "name": "formula",
+        "trans": [
+            "公式， 方程式； 分子式； 配方"
+        ],
+        "usphone": "'fɔrmjələ",
+        "ukphone": "'fɔːrmjələ"
+    },
+    {
+        "name": "formulate",
+        "trans": [
+            "阐明， 确切表达； 规划， 构想； 制定"
+        ],
+        "usphone": "'fɔrmjə'let",
+        "ukphone": "'fɔːrmjuleɪt"
+    },
+    {
+        "name": "forsake",
+        "trans": [
+            "遗弃， 放弃， 抛弃"
+        ],
+        "usphone": "fɔrˈsek, fə-",
+        "ukphone": "fər'seɪk"
+    },
+    {
+        "name": "fort",
+        "trans": [
+            "要塞， 堡垒； 营地"
+        ],
+        "usphone": "fɔrt",
+        "ukphone": "fɔːrt"
+    },
+    {
+        "name": "fortify",
+        "trans": [
+            "支持， 给…以勇气； 加强， 增强； 筑防御工事于"
+        ],
+        "usphone": "'fɔrtɪfaɪ",
+        "ukphone": "'fɔːrtɪfaɪ"
+    },
+    {
+        "name": "fortuitous",
+        "trans": [
+            "偶然的， 意外的"
+        ],
+        "usphone": "fɔr'tuɪtəs",
+        "ukphone": "fɔːr'tuːɪtəs"
+    },
+    {
+        "name": "forum",
+        "trans": [
+            "论坛； 讨论会"
+        ],
+        "usphone": "'fɔrəm",
+        "ukphone": "'fɔːrəm"
+    },
+    {
+        "name": "forward",
+        "trans": [
+            "向前；",
+            "发送；转交，转递"
+        ],
+        "usphone": "'fɔrwɚd",
+        "ukphone": "'fɔːrwərd"
+    },
+    {
+        "name": "fossil",
+        "trans": [
+            "化石的；陈腐的",
+            "化石； 老顽固"
+        ],
+        "usphone": "'fɑsl",
+        "ukphone": "'fɑːsl"
+    },
+    {
+        "name": "foster",
+        "trans": [
+            "鼓励，促进，助长；培养，抚育；领养",
+            "代养的"
+        ],
+        "usphone": "'fɔstɚ",
+        "ukphone": "'fɔːstər"
+    },
+    {
+        "name": "foul",
+        "trans": [
+            "污秽的， 肮脏的； 充满脏话的， 辱骂性的； 邪恶的"
+        ],
+        "usphone": "faʊl",
+        "ukphone": "faul"
+    },
+    {
+        "name": "fountain",
+        "trans": [
+            "喷泉； 丰富来源， 源泉"
+        ],
+        "usphone": "'faʊntn",
+        "ukphone": "'fauntn"
+    },
+    {
+        "name": "fraction",
+        "trans": [
+            "小部分， 一点儿， 少许"
+        ],
+        "usphone": "'frækʃən",
+        "ukphone": "'frækʃn"
+    },
+    {
+        "name": "fracture",
+        "trans": [
+            "断裂， 折断； 分裂",
+            "骨折；断裂；破裂"
+        ],
+        "usphone": "'fræktʃɚ",
+        "ukphone": "'fræktʃər"
+    },
+    {
+        "name": "fragile",
+        "trans": [
+            "易碎的； 脆弱的； 纤巧的； 虚弱的"
+        ],
+        "usphone": "'frædʒəl",
+        "ukphone": "'frædʒl"
+    },
+    {
+        "name": "fragment",
+        "trans": [
+            "分裂， 成碎片",
+            "碎片， 断片"
+        ],
+        "usphone": "'fræɡmənt",
+        "ukphone": "'frægm(ə)nt"
+    },
+    {
+        "name": "fragrant",
+        "trans": [
+            "芬芳的， 香的"
+        ],
+        "usphone": "'fregrənt",
+        "ukphone": "'freɪgrənt"
+    },
+    {
+        "name": "frail",
+        "trans": [
+            "体弱的， 虚弱的； 易碎的"
+        ],
+        "usphone": "frel",
+        "ukphone": "freɪl"
+    },
+    {
+        "name": "frame",
+        "trans": [
+            "框架；总的思想，体系",
+            "设计， 构成； 给…镶框； 表达"
+        ],
+        "usphone": "frem",
+        "ukphone": "freɪm"
+    },
+    {
+        "name": "framework",
+        "trans": [
+            "框架， 构架； 原则， 准则； 机制， 结构"
+        ],
+        "usphone": "'fremwɝk",
+        "ukphone": "'freɪmwɜːrk"
+    },
+    {
+        "name": "franchise",
+        "trans": [
+            "特权，特许；特许经销权；选举权",
+            "赋予特权； 赋予选举权"
+        ],
+        "usphone": "'fræntʃaɪz",
+        "ukphone": "'fræntʃaɪz"
+    },
+    {
+        "name": "frank",
+        "trans": [
+            "坦白的， 直率的"
+        ],
+        "usphone": "fræŋk",
+        "ukphone": "fræŋk"
+    },
+    {
+        "name": "fraud",
+        "trans": [
+            "骗子， 冒名顶替者； 冒牌货； 欺骗"
+        ],
+        "usphone": "frɔd",
+        "ukphone": "frɔːd"
+    },
+    {
+        "name": "fraudulent",
+        "trans": [
+            "欺诈的， 欺骗性的"
+        ],
+        "usphone": "'frɔdʒələnt",
+        "ukphone": "'frɔːdʒələnt"
+    },
+    {
+        "name": "fray",
+        "trans": [
+            "磨损，磨破；烦躁，恼火",
+            "争斗"
+        ],
+        "usphone": "fre",
+        "ukphone": "freɪ"
+    },
+    {
+        "name": "freeze",
+        "trans": [
+            "结冰， 凝固"
+        ],
+        "usphone": "friz",
+        "ukphone": "friːz"
+    },
+    {
+        "name": "freight",
+        "trans": [
+            "货运；运费",
+            "运送， 货运； 使充满"
+        ],
+        "usphone": "fret",
+        "ukphone": "freɪt"
+    },
+    {
+        "name": "frenzy",
+        "trans": [
+            "狂暴， 狂热， 疯狂"
+        ],
+        "usphone": "'frɛnzi",
+        "ukphone": "'frenzi"
+    },
+    {
+        "name": "fresco",
+        "trans": [
+            "绘湿壁画于",
+            "湿壁画；湿壁画技法"
+        ],
+        "usphone": "'frɛsko",
+        "ukphone": "'freskou"
+    },
+    {
+        "name": "friction",
+        "trans": [
+            "摩擦； 摩擦力； 矛盾， 冲突"
+        ],
+        "usphone": "'frɪkʃən",
+        "ukphone": "'frɪkʃn"
+    },
+    {
+        "name": "frigid",
+        "trans": [
+            "寒冷的； 冷淡的"
+        ],
+        "usphone": "'frɪdʒɪd",
+        "ukphone": "'frɪdʒɪd"
+    },
+    {
+        "name": "frivolity",
+        "trans": [
+            "轻浮； 愚蠢的行为"
+        ],
+        "usphone": "fri'vəliti",
+        "ukphone": "frɪ'vɑːləti"
+    },
+    {
+        "name": "frivolous",
+        "trans": [
+            "琐碎的， 无关紧要的； 愚蠢的， 可笑的； 无聊的， 不严肃的， 轻佻的"
+        ],
+        "usphone": "'frɪvələs",
+        "ukphone": "'frɪvələs"
+    },
+    {
+        "name": "frost",
+        "trans": [
+            "结霜，蒙上霜",
+            "霜； 霜冻； 严寒"
+        ],
+        "usphone": "frɔst",
+        "ukphone": "frɔːst"
+    },
+    {
+        "name": "frugal",
+        "trans": [
+            "节约的， 节俭的； 少量的"
+        ],
+        "usphone": "'fruɡl",
+        "ukphone": "'fruːgl"
+    },
+    {
+        "name": "frustrate",
+        "trans": [
+            "使感到灰心， 挫败； 阻止"
+        ],
+        "usphone": "'frʌstret",
+        "ukphone": "'frʌstreɪt"
+    },
+    {
+        "name": "fulfill",
+        "trans": [
+            "履行； 实现； 符合， 具备"
+        ],
+        "usphone": "ful'fil",
+        "ukphone": "ful'fɪl"
+    },
+    {
+        "name": "fume",
+        "trans": [
+            "冒烟； 大为恼火"
+        ],
+        "usphone": "fjum",
+        "ukphone": "fjuːm"
+    },
+    {
+        "name": "fumigate",
+        "trans": [
+            "烟熏， 香薰"
+        ],
+        "usphone": "'fjumɪɡet",
+        "ukphone": "'fjuːmɪgeɪt"
+    },
+    {
+        "name": "function",
+        "trans": [
+            "运行； 起作用",
+            "机能，功能，作用；函数"
+        ],
+        "usphone": "'fʌŋkʃən",
+        "ukphone": "'fʌŋkʃn"
+    },
+    {
+        "name": "fund",
+        "trans": [
+            "基金，专款；储备，蕴藏；",
+            "为…提供资金"
+        ],
+        "usphone": "fʌnd",
+        "ukphone": "fʌnd"
+    },
+    {
+        "name": "fundamental",
+        "trans": [
+            "基础的，基本的，根本的",
+            "基本原则； 基础"
+        ],
+        "usphone": ",fʌndə'mɛntl",
+        "ukphone": "ˌfʌndə'mentl"
+    },
+    {
+        "name": "funding",
+        "trans": [
+            "基金， 资金； 提供资金"
+        ],
+        "usphone": "'fʌndɪŋ",
+        "ukphone": "'fʌndɪŋ"
+    },
+    {
+        "name": "fungi",
+        "trans": [
+            "[fungus的复数]真菌"
+        ],
+        "usphone": "ˈfʌnˌdʒaɪ; ˈfʌŋˌgaɪ",
+        "ukphone": "'fʌŋgaɪ"
+    },
+    {
+        "name": "fungus",
+        "trans": [
+            "真菌"
+        ],
+        "usphone": "'fʌŋɡəs",
+        "ukphone": "'fʌŋgəs"
+    },
+    {
+        "name": "furious",
+        "trans": [
+            "狂怒的， 狂暴的； 强烈的， 猛烈的"
+        ],
+        "usphone": "'fjʊrɪəs",
+        "ukphone": "'fjuriəs"
+    },
+    {
+        "name": "furnace",
+        "trans": [
+            "火炉， 熔炉； 锅炉"
+        ],
+        "usphone": "'fɝnɪs",
+        "ukphone": "'fɜːrnɪs"
+    },
+    {
+        "name": "furnish",
+        "trans": [
+            "提供， 供应； 布置， 为…配备家具"
+        ],
+        "usphone": "'fɝnɪʃ",
+        "ukphone": "'fɜːrnɪʃ"
+    },
+    {
+        "name": "furry",
+        "trans": [
+            "毛皮似的； 盖着毛皮的； 生苔的"
+        ],
+        "usphone": "ˈfɜri",
+        "ukphone": "'fɜːri"
+    },
+    {
+        "name": "fuse",
+        "trans": [
+            "融合；熔接；熔化；因保险丝烧断而断电；合并",
+            "保险丝； 引信； 导火线"
+        ],
+        "usphone": "fjuz",
+        "ukphone": "fjuːz"
+    },
+    {
+        "name": "fusion",
+        "trans": [
+            "熔化， 熔解； 熔合； 核聚变； 联合， 合并"
+        ],
+        "usphone": "'fjʊʒən",
+        "ukphone": "'fjuːʒn"
+    },
+    {
+        "name": "futile",
+        "trans": [
+            "无效的， 无用的， 无意义的； 琐细的； 没出息的"
+        ],
+        "usphone": "'fjʊtaɪl",
+        "ukphone": "'fjuːtl"
+    },
+    {
+        "name": "gait",
+        "trans": [
+            "步法， 步态"
+        ],
+        "usphone": "ɡet",
+        "ukphone": "geɪt"
+    },
+    {
+        "name": "galaxy",
+        "trans": [
+            "星系； [G-]银河系， 银河； 群英"
+        ],
+        "usphone": "'ɡæləksi",
+        "ukphone": "'gæləksi"
+    },
+    {
+        "name": "gallery",
+        "trans": [
+            "画廊， 美术馆"
+        ],
+        "usphone": "'gæləri",
+        "ukphone": "'gæləri"
+    },
+    {
+        "name": "gallop",
+        "trans": [
+            "飞奔， 疾驰"
+        ],
+        "usphone": "'ɡæləp",
+        "ukphone": "'gæləp"
+    },
+    {
+        "name": "gamble",
+        "trans": [
+            "投机， 冒险； 赌博， 打赌"
+        ],
+        "usphone": "'ɡæmbl",
+        "ukphone": "'gæmbl"
+    },
+    {
+        "name": "gang",
+        "trans": [
+            "合伙",
+            "一帮，一伙；帮派"
+        ],
+        "usphone": "ɡæŋ",
+        "ukphone": "gæŋ"
+    },
+    {
+        "name": "garb",
+        "trans": [
+            "服装，装束",
+            "穿着， 装扮"
+        ],
+        "usphone": "ɡɑrb",
+        "ukphone": "gɑːrb"
+    },
+    {
+        "name": "garbage",
+        "trans": [
+            "垃圾， 废物； 废话， 无聊的东西； 垃圾箱"
+        ],
+        "usphone": "'ɡɑrbɪdʒ",
+        "ukphone": "'gɑːrbɪdʒ"
+    },
+    {
+        "name": "gaseous",
+        "trans": [
+            "气体的， 气态的"
+        ],
+        "usphone": "'ɡæsɪəs",
+        "ukphone": "'gæʃiəs"
+    },
+    {
+        "name": "gasoline",
+        "trans": [
+            "汽油"
+        ],
+        "usphone": "'gæsəlin",
+        "ukphone": "'gæsəliːn"
+    },
+    {
+        "name": "gauge",
+        "trans": [
+            "标准，规格；测量仪表，计量器",
+            "测量， 度量"
+        ],
+        "usphone": "gedʒ",
+        "ukphone": "geɪdʒ"
+    },
+    {
+        "name": "gear",
+        "trans": [
+            "齿轮，传动装置；挡；设备",
+            "调节， 使适应"
+        ],
+        "usphone": "ɡɪr",
+        "ukphone": "gɪr"
+    },
+    {
+        "name": "gem",
+        "trans": [
+            "宝石， 珍品； 美丽绝伦的事物"
+        ],
+        "usphone": "dʒɛm",
+        "ukphone": "dʒem"
+    },
+    {
+        "name": "gemstone",
+        "trans": [
+            "经雕琢的宝石"
+        ],
+        "usphone": "'dʒɛm,ston",
+        "ukphone": "'dʒemstoun"
+    },
+    {
+        "name": "gender",
+        "trans": [
+            "性别； 性"
+        ],
+        "usphone": "'dʒɛndɚ",
+        "ukphone": "'dʒendər"
+    },
+    {
+        "name": "generalization",
+        "trans": [
+            "概括， 归纳"
+        ],
+        "usphone": ",dʒɛnrələ'zeʃən",
+        "ukphone": "ˌdʒenrəlaɪ'zeɪʃn"
+    },
+    {
+        "name": "generalize",
+        "trans": [
+            "概括， 归纳； 推广"
+        ],
+        "usphone": "'dʒɛnrəlaɪz",
+        "ukphone": "'dʒenrəlaɪz"
+    },
+    {
+        "name": "generate",
+        "trans": [
+            "产生； 引起， 导致"
+        ],
+        "usphone": "'dʒɛnəret",
+        "ukphone": "'dʒenəreɪt"
+    },
+    {
+        "name": "generic",
+        "trans": [
+            "种类的， 属的； 一般的， 普通的"
+        ],
+        "usphone": "dʒə'nɛrɪk",
+        "ukphone": "dʒə'nerɪk"
+    },
+    {
+        "name": "generous",
+        "trans": [
+            "慷慨的， 大方的； 大量的， 丰富的； 宽厚的， 宽宏大量的"
+        ],
+        "usphone": "'dʒɛnərəs",
+        "ukphone": "'dʒenərəs"
+    },
+    {
+        "name": "genesis",
+        "trans": [
+            "起源， 开端"
+        ],
+        "usphone": "'dʒɛnəsɪs",
+        "ukphone": "'dʒenəsɪs"
+    },
+    {
+        "name": "genetic",
+        "trans": [
+            "基因的， 遗传的"
+        ],
+        "usphone": "dʒə'nɛtɪk",
+        "ukphone": "dʒə'netɪk"
+    },
+    {
+        "name": "genetics",
+        "trans": [
+            "遗传学"
+        ],
+        "usphone": "dʒə'nɛtɪks",
+        "ukphone": "dʒə'netɪks"
+    },
+    {
+        "name": "genial",
+        "trans": [
+            "亲切的， 和蔼的； 温和的， 温暖的"
+        ],
+        "usphone": "'dʒinɪəl",
+        "ukphone": "'dʒiːniəl"
+    },
+    {
+        "name": "genius",
+        "trans": [
+            "天才； 天赋"
+        ],
+        "usphone": "'dʒinjəs",
+        "ukphone": "'dʒiːniəs"
+    },
+    {
+        "name": "genre",
+        "trans": [
+            "类型； 流派"
+        ],
+        "usphone": "'ʒɑnrə",
+        "ukphone": "'ʒɑːnrə"
+    },
+    {
+        "name": "gentility",
+        "trans": [
+            "有教养， 文雅"
+        ],
+        "usphone": "dʒɛn'tɪləti",
+        "ukphone": "dʒen'tɪləti"
+    },
+    {
+        "name": "genuine",
+        "trans": [
+            "真的， 非人造的； 真诚的， 诚实的"
+        ],
+        "usphone": "'dʒɛnjʊɪn",
+        "ukphone": "'dʒenjuɪn"
+    },
+    {
+        "name": "geology",
+        "trans": [
+            "地质学； 地质概况"
+        ],
+        "usphone": "dʒɪ'ɑlədʒi",
+        "ukphone": "dʒi'ɑːlədʒi"
+    },
+    {
+        "name": "geometric",
+        "trans": [
+            "几何的， 几何学的"
+        ],
+        "usphone": ",dʒiə'mɛtrɪk",
+        "ukphone": "ˌdʒiːə'metrɪk"
+    },
+    {
+        "name": "geometry",
+        "trans": [
+            "几何， 几何学"
+        ],
+        "usphone": "dʒɪ'ɑmətri",
+        "ukphone": "dʒi'ɑːmətri"
+    },
+    {
+        "name": "germ",
+        "trans": [
+            "微生物， 细菌； 萌芽"
+        ],
+        "usphone": "dʒɝm",
+        "ukphone": "dʒɜːrm"
+    },
+    {
+        "name": "germinate",
+        "trans": [
+            "发芽， 萌芽； 发展"
+        ],
+        "usphone": "'dʒɝmɪnet",
+        "ukphone": "'dʒɜːrmɪneɪt"
+    },
+    {
+        "name": "giant",
+        "trans": [
+            "巨大的；超群的",
+            "巨大的动物； 才智超群的人"
+        ],
+        "usphone": "'dʒaɪənt",
+        "ukphone": "'dʒaɪənt"
+    },
+    {
+        "name": "gibe",
+        "trans": [
+            "嘲弄， 讥笑"
+        ],
+        "usphone": "dʒaib",
+        "ukphone": "dʒaɪb"
+    },
+    {
+        "name": "gigantic",
+        "trans": [
+            "巨大的， 庞大的"
+        ],
+        "usphone": "dʒaɪ'ɡæntɪk",
+        "ukphone": "dʒaɪ'gæntɪk"
+    },
+    {
+        "name": "gilding",
+        "trans": [
+            "镀金； 贴金层， 镀金层； 金色涂层"
+        ],
+        "usphone": "'ɡɪldɪŋ",
+        "ukphone": "'gɪldɪŋ"
+    },
+    {
+        "name": "gin",
+        "trans": [
+            "杜松子酒；弹棉机，"
+        ],
+        "usphone": "dʒɪn",
+        "ukphone": "dʒɪn"
+    },
+    {
+        "name": "giraffe",
+        "trans": [
+            "长颈鹿"
+        ],
+        "usphone": "dʒəˈræf; dʒəˈræf",
+        "ukphone": "dʒə'ræf"
+    },
+    {
+        "name": "girder",
+        "trans": [
+            "主梁， 大梁"
+        ],
+        "usphone": "'ɡədɚ",
+        "ukphone": "'gɜːrdər"
+    },
+    {
+        "name": "gist",
+        "trans": [
+            "主旨， 要点， 大意"
+        ],
+        "usphone": "dʒɪst",
+        "ukphone": "dʒɪst"
+    },
+    {
+        "name": "given",
+        "trans": [
+            "规定的，特定的；假定的",
+            "考虑到， 鉴于"
+        ],
+        "usphone": "'ɡɪvn",
+        "ukphone": "'gɪvn"
+    },
+    {
+        "name": "glacial",
+        "trans": [
+            "冰川期的， 冰河时代的； 寒冷的， 冰冷的； 冷若冰霜的"
+        ],
+        "usphone": "'ɡleʃl",
+        "ukphone": "'gleɪʃl"
+    },
+    {
+        "name": "glacier",
+        "trans": [
+            "冰川， 冰河"
+        ],
+        "usphone": "'ɡleʃɚ",
+        "ukphone": "'gleɪʃər"
+    },
+    {
+        "name": "glamorous",
+        "trans": [
+            "富有魅力的， 迷人的"
+        ],
+        "usphone": "'glæmərəs",
+        "ukphone": "'glæmərəs"
+    },
+    {
+        "name": "gland",
+        "trans": [
+            "腺"
+        ],
+        "usphone": "ɡlænd",
+        "ukphone": "glænd"
+    },
+    {
+        "name": "glare",
+        "trans": [
+            "怒目而视； 发出刺眼的光",
+            "耀眼的光；怒视，瞪眼"
+        ],
+        "usphone": "ɡlɛr",
+        "ukphone": "gler"
+    },
+    {
+        "name": "glaze",
+        "trans": [
+            "上釉； 给…装玻璃",
+            "釉料；糖浆"
+        ],
+        "usphone": "ɡlez",
+        "ukphone": "gleɪz"
+    },
+    {
+        "name": "gleam",
+        "trans": [
+            "闪光， 闪烁； 流露出",
+            "微光；一丝，一线；表露"
+        ],
+        "usphone": "ɡlim",
+        "ukphone": "gliːm"
+    },
+    {
+        "name": "glean",
+        "trans": [
+            "点滴搜集， 四处收集"
+        ],
+        "usphone": "ɡlin",
+        "ukphone": "gliːn"
+    },
+    {
+        "name": "glimmer",
+        "trans": [
+            "发微光； 隐约出现",
+            "闪烁的微光；隐约的迹象；一丝，一线"
+        ],
+        "usphone": "'ɡlɪmɚ",
+        "ukphone": "'glɪmər"
+    },
+    {
+        "name": "glimpse",
+        "trans": [
+            "一看，一瞥",
+            "瞥见"
+        ],
+        "usphone": "ɡlɪmps",
+        "ukphone": "glɪmps"
+    },
+    {
+        "name": "glitter",
+        "trans": [
+            "闪烁，闪耀",
+            "灿烂的光辉； 诱惑力， 魅力"
+        ],
+        "usphone": "'ɡlɪtɚ",
+        "ukphone": "'glɪtər"
+    },
+    {
+        "name": "gloomy",
+        "trans": [
+            "忧郁的， 令人沮丧的； 昏暗的， 阴暗的， 阴沉的"
+        ],
+        "usphone": "'ɡlumi",
+        "ukphone": "'gluːmi"
+    },
+    {
+        "name": "glorify",
+        "trans": [
+            "吹捧， 美化； 赞美， 赞扬"
+        ],
+        "usphone": "'ɡlɔrɪfaɪ",
+        "ukphone": "'glɔːrɪfaɪ"
+    },
+    {
+        "name": "glorious",
+        "trans": [
+            "壮丽的， 辉煌的； 光荣的； 令人愉快的， 极好的"
+        ],
+        "usphone": "'ɡlɔriəs; 'ɡloriəs",
+        "ukphone": "'glɔːriəs"
+    },
+    {
+        "name": "gloss",
+        "trans": [
+            "有光泽",
+            "光泽，色泽；亮光漆；注解"
+        ],
+        "usphone": "ɡlɑs",
+        "ukphone": "glɑːs"
+    },
+    {
+        "name": "glossy",
+        "trans": [
+            "光滑的； 光彩夺目的； 浮华的"
+        ],
+        "usphone": "'ɡlɑsi",
+        "ukphone": "'glɑːsi"
+    },
+    {
+        "name": "glow",
+        "trans": [
+            "发光；发红，发热；洋溢",
+            "暗淡的光； 容光焕发； 喜悦"
+        ],
+        "usphone": "ɡlo",
+        "ukphone": "glou"
+    },
+    {
+        "name": "glue",
+        "trans": [
+            "胶合，黏合；紧附于",
+            "胶， 胶水"
+        ],
+        "usphone": "ɡlu",
+        "ukphone": "gluː"
+    },
+    {
+        "name": "gnaw",
+        "trans": [
+            "啃， 咬"
+        ],
+        "usphone": "nɔ",
+        "ukphone": "nɔː"
+    },
+    {
+        "name": "gorge",
+        "trans": [
+            "狼吞虎咽",
+            "山峡， 峡谷"
+        ],
+        "usphone": "ɡɔrdʒ",
+        "ukphone": "gɔːrdʒ"
+    },
+    {
+        "name": "gorgeous",
+        "trans": [
+            "漂亮的； 令人愉快的； 华丽的， 灿烂的"
+        ],
+        "usphone": "'ɡɔrdʒəs",
+        "ukphone": "'gɔːrdʒəs"
+    },
+    {
+        "name": "gorilla",
+        "trans": [
+            "大猩猩"
+        ],
+        "usphone": "ɡə'rɪlə",
+        "ukphone": "gə'rɪlə"
+    },
+    {
+        "name": "gospel",
+        "trans": [
+            "准则， 信条； 绝对真理； [G-]福音； 福音音乐； 训示"
+        ],
+        "usphone": "'ɡɑspl",
+        "ukphone": "'gɑːspl"
+    },
+    {
+        "name": "gossip",
+        "trans": [
+            "传播流言飞语， 说长道短",
+            "闲话，流言飞语；爱说长道短的人"
+        ],
+        "usphone": "'ɡɑsɪp",
+        "ukphone": "'gɑːsɪp"
+    },
+    {
+        "name": "Gothic",
+        "trans": [
+            "哥特式的，哥特风格的",
+            "哥特式建筑"
+        ],
+        "usphone": "'ɡɔθik",
+        "ukphone": "'gɑːθɪk"
+    },
+    {
+        "name": "gouge",
+        "trans": [
+            "挖出；敲竹杠",
+            "凿子"
+        ],
+        "usphone": "ɡaʊdʒ",
+        "ukphone": "gaudʒ"
+    },
+    {
+        "name": "gourd",
+        "trans": [
+            "葫芦； 葫芦制成的容器"
+        ],
+        "usphone": "ɡʊrd",
+        "ukphone": "gurd"
+    },
+    {
+        "name": "gourmet",
+        "trans": [
+            "美味的",
+            "美食家"
+        ],
+        "usphone": "'ɡʊrme",
+        "ukphone": "'gurmeɪ"
+    },
+    {
+        "name": "govern",
+        "trans": [
+            "统治， 治理， 管理； 决定， 支配； 控制， 影响"
+        ],
+        "usphone": "'ɡʌvɚn",
+        "ukphone": "'gʌvərn"
+    },
+    {
+        "name": "grab",
+        "trans": [
+            "拿， 抓， 夺"
+        ],
+        "usphone": "ɡræb",
+        "ukphone": "græb"
+    },
+    {
+        "name": "gradient",
+        "trans": [
+            "坡度； 倾斜度， 斜率； 梯度"
+        ],
+        "usphone": "'ɡredɪənt",
+        "ukphone": "'greɪdiənt"
+    },
+    {
+        "name": "grading",
+        "trans": [
+            "评分； 等级"
+        ],
+        "usphone": "'ɡredɪŋ",
+        "ukphone": "'greɪdɪŋ"
+    },
+    {
+        "name": "gradual",
+        "trans": [
+            "逐渐的， 逐步的； 坡度平缓的， 不陡的"
+        ],
+        "usphone": "'ɡrædʒuəl",
+        "ukphone": "'grædʒuəl"
+    },
+    {
+        "name": "grain",
+        "trans": [
+            "谷物； 颗粒； 纹理； 少量"
+        ],
+        "usphone": "ɡren",
+        "ukphone": "greɪn"
+    },
+    {
+        "name": "granite",
+        "trans": [
+            "花岗岩， 花岗石"
+        ],
+        "usphone": "'grænɪt",
+        "ukphone": "'grænɪt"
+    },
+    {
+        "name": "grant",
+        "trans": [
+            "给予，授予；允许，同意；承认",
+            "拨款； 津贴； 授予物"
+        ],
+        "usphone": "ɡrænt",
+        "ukphone": "grænt"
+    },
+    {
+        "name": "granular",
+        "trans": [
+            "粒状的； 含颗粒的"
+        ],
+        "usphone": "'grænjəlɚ",
+        "ukphone": "'grænjələr"
+    },
+    {
+        "name": "graph",
+        "trans": [
+            "图表"
+        ],
+        "usphone": "ɡræf",
+        "ukphone": "græf"
+    },
+    {
+        "name": "graphics",
+        "trans": [
+            "图形， 图像； 制图法， 制图学"
+        ],
+        "usphone": "'græfɪks",
+        "ukphone": "'græfɪks"
+    },
+    {
+        "name": "graphite",
+        "trans": [
+            "石墨"
+        ],
+        "usphone": "ˈɡræfˌaɪt",
+        "ukphone": "'græfaɪt"
+    },
+    {
+        "name": "grasp",
+        "trans": [
+            "抓住； 掌握， 理解， 领会"
+        ],
+        "usphone": "ɡræsp",
+        "ukphone": "græsp"
+    },
+    {
+        "name": "grasshopper",
+        "trans": [
+            "蚂蚱， 蝗虫"
+        ],
+        "usphone": "'ɡræshɑpɚ",
+        "ukphone": "'græshɑːpər"
+    },
+    {
+        "name": "gratify",
+        "trans": [
+            "使满意， 使高兴； 满足"
+        ],
+        "usphone": "'grætə'fai",
+        "ukphone": "'grætɪfaɪ"
+    },
+    {
+        "name": "gravel",
+        "trans": [
+            "沙砾， 砾石"
+        ],
+        "usphone": "'ɡrævl",
+        "ukphone": "'grævl"
+    },
+    {
+        "name": "gravitational",
+        "trans": [
+            "重力的， 万有引力的"
+        ],
+        "usphone": ",ɡrævɪ'teʃənl",
+        "ukphone": "ˌgrævɪ'teɪʃənl"
+    },
+    {
+        "name": "gravity",
+        "trans": [
+            "重力； 严重性； 严肃， 庄严"
+        ],
+        "usphone": "ˈɡrævətɪ",
+        "ukphone": "'grævəti"
+    },
+    {
+        "name": "graze",
+        "trans": [
+            "吃草；放牧；擦伤",
+            "擦伤"
+        ],
+        "usphone": "ɡrez",
+        "ukphone": "greɪz"
+    },
+    {
+        "name": "grazing",
+        "trans": [
+            "放牧； 牧场"
+        ],
+        "usphone": "'ɡrezɪŋ",
+        "ukphone": "'greɪzɪŋ"
+    },
+    {
+        "name": "gregarious",
+        "trans": [
+            "群居的； 合群的， 爱社交的"
+        ],
+        "usphone": "grɪ'gɛrɪəs",
+        "ukphone": "grɪ'geriəs"
+    },
+    {
+        "name": "grid",
+        "trans": [
+            "格子， 栅格； 地图上的坐标方格， 网格； 输电网， 煤气输送网"
+        ],
+        "usphone": "ɡrɪd",
+        "ukphone": "grɪd"
+    },
+    {
+        "name": "grievous",
+        "trans": [
+            "令人忧伤的； 极严重的"
+        ],
+        "usphone": "'ɡrivəs",
+        "ukphone": "'griːvəs"
+    },
+    {
+        "name": "grill",
+        "trans": [
+            "烧烤；拷问，盘问",
+            "烤架"
+        ],
+        "usphone": "ɡrɪl",
+        "ukphone": "grɪl"
+    },
+    {
+        "name": "grimly",
+        "trans": [
+            "冷酷地； 严肃地； 坚定地"
+        ],
+        "usphone": "'grɪmlɪ",
+        "ukphone": "'grɪmli"
+    },
+    {
+        "name": "grind",
+        "trans": [
+            "打磨；磨，碾",
+            "磨碎， 碾碎； 苦差事"
+        ],
+        "usphone": "ɡraɪnd",
+        "ukphone": "graɪnd"
+    },
+    {
+        "name": "grip",
+        "trans": [
+            "控制；紧握；吸引住…的注意",
+            "控制， 影响力； 紧握； 理解"
+        ],
+        "usphone": "ɡrɪp",
+        "ukphone": "grɪp"
+    },
+    {
+        "name": "groan",
+        "trans": [
+            "呻吟；叹息；发出呻吟般的声音",
+            "呻吟； 抱怨； 呻吟声， 叹息声"
+        ],
+        "usphone": "ɡron",
+        "ukphone": "groun"
+    },
+    {
+        "name": "grocery",
+        "trans": [
+            "杂货店； 杂货"
+        ],
+        "usphone": "'ɡrosəri",
+        "ukphone": "'grousəri"
+    },
+    {
+        "name": "groom",
+        "trans": [
+            "刷洗；梳理毛发；培养，"
+        ],
+        "usphone": "ɡrum",
+        "ukphone": "gruːm"
+    },
+    {
+        "name": "groove",
+        "trans": [
+            "沟； 槽； 唱片上的纹路"
+        ],
+        "usphone": "ɡruv",
+        "ukphone": "gruːv"
+    },
+    {
+        "name": "gross",
+        "trans": [
+            "总的，毛的；粗俗的，粗野的；令人不快的",
+            "总收入为",
+            "一罗；"
+        ],
+        "usphone": "ɡros",
+        "ukphone": "grous"
+    },
+    {
+        "name": "grouse",
+        "trans": [
+            "发牢骚，抱怨",
+            "松鸡； 怨言"
+        ],
+        "usphone": "ɡraʊs",
+        "ukphone": "graus"
+    },
+    {
+        "name": "grovel",
+        "trans": [
+            "摇尾乞怜， 奴颜婢膝"
+        ],
+        "usphone": "'ɡrɑvl",
+        "ukphone": "'grɑːvl"
+    },
+    {
+        "name": "grudge",
+        "trans": [
+            "勉强做； 不情愿地给",
+            "怨恨，积怨"
+        ],
+        "usphone": "ɡrʌdʒ",
+        "ukphone": "grʌdʒ"
+    },
+    {
+        "name": "grump",
+        "trans": [
+            "发脾气，发牢骚",
+            "脾气不好的人"
+        ],
+        "usphone": "ɡrʌmp",
+        "ukphone": "grʌmp"
+    },
+    {
+        "name": "guarantee",
+        "trans": [
+            "保证；担保",
+            "保证， 担保； 保证书"
+        ],
+        "usphone": ",ɡærən'ti",
+        "ukphone": "ˌgærən'tiː"
+    },
+    {
+        "name": "guideline",
+        "trans": [
+            "指导方针，指导原则"
+        ],
+        "usphone": "'ɡaɪdlaɪn",
+        "ukphone": "'gaɪdlaɪn"
+    },
+    {
+        "name": "guilty",
+        "trans": [
+            "有罪的， 犯罪的； 内疚的"
+        ],
+        "usphone": "'ɡɪlti",
+        "ukphone": "'gɪlti"
+    },
+    {
+        "name": "gulf",
+        "trans": [
+            "海湾； 分歧， 隔阂， 鸿沟"
+        ],
+        "usphone": "ɡʌlf",
+        "ukphone": "gʌlf"
+    },
+    {
+        "name": "gull",
+        "trans": [
+            "鸥， 海鸥"
+        ],
+        "usphone": "ɡʌl",
+        "ukphone": "gʌl"
+    },
+    {
+        "name": "gush",
+        "trans": [
+            "滔滔不绝地说；喷涌",
+            "喷出， 涌出； 迸发， 发作"
+        ],
+        "usphone": "ɡʌʃ",
+        "ukphone": "gʌʃ"
+    },
+    {
+        "name": "gymnasium",
+        "trans": [
+            "体育馆； 健身房"
+        ],
+        "usphone": "dʒɪm'nezɪəm",
+        "ukphone": "dʒɪm'neɪziəm"
+    },
+    {
+        "name": "habit",
+        "trans": [
+            "习惯； 习性， 脾性"
+        ],
+        "usphone": "'hæbɪt",
+        "ukphone": "'hæbɪt"
+    },
+    {
+        "name": "habitat",
+        "trans": [
+            "自然环境， 栖息地"
+        ],
+        "usphone": "'hæbə'tæt",
+        "ukphone": "'hæbɪtæt"
+    },
+    {
+        "name": "hail",
+        "trans": [
+            "招呼； 高呼； 赞扬， 称颂； 下冰雹",
+            "冰雹；一阵"
+        ],
+        "usphone": "hel",
+        "ukphone": "heɪl"
+    },
+    {
+        "name": "haircut",
+        "trans": [
+            "理发"
+        ],
+        "usphone": "'hɛrkʌt",
+        "ukphone": "'herkʌt"
+    },
+    {
+        "name": "halt",
+        "trans": [
+            "停住， 停下",
+            "停止，阻止；暂停"
+        ],
+        "usphone": "hɔlt",
+        "ukphone": "hɔːlt"
+    },
+    {
+        "name": "hammer",
+        "trans": [
+            "锤打",
+            "锤， 槌； 锤子"
+        ],
+        "usphone": "'hæmɚ",
+        "ukphone": "'hæmər"
+    },
+    {
+        "name": "hamper",
+        "trans": [
+            "妨碍，阻挠",
+            "大篮子"
+        ],
+        "usphone": "'hæmpɚ",
+        "ukphone": "'hæmpər"
+    },
+    {
+        "name": "handful",
+        "trans": [
+            "一把； 少数人"
+        ],
+        "usphone": "'hænd,fʊl",
+        "ukphone": "'hændful"
+    },
+    {
+        "name": "handle",
+        "trans": [
+            "处理；对待；操纵；触，摸",
+            "柄， 把手， 拉手"
+        ],
+        "usphone": "'hændl",
+        "ukphone": "'hændl"
+    },
+    {
+        "name": "handy",
+        "trans": [
+            "可用的； 易使用的， 便利的； 手巧的"
+        ],
+        "usphone": "'hændi",
+        "ukphone": "'hændi"
+    },
+    {
+        "name": "haphazard",
+        "trans": [
+            "偶然的， 任意的； 无计划的， 无秩序的"
+        ],
+        "usphone": "'hæphæzəd",
+        "ukphone": "hæp'hæzərd"
+    },
+    {
+        "name": "harbor",
+        "trans": [
+            "窝藏；藏有",
+            "港口"
+        ],
+        "usphone": "'hɑrbɚ",
+        "ukphone": "'hɑːrbər"
+    },
+    {
+        "name": "hardly",
+        "trans": [
+            "几乎不， 简直不； 刚刚， 仅仅"
+        ],
+        "usphone": "'hɑrdli",
+        "ukphone": "'hɑːrdli"
+    },
+    {
+        "name": "hardware",
+        "trans": [
+            "五金制品， 金属制品； 硬件"
+        ],
+        "usphone": "'hɑrdwɛr",
+        "ukphone": "'hɑːrdwer"
+    },
+    {
+        "name": "hardy",
+        "trans": [
+            "强壮的； 耐寒的； 能吃苦耐劳的"
+        ],
+        "usphone": "",
+        "ukphone": "'hɑːrdi"
+    },
+    {
+        "name": "harmonic",
+        "trans": [
+            "泛音；"
+        ],
+        "usphone": "hɑr'mɑnɪk",
+        "ukphone": "hɑːr'mɑːnɪk"
+    },
+    {
+        "name": "harmonious",
+        "trans": [
+            "和谐的， 协调的； 和睦的， 融洽的"
+        ],
+        "usphone": "hɑr'monɪəs",
+        "ukphone": "hɑːr'mouniəs"
+    },
+    {
+        "name": "harmony",
+        "trans": [
+            "和声； 和谐， 融洽， 协调； 相符， 一致"
+        ],
+        "usphone": "'hɑrməni",
+        "ukphone": "'hɑːrməni"
+    },
+    {
+        "name": "harness",
+        "trans": [
+            "利用…产生动力；给上挽具",
+            "马具"
+        ],
+        "usphone": "'hɑrnɪs",
+        "ukphone": "'hɑːrnɪs"
+    },
+    {
+        "name": "harsh",
+        "trans": [
+            "恶劣的， 严酷的； 刺耳的； 粗糙的， 毛糙的"
+        ],
+        "usphone": "hɑrʃ",
+        "ukphone": "hɑːrʃ"
+    },
+    {
+        "name": "haste",
+        "trans": [
+            "赶快， 匆忙",
+            "急忙，急速，匆忙"
+        ],
+        "usphone": "hest",
+        "ukphone": "heɪst"
+    },
+    {
+        "name": "hatch",
+        "trans": [
+            "孵化，孵出",
+            "开口； 舱门"
+        ],
+        "usphone": "hætʃ",
+        "ukphone": "hætʃ"
+    },
+    {
+        "name": "haul",
+        "trans": [
+            "拖，拖运",
+            "拖， 拉， 拖运； 一次获得的数量； 旅行的距离"
+        ],
+        "usphone": "hɔl",
+        "ukphone": "hɔːl"
+    },
+    {
+        "name": "haunt",
+        "trans": [
+            "出没于；萦绕在心头；长期缠扰",
+            "常去的地方"
+        ],
+        "usphone": "hɔnt",
+        "ukphone": "hɔːnt"
+    },
+    {
+        "name": "haven",
+        "trans": [
+            "港口； 庇护所， 避难所； 栖息处"
+        ],
+        "usphone": "'hevn",
+        "ukphone": "'heɪvn"
+    },
+    {
+        "name": "havoc",
+        "trans": [
+            "混乱， 大破坏"
+        ],
+        "usphone": "'hævək",
+        "ukphone": "'hævək"
+    },
+    {
+        "name": "hawk",
+        "trans": [
+            "鹰，隼；主战分子",
+            "叫卖， 兜售"
+        ],
+        "usphone": "hɔk",
+        "ukphone": "hɔːk"
+    },
+    {
+        "name": "hay",
+        "trans": [
+            "干草"
+        ],
+        "usphone": "",
+        "ukphone": "heɪ"
+    },
+    {
+        "name": "hazard",
+        "trans": [
+            "危险；风险",
+            "尝试着做； 冒…风险， 使处于危险"
+        ],
+        "usphone": "'hæzɚd",
+        "ukphone": "'hæzərd"
+    },
+    {
+        "name": "hazel",
+        "trans": [
+            "榛树",
+            "〔眼睛〕绿褐色的"
+        ],
+        "usphone": "'hezl",
+        "ukphone": "'heɪzl"
+    },
+    {
+        "name": "heading",
+        "trans": [
+            "标题； 主题"
+        ],
+        "usphone": "'hɛdɪŋ",
+        "ukphone": "'hedɪŋ"
+    },
+    {
+        "name": "healing",
+        "trans": [
+            "有治疗功用的",
+            "康复， 治疗； 复原"
+        ],
+        "usphone": "'hilɪŋ",
+        "ukphone": "'hiːlɪŋ"
+    },
+    {
+        "name": "healthful",
+        "trans": [
+            "有益健康的"
+        ],
+        "usphone": "'hɛlθfl",
+        "ukphone": "'helθfl"
+    },
+    {
+        "name": "hearsay",
+        "trans": [
+            "谣言， 传闻， 道听途说"
+        ],
+        "usphone": "'hɪrse",
+        "ukphone": "'hɪrseɪ"
+    },
+    {
+        "name": "hedge",
+        "trans": [
+            "用篱笆围； 避免直接回答",
+            "树篱；防止损失的措施；防备"
+        ],
+        "usphone": "hɛdʒ",
+        "ukphone": "hedʒ"
+    },
+    {
+        "name": "heed",
+        "trans": [
+            "注意， 留心"
+        ],
+        "usphone": "hid",
+        "ukphone": "hiːd"
+    },
+    {
+        "name": "hemisphere",
+        "trans": [
+            "半球； 大脑半球"
+        ],
+        "usphone": "'hɛmɪsfɪr",
+        "ukphone": "'hemɪsfɪr"
+    },
+    {
+        "name": "hemp",
+        "trans": [
+            "大麻； 由大麻制成的麻醉药"
+        ],
+        "usphone": "hɛmp",
+        "ukphone": "hemp"
+    },
+    {
+        "name": "henceforth",
+        "trans": [
+            "从此以后"
+        ],
+        "usphone": ",hɛns'fɔrθ",
+        "ukphone": "ˌhens'fɔːrθ"
+    },
+    {
+        "name": "herald",
+        "trans": [
+            "预示；宣布，宣告",
+            "信使； 预示， 预兆"
+        ],
+        "usphone": "'hɛrəld",
+        "ukphone": "'herəld"
+    },
+    {
+        "name": "herb",
+        "trans": [
+            "药草， 香草； 草本植物"
+        ],
+        "usphone": "ɝb",
+        "ukphone": "ɜːrb"
+    },
+    {
+        "name": "herbivore",
+        "trans": [
+            "食草动物"
+        ],
+        "usphone": "ɝ​bəˌvɔr",
+        "ukphone": "'hɜːrbɪvɔːr"
+    },
+    {
+        "name": "herd",
+        "trans": [
+            "放牧； 成群， 聚集",
+            "牧群，兽群；人群，芸芸众生"
+        ],
+        "usphone": "hɝd",
+        "ukphone": "hɜːrd"
+    },
+    {
+        "name": "hereditary",
+        "trans": [
+            "遗传的； 可继承的， 世袭的"
+        ],
+        "usphone": "hə'rɛdə'tɛri",
+        "ukphone": "hə'redɪteri"
+    },
+    {
+        "name": "heritage",
+        "trans": [
+            "遗产； 传统"
+        ],
+        "usphone": "'hɛrɪtɪdʒ",
+        "ukphone": "'herɪtɪdʒ"
+    },
+    {
+        "name": "hesitant",
+        "trans": [
+            "犹豫的， 吞吞吐吐的， 犹豫不定的"
+        ],
+        "usphone": "'hɛzɪtənt",
+        "ukphone": "'hezɪtənt"
+    },
+    {
+        "name": "heyday",
+        "trans": [
+            "全盛期"
+        ],
+        "usphone": "'hede",
+        "ukphone": "'heɪdeɪ"
+    },
+    {
+        "name": "hibernation",
+        "trans": [
+            "冬眠； 休眠， 蛰伏"
+        ],
+        "usphone": ",haibə'neiʃən",
+        "ukphone": "ˌhaɪbər'neɪʃn"
+    },
+    {
+        "name": "hide",
+        "trans": [
+            "躲藏；掩藏；掩盖",
+            "兽皮"
+        ],
+        "usphone": "haɪd",
+        "ukphone": "haɪd"
+    },
+    {
+        "name": "hierarchy",
+        "trans": [
+            "统治集团； 等级制度； 阶层"
+        ],
+        "usphone": "'haɪərɑrki",
+        "ukphone": "'haɪərɑːrki"
+    },
+    {
+        "name": "hieratic",
+        "trans": [
+            "僧侣的；"
+        ],
+        "usphone": "'haɪə'rætɪk",
+        "ukphone": "ˌhaɪə'rætɪk"
+    },
+    {
+        "name": "hieroglyph",
+        "trans": [
+            "象形文字， 象形符号"
+        ],
+        "usphone": "'haɪərəɡlɪf",
+        "ukphone": "'haɪərəglɪf"
+    },
+    {
+        "name": "highlight",
+        "trans": [
+            "强调，突出；以强烈光线照射",
+            "最精彩部分"
+        ],
+        "usphone": "'haɪlaɪt",
+        "ukphone": "'haɪlaɪt"
+    },
+    {
+        "name": "hike",
+        "trans": [
+            "徒步旅行， 远足"
+        ],
+        "usphone": "haɪk",
+        "ukphone": "haɪk"
+    },
+    {
+        "name": "hind",
+        "trans": [
+            "后面的， 在后的"
+        ],
+        "usphone": "haɪnd",
+        "ukphone": "haɪnd"
+    },
+    {
+        "name": "hinder",
+        "trans": [
+            "阻碍， 妨碍"
+        ],
+        "usphone": "'hɪndɚ",
+        "ukphone": "'hɪndər"
+    },
+    {
+        "name": "hint",
+        "trans": [
+            "暗示， 示意",
+            "暗示，提示；"
+        ],
+        "usphone": "hɪnt",
+        "ukphone": "hɪnt"
+    },
+    {
+        "name": "hinterland",
+        "trans": [
+            "内地， 腹地； 内地贸易区"
+        ],
+        "usphone": "'hɪntɚlænd",
+        "ukphone": "'hɪntərlænd"
+    },
+    {
+        "name": "hitch",
+        "trans": [
+            "搭便车；提起，拉起；拴住",
+            "故障， 障碍"
+        ],
+        "usphone": "hɪtʃ",
+        "ukphone": "hɪtʃ"
+    },
+    {
+        "name": "hitherto",
+        "trans": [
+            "迄今， 至今"
+        ],
+        "usphone": ",hɪðɚ'tu",
+        "ukphone": "ˌhɪðər'tuː"
+    },
+    {
+        "name": "hive",
+        "trans": [
+            "入蜂箱；群居",
+            "蜂箱， 蜂房； 闹市， 忙碌之地"
+        ],
+        "usphone": "haɪv",
+        "ukphone": "haɪv"
+    },
+    {
+        "name": "hoard",
+        "trans": [
+            "贮藏，囤积",
+            "储藏， 贮存"
+        ],
+        "usphone": "hɔrd",
+        "ukphone": "hɔːrd"
+    },
+    {
+        "name": "hockey",
+        "trans": [
+            "曲棍球"
+        ],
+        "usphone": "'hɑki",
+        "ukphone": "'hɑːki"
+    },
+    {
+        "name": "hoe",
+        "trans": [
+            "用锄头锄",
+            "锄头"
+        ],
+        "usphone": "ho",
+        "ukphone": "hou"
+    },
+    {
+        "name": "holistic",
+        "trans": [
+            "整体的， 全面的； 功能整体性的"
+        ],
+        "usphone": "ho'lɪstɪk",
+        "ukphone": "hou'lɪstɪk"
+    },
+    {
+        "name": "hollow",
+        "trans": [
+            "空心的，中空的；凹陷的；空洞的，虚伪的；沉闷的，",
+            "挖空， 凿空"
+        ],
+        "usphone": "'hɑlo",
+        "ukphone": "'hɑːlou"
+    },
+    {
+        "name": "homage",
+        "trans": [
+            "尊敬， 敬意"
+        ],
+        "usphone": "'hɑmɪdʒ",
+        "ukphone": "'hɑːmɪdʒ"
+    },
+    {
+        "name": "homestead",
+        "trans": [
+            "家宅， 农庄； 宅地"
+        ],
+        "usphone": "'homstɛd",
+        "ukphone": "'houmsted"
+    },
+    {
+        "name": "homing",
+        "trans": [
+            "有返回原地本能的"
+        ],
+        "usphone": "'homɪŋ",
+        "ukphone": "'houmɪŋ"
+    },
+    {
+        "name": "hominid",
+        "trans": [
+            "灵长目的",
+            "原始人类；人科动物"
+        ],
+        "usphone": "'hɑmɪnɪd",
+        "ukphone": "'hɑːmɪnɪd"
+    },
+    {
+        "name": "homogeneous",
+        "trans": [
+            "同类的， 相似的， 同质的"
+        ],
+        "usphone": ",homə'dʒinɪəs",
+        "ukphone": "ˌhoumə'dʒiːniəs"
+    },
+    {
+        "name": "homosexuality",
+        "trans": [
+            "同性恋； 同性恋行为"
+        ],
+        "usphone": ",homəsɛkʃʊ'æləti",
+        "ukphone": "ˌhouməˌsekʃu'æləti"
+    },
+    {
+        "name": "hoof",
+        "trans": [
+            "蹄"
+        ],
+        "usphone": "huf",
+        "ukphone": "huːf"
+    },
+    {
+        "name": "hook",
+        "trans": [
+            "连接到无线电设备；勾住",
+            "钩， 吊钩； 钩状物"
+        ],
+        "usphone": "hʊk",
+        "ukphone": "huk"
+    },
+    {
+        "name": "hop",
+        "trans": [
+            "单足跳行；齐足跳行；跳上",
+            "蹦跳； 短程旅行"
+        ],
+        "usphone": "hɑp",
+        "ukphone": "hɑːp"
+    },
+    {
+        "name": "horde",
+        "trans": [
+            "一大群人； 游牧部落"
+        ],
+        "usphone": "hɔrd",
+        "ukphone": "hɔːrd"
+    },
+    {
+        "name": "horizon",
+        "trans": [
+            "地平线；"
+        ],
+        "usphone": "hə'raɪzn",
+        "ukphone": "hə'raɪzn"
+    },
+    {
+        "name": "horizontal",
+        "trans": [
+            "水平的； 与地面平行的"
+        ],
+        "usphone": "'hɔrə'zɑntl",
+        "ukphone": "ˌhɔːrə'zɑːntl"
+    },
+    {
+        "name": "hormone",
+        "trans": [
+            "激素， 荷尔蒙"
+        ],
+        "usphone": "'hɔrmon",
+        "ukphone": "'hɔːrmoun"
+    },
+    {
+        "name": "horn",
+        "trans": [
+            "角； 号角， 喇叭"
+        ],
+        "usphone": "hɔrn",
+        "ukphone": "hɔːrn"
+    },
+    {
+        "name": "hospitable",
+        "trans": [
+            "宜人的； 好客的， 殷勤的； 开通的"
+        ],
+        "usphone": "hɑ'spɪtəbl",
+        "ukphone": "hɑː'spɪtəbl"
+    },
+    {
+        "name": "hostile",
+        "trans": [
+            "不友好的， 敌意的； 敌方的"
+        ],
+        "usphone": "ˈhɑstl",
+        "ukphone": "'hɑːstl"
+    },
+    {
+        "name": "household",
+        "trans": [
+            "家庭的，家用的；家喻户晓的",
+            "家庭"
+        ],
+        "usphone": "'haʊshold",
+        "ukphone": "'haushould"
+    },
+    {
+        "name": "hover",
+        "trans": [
+            "徘徊， 彷徨； 翱翔， 盘旋"
+        ],
+        "usphone": "'hʌvɚ",
+        "ukphone": "'hʌvər"
+    },
+    {
+        "name": "huddle",
+        "trans": [
+            "聚集在一起， 挤作一团； 蜷缩， 缩成一团， 蜷缩",
+            "挤在一起的人"
+        ],
+        "usphone": "'hʌdl",
+        "ukphone": "'hʌdl"
+    },
+    {
+        "name": "hue",
+        "trans": [
+            "颜色； 色度， 色调； 信仰， 观点； 形式， 样子"
+        ],
+        "usphone": "",
+        "ukphone": "hjuː"
+    },
+    {
+        "name": "hull",
+        "trans": [
+            "外壳；船身，船体",
+            "给…去外壳"
+        ],
+        "usphone": "",
+        "ukphone": "hʌl"
+    },
+    {
+        "name": "humanitarian",
+        "trans": [
+            "人道主义的，慈善的",
+            "人道主义者， 博爱者， 慈善家"
+        ],
+        "usphone": "hju,mænɪ'tɛrɪən",
+        "ukphone": "hjuːˌmænɪ'teriən"
+    },
+    {
+        "name": "humanity",
+        "trans": [
+            "人类； 人性； 人道， 仁慈"
+        ],
+        "usphone": "hjʊ'mænəti",
+        "ukphone": "hjuː'mænəti"
+    },
+    {
+        "name": "humble",
+        "trans": [
+            "谦卑的；卑贱的；简陋的，低劣的",
+            "降低， 贬抑"
+        ],
+        "usphone": "'hʌmbl",
+        "ukphone": "'hʌmbl"
+    },
+    {
+        "name": "humid",
+        "trans": [
+            "湿的， 潮湿的； 湿润的"
+        ],
+        "usphone": "'hjumɪd",
+        "ukphone": "'hjuːmɪd"
+    },
+    {
+        "name": "humidity",
+        "trans": [
+            "湿度； 潮湿"
+        ],
+        "usphone": "hju'mɪdəti",
+        "ukphone": "hjuː'mɪdəti"
+    },
+    {
+        "name": "hummingbird",
+        "trans": [
+            "蜂鸟"
+        ],
+        "usphone": "'hʌmɪŋbɝd",
+        "ukphone": "'hʌmɪŋbɜːrd"
+    },
+    {
+        "name": "humorous",
+        "trans": [
+            "幽默的， 滑稽的， 诙谐的"
+        ],
+        "usphone": "'hjumərəs",
+        "ukphone": "'hjuːmərəs"
+    },
+    {
+        "name": "hurl",
+        "trans": [
+            "猛投； 大声斥责"
+        ],
+        "usphone": "hɝl",
+        "ukphone": "hɜːrl"
+    },
+    {
+        "name": "hurricane",
+        "trans": [
+            "飓风， 暴风"
+        ],
+        "usphone": "ˈhʌrɪken",
+        "ukphone": "'hɜːrəkən"
+    },
+    {
+        "name": "hurry",
+        "trans": [
+            "使加快，催促；赶快，匆忙",
+            "急忙， 匆忙， 仓促"
+        ],
+        "usphone": "'hɝrɪ",
+        "ukphone": "'hɜːri"
+    },
+    {
+        "name": "husbandry",
+        "trans": [
+            "耕种， 务农， 农牧业"
+        ],
+        "usphone": "'hʌzbəndri",
+        "ukphone": "'hʌzbəndri"
+    },
+    {
+        "name": "husk",
+        "trans": [
+            "外壳，外皮",
+            "去壳， 削皮"
+        ],
+        "usphone": "hʌsk",
+        "ukphone": "hʌsk"
+    },
+    {
+        "name": "hustle",
+        "trans": [
+            "推搡，硬挤",
+            "忙碌；喧闹"
+        ],
+        "usphone": "'hʌsl",
+        "ukphone": "'hʌsl"
+    },
+    {
+        "name": "hybrid",
+        "trans": [
+            "杂交产生的；混合的，合成的",
+            "杂交植物； 混合物， 合成物"
+        ],
+        "usphone": "'haɪbrɪd",
+        "ukphone": "'haɪbrɪd"
+    },
+    {
+        "name": "hydraulic",
+        "trans": [
+            "水力的， 液压的； 液压驱动的； 与水力系统有关的"
+        ],
+        "usphone": "haɪ'drɔlɪk",
+        "ukphone": "haɪ'drɔːlɪk"
+    },
+    {
+        "name": "hydrogen",
+        "trans": [
+            "氢"
+        ],
+        "usphone": "'haɪdrədʒən",
+        "ukphone": "'haɪdrədʒən"
+    },
+    {
+        "name": "hydrothermal",
+        "trans": [
+            "热液的"
+        ],
+        "usphone": ",haɪdrə'θɝml",
+        "ukphone": "ˌhaɪdrə'θɜːml"
+    },
+    {
+        "name": "hygiene",
+        "trans": [
+            "卫生； 卫生学"
+        ],
+        "usphone": "'haɪdʒin",
+        "ukphone": "'haɪdʒiːn"
+    },
+    {
+        "name": "hypertext",
+        "trans": [
+            "超文本"
+        ],
+        "usphone": "'haɪpɚ'tɛkst",
+        "ukphone": "'haɪpərtekst"
+    },
+    {
+        "name": "hypocritical",
+        "trans": [
+            "伪善的， 虚伪的"
+        ],
+        "usphone": ",hɪpə'krɪtɪkl",
+        "ukphone": "ˌhɪpə'krɪtɪkl"
+    },
+    {
+        "name": "hypothesis",
+        "trans": [
+            "假设， 假说； 前提"
+        ],
+        "usphone": "haɪ'pɑθəsɪs",
+        "ukphone": "haɪ'pɑːθəsɪs"
+    },
+    {
+        "name": "hypothesize",
+        "trans": [
+            "假定， 假设"
+        ],
+        "usphone": "haɪ'pɑθəsaɪz",
+        "ukphone": "haɪ'pɑːθəsaɪz"
+    },
+    {
+        "name": "hypothetical",
+        "trans": [
+            "假设的"
+        ],
+        "usphone": ",haɪpə'θɛtɪkl",
+        "ukphone": "ˌhaɪpə'θetɪkl"
+    },
+    {
+        "name": "iceberg",
+        "trans": [
+            "冰山； 冷冰冰的人"
+        ],
+        "usphone": "'aɪs'bɝg",
+        "ukphone": "'aɪsbɜːrg"
+    },
+    {
+        "name": "idealize",
+        "trans": [
+            "将…理想化"
+        ],
+        "usphone": "aɪ'diə'laɪz",
+        "ukphone": "aɪ'diːəlaɪz"
+    },
+    {
+        "name": "identical",
+        "trans": [
+            "相同的； 同一的"
+        ],
+        "usphone": "aɪ'dɛntɪkl",
+        "ukphone": "aɪ'dentɪkl"
+    },
+    {
+        "name": "identification",
+        "trans": [
+            "身份证明； 辨认， 鉴定"
+        ],
+        "usphone": "aɪˌdentɪfɪ'keʃn",
+        "ukphone": "aɪˌdentɪfɪ'keɪʃn"
+    },
+    {
+        "name": "identify",
+        "trans": [
+            "识别； 鉴定； 找到， 发现"
+        ],
+        "usphone": "aɪ'dɛntɪfaɪ",
+        "ukphone": "aɪ'dentɪfaɪ"
+    },
+    {
+        "name": "identity",
+        "trans": [
+            "身份； 特征， 特性； 同一性"
+        ],
+        "usphone": "aɪ'dɛntəti",
+        "ukphone": "aɪ'dentəti"
+    },
+    {
+        "name": "ideology",
+        "trans": [
+            "思想体系； 意识形态"
+        ],
+        "usphone": ",aidi'ɔlədʒi, ,idi-",
+        "ukphone": "ˌaɪdi'ɑːlədʒi"
+    },
+    {
+        "name": "ideomotor",
+        "trans": [
+            "观念运动的"
+        ],
+        "usphone": "ɪdɪə'motɚ",
+        "ukphone": "ˌaɪdiə'moutər"
+    },
+    {
+        "name": "idiom",
+        "trans": [
+            "习惯用语； 术语； 风格， 特色"
+        ],
+        "usphone": "'ɪdɪəm",
+        "ukphone": "'ɪdiəm"
+    },
+    {
+        "name": "idle",
+        "trans": [
+            "懒散的；没有工作的，闲散的；空闲的；漫无目的的；无用的，无效的",
+            "无所事事， 虚度"
+        ],
+        "usphone": "'aɪdl",
+        "ukphone": "'aɪdl"
+    },
+    {
+        "name": "idyllic",
+        "trans": [
+            "田园诗般的， 田园风光的， 牧歌的"
+        ],
+        "usphone": "aɪ'dɪlɪk",
+        "ukphone": "aɪ'dɪlɪk"
+    },
+    {
+        "name": "igneous",
+        "trans": [
+            "火的， 似火的； 火成的， 火成岩的"
+        ],
+        "usphone": "'ɪgnɪəs",
+        "ukphone": "'ɪgniəs"
+    },
+    {
+        "name": "ignite",
+        "trans": [
+            "点燃， 着火"
+        ],
+        "usphone": "ɪɡ'naɪt",
+        "ukphone": "ɪg'naɪt"
+    },
+    {
+        "name": "ignorant",
+        "trans": [
+            "无知的， 愚昧的； 无知觉的"
+        ],
+        "usphone": "'ɪɡnərənt",
+        "ukphone": "'ɪgnərənt"
+    },
+    {
+        "name": "ignore",
+        "trans": [
+            "忽视； 不顾， 不理"
+        ],
+        "usphone": "ɪɡ'nɔr",
+        "ukphone": "ɪg'nɔːr"
+    },
+    {
+        "name": "illegible",
+        "trans": [
+            "难以辨认的， 模糊的"
+        ],
+        "usphone": "ɪ'lɛdʒəbl",
+        "ukphone": "ɪ'ledʒəbl"
+    },
+    {
+        "name": "illuminate",
+        "trans": [
+            "照亮； 启发， 启迪； 阐明， 说明"
+        ],
+        "usphone": "ɪ'lumɪnet",
+        "ukphone": "ɪ'lʊːmɪneɪt"
+    },
+    {
+        "name": "illusion",
+        "trans": [
+            "幻觉， 错觉； 幻想中的事物"
+        ],
+        "usphone": "ɪ'luʒn",
+        "ukphone": "ɪ'luːʒn"
+    },
+    {
+        "name": "illusory",
+        "trans": [
+            "虚幻的， 幻觉的"
+        ],
+        "usphone": "ɪ'lusəri",
+        "ukphone": "ɪ'luːsəri"
+    },
+    {
+        "name": "illustrate",
+        "trans": [
+            "说明， 解释； 加插图于； 显示…存在"
+        ],
+        "usphone": "'ɪləstret",
+        "ukphone": "'ɪləstreɪt"
+    },
+    {
+        "name": "illustrative",
+        "trans": [
+            "作为例证的； 用做说明的； 解释性的"
+        ],
+        "usphone": "ɪ'lʌstrətɪv",
+        "ukphone": "ɪ'ləstrətɪv"
+    },
+    {
+        "name": "image",
+        "trans": [
+            "形象， 印象； 画像； 影像， 映像； 意象， 比喻"
+        ],
+        "usphone": "'ɪmɪdʒ",
+        "ukphone": "'ɪmɪdʒ"
+    },
+    {
+        "name": "imaginary",
+        "trans": [
+            "想象中的， 虚构的， 假想的"
+        ],
+        "usphone": "ɪ'mædʒɪnɛri",
+        "ukphone": "ɪ'mædʒɪneri"
+    },
+    {
+        "name": "imaginative",
+        "trans": [
+            "富有想象力的； 创新的"
+        ],
+        "usphone": "ɪ'mædʒɪnətɪv",
+        "ukphone": "ɪ'mædʒɪnətɪv"
+    },
+    {
+        "name": "imagist",
+        "trans": [
+            "意象派的",
+            "意象派诗人"
+        ],
+        "usphone": "'imidʒist",
+        "ukphone": "'ɪmɪdʒɪst"
+    },
+    {
+        "name": "imbibe",
+        "trans": [
+            "喝； 吸收， 接受"
+        ],
+        "usphone": "ɪm'baɪb",
+        "ukphone": "ɪm'baɪb"
+    },
+    {
+        "name": "imitate",
+        "trans": [
+            "模仿， 效仿； 仿制， 仿造"
+        ],
+        "usphone": "'ɪmɪtet",
+        "ukphone": "'ɪmɪteɪt"
+    },
+    {
+        "name": "imitation",
+        "trans": [
+            "模仿， 仿效； 仿制； 仿造品"
+        ],
+        "usphone": ",ɪmɪ'teʃən",
+        "ukphone": "ˌɪmɪ'teɪʃn"
+    },
+    {
+        "name": "immature",
+        "trans": [
+            "未成熟的， 未充分发展的"
+        ],
+        "usphone": ",ɪmə'tʃʊr",
+        "ukphone": "ˌɪmə'tʃur"
+    },
+    {
+        "name": "immediate",
+        "trans": [
+            "即刻的； 当前的； 最接近的； 紧接的， 紧靠的"
+        ],
+        "usphone": "ɪ'midɪət",
+        "ukphone": "ɪ'miːdiət"
+    },
+    {
+        "name": "immense",
+        "trans": [
+            "巨大的， 极大的"
+        ],
+        "usphone": "ɪ'mɛns",
+        "ukphone": "ɪ'mens"
+    },
+    {
+        "name": "immerse",
+        "trans": [
+            "使浸没于； 使沉浸于， 使陷入"
+        ],
+        "usphone": "ɪ'mɝs",
+        "ukphone": "ɪ'mɜːrs"
+    },
+    {
+        "name": "immigrant",
+        "trans": [
+            "移来的，移民的",
+            "移民； 侨民"
+        ],
+        "usphone": "'ɪmɪɡrənt",
+        "ukphone": "'ɪmɪgrənt"
+    },
+    {
+        "name": "immigrate",
+        "trans": [
+            "移居入境"
+        ],
+        "usphone": "'ɪmɪɡret",
+        "ukphone": "'ɪmɪgreɪt"
+    },
+    {
+        "name": "immune",
+        "trans": [
+            "免疫的， 有免疫力的； 不受影响的； 免除的， 豁免的"
+        ],
+        "usphone": "ɪ'mjʊn",
+        "ukphone": "ɪ'mjuːn"
+    },
+    {
+        "name": "immunity",
+        "trans": [
+            "免疫力； 保护； 免除， 豁免"
+        ],
+        "usphone": "ɪ'mjʊnəti",
+        "ukphone": "ɪ'mjuːnəti"
+    },
+    {
+        "name": "immutable",
+        "trans": [
+            "不可改变的， 永恒不变的"
+        ],
+        "usphone": "ɪ'mjutəbl",
+        "ukphone": "ɪ'mjuːtəbl"
+    },
+    {
+        "name": "impact",
+        "trans": [
+            "影响； 冲击， 撞击",
+            "影响； 冲击， 撞击"
+        ],
+        "usphone": "ɪm'pækt",
+        "ukphone": "'ɪmpækt"
+    },
+    {
+        "name": "impair",
+        "trans": [
+            "削弱； 损害"
+        ],
+        "usphone": "ɪm'pɛr",
+        "ukphone": "ɪm'per"
+    },
+    {
+        "name": "impart",
+        "trans": [
+            "传授； 传达； 给予"
+        ],
+        "usphone": "ɪm'pɑrt",
+        "ukphone": "ɪm'pɑːrt"
+    },
+    {
+        "name": "impede",
+        "trans": [
+            "妨碍， 阻碍， 阻止"
+        ],
+        "usphone": "ɪm'pid",
+        "ukphone": "ɪm'piːd"
+    },
+    {
+        "name": "impel",
+        "trans": [
+            "驱使， 促使"
+        ],
+        "usphone": "ɪm'pɛl",
+        "ukphone": "ɪm'pel"
+    },
+    {
+        "name": "impending",
+        "trans": [
+            "即将发生的， 迫近的"
+        ],
+        "usphone": "ɪm'pɛndɪŋ",
+        "ukphone": "ɪm'pendɪŋ"
+    },
+    {
+        "name": "impenetrable",
+        "trans": [
+            "不能穿透的； 不可理解的， 高深莫测的"
+        ],
+        "usphone": "ɪm'pɛnɪtrəbl",
+        "ukphone": "ɪm'penɪtrəbl"
+    },
+    {
+        "name": "imperative",
+        "trans": [
+            "迫切的，重要紧急的；必要的；命令的；"
+        ],
+        "usphone": "ɪm'pɛrətɪv",
+        "ukphone": "ɪm'perətɪv"
+    },
+    {
+        "name": "imperial",
+        "trans": [
+            "帝国的， 帝王的； 至尊的； 专横的"
+        ],
+        "usphone": "ɪm'pɪrɪəl",
+        "ukphone": "ɪm'pɪriəl"
+    },
+    {
+        "name": "impermeable",
+        "trans": [
+            "不可渗透的， 不透水的"
+        ],
+        "usphone": "ɪm'pɝmɪəbl",
+        "ukphone": "ɪm'pɜːrmiəbl"
+    },
+    {
+        "name": "impersonal",
+        "trans": [
+            "没有人情味的， 冷淡的； 客观的"
+        ],
+        "usphone": "ɪm'pɝsnl",
+        "ukphone": "ɪm'pɜːrsənl"
+    },
+    {
+        "name": "impetus",
+        "trans": [
+            "促进， 推动； 刺激； 推动力"
+        ],
+        "usphone": "'ɪmpɪtəs",
+        "ukphone": "'ɪmpɪtəs"
+    },
+    {
+        "name": "implement",
+        "trans": [
+            "使生效， 执行， 实施"
+        ],
+        "usphone": "'ɪmplɪmɛnt",
+        "ukphone": "'ɪmplɪm(ə)nt"
+    },
+    {
+        "name": "implication",
+        "trans": [
+            "含义； 暗示， 暗指； 卷入， 牵连"
+        ],
+        "usphone": "'ɪmplɪ'keʃən",
+        "ukphone": "ˌɪmplɪ'keɪʃn"
+    },
+    {
+        "name": "implicit",
+        "trans": [
+            "含蓄的； 绝对的； 内含的"
+        ],
+        "usphone": "ɪm'plɪsɪt",
+        "ukphone": "ɪm'plɪsɪt"
+    },
+    {
+        "name": "implore",
+        "trans": [
+            "哀求， 恳求"
+        ],
+        "usphone": "ɪm'plɔr",
+        "ukphone": "ɪm'plɔːr"
+    },
+    {
+        "name": "imply",
+        "trans": [
+            "意味着， 暗示； 说明， 表明； 使有必要"
+        ],
+        "usphone": "ɪm'plai",
+        "ukphone": "ɪm'plaɪ"
+    },
+    {
+        "name": "import",
+        "trans": [
+            "进口， 输入； 意义， 要旨， 重要性",
+            "进口， 输入"
+        ],
+        "usphone": "'ɪmpɔt",
+        "ukphone": "ɪm'pɔːt; 'ɪm-"
+    },
+    {
+        "name": "impose",
+        "trans": [
+            "把…强加于； 征； 处以"
+        ],
+        "usphone": "ɪm'poz",
+        "ukphone": "ɪm'pouz"
+    },
+    {
+        "name": "imprecise",
+        "trans": [
+            "不精确的； 不严密的"
+        ],
+        "usphone": "'ɪmprɪ'saɪs",
+        "ukphone": "ˌɪmprɪ'saɪs"
+    },
+    {
+        "name": "impressive",
+        "trans": [
+            "给人深刻印象的； 感人的"
+        ],
+        "usphone": "ɪm'prɛsɪv",
+        "ukphone": "ɪm'presɪv"
+    },
+    {
+        "name": "imprint",
+        "trans": [
+            "使铭记， 使牢记； 压印",
+            "印记， 印痕； 持久的影响"
+        ],
+        "usphone": "'ɪmprɪnt",
+        "ukphone": "ɪm'prɪnt"
+    },
+    {
+        "name": "improve",
+        "trans": [
+            "改善， 改进， 增进； 好转， 进步"
+        ],
+        "usphone": "ɪm'pruv",
+        "ukphone": "ɪm'pruːv"
+    },
+    {
+        "name": "improvise",
+        "trans": [
+            "即兴创作； 临时准备"
+        ],
+        "usphone": "'ɪmprəvaɪz",
+        "ukphone": "'ɪmprəvaɪz"
+    },
+    {
+        "name": "impulse",
+        "trans": [
+            "冲动， 一时的念头； 刺激， 推动力； 脉冲"
+        ],
+        "usphone": "'ɪmpʌls",
+        "ukphone": "'ɪmpʌls"
+    },
+    {
+        "name": "inaccessible",
+        "trans": [
+            "难达到的， 不可及的； 不能得到的"
+        ],
+        "usphone": ",ɪnæk'sɛsəbl",
+        "ukphone": "ˌɪnæk'sesəbl"
+    },
+    {
+        "name": "inactivate",
+        "trans": [
+            "使不活动， 使不活跃"
+        ],
+        "usphone": "ɪn'æktə,vet",
+        "ukphone": "ɪn'æktɪveɪt"
+    },
+    {
+        "name": "inactive",
+        "trans": [
+            "不活动的； 怠惰的"
+        ],
+        "usphone": "ɪn'æktɪv",
+        "ukphone": "ɪn'æktɪv"
+    },
+    {
+        "name": "inanimate",
+        "trans": [
+            "无生命的； 无生气的"
+        ],
+        "usphone": "ɪn'ænɪmət",
+        "ukphone": "ɪn'ænɪmət"
+    },
+    {
+        "name": "inanity",
+        "trans": [
+            "空虚， 空洞； 无意义的事物"
+        ],
+        "usphone": "i'nænəti",
+        "ukphone": "ɪ'nænəti"
+    },
+    {
+        "name": "inaugurate",
+        "trans": [
+            "为…举行就职典礼； 为…举行开幕式； 开始， 开创"
+        ],
+        "usphone": "ɪ'nɔɡjəret",
+        "ukphone": "ɪ'nɔːgjəreɪt"
+    },
+    {
+        "name": "incapacitate",
+        "trans": [
+            "使无资格； 使失去能力； 使不胜任"
+        ],
+        "usphone": ",ɪnkə'pæsɪtet",
+        "ukphone": "ˌɪnkə'pæsɪteɪt"
+    },
+    {
+        "name": "incense",
+        "trans": [
+            "〔燃烧时发出怡人香味的〕香",
+            "使〔某人〕十分愤怒"
+        ],
+        "usphone": "'ɪnsɛns",
+        "ukphone": "'ɪnsens"
+    },
+    {
+        "name": "incentive",
+        "trans": [
+            "刺激； 动机"
+        ],
+        "usphone": "ɪn'sɛntɪv",
+        "ukphone": "ɪn'sentɪv"
+    },
+    {
+        "name": "inception",
+        "trans": [
+            "开端， 开始"
+        ],
+        "usphone": "ɪn'sɛpʃən",
+        "ukphone": "ɪn'sepʃn"
+    },
+    {
+        "name": "incessant",
+        "trans": [
+            "不断的， 不停的"
+        ],
+        "usphone": "ɪn'sɛsnt",
+        "ukphone": "ɪn'sesnt"
+    },
+    {
+        "name": "incessantly",
+        "trans": [
+            "不断地"
+        ],
+        "usphone": "in'sesntli",
+        "ukphone": "ɪn'sesntlɪ"
+    },
+    {
+        "name": "incident",
+        "trans": [
+            "事情， 事件； 摩擦， 冲突"
+        ],
+        "usphone": "'ɪnsɪdənt",
+        "ukphone": "'ɪnsɪdənt"
+    },
+    {
+        "name": "incidental",
+        "trans": [
+            "偶然的； 附带发生的， 伴随而来的"
+        ],
+        "usphone": "'ɪnsə'dɛntl",
+        "ukphone": "ˌɪnsɪ'dentl"
+    },
+    {
+        "name": "incinerate",
+        "trans": [
+            "焚化， 焚毁"
+        ],
+        "usphone": "in'sinəreit",
+        "ukphone": "ɪn'sɪnəreɪt"
+    },
+    {
+        "name": "inclination",
+        "trans": [
+            "爱好， 意愿； 趋向， 趋势； 倾斜度"
+        ],
+        "usphone": "'ɪnklə'neʃən",
+        "ukphone": "ˌɪnklɪ'neɪʃn"
+    },
+    {
+        "name": "incline",
+        "trans": [
+            "倾斜； 倾向于",
+            "斜坡， 斜面"
+        ],
+        "usphone": "ɪn'klaɪn",
+        "ukphone": "ɪn'klaɪn"
+    },
+    {
+        "name": "incoming",
+        "trans": [
+            "引入的；新任的；正来临的，刚收到的",
+            "进来，到来；"
+        ],
+        "usphone": "'ɪnkʌmɪŋ",
+        "ukphone": "'ɪnkʌmɪŋ"
+    },
+    {
+        "name": "incompatible",
+        "trans": [
+            "不兼容的； 不协调的， 合不来的"
+        ],
+        "usphone": ",ɪnkəm'pætəbl",
+        "ukphone": "ˌɪnkəm'pætəbl"
+    },
+    {
+        "name": "incongruity",
+        "trans": [
+            "不一致， 不和谐"
+        ],
+        "usphone": ",ɪnkɑŋ'grʊəti",
+        "ukphone": "ˌɪnkɑːn'gruːəti"
+    },
+    {
+        "name": "inconspicuous",
+        "trans": [
+            "不引人瞩目的， 不显眼的"
+        ],
+        "usphone": "'ɪnkən'spɪkjʊəs",
+        "ukphone": "ˌɪnkən'spɪkjuəs"
+    },
+    {
+        "name": "inconvenient",
+        "trans": [
+            "不便的； 让人不舒服的"
+        ],
+        "usphone": ",ɪnkən'vinɪənt",
+        "ukphone": "ˌɪnkən'viːniənt"
+    },
+    {
+        "name": "incorporate",
+        "trans": [
+            "纳入， 合并； 包含； 吸收； 注册成立"
+        ],
+        "usphone": "",
+        "ukphone": "ɪn'kɔːrpəreɪt"
+    },
+    {
+        "name": "incredible",
+        "trans": [
+            "惊人的， 难以置信的"
+        ],
+        "usphone": "ɪn'krɛdəbl",
+        "ukphone": "ɪn'kredəbl"
+    },
+    {
+        "name": "incredulous",
+        "trans": [
+            "怀疑的， 不轻信的"
+        ],
+        "usphone": "ɪn'krɛdʒələs",
+        "ukphone": "ɪn'kredʒələs"
+    },
+    {
+        "name": "increment",
+        "trans": [
+            "增加； 增量； 定期的加薪"
+        ],
+        "usphone": "'ɪŋkrəmənt",
+        "ukphone": "'ɪŋkrəmənt"
+    },
+    {
+        "name": "incubate",
+        "trans": [
+            "孵化； 培育； 潜伏"
+        ],
+        "usphone": "'ɪŋkjubet",
+        "ukphone": "'ɪŋkjubeɪt"
+    },
+    {
+        "name": "incur",
+        "trans": [
+            "招致， 招惹， 遭受"
+        ],
+        "usphone": "ɪn'kɝ",
+        "ukphone": "ɪn'kɜːr"
+    },
+    {
+        "name": "incursion",
+        "trans": [
+            "袭击， 突然入侵； 介入"
+        ],
+        "usphone": "ɪn'kɝʒn",
+        "ukphone": "ɪn'kɜːrʒn"
+    },
+    {
+        "name": "indecipherable",
+        "trans": [
+            "无法破译的； 难以领悟的"
+        ],
+        "usphone": "'ɪndɪ'saɪfrəbl",
+        "ukphone": "ˌɪndɪ'saɪfrəbl"
+    },
+    {
+        "name": "independent",
+        "trans": [
+            "独立的， 自主的； 自立的； 不相干的， 不受影响的； 无偏见的， 中立的； 私立的； 有主见的； 无党派的"
+        ],
+        "usphone": "'ɪndɪ'pɛndənt",
+        "ukphone": "ˌɪndɪ'pendənt"
+    },
+    {
+        "name": "indicate",
+        "trans": [
+            "表明， 显示； 指出， 指示； 象征， 预示； 暗示， 间接提及"
+        ],
+        "usphone": "'ɪndɪket",
+        "ukphone": "'ɪndɪkeɪt"
+    },
+    {
+        "name": "indict",
+        "trans": [
+            "控诉， 起诉， 控告"
+        ],
+        "usphone": "ɪn'daɪt",
+        "ukphone": "ɪn'daɪt"
+    },
+    {
+        "name": "indifference",
+        "trans": [
+            "冷漠， 不关心"
+        ],
+        "usphone": "ɪn'dɪfrəns",
+        "ukphone": "ɪn'dɪfrəns"
+    },
+    {
+        "name": "indigenous",
+        "trans": [
+            "本地的， 本土的； 土产的； 土著的"
+        ],
+        "usphone": "ɪn'dɪdʒənəs",
+        "ukphone": "ɪn'dɪdʒənəs"
+    },
+    {
+        "name": "indigent",
+        "trans": [
+            "贫困的， 贫穷的"
+        ],
+        "usphone": "'ɪndɪdʒənt",
+        "ukphone": "'ɪndɪdʒənt"
+    },
+    {
+        "name": "indigestion",
+        "trans": [
+            "消化不良"
+        ],
+        "usphone": ",ɪndɪ'dʒɛstʃən",
+        "ukphone": "ˌɪndɪ'dʒestʃən"
+    },
+    {
+        "name": "indignant",
+        "trans": [
+            "愤慨的， 恼怒的"
+        ],
+        "usphone": "ɪn'dɪɡnənt",
+        "ukphone": "ɪn'dɪgnənt"
+    },
+    {
+        "name": "indispensable",
+        "trans": [
+            "必不可少的"
+        ],
+        "usphone": "'ɪndɪ'spɛnsəbl",
+        "ukphone": "ˌɪndɪ'spensəbl"
+    },
+    {
+        "name": "individual",
+        "trans": [
+            "单独的；独特的",
+            "个人， 个体"
+        ],
+        "usphone": "ˌɪndəˈvɪdʒʊəl",
+        "ukphone": "ˌɪndɪ'vɪdʒuəl"
+    },
+    {
+        "name": "indolent",
+        "trans": [
+            "懒惰的， 懒散的； 不活跃的"
+        ],
+        "usphone": "'ɪndələnt",
+        "ukphone": "'ɪndələnt"
+    },
+    {
+        "name": "induce",
+        "trans": [
+            "引起， 导致； 诱使， 劝诱； 感应"
+        ],
+        "usphone": "ɪn'dus",
+        "ukphone": "ɪn'djuːs"
+    },
+    {
+        "name": "induct",
+        "trans": [
+            "使正式就任； 使了解， 传授； 使入伍"
+        ],
+        "usphone": "ɪn'dʌkt",
+        "ukphone": "ɪn'dʌkt"
+    },
+    {
+        "name": "industry",
+        "trans": [
+            "勤劳， 勤奋； 工业， 行业"
+        ],
+        "usphone": "'ɪndəstri",
+        "ukphone": "'ɪndəstri"
+    },
+    {
+        "name": "inert",
+        "trans": [
+            "无活动的， 惰性的； 不活泼的， 迟钝的"
+        ],
+        "usphone": "ɪ'nɝt",
+        "ukphone": "ɪ'nɜːrt"
+    },
+    {
+        "name": "inertia",
+        "trans": [
+            "惯性； 惰性"
+        ],
+        "usphone": "ɪ'nɝʃə",
+        "ukphone": "ɪ'nɜːrʃə"
+    },
+    {
+        "name": "inevitably",
+        "trans": [
+            "不可避免地， 必然地"
+        ],
+        "usphone": "ɪn'ɛvɪtəbli",
+        "ukphone": "ɪn'evɪtəbli"
+    },
+    {
+        "name": "infancy",
+        "trans": [
+            "幼年； 初期"
+        ],
+        "usphone": "'ɪnfənsi",
+        "ukphone": "'ɪnfənsi"
+    },
+    {
+        "name": "infant",
+        "trans": [
+            "婴儿的； 初期的",
+            "婴儿，幼儿"
+        ],
+        "usphone": "'ɪnfənt",
+        "ukphone": "'ɪnfənt"
+    },
+    {
+        "name": "infatuate",
+        "trans": [
+            "使迷恋； 使糊涂"
+        ],
+        "usphone": "ɪn'fætjʊɪt",
+        "ukphone": "ɪn'fætʃueɪt"
+    },
+    {
+        "name": "infection",
+        "trans": [
+            "传染， 感染； 传染病"
+        ],
+        "usphone": "ɪn'fɛkʃən",
+        "ukphone": "ɪn'fekʃn"
+    },
+    {
+        "name": "infectious",
+        "trans": [
+            "传染性的， 传染病的； 有感染力的"
+        ],
+        "usphone": "ɪn'fɛkʃəs",
+        "ukphone": "ɪn'fekʃəs"
+    },
+    {
+        "name": "inferior",
+        "trans": [
+            "劣等的，较差的；次要的；级别低的",
+            "下级， 下属， 晚辈"
+        ],
+        "usphone": "ɪn'fɪrɪɚ",
+        "ukphone": "ɪn'fɪriər"
+    },
+    {
+        "name": "infest",
+        "trans": [
+            "大批滋生， 大批出没于"
+        ],
+        "usphone": "ɪn'fɛst",
+        "ukphone": "ɪn'fest"
+    },
+    {
+        "name": "infiltrate",
+        "trans": [
+            "渗入， 渗透； 悄悄进入， 潜入"
+        ],
+        "usphone": "ɪn'fɪltret",
+        "ukphone": "'ɪnfɪltreɪt"
+    },
+    {
+        "name": "infirm",
+        "trans": [
+            "虚弱的； 不坚定的"
+        ],
+        "usphone": "ɪn'fɝm",
+        "ukphone": "ɪn'fɜːrm"
+    },
+    {
+        "name": "inflammation",
+        "trans": [
+            "炎症， 发炎"
+        ],
+        "usphone": "'ɪnflə'meʃən",
+        "ukphone": "ˌɪnflə'meɪʃn"
+    },
+    {
+        "name": "inflate",
+        "trans": [
+            "充气， 膨胀； 鼓吹， 吹捧； 涨价"
+        ],
+        "usphone": "ɪn'flet",
+        "ukphone": "ɪn'fleɪt"
+    },
+    {
+        "name": "inflation",
+        "trans": [
+            "通货膨胀， 物价上涨； 膨胀"
+        ],
+        "usphone": "ɪn'fleʃən",
+        "ukphone": "ɪn'fleɪʃn"
+    },
+    {
+        "name": "influential",
+        "trans": [
+            "有影响力的； 有权势的"
+        ],
+        "usphone": ",ɪnflu'ɛnʃl",
+        "ukphone": "ˌɪnflu'enʃl"
+    },
+    {
+        "name": "influenza",
+        "trans": [
+            "流行性感冒"
+        ],
+        "usphone": ",ɪnflu'ɛnzə",
+        "ukphone": "ˌɪnflu'enzə"
+    },
+    {
+        "name": "influx",
+        "trans": [
+            "注入， 涌入"
+        ],
+        "usphone": "'ɪnflʌks",
+        "ukphone": "'ɪnflʌks"
+    },
+    {
+        "name": "inform",
+        "trans": [
+            "通知， 通告； 了解， 熟悉； 告发， 检举， 告密"
+        ],
+        "usphone": "ɪn'fɔrm",
+        "ukphone": "ɪn'fɔːrm"
+    },
+    {
+        "name": "informant",
+        "trans": [
+            "提供消息或情报的人， 线人； 提供资料的人； 合作者"
+        ],
+        "usphone": "ɪn'fɔrmənt",
+        "ukphone": "ɪn'fɔːrmənt"
+    },
+    {
+        "name": "informative",
+        "trans": [
+            "提供消息的， 给予知识的； 见闻广博的"
+        ],
+        "usphone": "ɪn'fɔrmətɪv",
+        "ukphone": "ɪn'fɔːrmətɪv"
+    },
+    {
+        "name": "informed",
+        "trans": [
+            "有学识的； 见多识广的， 有见识的"
+        ],
+        "usphone": "ɪn'fɔrmd",
+        "ukphone": "ɪn'fɔːrmd"
+    },
+    {
+        "name": "infrared",
+        "trans": [
+            "红外线的；产生红外线的",
+            "红外线"
+        ],
+        "usphone": ",ɪnfrə'rɛd",
+        "ukphone": "ˌɪnfrə'red"
+    },
+    {
+        "name": "infrastructure",
+        "trans": [
+            "基础设施， 基础结构"
+        ],
+        "usphone": "'ɪnfrə'strʌktʃɚ",
+        "ukphone": "'ɪnfrəˌstrʌktʃər"
+    },
+    {
+        "name": "infuriate",
+        "trans": [
+            "激怒"
+        ],
+        "usphone": "ɪn'fjʊrɪet",
+        "ukphone": "ɪn'fjurieɪt"
+    },
+    {
+        "name": "ingenious",
+        "trans": [
+            "巧妙的； 聪明的， 机敏的； 善于创造发明的； 设计独特的， 别致的"
+        ],
+        "usphone": "ɪn'dʒinɪəs",
+        "ukphone": "ɪn'dʒiːniəs"
+    },
+    {
+        "name": "ingredient",
+        "trans": [
+            "成分， 要素； 原料"
+        ],
+        "usphone": "ɪn'ɡridɪənt",
+        "ukphone": "ɪn'griːdiənt"
+    },
+    {
+        "name": "inhabit",
+        "trans": [
+            "居住于， 栖居于"
+        ],
+        "usphone": "ɪn'hæbɪt",
+        "ukphone": "ɪn'hæbɪt"
+    },
+    {
+        "name": "inherent",
+        "trans": [
+            "固有的； 内在的"
+        ],
+        "usphone": "ɪn'hɪrənt",
+        "ukphone": "ɪn'hɪrənt"
+    },
+    {
+        "name": "inherit",
+        "trans": [
+            "继承， 遗传而得"
+        ],
+        "usphone": "ɪn'hɛrɪt",
+        "ukphone": "ɪn'herɪt"
+    },
+    {
+        "name": "inheritance",
+        "trans": [
+            "遗产， 继承物； 继承； 遗传"
+        ],
+        "usphone": "ɪn'hɛrɪtəns",
+        "ukphone": "ɪn'herɪtəns"
+    },
+    {
+        "name": "inhibit",
+        "trans": [
+            "阻碍， 抑制"
+        ],
+        "usphone": "ɪn'hɪbɪt",
+        "ukphone": "ɪn'hɪbɪt"
+    },
+    {
+        "name": "initial",
+        "trans": [
+            "开始的，最初的",
+            "词首大写字母"
+        ],
+        "usphone": "ɪ'nɪʃəl",
+        "ukphone": "ɪ'nɪʃl"
+    },
+    {
+        "name": "initiate",
+        "trans": [
+            "发起， 开始， 创始； 接纳， 让…加入",
+            "新加入组织的人"
+        ],
+        "usphone": "ɪ'nɪʃɪet",
+        "ukphone": "ɪ'nɪʃɪeɪt"
+    },
+    {
+        "name": "inject",
+        "trans": [
+            "注射； 注入， 灌输； 投入"
+        ],
+        "usphone": "ɪn'dʒɛkt",
+        "ukphone": "ɪn'dʒekt"
+    },
+    {
+        "name": "injurious",
+        "trans": [
+            "侮辱的， 诽谤的； 造成伤害的， 有害的"
+        ],
+        "usphone": "ɪn'dʒʊrərɪəs",
+        "ukphone": "ɪn'dʒurəriəs"
+    },
+    {
+        "name": "innate",
+        "trans": [
+            "天生的， 固有的； 内在的， 直觉的"
+        ],
+        "usphone": "ɪ'net",
+        "ukphone": "ɪ'neɪt"
+    },
+    {
+        "name": "inner",
+        "trans": [
+            "内部的；内心的",
+            "内部； 内心"
+        ],
+        "usphone": "'ɪnɚ",
+        "ukphone": "'ɪnər"
+    },
+    {
+        "name": "innocent",
+        "trans": [
+            "天真的； 清白的； 无恶意的"
+        ],
+        "usphone": "'ɪnəsnt",
+        "ukphone": "'ɪnəsnt"
+    },
+    {
+        "name": "innovate",
+        "trans": [
+            "革新， 创新"
+        ],
+        "usphone": "'ɪnəvet",
+        "ukphone": "'ɪnəveɪt"
+    },
+    {
+        "name": "innovative",
+        "trans": [
+            "革新的， 创新的； 富有革新精神的"
+        ],
+        "usphone": "'ɪnəvetɪv",
+        "ukphone": "'ɪnəveɪtɪv"
+    },
+    {
+        "name": "inquire",
+        "trans": [
+            "打听， 询问"
+        ],
+        "usphone": "ɪn'kwaɪr",
+        "ukphone": "ɪn'kwaɪə"
+    },
+    {
+        "name": "insanity",
+        "trans": [
+            "精神错乱， 疯狂"
+        ],
+        "usphone": "ɪn'sænəti",
+        "ukphone": "ɪn'sænəti"
+    },
+    {
+        "name": "inscribe",
+        "trans": [
+            "写、 题、 铭刻； 铭记"
+        ],
+        "usphone": "ɪn'skraɪb",
+        "ukphone": "ɪn'skraɪb"
+    },
+    {
+        "name": "insect",
+        "trans": [
+            "昆虫， 虫"
+        ],
+        "usphone": "'ɪnsɛkt",
+        "ukphone": "'ɪnsekt"
+    },
+    {
+        "name": "insert",
+        "trans": [
+            "插入"
+        ],
+        "usphone": "'ɪnsɝt",
+        "ukphone": "ɪn'sɜːrt"
+    },
+    {
+        "name": "insight",
+        "trans": [
+            "洞察力； 领悟"
+        ],
+        "usphone": "'ɪn'saɪt",
+        "ukphone": "'ɪnsaɪt"
+    },
+    {
+        "name": "insist",
+        "trans": [
+            "坚持要求； 坚决主张"
+        ],
+        "usphone": "ɪn'sɪst",
+        "ukphone": "ɪn'sɪst"
+    },
+    {
+        "name": "insistence",
+        "trans": [
+            "坚持， 坚决主张"
+        ],
+        "usphone": "in'sistəns",
+        "ukphone": "ɪn'sɪstəns"
+    },
+    {
+        "name": "insolvent",
+        "trans": [
+            "财力不足的， 破产的"
+        ],
+        "usphone": "ɪn'sɑlvənt",
+        "ukphone": "ɪn'sɑːlvənt"
+    },
+    {
+        "name": "inspect",
+        "trans": [
+            "检查， 视察"
+        ],
+        "usphone": "ɪn'spɛkt",
+        "ukphone": "ɪn'spekt"
+    },
+    {
+        "name": "inspire",
+        "trans": [
+            "鼓舞， 激励； 给…以灵感"
+        ],
+        "usphone": "ɪn'spaɪɚ",
+        "ukphone": "ɪn'spaɪər"
+    },
+    {
+        "name": "install",
+        "trans": [
+            "安置， 安装"
+        ],
+        "usphone": "ɪn'stɔl",
+        "ukphone": "ɪn'stɔːl"
+    },
+    {
+        "name": "instance",
+        "trans": [
+            "例子， 事例"
+        ],
+        "usphone": "'ɪnstəns",
+        "ukphone": "'ɪnstəns"
+    },
+    {
+        "name": "instantaneous",
+        "trans": [
+            "瞬间的， 即刻的， 立即的"
+        ],
+        "usphone": ",ɪnstən'tenɪəs",
+        "ukphone": "ˌɪnstən'teɪniəs"
+    },
+    {
+        "name": "instead",
+        "trans": [
+            "代替， 顶替； 反而， 却"
+        ],
+        "usphone": "ɪn'stɛd",
+        "ukphone": "ɪn'sted"
+    },
+    {
+        "name": "instill",
+        "trans": [
+            "慢慢灌输； 逐渐培养"
+        ],
+        "usphone": "ɪn'stɪl",
+        "ukphone": "ɪn'stɪl"
+    },
+    {
+        "name": "instinct",
+        "trans": [
+            "本能， 直觉； 生性， 天性"
+        ],
+        "usphone": "'ɪnstɪŋkt",
+        "ukphone": "'ɪnstɪŋkt"
+    },
+    {
+        "name": "instinctual",
+        "trans": [
+            "本能的"
+        ],
+        "usphone": "ɪn'stɪŋktʃuəl",
+        "ukphone": "ɪn'stɪŋktʃuəl"
+    },
+    {
+        "name": "institute",
+        "trans": [
+            "设立；制定；开创",
+            "研究所， 学院"
+        ],
+        "usphone": "'ɪnstɪtut",
+        "ukphone": "'ɪnstɪtjuːt"
+    },
+    {
+        "name": "instruct",
+        "trans": [
+            "指示； 教授"
+        ],
+        "usphone": "ɪn'strʌkt",
+        "ukphone": "ɪn'strʌkt"
+    },
+    {
+        "name": "instruction",
+        "trans": [
+            "说明用法的",
+            "教导；"
+        ],
+        "usphone": "ɪn'strʌkʃən",
+        "ukphone": "ɪn'strʌkʃn"
+    },
+    {
+        "name": "instructor",
+        "trans": [
+            "导师， 讲师； 教练， 指导员"
+        ],
+        "usphone": "ɪn'strʌktɚ",
+        "ukphone": "ɪn'strʌktər"
+    },
+    {
+        "name": "instrument",
+        "trans": [
+            "仪器， 器械， 工具； 乐器"
+        ],
+        "usphone": "'ɪnstrəmənt",
+        "ukphone": "'ɪnstrəmənt"
+    },
+    {
+        "name": "insufficient",
+        "trans": [
+            "不足的， 不够的"
+        ],
+        "usphone": ",ɪnsə'fɪʃnt",
+        "ukphone": "ˌɪnsə'fɪʃnt"
+    },
+    {
+        "name": "insulate",
+        "trans": [
+            "使隔离， 使隔绝"
+        ],
+        "usphone": "ˈɪnsəˌleɪt ; ˈɪnsjʊˌleɪt",
+        "ukphone": "'ɪnsəleɪt"
+    },
+    {
+        "name": "insulin",
+        "trans": [
+            "胰岛素"
+        ],
+        "usphone": "'ɪnsəlɪn",
+        "ukphone": "'ɪnsəlɪn"
+    },
+    {
+        "name": "insult",
+        "trans": [
+            "侮辱， 凌辱",
+            "侮辱， 凌辱"
+        ],
+        "usphone": "ɪn'sʌlt",
+        "ukphone": "ɪn'sʌlt"
+    },
+    {
+        "name": "insurance",
+        "trans": [
+            "保险； 保险费； 保险业"
+        ],
+        "usphone": "ɪn'ʃʊrəns",
+        "ukphone": "ɪn'ʃurəns"
+    },
+    {
+        "name": "intact",
+        "trans": [
+            "无损伤的， 完整的"
+        ],
+        "usphone": "ɪn'tækt",
+        "ukphone": "ɪn'tækt"
+    },
+    {
+        "name": "integral",
+        "trans": [
+            "构成整体所必需的， 不可或缺的； 完整的"
+        ],
+        "usphone": "'ɪntɪɡrəl",
+        "ukphone": "'ɪntɪgrəl"
+    },
+    {
+        "name": "integrate",
+        "trans": [
+            "合并， 成为一体"
+        ],
+        "usphone": "'ɪntɪɡret",
+        "ukphone": "'ɪntɪgreɪt"
+    },
+    {
+        "name": "integrity",
+        "trans": [
+            "正直； 完整"
+        ],
+        "usphone": "ɪn'tɛɡrəti",
+        "ukphone": "ɪn'tegrəti"
+    },
+    {
+        "name": "intellect",
+        "trans": [
+            "智力， 理解力； 知识分子"
+        ],
+        "usphone": "'ɪntəlɛkt",
+        "ukphone": "'ɪntəlekt"
+    },
+    {
+        "name": "intelligence",
+        "trans": [
+            "智力， 智慧； 情报"
+        ],
+        "usphone": "ɪn'tɛlɪdʒəns",
+        "ukphone": "ɪn'telɪdʒəns"
+    },
+    {
+        "name": "intelligent",
+        "trans": [
+            "有才智的， 聪明的"
+        ],
+        "usphone": "ɪn'tɛlɪdʒənt",
+        "ukphone": "ɪn'telɪdʒənt"
+    },
+    {
+        "name": "intelligible",
+        "trans": [
+            "聪明的， 理智的； 易懂的， 易理解的"
+        ],
+        "usphone": "ɪn'tɛlɪdʒəbl",
+        "ukphone": "ɪn'telɪdʒəbl"
+    },
+    {
+        "name": "intense",
+        "trans": [
+            "强烈的； 热切的； 激烈的"
+        ],
+        "usphone": "ɪn'tɛns",
+        "ukphone": "ɪn'tens"
+    },
+    {
+        "name": "intent",
+        "trans": [
+            "专心的， 专注的； 急切的",
+            "意图，目的"
+        ],
+        "usphone": "ɪn'tɛnt",
+        "ukphone": "ɪn'tent"
+    },
+    {
+        "name": "intentionally",
+        "trans": [
+            "有意地， 故意地"
+        ],
+        "usphone": "in'tenʃənli",
+        "ukphone": "ɪn'tenʃənli"
+    },
+    {
+        "name": "interact",
+        "trans": [
+            "相互作用； 互相配合"
+        ],
+        "usphone": ",ɪntɚ'ækt",
+        "ukphone": "ˌɪntər'ækt"
+    },
+    {
+        "name": "interactive",
+        "trans": [
+            "交互式的； 合作的， 互相配合的"
+        ],
+        "usphone": ",ɪntɚ'æktɪv",
+        "ukphone": "ˌɪntər'æktɪv"
+    },
+    {
+        "name": "interest",
+        "trans": [
+            "兴趣，关注；业余爱好；利息；利害关系",
+            "使感兴趣， 引起…关注"
+        ],
+        "usphone": "'ɪntrəst",
+        "ukphone": "'ɪntrəst"
+    },
+    {
+        "name": "interface",
+        "trans": [
+            "界面， 分界面； 接口"
+        ],
+        "usphone": "'ɪntɚ'fes",
+        "ukphone": "'ɪntərfeɪs"
+    },
+    {
+        "name": "interfere",
+        "trans": [
+            "干涉， 干扰， 妨碍"
+        ],
+        "usphone": ",ɪntɚ'fɪr",
+        "ukphone": "ˌɪntər'fɪr"
+    },
+    {
+        "name": "interim",
+        "trans": [
+            "暂时的， 过渡的",
+            "间歇，过渡期间"
+        ],
+        "usphone": "'ɪntərɪm",
+        "ukphone": "'ɪntərɪm"
+    },
+    {
+        "name": "interior",
+        "trans": [
+            "内部的；内地的",
+            "内部； [the ～]内陆"
+        ],
+        "usphone": "ɪn'tɪrɪɚ",
+        "ukphone": "ɪn'tɪriər"
+    },
+    {
+        "name": "intermediate",
+        "trans": [
+            "中间的；中级的",
+            "中间体， 媒介"
+        ],
+        "usphone": ",ɪntɚ'midɪət",
+        "ukphone": "ˌɪntər'miːdiət"
+    },
+    {
+        "name": "intern",
+        "trans": [
+            "实习生",
+            "拘禁， 软禁"
+        ],
+        "usphone": "'ɪntɝn",
+        "ukphone": "'ɪntɜːn"
+    },
+    {
+        "name": "internal",
+        "trans": [
+            "内在的， 内部的； 国内的， 内政的； 内心的"
+        ],
+        "usphone": "ɪn'tɝnl",
+        "ukphone": "ɪn'tɜːrnl"
+    },
+    {
+        "name": "internship",
+        "trans": [
+            "实习期"
+        ],
+        "usphone": "'ɪntɝnʃɪp",
+        "ukphone": "'ɪntɜːrnʃɪp"
+    },
+    {
+        "name": "interplay",
+        "trans": [
+            "相互作用， 相互影响"
+        ],
+        "usphone": ",ɪntɚ'plɛi",
+        "ukphone": "'ɪntərpleɪ"
+    },
+    {
+        "name": "interpret",
+        "trans": [
+            "解释， 说明； 理解； 翻译"
+        ],
+        "usphone": "ɪn'tɝprɪt",
+        "ukphone": "ɪn'tɜːrprɪt"
+    },
+    {
+        "name": "interrelate",
+        "trans": [
+            "相互关联， 紧密联系"
+        ],
+        "usphone": "'ɪntɚrɪ'let",
+        "ukphone": "ˌɪntərɪ'leɪt"
+    },
+    {
+        "name": "interrogate",
+        "trans": [
+            "审问， 讯问， 盘问"
+        ],
+        "usphone": "ɪn'tɛrəɡet",
+        "ukphone": "ɪn'terəgeɪt"
+    },
+    {
+        "name": "interrupt",
+        "trans": [
+            "打扰； 中断； 阻碍"
+        ],
+        "usphone": "'ɪntə'rʌpt",
+        "ukphone": "ˌɪntə'rʌpt"
+    },
+    {
+        "name": "intersection",
+        "trans": [
+            "交点； 十字路口， 道路交叉口"
+        ],
+        "usphone": ",ɪntɚ'sɛkʃən",
+        "ukphone": "ˌɪntər'sekʃn"
+    },
+    {
+        "name": "interstellar",
+        "trans": [
+            "星际的"
+        ],
+        "usphone": ",ɪntɚ'stɛlɚ",
+        "ukphone": "ˌɪntər'stelər"
+    },
+    {
+        "name": "interval",
+        "trans": [
+            "间隔时间； 间距； 幕间休息"
+        ],
+        "usphone": "'ɪntɚvl",
+        "ukphone": "'ɪntərvl"
+    },
+    {
+        "name": "intervening",
+        "trans": [
+            "介于中间的， 发生于期间的"
+        ],
+        "usphone": ",ɪntɚ'vinɪŋ",
+        "ukphone": "ˌɪntər'viːnɪŋ"
+    },
+    {
+        "name": "interweave",
+        "trans": [
+            "交织， 编结"
+        ],
+        "usphone": ",ɪntɚ'wiv",
+        "ukphone": "ˌɪntər'wiːv"
+    },
+    {
+        "name": "intimate",
+        "trans": [
+            "亲密的，密切的；详尽的，精通的；个人隐私的",
+            "暗示， 透露",
+            "至交， 密友"
+        ],
+        "usphone": "ˈɪntəmɪt",
+        "ukphone": "'ɪntɪmət"
+    },
+    {
+        "name": "intoxication",
+        "trans": [
+            "醉， 醉酒； 极度兴奋"
+        ],
+        "usphone": "ɪn,tɑksə'keʃən",
+        "ukphone": "ɪnˌtɑːksɪ'keɪʃn"
+    },
+    {
+        "name": "intrepid",
+        "trans": [
+            "勇敢的， 无畏的"
+        ],
+        "usphone": "ɪn'trɛpɪd",
+        "ukphone": "ɪn'trepɪd"
+    },
+    {
+        "name": "intricate",
+        "trans": [
+            "错综复杂的"
+        ],
+        "usphone": "ˈɪntrəkət",
+        "ukphone": "'ɪntrɪkət"
+    },
+    {
+        "name": "intrigue",
+        "trans": [
+            "密谋； 迷住",
+            "阴谋， 诡计"
+        ],
+        "usphone": "'ɪn'triɡ",
+        "ukphone": "ɪn'triːg"
+    },
+    {
+        "name": "intriguing",
+        "trans": [
+            "引起兴趣的， 吸引人的"
+        ],
+        "usphone": "ɪn'triɡɪŋ",
+        "ukphone": "ɪn'triːgɪŋ"
+    },
+    {
+        "name": "intrinsic",
+        "trans": [
+            "固有的， 本质的， 内在的"
+        ],
+        "usphone": "ɪn'trɪnsɪk",
+        "ukphone": "ɪn'trɪnsɪk"
+    },
+    {
+        "name": "introduction",
+        "trans": [
+            "介绍； 传入， 引进； 导言， 绪论"
+        ],
+        "usphone": ",ɪntrə'dʌkʃən",
+        "ukphone": "ˌɪntrə'dʌkʃn"
+    },
+    {
+        "name": "intrude",
+        "trans": [
+            "侵入， 闯入； 打扰， 侵扰"
+        ],
+        "usphone": "ɪn'trʊd",
+        "ukphone": "ɪn'truːd"
+    },
+    {
+        "name": "intrusion",
+        "trans": [
+            "侵扰， 干扰； 侵犯； 侵入， 闯入"
+        ],
+        "usphone": "ɪn'truʒn",
+        "ukphone": "ɪn'truːʒn"
+    },
+    {
+        "name": "intuitive",
+        "trans": [
+            "直觉的"
+        ],
+        "usphone": "ɪn'tuɪtɪv",
+        "ukphone": "ɪn'tuːɪtɪv"
+    },
+    {
+        "name": "invade",
+        "trans": [
+            "侵入， 侵略； 侵扰"
+        ],
+        "usphone": "ɪn'ved",
+        "ukphone": "ɪn'veɪd"
+    },
+    {
+        "name": "invalid",
+        "trans": [
+            "无效的； 无可靠根据的， 站不住脚的",
+            "病弱者， 残疾者"
+        ],
+        "usphone": "ˈɪnvəlɪd；ɪnˈvælɪd",
+        "ukphone": "ˈɪnvəlɪd；ɪnˈvælɪd"
+    },
+    {
+        "name": "invasion",
+        "trans": [
+            "侵入， 侵略， 侵犯"
+        ],
+        "usphone": "ɪn'veʒn",
+        "ukphone": "ɪn'veɪʒn"
+    },
+    {
+        "name": "invasive",
+        "trans": [
+            "侵入的， 侵略的； 开刀的"
+        ],
+        "usphone": "ɪn'vesɪv",
+        "ukphone": "ɪn'veɪsɪv"
+    },
+    {
+        "name": "inventory",
+        "trans": [
+            "目录， 清单； 库存"
+        ],
+        "usphone": "'ɪnvəntɔri",
+        "ukphone": "'ɪnvəntɔːri"
+    },
+    {
+        "name": "inverse",
+        "trans": [
+            "相反的，反向的",
+            "反面； 倒数"
+        ],
+        "usphone": ",ɪn'vɝs",
+        "ukphone": "ˌɪn'vɜːrs"
+    },
+    {
+        "name": "invert",
+        "trans": [
+            "使倒转， 使倒置， 使颠倒"
+        ],
+        "usphone": "'ɪnvɝt",
+        "ukphone": "ɪn'vɜːrt"
+    },
+    {
+        "name": "invertebrate",
+        "trans": [
+            "无脊椎的",
+            "无脊椎动物"
+        ],
+        "usphone": "ɪn'vɝtɪbret",
+        "ukphone": "ɪn'vɜːrtɪbrət"
+    },
+    {
+        "name": "investigate",
+        "trans": [
+            "研究， 调查"
+        ],
+        "usphone": "ɪn'vɛstɪɡet",
+        "ukphone": "ɪn'vestɪgeɪt"
+    },
+    {
+        "name": "invitation",
+        "trans": [
+            "邀请； 请柬； 吸引， 诱惑"
+        ],
+        "usphone": "ˌɪnvɪˈteɪʃn",
+        "ukphone": "ˌɪnvɪ'teɪʃn"
+    },
+    {
+        "name": "inviting",
+        "trans": [
+            "动人的， 诱人的； 引人注目的"
+        ],
+        "usphone": "ɪn'vaɪtɪŋ",
+        "ukphone": "ɪn'vaɪtɪŋ"
+    },
+    {
+        "name": "involve",
+        "trans": [
+            "包含； 牵涉， 牵连； 使参加"
+        ],
+        "usphone": "ɪn'vɑlv",
+        "ukphone": "ɪn'vɑːlv"
+    },
+    {
+        "name": "ironic",
+        "trans": [
+            "说反话的， 讽刺的； 出乎意料的"
+        ],
+        "usphone": "aɪ'rɑnɪk",
+        "ukphone": "aɪ'rɑːnɪk"
+    },
+    {
+        "name": "irony",
+        "trans": [
+            "反话， 讽刺， 嘲弄； 具有讽刺意味的事"
+        ],
+        "usphone": "'aɪrəni",
+        "ukphone": "'aɪrəni"
+    },
+    {
+        "name": "irregular",
+        "trans": [
+            "不规则的， 无规律的； 不整齐的； 不合常规的"
+        ],
+        "usphone": "ɪ'rɛɡjəlɚ",
+        "ukphone": "ɪ'regjələr"
+    },
+    {
+        "name": "irresistible",
+        "trans": [
+            "无法抗拒的， 诱人的； 不能自已的"
+        ],
+        "usphone": ",ɪrɪ'zɪstəbl",
+        "ukphone": "ˌɪrɪ'zɪstəbl"
+    },
+    {
+        "name": "irreverent",
+        "trans": [
+            "不敬的"
+        ],
+        "usphone": "ɪ'rɛvərənt",
+        "ukphone": "ɪ'revərənt"
+    },
+    {
+        "name": "irrigate",
+        "trans": [
+            "灌溉； 冲洗"
+        ],
+        "usphone": "'ɪrəget",
+        "ukphone": "'ɪrɪgeɪt"
+    },
+    {
+        "name": "irritable",
+        "trans": [
+            "急躁的， 易怒的； 易受刺激的； 过敏的"
+        ],
+        "usphone": "'ɪrɪtəbl",
+        "ukphone": "'ɪrɪtəbl"
+    },
+    {
+        "name": "irritate",
+        "trans": [
+            "激怒， 使烦躁； 刺激"
+        ],
+        "usphone": "'ɪrɪtet",
+        "ukphone": "'ɪrɪteɪt"
+    },
+    {
+        "name": "isolate",
+        "trans": [
+            "使隔离， 使孤立"
+        ],
+        "usphone": "aɪslˌet",
+        "ukphone": "'aɪsəleɪt"
+    },
+    {
+        "name": "issue",
+        "trans": [
+            "问题，争论点；发行；"
+        ],
+        "usphone": "'ɪʃu",
+        "ukphone": "'ɪʃuː"
+    },
+    {
+        "name": "item",
+        "trans": [
+            "项目， 条款； 一件商品； 一条， 一则"
+        ],
+        "usphone": "'aɪtəm",
+        "ukphone": "'aɪtəm"
+    },
+    {
+        "name": "ivory",
+        "trans": [
+            "象牙； 象牙制品； 象牙色， 乳白色"
+        ],
+        "usphone": "'aɪvəri",
+        "ukphone": "'aɪvəri"
+    },
+    {
+        "name": "jar",
+        "trans": [
+            "震动；冲突，抵触；感到不快",
+            "坛子； 广口瓶"
+        ],
+        "usphone": "dʒɑr",
+        "ukphone": "dʒɑːr"
+    },
+    {
+        "name": "jaw",
+        "trans": [
+            "颌，颚；"
+        ],
+        "usphone": "dʒɔ",
+        "ukphone": "dʒɔː"
+    },
+    {
+        "name": "jeans",
+        "trans": [
+            "牛仔裤"
+        ],
+        "usphone": "",
+        "ukphone": "dʒɪːnz"
+    },
+    {
+        "name": "jelly",
+        "trans": [
+            "果冻， 胶状物"
+        ],
+        "usphone": "'dʒɛli",
+        "ukphone": "'dʒeli"
+    },
+    {
+        "name": "jeopardize",
+        "trans": [
+            "破坏， 危及"
+        ],
+        "usphone": "'dʒɛpɚdaɪz",
+        "ukphone": "'dʒepərdaɪz"
+    },
+    {
+        "name": "jewelry",
+        "trans": [
+            "〈总称〉首饰； 珠宝"
+        ],
+        "usphone": "'dʒʊəlri",
+        "ukphone": "'dʒuːəlri"
+    },
+    {
+        "name": "jog",
+        "trans": [
+            "慢跑； 轻轻触碰"
+        ],
+        "usphone": "dʒɑɡ",
+        "ukphone": "dʒɑːg"
+    },
+    {
+        "name": "joint",
+        "trans": [
+            "连接的； 共同的， 共有的， 联合的",
+            "关节，骨节；接头，接合处"
+        ],
+        "usphone": "dʒɔɪnt",
+        "ukphone": "dʒɔɪnt"
+    },
+    {
+        "name": "jolt",
+        "trans": [
+            "震动，颠簸；震惊",
+            "震动， 颠簸； 震惊； 一阵强烈的感情等"
+        ],
+        "usphone": "dʒolt",
+        "ukphone": "dʒoult"
+    },
+    {
+        "name": "jot",
+        "trans": [
+            "草草记下， 匆匆记下"
+        ],
+        "usphone": "dʒɑt",
+        "ukphone": "dʒɑːt"
+    },
+    {
+        "name": "journal",
+        "trans": [
+            "期刊， 杂志； 日记， 日志"
+        ],
+        "usphone": "'dʒɝnl",
+        "ukphone": "'dʒɜːrnl"
+    },
+    {
+        "name": "journalism",
+        "trans": [
+            "新闻业， 新闻工作"
+        ],
+        "usphone": "'dʒɝnl'ɪzəm",
+        "ukphone": "'dʒɜːrnəlɪzəm"
+    },
+    {
+        "name": "juice",
+        "trans": [
+            "榨出汁液",
+            "汁， 液"
+        ],
+        "usphone": "dʒus",
+        "ukphone": "dʒuːs"
+    },
+    {
+        "name": "jumble",
+        "trans": [
+            "混杂，掺杂",
+            "杂乱的一堆， 混乱的一团"
+        ],
+        "usphone": "'dʒʌmbl",
+        "ukphone": "'dʒʌmbl"
+    },
+    {
+        "name": "junction",
+        "trans": [
+            "交叉点， 汇合处； 连接， 接合"
+        ],
+        "usphone": "'dʒʌŋkʃən",
+        "ukphone": "'dʒʌŋkʃn"
+    },
+    {
+        "name": "Jupiter",
+        "trans": [
+            "木星"
+        ],
+        "usphone": "'dʒʊpətɚ",
+        "ukphone": "'dʒuːpɪtər"
+    },
+    {
+        "name": "juridical",
+        "trans": [
+            "法律的， 司法的"
+        ],
+        "usphone": "dʒʊ'rɪdɪkl",
+        "ukphone": "dʒu'rɪdɪkl"
+    },
+    {
+        "name": "justice",
+        "trans": [
+            "法官； 司法； 正义， 公正"
+        ],
+        "usphone": "'dʒʌstɪs",
+        "ukphone": "'dʒʌstɪs"
+    },
+    {
+        "name": "justify",
+        "trans": [
+            "证明…是正当的； 为…辩护"
+        ],
+        "usphone": "'dʒʌstə'fai",
+        "ukphone": "'dʒʌstɪfaɪ"
+    },
+    {
+        "name": "juvenile",
+        "trans": [
+            "幼稚的， 不成熟的； 少年的， 未成年的",
+            "幼体；未成年人，少年"
+        ],
+        "usphone": "'dʒʊvənaɪl",
+        "ukphone": "'dʒuːvənl"
+    },
+    {
+        "name": "keen",
+        "trans": [
+            "灵敏的， 敏锐的； 热心的， 渴望的； 激烈的； 锋利的"
+        ],
+        "usphone": "kin",
+        "ukphone": "kiːn"
+    },
+    {
+        "name": "kennel",
+        "trans": [
+            "狗窝； 养狗场"
+        ],
+        "usphone": "'kɛnl",
+        "ukphone": "'kenl"
+    },
+    {
+        "name": "kernel",
+        "trans": [
+            "仁； 粒； 核心， 要点"
+        ],
+        "usphone": "'kɝnl",
+        "ukphone": "'kɜːrnl"
+    },
+    {
+        "name": "kerosene",
+        "trans": [
+            "煤油， 火油"
+        ],
+        "usphone": "'kɛrəsin",
+        "ukphone": "'kerəsiːn"
+    },
+    {
+        "name": "kiln",
+        "trans": [
+            "窑， 炉"
+        ],
+        "usphone": "kɪln",
+        "ukphone": "kɪln"
+    },
+    {
+        "name": "kindle",
+        "trans": [
+            "点燃， 开始燃烧； 激起"
+        ],
+        "usphone": "'kɪndl",
+        "ukphone": "'kɪndl"
+    },
+    {
+        "name": "kinetic",
+        "trans": [
+            "运动的， 运动引起的； 动力学的"
+        ],
+        "usphone": "kɪ'nɛtɪk",
+        "ukphone": "kɪ'netɪk"
+    },
+    {
+        "name": "kingdom",
+        "trans": [
+            "王国； 领域， 界"
+        ],
+        "usphone": "'kɪŋdəm",
+        "ukphone": "'kɪŋdəm"
+    },
+    {
+        "name": "kinship",
+        "trans": [
+            "血缘关系， 亲属关系"
+        ],
+        "usphone": "'kɪnʃɪp",
+        "ukphone": "'kɪnʃɪp"
+    },
+    {
+        "name": "knack",
+        "trans": [
+            "诀窍； 技能， 本领； 习惯， 癖好"
+        ],
+        "usphone": "næk",
+        "ukphone": "næk"
+    },
+    {
+        "name": "knit",
+        "trans": [
+            "编结， 编织； 紧密结合， 使紧凑； 愈合； 皱紧， 皱"
+        ],
+        "usphone": "nɪt",
+        "ukphone": "nɪt"
+    },
+    {
+        "name": "label",
+        "trans": [
+            "标记",
+            "标签； 称号"
+        ],
+        "usphone": "ˈlebəl",
+        "ukphone": "'leɪbl"
+    },
+    {
+        "name": "laboratory",
+        "trans": [
+            "实验室， 研究室"
+        ],
+        "usphone": "ˈlæbrəˌtɔrɪ",
+        "ukphone": "'læbrətɔːri"
+    },
+    {
+        "name": "laborious",
+        "trans": [
+            "艰苦的， 费力的， 艰难的； 勤劳的"
+        ],
+        "usphone": "lə'bɔrɪəs",
+        "ukphone": "lə'bɔːriəs"
+    },
+    {
+        "name": "labyrinth",
+        "trans": [
+            "迷宫； 错综复杂的事件"
+        ],
+        "usphone": "'læbərɪnθ",
+        "ukphone": "'læbərɪnθ"
+    },
+    {
+        "name": "lace",
+        "trans": [
+            "用带子束紧",
+            "蕾丝；缎带；鞋带，系带"
+        ],
+        "usphone": "les",
+        "ukphone": "leɪs"
+    },
+    {
+        "name": "lack",
+        "trans": [
+            "缺乏， 不足"
+        ],
+        "usphone": "læk",
+        "ukphone": "læk"
+    },
+    {
+        "name": "lament",
+        "trans": [
+            "挽歌，悼词",
+            "抱怨； 痛惜"
+        ],
+        "usphone": "lə'mɛnt",
+        "ukphone": "lə'ment"
+    },
+    {
+        "name": "landing",
+        "trans": [
+            "登陆； 着陆， 降落"
+        ],
+        "usphone": "'lændɪŋ",
+        "ukphone": "'lændɪŋ"
+    },
+    {
+        "name": "landmark",
+        "trans": [
+            "路标， 地标； 〈喻〉里程碑"
+        ],
+        "usphone": "'lændmɑrk",
+        "ukphone": "'lændmɑːrk"
+    },
+    {
+        "name": "landmass",
+        "trans": [
+            "大片陆地"
+        ],
+        "usphone": "'lændmæs",
+        "ukphone": "'lændmæs"
+    },
+    {
+        "name": "landscape",
+        "trans": [
+            "风景，景色；地貌，地形；风景画",
+            "美化…的环境"
+        ],
+        "usphone": "ˈlændskep",
+        "ukphone": "'lændskeɪp"
+    },
+    {
+        "name": "landslide",
+        "trans": [
+            "山崩， 塌方； 压倒性胜利"
+        ],
+        "usphone": "'lændslaɪd",
+        "ukphone": "'lændslaɪd"
+    },
+    {
+        "name": "languish",
+        "trans": [
+            "憔悴； 凋谢， 枯萎； 受煎熬"
+        ],
+        "usphone": "'læŋɡwɪʃ",
+        "ukphone": "'læŋgwɪʃ"
+    },
+    {
+        "name": "lapse",
+        "trans": [
+            "期满终止， 失效； 衰退； 背弃",
+            "失误；失足"
+        ],
+        "usphone": "læps",
+        "ukphone": "læps"
+    },
+    {
+        "name": "larva",
+        "trans": [
+            "〔昆虫的〕幼虫，幼体"
+        ],
+        "usphone": "'lɑrvə",
+        "ukphone": "'lɑːrvə"
+    },
+    {
+        "name": "larynx",
+        "trans": [
+            "喉"
+        ],
+        "usphone": "'lærɪŋks",
+        "ukphone": "'lærɪŋks"
+    },
+    {
+        "name": "laser",
+        "trans": [
+            "激光； 激光器"
+        ],
+        "usphone": "'lezɚ",
+        "ukphone": "'leɪzər"
+    },
+    {
+        "name": "lash",
+        "trans": [
+            "将系牢，捆绑；猛烈打击；鞭打；猛烈抨击，严厉斥责",
+            "鞭打； 睫毛"
+        ],
+        "usphone": "læʃ",
+        "ukphone": "læʃ"
+    },
+    {
+        "name": "lasting",
+        "trans": [
+            "持久的， 永久的"
+        ],
+        "usphone": "'læstɪŋ",
+        "ukphone": "'læstɪŋ"
+    },
+    {
+        "name": "latent",
+        "trans": [
+            "潜在的， 隐伏的； 潜伏的； 休眠的"
+        ],
+        "usphone": "'letnt",
+        "ukphone": "'leɪtnt"
+    },
+    {
+        "name": "lateral",
+        "trans": [
+            "侧面的， 旁边的； 横向的"
+        ],
+        "usphone": "'lætərəl",
+        "ukphone": "'lætərəl"
+    },
+    {
+        "name": "Latin",
+        "trans": [
+            "拉丁的；拉丁语的",
+            "拉丁语"
+        ],
+        "usphone": "'lætn",
+        "ukphone": "'lætn"
+    },
+    {
+        "name": "latitude",
+        "trans": [
+            "纬度；"
+        ],
+        "usphone": "'lætɪtud",
+        "ukphone": "'lætɪtjuːd"
+    },
+    {
+        "name": "latter",
+        "trans": [
+            "后面的，后半期的；后者的",
+            "后者"
+        ],
+        "usphone": "'lætɚ",
+        "ukphone": "'lætər"
+    },
+    {
+        "name": "laudable",
+        "trans": [
+            "值得赞美的， 值得称赞的"
+        ],
+        "usphone": "'lɔdəbl",
+        "ukphone": "'lɔːdəbl"
+    },
+    {
+        "name": "launch",
+        "trans": [
+            "发动，发起；推出；使下水；"
+        ],
+        "usphone": "lɔntʃ",
+        "ukphone": "lɔːntʃ"
+    },
+    {
+        "name": "laundry",
+        "trans": [
+            "洗衣店， 洗衣房； 洗好的衣服； 待洗的衣服"
+        ],
+        "usphone": "'lɔndri",
+        "ukphone": "'lɔːndri"
+    },
+    {
+        "name": "laureate",
+        "trans": [
+            "享有殊荣的",
+            "桂冠诗人；荣誉获得者"
+        ],
+        "usphone": "'lɔrɪət",
+        "ukphone": "'lɔːriət"
+    },
+    {
+        "name": "lava",
+        "trans": [
+            "岩浆， 熔岩"
+        ],
+        "usphone": "'lɑvə",
+        "ukphone": "'lɑːvə"
+    },
+    {
+        "name": "lavish",
+        "trans": [
+            "大方的， 慷慨的； 大量的； 浪费的",
+            "慷慨给予，滥用；浪费，挥霍"
+        ],
+        "usphone": "'lævɪʃ",
+        "ukphone": "'lævɪʃ"
+    },
+    {
+        "name": "lawn",
+        "trans": [
+            "草地， 草坪； 操场"
+        ],
+        "usphone": "lɔn",
+        "ukphone": "lɔːn"
+    },
+    {
+        "name": "lawsuit",
+        "trans": [
+            "诉讼"
+        ],
+        "usphone": "'lɔsut",
+        "ukphone": "'lɔːsuːt"
+    },
+    {
+        "name": "lax",
+        "trans": [
+            "懒散的； 不严格的， 马虎的"
+        ],
+        "usphone": "læks",
+        "ukphone": "læks"
+    },
+    {
+        "name": "lay",
+        "trans": [
+            "产； 放置； 铺； 筹划， 设置； 提出， 提交"
+        ],
+        "usphone": "le",
+        "ukphone": "leɪ"
+    },
+    {
+        "name": "layer",
+        "trans": [
+            "层， 层次"
+        ],
+        "usphone": "'leɪr",
+        "ukphone": "'ler"
+    },
+    {
+        "name": "layout",
+        "trans": [
+            "编排， 版面设计； 规划， 布局"
+        ],
+        "usphone": "'leaʊt",
+        "ukphone": "'leɪaut"
+    },
+    {
+        "name": "leach",
+        "trans": [
+            "过滤；溶解",
+            "过滤器； 过滤剂"
+        ],
+        "usphone": "litʃ",
+        "ukphone": "liːtʃ"
+    },
+    {
+        "name": "lead",
+        "trans": [
+            "领导，引导；领先，占首位；通向，导致，"
+        ],
+        "usphone": "lid; lɛd",
+        "ukphone": "liːd"
+    },
+    {
+        "name": "league",
+        "trans": [
+            "联盟， 同盟； 等级， 级别"
+        ],
+        "usphone": "lig",
+        "ukphone": "liːg"
+    },
+    {
+        "name": "leak",
+        "trans": [
+            "漏，渗出，泄漏",
+            "漏洞， 裂缝； 泄露； 走漏"
+        ],
+        "usphone": "lik",
+        "ukphone": "liːk"
+    },
+    {
+        "name": "leap",
+        "trans": [
+            "跳跃； 急速行动； 骤变； 激增",
+            "跳跃；骤变；激增"
+        ],
+        "usphone": "lip",
+        "ukphone": "liːp"
+    },
+    {
+        "name": "lease",
+        "trans": [
+            "租约；租期",
+            "出租"
+        ],
+        "usphone": "lis",
+        "ukphone": "liːs"
+    },
+    {
+        "name": "least",
+        "trans": [
+            "最小； 最少； 微不足道",
+            "最小的；最少的；最不重要的"
+        ],
+        "usphone": "list",
+        "ukphone": "liːst"
+    },
+    {
+        "name": "ledge",
+        "trans": [
+            "突出部分； 暗礁"
+        ],
+        "usphone": "lɛdʒ",
+        "ukphone": "ledʒ"
+    },
+    {
+        "name": "leftover",
+        "trans": [
+            "剩余的"
+        ],
+        "usphone": "'lɛftovɚ",
+        "ukphone": "'leftouvər"
+    },
+    {
+        "name": "legend",
+        "trans": [
+            "传奇故事， 传说； 传奇文学"
+        ],
+        "usphone": "'lɛdʒənd",
+        "ukphone": "'ledʒənd"
+    },
+    {
+        "name": "legible",
+        "trans": [
+            "清楚的； 易读的"
+        ],
+        "usphone": "'lɛdʒəbl",
+        "ukphone": "'ledʒəbl"
+    },
+    {
+        "name": "legislate",
+        "trans": [
+            "制定法律； 通过立法"
+        ],
+        "usphone": "'lɛdʒɪslet",
+        "ukphone": "'ledʒɪsleɪt"
+    },
+    {
+        "name": "legislative",
+        "trans": [
+            "立法的， 有立法权的； 根据法规执行的",
+            "立法机关"
+        ],
+        "usphone": "'lɛdʒɪsletɪv",
+        "ukphone": "'ledʒɪsleɪtɪv"
+    },
+    {
+        "name": "legislature",
+        "trans": [
+            "立法机关， 立法团体"
+        ],
+        "usphone": "'lɛdʒɪsletʃɚ",
+        "ukphone": "'ledʒɪsleɪtʃər"
+    },
+    {
+        "name": "legitimate",
+        "trans": [
+            "合法的， 法定的； 正当合理的， 合情合理的"
+        ],
+        "usphone": "ləˈdʒɪtəmɪt",
+        "ukphone": "lɪ'dʒɪtɪmət"
+    },
+    {
+        "name": "leisure",
+        "trans": [
+            "空闲， 闲暇"
+        ],
+        "usphone": "'liʒɚ",
+        "ukphone": "'liːʒər"
+    },
+    {
+        "name": "lengthen",
+        "trans": [
+            "延长， 变长"
+        ],
+        "usphone": "'lɛŋθən",
+        "ukphone": "'leŋθən"
+    },
+    {
+        "name": "lens",
+        "trans": [
+            "透镜； 镜头； 镜片"
+        ],
+        "usphone": "lɛnz",
+        "ukphone": "lenz"
+    },
+    {
+        "name": "lessen",
+        "trans": [
+            "变小， 变少， 减轻"
+        ],
+        "usphone": "'lɛsn",
+        "ukphone": "'lesn"
+    },
+    {
+        "name": "lethal",
+        "trans": [
+            "致命的； 破坏性极大的， 极其有害的"
+        ],
+        "usphone": "'liθl",
+        "ukphone": "'liːθl"
+    },
+    {
+        "name": "lethargy",
+        "trans": [
+            "死气沉沉； 无精打采， 倦怠"
+        ],
+        "usphone": "'lɛθɚdʒi",
+        "ukphone": "'leθərdʒi"
+    },
+    {
+        "name": "lettuce",
+        "trans": [
+            "生菜； 莴苣"
+        ],
+        "usphone": "'lɛtɪs",
+        "ukphone": "'letɪs"
+    },
+    {
+        "name": "level",
+        "trans": [
+            "平坦的；等高的",
+            "水平；高度；级别",
+            "夷平， 使平坦"
+        ],
+        "usphone": "'lɛvl",
+        "ukphone": "'levl"
+    },
+    {
+        "name": "levy",
+        "trans": [
+            "征收",
+            "征收额； 税款； 征兵"
+        ],
+        "usphone": "'lɛvi",
+        "ukphone": "'levi"
+    },
+    {
+        "name": "liable",
+        "trans": [
+            "有责任的， 有义务的； 易于…的"
+        ],
+        "usphone": "'laɪəbl",
+        "ukphone": "'laɪəbl"
+    },
+    {
+        "name": "libel",
+        "trans": [
+            "诽谤",
+            "诽谤； 诽谤性文字"
+        ],
+        "usphone": "'laɪbl",
+        "ukphone": "'laɪbl"
+    },
+    {
+        "name": "liberal",
+        "trans": [
+            "自由的， 开明的； 慷慨的； 不严格的； 人文的"
+        ],
+        "usphone": "'lɪbərəl",
+        "ukphone": "'lɪbərəl"
+    },
+    {
+        "name": "liberate",
+        "trans": [
+            "解放； 释放"
+        ],
+        "usphone": "'lɪbə'ret",
+        "ukphone": "'lɪbəreɪt"
+    },
+    {
+        "name": "librarian",
+        "trans": [
+            "图书馆馆长； 图书管理员"
+        ],
+        "usphone": "laɪ'brɛrɪən",
+        "ukphone": "laɪ'breriən"
+    },
+    {
+        "name": "license",
+        "trans": [
+            "许可证，执照",
+            "批准， 许可"
+        ],
+        "usphone": "'laɪsns",
+        "ukphone": "'laɪsns"
+    },
+    {
+        "name": "lichen",
+        "trans": [
+            "青苔， 地衣"
+        ],
+        "usphone": "'laɪkən",
+        "ukphone": "'laɪkən"
+    },
+    {
+        "name": "lighthearted",
+        "trans": [
+            "无忧无虑的； 愉快的"
+        ],
+        "usphone": "'lait'hɑ:tid",
+        "ukphone": "ˌlaɪt'hɑːrtɪd"
+    },
+    {
+        "name": "lightning",
+        "trans": [
+            "闪电般的， 快速的",
+            "闪电"
+        ],
+        "usphone": "'laɪtnɪŋ",
+        "ukphone": "'laɪtnɪŋ"
+    },
+    {
+        "name": "likewise",
+        "trans": [
+            "同样； 也"
+        ],
+        "usphone": "'laɪkwaɪz",
+        "ukphone": "'laɪkwaɪz"
+    },
+    {
+        "name": "limb",
+        "trans": [
+            "肢， 臂； 主枝"
+        ],
+        "usphone": "lɪm",
+        "ukphone": "lɪm"
+    },
+    {
+        "name": "limestone",
+        "trans": [
+            "石灰石"
+        ],
+        "usphone": "'laɪmston",
+        "ukphone": "'laɪmstoun"
+    },
+    {
+        "name": "limitation",
+        "trans": [
+            "限制； 局限性"
+        ],
+        "usphone": ",lɪmɪ'teʃən",
+        "ukphone": "ˌlɪmɪ'teɪʃn"
+    },
+    {
+        "name": "lineage",
+        "trans": [
+            "宗系， 世系， 血统"
+        ],
+        "usphone": "'lɪnɪɪdʒ",
+        "ukphone": "'lɪniɪdʒ"
+    },
+    {
+        "name": "linear",
+        "trans": [
+            "线的， 直线的； 线性的； 长度的"
+        ],
+        "usphone": "'lɪnɪɚ",
+        "ukphone": "'lɪniər"
+    },
+    {
+        "name": "linen",
+        "trans": [
+            "亚麻织品； 亚麻布"
+        ],
+        "usphone": "'lɪnɪn",
+        "ukphone": "'lɪnɪn"
+    },
+    {
+        "name": "linger",
+        "trans": [
+            "徘徊， 流连； 继续存留； 缓慢消失"
+        ],
+        "usphone": "'lɪŋɡɚ",
+        "ukphone": "'lɪŋgər"
+    },
+    {
+        "name": "linguist",
+        "trans": [
+            "语言学家； 通晓数国语言的人"
+        ],
+        "usphone": "'lɪŋgwɪst",
+        "ukphone": "'lɪŋgwɪst"
+    },
+    {
+        "name": "linguistic",
+        "trans": [
+            "语言的， 语言学的"
+        ],
+        "usphone": "lɪŋ'gwɪstɪk",
+        "ukphone": "lɪŋ'gwɪstɪk"
+    },
+    {
+        "name": "lipid",
+        "trans": [
+            "脂质， 类脂"
+        ],
+        "usphone": "lɪpɪd",
+        "ukphone": "'lɪpɪd"
+    },
+    {
+        "name": "liquefy",
+        "trans": [
+            "溶解， 液化"
+        ],
+        "usphone": "'lɪkwɪfaɪ",
+        "ukphone": "'lɪkwɪfaɪ"
+    },
+    {
+        "name": "liquid",
+        "trans": [
+            "液体的，液态的，流体的；清澈的；流畅的",
+            "液体； 液态"
+        ],
+        "usphone": "'lɪkwɪd",
+        "ukphone": "'lɪkwɪd"
+    },
+    {
+        "name": "listless",
+        "trans": [
+            "倦怠的， 没精打采的"
+        ],
+        "usphone": "'lɪstləs",
+        "ukphone": "'lɪstləs"
+    },
+    {
+        "name": "literacy",
+        "trans": [
+            "有文化， 有教养； 读写能力"
+        ],
+        "usphone": "'lɪtərəsi",
+        "ukphone": "'lɪtərəsi"
+    },
+    {
+        "name": "literary",
+        "trans": [
+            "文学的； 文人的， 书卷气的"
+        ],
+        "usphone": "lɪtərɛri",
+        "ukphone": "'lɪtəreri"
+    },
+    {
+        "name": "literature",
+        "trans": [
+            "文学； 文学作品； 文献"
+        ],
+        "usphone": "lɪtərəˌtʃʊr",
+        "ukphone": "'lɪtrətʃər"
+    },
+    {
+        "name": "lithosphere",
+        "trans": [
+            "岩石圈"
+        ],
+        "usphone": "'lɪθəsfɪr",
+        "ukphone": "'lɪθəsfɪr"
+    },
+    {
+        "name": "litter",
+        "trans": [
+            "乱扔； 使凌乱",
+            "废弃物，垃圾；一窝幼崽"
+        ],
+        "usphone": "'lɪtɚ",
+        "ukphone": "'lɪtər"
+    },
+    {
+        "name": "livelihood",
+        "trans": [
+            "生计， 谋生手段"
+        ],
+        "usphone": "'laɪvlɪhʊd",
+        "ukphone": "'laɪvlihud"
+    },
+    {
+        "name": "livestock",
+        "trans": [
+            "〈总称〉家畜， 牲畜"
+        ],
+        "usphone": "'laɪvstɑk",
+        "ukphone": "'laɪvstɑːk"
+    },
+    {
+        "name": "lizard",
+        "trans": [
+            "蜥蜴"
+        ],
+        "usphone": "'lɪzɚd",
+        "ukphone": "'lɪzərd"
+    },
+    {
+        "name": "load",
+        "trans": [
+            "负荷，负担；装载",
+            "装载， 使负担"
+        ],
+        "usphone": "lod",
+        "ukphone": "loud"
+    },
+    {
+        "name": "loan",
+        "trans": [
+            "贷款；出借，借出；暂借的东西",
+            "借出； 贷给"
+        ],
+        "usphone": "lon",
+        "ukphone": "loun"
+    },
+    {
+        "name": "loath",
+        "trans": [
+            "不情愿的， 勉强的"
+        ],
+        "usphone": "loθ",
+        "ukphone": "louθ"
+    },
+    {
+        "name": "loathsome",
+        "trans": [
+            "令人厌恶的， 讨厌的"
+        ],
+        "usphone": "'loθsəm",
+        "ukphone": "'louðsəm"
+    },
+    {
+        "name": "lobby",
+        "trans": [
+            "游说",
+            "休息室，大厅；游说团"
+        ],
+        "usphone": "'lɑbi",
+        "ukphone": "'lɑːbi"
+    },
+    {
+        "name": "locality",
+        "trans": [
+            "地点； 位置"
+        ],
+        "usphone": "lo'kæləti",
+        "ukphone": "lou'kæləti"
+    },
+    {
+        "name": "locate",
+        "trans": [
+            "使坐落于； 找出， 定位"
+        ],
+        "usphone": "ˈloˌket; loˈket",
+        "ukphone": "'loukeɪt"
+    },
+    {
+        "name": "locomotion",
+        "trans": [
+            "移动； 运动"
+        ],
+        "usphone": ",lokə'moʃən",
+        "ukphone": "ˌloukə'mouʃn"
+    },
+    {
+        "name": "locomotive",
+        "trans": [
+            "运动的； 移动的",
+            "机车，火车头"
+        ],
+        "usphone": ",lokə'motɪv",
+        "ukphone": "ˌloukə'moutɪv"
+    },
+    {
+        "name": "lodge",
+        "trans": [
+            "正式提出； 租住， 借宿； 为…提供住宿； 寄存",
+            "巢穴；旅社；乡间小屋"
+        ],
+        "usphone": "lɑdʒ",
+        "ukphone": "lɑːdʒ"
+    },
+    {
+        "name": "lofty",
+        "trans": [
+            "高耸的； 崇高的； 高傲的"
+        ],
+        "usphone": "'lɔfti",
+        "ukphone": "'lɔːfti"
+    },
+    {
+        "name": "log",
+        "trans": [
+            "原木，木材；日志，航海日志，飞行日志",
+            "记录； 伐木"
+        ],
+        "usphone": "lɔɡ",
+        "ukphone": "lɔːg"
+    },
+    {
+        "name": "logical",
+        "trans": [
+            "逻辑的； 符合逻辑的， 合理的； 有逻辑头脑的"
+        ],
+        "usphone": "'lɑdʒɪkl",
+        "ukphone": "'lɑːdʒɪkl"
+    },
+    {
+        "name": "longevity",
+        "trans": [
+            "长寿； 寿命"
+        ],
+        "usphone": "lɔn'dʒɛvəti",
+        "ukphone": "lɔːn'dʒevəti"
+    },
+    {
+        "name": "longitude",
+        "trans": [
+            "经度， 经线"
+        ],
+        "usphone": "'lɑndʒətud",
+        "ukphone": "'lɑːngətjuːd"
+    },
+    {
+        "name": "loose",
+        "trans": [
+            "松散的， 宽松的； 不精确的， 不严密的； 不牢固的； 自由的， 散漫的"
+        ],
+        "usphone": "lus",
+        "ukphone": "luːs"
+    },
+    {
+        "name": "lope",
+        "trans": [
+            "轻松地大步跑",
+            "轻快的步伐"
+        ],
+        "usphone": "lop",
+        "ukphone": "loup"
+    },
+    {
+        "name": "lore",
+        "trans": [
+            "学问， 学识； 传说， 传统"
+        ],
+        "usphone": "lɔr",
+        "ukphone": "lɔːr"
+    },
+    {
+        "name": "lost-and-found",
+        "trans": [
+            "失物招领"
+        ],
+        "usphone": ",lɔstənd'faund",
+        "ukphone": "ˌlɔːstənd'faund"
+    },
+    {
+        "name": "lounge",
+        "trans": [
+            "懒洋洋地站",
+            "等候室，休息室"
+        ],
+        "usphone": "laʊndʒ",
+        "ukphone": "laundʒ"
+    },
+    {
+        "name": "lower",
+        "trans": [
+            "降低",
+            "较低的； 下级的， 下等的"
+        ],
+        "usphone": "'loɚ",
+        "ukphone": "'louər"
+    },
+    {
+        "name": "loyal",
+        "trans": [
+            "忠诚的， 忠贞的"
+        ],
+        "usphone": "'lɔɪəl",
+        "ukphone": "'lɔɪəl"
+    },
+    {
+        "name": "lubricant",
+        "trans": [
+            "润滑剂"
+        ],
+        "usphone": "'lubrɪkənt",
+        "ukphone": "'luːbrɪkənt"
+    },
+    {
+        "name": "lucrative",
+        "trans": [
+            "赚钱的， 获利的， 有利可图的"
+        ],
+        "usphone": "'lukrətɪv",
+        "ukphone": "'luːkrətɪv"
+    },
+    {
+        "name": "lumber",
+        "trans": [
+            "笨拙地移动；迫使担负",
+            "木材， 木料； 杂物"
+        ],
+        "usphone": "'lʌmbɚ",
+        "ukphone": "'lʌmbər"
+    },
+    {
+        "name": "luminosity",
+        "trans": [
+            "亮度， 发光度； 光明"
+        ],
+        "usphone": ",lʊmə'nɑsəti",
+        "ukphone": "ˌluːmɪ'nɑːsətɪ"
+    },
+    {
+        "name": "luminous",
+        "trans": [
+            "发光的， 明亮的"
+        ],
+        "usphone": "'lʊmənəs",
+        "ukphone": "'luːmɪnəs"
+    },
+    {
+        "name": "lunar",
+        "trans": [
+            "月亮的"
+        ],
+        "usphone": "'lunɚ",
+        "ukphone": "'luːnər"
+    },
+    {
+        "name": "lunge",
+        "trans": [
+            "猛冲， 猛扑"
+        ],
+        "usphone": "lʌndʒ",
+        "ukphone": "lʌndʒ"
+    },
+    {
+        "name": "lure",
+        "trans": [
+            "吸引，诱惑",
+            "诱惑力； 诱饵"
+        ],
+        "usphone": "lʊr",
+        "ukphone": "lur"
+    },
+    {
+        "name": "lush",
+        "trans": [
+            "茂盛的"
+        ],
+        "usphone": "lʌʃ",
+        "ukphone": "lʌʃ"
+    },
+    {
+        "name": "lust",
+        "trans": [
+            "对…有强烈的欲望",
+            "性欲；强烈的欲望"
+        ],
+        "usphone": "lʌst",
+        "ukphone": "lʌst"
+    },
+    {
+        "name": "luster",
+        "trans": [
+            "光亮， 光泽； 荣耀"
+        ],
+        "usphone": "'lʌstɚ",
+        "ukphone": "'lʌstər"
+    },
+    {
+        "name": "luxurious",
+        "trans": [
+            "奢侈的， 奢华的"
+        ],
+        "usphone": "lʌɡ'ʒʊrɪəs",
+        "ukphone": "lʌg'ʒuriəs"
+    },
+    {
+        "name": "luxury",
+        "trans": [
+            "奢华的",
+            "奢侈， 奢华； 奢侈品"
+        ],
+        "usphone": "'lʌɡʒəri",
+        "ukphone": "'lʌkʃəri"
+    },
+    {
+        "name": "lyric",
+        "trans": [
+            "抒情的",
+            "抒情诗；"
+        ],
+        "usphone": "'lɪrɪk",
+        "ukphone": "'lɪrɪk"
+    },
+    {
+        "name": "machinery",
+        "trans": [
+            "〈总称〉机器， 机械； 机构"
+        ],
+        "usphone": "mə'ʃinəri",
+        "ukphone": "mə'ʃiːnəri"
+    },
+    {
+        "name": "maglev",
+        "trans": [
+            "磁力悬浮火车"
+        ],
+        "usphone": "'mæglɛv",
+        "ukphone": "'mæglev"
+    },
+    {
+        "name": "magma",
+        "trans": [
+            "岩浆"
+        ],
+        "usphone": "'mæɡmə",
+        "ukphone": "'mægmə"
+    },
+    {
+        "name": "magnesium",
+        "trans": [
+            "镁"
+        ],
+        "usphone": "mæg'nizɪrm",
+        "ukphone": "mæg'niːziəm"
+    },
+    {
+        "name": "magnet",
+        "trans": [
+            "磁铁， 磁体； 有吸引力的人"
+        ],
+        "usphone": "'mægnɪt",
+        "ukphone": "'mægnət"
+    },
+    {
+        "name": "magnetic",
+        "trans": [
+            "磁的， 磁石的； 有磁性的； 有吸引力的"
+        ],
+        "usphone": "mæg'nɛtɪk",
+        "ukphone": "mæg'netɪk"
+    },
+    {
+        "name": "magnificent",
+        "trans": [
+            "极好的； 宏伟的， 华丽的； 崇高的， 高尚的"
+        ],
+        "usphone": "mæg'nɪfəsnt",
+        "ukphone": "mæg'nɪfɪsnt"
+    },
+    {
+        "name": "magnify",
+        "trans": [
+            "放大， 扩大； 夸大"
+        ],
+        "usphone": "'mæɡnɪfaɪ",
+        "ukphone": "'mægnɪfaɪ"
+    },
+    {
+        "name": "magnitude",
+        "trans": [
+            "巨大； 重要性； 星等， 星球的亮度"
+        ],
+        "usphone": "'mæɡnɪtud",
+        "ukphone": "'mægnɪtjuːd"
+    },
+    {
+        "name": "mail",
+        "trans": [
+            "邮件",
+            "邮寄"
+        ],
+        "usphone": "mel",
+        "ukphone": "meɪl"
+    },
+    {
+        "name": "mainstream",
+        "trans": [
+            "主流， 主要倾向； 主流思想"
+        ],
+        "usphone": "'menstrim",
+        "ukphone": "'meɪnstriːm"
+    },
+    {
+        "name": "maintain",
+        "trans": [
+            "维持， 保持； 维修， 保养； 主张， 坚持； 赡养， 负担"
+        ],
+        "usphone": "men'ten",
+        "ukphone": "meɪn'teɪn"
+    },
+    {
+        "name": "maize",
+        "trans": [
+            "玉米"
+        ],
+        "usphone": "mez",
+        "ukphone": "meɪz"
+    },
+    {
+        "name": "major",
+        "trans": [
+            "主修， 专攻",
+            "较大的；主要的；主修的",
+            "专业"
+        ],
+        "usphone": "'medʒɚ",
+        "ukphone": "'meɪdʒər"
+    },
+    {
+        "name": "male",
+        "trans": [
+            "雄的，公的；"
+        ],
+        "usphone": "mel",
+        "ukphone": "meɪl"
+    },
+    {
+        "name": "malice",
+        "trans": [
+            "恶意， 怨恨"
+        ],
+        "usphone": "'mælɪs",
+        "ukphone": "'mælɪs"
+    },
+    {
+        "name": "malicious",
+        "trans": [
+            "怀有恶意的， 恶毒的"
+        ],
+        "usphone": "mə'lɪʃəs",
+        "ukphone": "mə'lɪʃəs"
+    },
+    {
+        "name": "malleable",
+        "trans": [
+            "有延展性的， 易成型的； 易受影响的， 可塑的"
+        ],
+        "usphone": "'mælɪəbl",
+        "ukphone": "'mæliəbl"
+    },
+    {
+        "name": "malnutrition",
+        "trans": [
+            "营养不良"
+        ],
+        "usphone": "'mælnʊ'trɪʃən",
+        "ukphone": "ˌmælnuː'trɪʃn"
+    },
+    {
+        "name": "mammal",
+        "trans": [
+            "哺乳动物"
+        ],
+        "usphone": "'mæml",
+        "ukphone": "'mæml"
+    },
+    {
+        "name": "mammoth",
+        "trans": [
+            "巨大的",
+            "猛犸， 毛象"
+        ],
+        "usphone": "'mæməθ",
+        "ukphone": "'mæməθ"
+    },
+    {
+        "name": "manage",
+        "trans": [
+            "勉力完成； 应付； 操纵， 控制； 管理"
+        ],
+        "usphone": "'mænɪdʒ",
+        "ukphone": "'mænɪdʒ"
+    },
+    {
+        "name": "mandate",
+        "trans": [
+            "强制执行； 授权",
+            "授权；委托书，授权令；任期"
+        ],
+        "usphone": "'mændet",
+        "ukphone": "'mændeɪt"
+    },
+    {
+        "name": "mandatory",
+        "trans": [
+            "强制的，法定的，义务的； 受托人； 代理人"
+        ],
+        "usphone": "'mændətɔri",
+        "ukphone": "'mændətɔːri"
+    },
+    {
+        "name": "maneuver",
+        "trans": [
+            "操纵，控制；耍花招",
+            "策略； 花招"
+        ],
+        "usphone": "mə'nʊvɚ; mə'njʊvɚ",
+        "ukphone": "mə'nuːvər"
+    },
+    {
+        "name": "mania",
+        "trans": [
+            "躁狂； 狂热； 癖好"
+        ],
+        "usphone": "'menɪə",
+        "ukphone": "'meɪniə"
+    },
+    {
+        "name": "manifest",
+        "trans": [
+            "明显的",
+            "表明，显示",
+            "货物清单"
+        ],
+        "usphone": "'mænɪfɛst",
+        "ukphone": "'mænɪfest"
+    },
+    {
+        "name": "manifestation",
+        "trans": [
+            "显示，表明；"
+        ],
+        "usphone": "'mænəfɛ'steʃən",
+        "ukphone": "ˌmænɪfe'steɪʃn"
+    },
+    {
+        "name": "manifesto",
+        "trans": [
+            "宣言， 声明"
+        ],
+        "usphone": ",mænɪ'fɛsto",
+        "ukphone": "ˌmænɪ'festou"
+    },
+    {
+        "name": "manipulate",
+        "trans": [
+            "操作， 处理； 利用， 操纵"
+        ],
+        "usphone": "mə'nɪpjulet",
+        "ukphone": "mə'nɪpjuleɪt"
+    },
+    {
+        "name": "manner",
+        "trans": [
+            "方式，风格；"
+        ],
+        "usphone": "'mænɚ",
+        "ukphone": "'mænər"
+    },
+    {
+        "name": "mannerism",
+        "trans": [
+            "怪癖， 癖性； 过分的独特风格"
+        ],
+        "usphone": "'mænə'rɪzəm",
+        "ukphone": "'mænərɪzəm"
+    },
+    {
+        "name": "mansion",
+        "trans": [
+            "公寓， 府邸； 大厦"
+        ],
+        "usphone": "'mænʃən",
+        "ukphone": "'mænʃn"
+    },
+    {
+        "name": "mantle",
+        "trans": [
+            "覆盖物； 披风， 斗篷； 纱罩； 【地】地幔"
+        ],
+        "usphone": "'mæntl",
+        "ukphone": "'mæntl"
+    },
+    {
+        "name": "manual",
+        "trans": [
+            "手工的；体力的",
+            "手册， 指南"
+        ],
+        "usphone": "'mænjuəl",
+        "ukphone": "'mænjuəl"
+    },
+    {
+        "name": "manufacture",
+        "trans": [
+            "大量制造，成批生产；捏造",
+            "大量制造；"
+        ],
+        "usphone": "'mænjə'fæktʃɚ",
+        "ukphone": "ˌmænju'fæktʃər"
+    },
+    {
+        "name": "mar",
+        "trans": [
+            "损坏， 损毁"
+        ],
+        "usphone": "mɑr",
+        "ukphone": "mɑːr"
+    },
+    {
+        "name": "marble",
+        "trans": [
+            "大理石； 子弹"
+        ],
+        "usphone": "'mɑrbl",
+        "ukphone": "'mɑːrbl"
+    },
+    {
+        "name": "march",
+        "trans": [
+            "前进， 进发； 行进， 齐步走； 游行示威",
+            "行进，行军；示威游行；进行曲；进行，进展"
+        ],
+        "usphone": "mɑrtʃ",
+        "ukphone": "mɑːrtʃ"
+    },
+    {
+        "name": "margin",
+        "trans": [
+            "边缘； 页边空白； 差数， 差额； 余地， 余裕"
+        ],
+        "usphone": "'mɑrdʒən",
+        "ukphone": "'mɑːrdʒən"
+    },
+    {
+        "name": "marine",
+        "trans": [
+            "海的；海生的；海上贸易的",
+            "海军陆战队士兵"
+        ],
+        "usphone": "mə'rin",
+        "ukphone": "mə'riːn"
+    },
+    {
+        "name": "maritime",
+        "trans": [
+            "海的， 海事的； 航海的"
+        ],
+        "usphone": "'mærɪtaɪm",
+        "ukphone": "'mærɪtaɪm"
+    },
+    {
+        "name": "marked",
+        "trans": [
+            "显著的； 有记号的； 被监视的"
+        ],
+        "usphone": "mɑrkt",
+        "ukphone": "mɑːrkt"
+    },
+    {
+        "name": "marsh",
+        "trans": [
+            "沼泽， 湿地"
+        ],
+        "usphone": "mɑrʃ",
+        "ukphone": "mɑːrʃ"
+    },
+    {
+        "name": "marvel",
+        "trans": [
+            "对…感到惊异，大为赞叹",
+            "令人惊异的人， 奇迹； 不凡的成果"
+        ],
+        "usphone": "'mɑrvl",
+        "ukphone": "'mɑːrvl"
+    },
+    {
+        "name": "mask",
+        "trans": [
+            "面具；面罩；假面具，"
+        ],
+        "usphone": "mæsk",
+        "ukphone": "mæsk"
+    },
+    {
+        "name": "mason",
+        "trans": [
+            "石匠， 泥瓦匠"
+        ],
+        "usphone": "'mesn",
+        "ukphone": "'meɪsn"
+    },
+    {
+        "name": "mass",
+        "trans": [
+            "大量的",
+            "质量；块，团；众多；群众，平民百姓"
+        ],
+        "usphone": "mæs",
+        "ukphone": "mæs"
+    },
+    {
+        "name": "mast",
+        "trans": [
+            "船桅； 旗杆； 天线塔"
+        ],
+        "usphone": "mæst",
+        "ukphone": "mæst"
+    },
+    {
+        "name": "mat",
+        "trans": [
+            "垫子"
+        ],
+        "usphone": "mæt",
+        "ukphone": "mæt"
+    },
+    {
+        "name": "match",
+        "trans": [
+            "匹配",
+            "比赛；对手"
+        ],
+        "usphone": "mætʃ",
+        "ukphone": "mætʃ"
+    },
+    {
+        "name": "mate",
+        "trans": [
+            "交配",
+            "配偶；朋友，伙伴；同事；大副"
+        ],
+        "usphone": "met",
+        "ukphone": "meɪt"
+    },
+    {
+        "name": "material",
+        "trans": [
+            "物质的， 身体上的； 重要的； 实质性的， 客观存在的",
+            "材料，原料；素材，资料"
+        ],
+        "usphone": "mə'tɪrɪəl",
+        "ukphone": "mə'tɪriəl"
+    },
+    {
+        "name": "maternal",
+        "trans": [
+            "母亲的， 母系的"
+        ],
+        "usphone": "mə'tɝnl",
+        "ukphone": "mə'tɜːrnl"
+    },
+    {
+        "name": "mathematics",
+        "trans": [
+            "数学"
+        ],
+        "usphone": ",mæθə'mætɪks",
+        "ukphone": "ˌmæθə'mætɪks"
+    },
+    {
+        "name": "matrimony",
+        "trans": [
+            "婚姻， 婚配"
+        ],
+        "usphone": "'mætrɪmoni",
+        "ukphone": "'mætrɪmouni"
+    },
+    {
+        "name": "mature",
+        "trans": [
+            "成熟的；"
+        ],
+        "usphone": "mə'tʃʊr",
+        "ukphone": "mə'tʃur"
+    },
+    {
+        "name": "maturity",
+        "trans": [
+            "成熟； 完备"
+        ],
+        "usphone": "mə'tʃʊrəti",
+        "ukphone": "mə'turəti"
+    },
+    {
+        "name": "maximum",
+        "trans": [
+            "最大的，最大限度的",
+            "最大量， 极限"
+        ],
+        "usphone": "ˈmæksəməm",
+        "ukphone": "'mæksɪməm"
+    },
+    {
+        "name": "maze",
+        "trans": [
+            "迷宫；复杂难懂的细节；困惑，迷惘",
+            "使混乱； 使困惑， 迷惑"
+        ],
+        "usphone": "mez",
+        "ukphone": "meɪz"
+    },
+    {
+        "name": "meager",
+        "trans": [
+            "不足的， 贫乏的； 消瘦的"
+        ],
+        "usphone": "'migɚ",
+        "ukphone": "'miːgər"
+    },
+    {
+        "name": "meaningful",
+        "trans": [
+            "意味深长的； 有目的的， 有用意的； 有意义的"
+        ],
+        "usphone": "'minɪŋfl",
+        "ukphone": "'miːnɪŋfl"
+    },
+    {
+        "name": "meantime",
+        "trans": [
+            "其时， 同时"
+        ],
+        "usphone": "'min'taɪm",
+        "ukphone": "'miːntaɪm"
+    },
+    {
+        "name": "measure",
+        "trans": [
+            "量，测量",
+            "措施，办法"
+        ],
+        "usphone": "'mɛʒɚ",
+        "ukphone": "'meʒər"
+    },
+    {
+        "name": "mechanic",
+        "trans": [
+            "技工， 机修工"
+        ],
+        "usphone": "mə'kænɪk",
+        "ukphone": "mə'kænɪk"
+    },
+    {
+        "name": "mechanics",
+        "trans": [
+            "机械学， 力学； 技巧， 方法"
+        ],
+        "usphone": "mə'kænɪks",
+        "ukphone": "mə'kænɪks"
+    },
+    {
+        "name": "mechanize",
+        "trans": [
+            "使机械化"
+        ],
+        "usphone": "'mɛkənaɪz",
+        "ukphone": "'mekənaɪz"
+    },
+    {
+        "name": "medal",
+        "trans": [
+            "奖牌， 奖章"
+        ],
+        "usphone": "'mɛdl",
+        "ukphone": "'medl"
+    },
+    {
+        "name": "media",
+        "trans": [
+            "媒介， 媒体"
+        ],
+        "usphone": "",
+        "ukphone": "'miːdiə"
+    },
+    {
+        "name": "mediate",
+        "trans": [
+            "调解， 调停， 斡旋"
+        ],
+        "usphone": "'midɪet",
+        "ukphone": "'miːdieɪt"
+    },
+    {
+        "name": "medication",
+        "trans": [
+            "药物治疗； 药物"
+        ],
+        "usphone": "'mɛdɪ'keʃən",
+        "ukphone": "ˌmedɪ'keɪʃn"
+    },
+    {
+        "name": "medieval",
+        "trans": [
+            "中世纪的， 中古的"
+        ],
+        "usphone": ",midɪ'ivəl",
+        "ukphone": "ˌmiːd'iːvl"
+    },
+    {
+        "name": "meditate",
+        "trans": [
+            "沉思， 冥想； 考虑； 谋划"
+        ],
+        "usphone": "'mɛdɪtet",
+        "ukphone": "'medɪteɪt"
+    },
+    {
+        "name": "medium",
+        "trans": [
+            "〔大小、水平或数量〕中等的；中号的",
+            "传播媒介〔如报纸、电视等〕",
+            "灵媒，巫师，通灵的人"
+        ],
+        "usphone": "'midɪəm",
+        "ukphone": "'miːdiəm"
+    },
+    {
+        "name": "melanin",
+        "trans": [
+            "黑色素"
+        ],
+        "usphone": "'mɛlənɪn",
+        "ukphone": "'melənɪn"
+    },
+    {
+        "name": "mellow",
+        "trans": [
+            "醇香的；柔和的；成熟的",
+            "醇香； 柔和； 成熟"
+        ],
+        "usphone": "'mɛlo",
+        "ukphone": "'melou"
+    },
+    {
+        "name": "melodic",
+        "trans": [
+            "旋律的， 曲调的； 音调优美的"
+        ],
+        "usphone": "mə'lɑdɪk",
+        "ukphone": "mə'lɑːdɪk"
+    },
+    {
+        "name": "melodious",
+        "trans": [
+            "旋律优美的， 悦耳的"
+        ],
+        "usphone": "mə'lodɪəs",
+        "ukphone": "mə'loudiəs"
+    },
+    {
+        "name": "melodrama",
+        "trans": [
+            "情节剧， 通俗剧； 戏剧性的事件"
+        ],
+        "usphone": "'mɛlədrɑmə",
+        "ukphone": "'melədrɑːmə"
+    },
+    {
+        "name": "melody",
+        "trans": [
+            "旋律， 曲调； 乐曲， 歌曲"
+        ],
+        "usphone": "'mɛlədi",
+        "ukphone": "'melədi"
+    },
+    {
+        "name": "melt",
+        "trans": [
+            "融化， 熔化； 溶化； 消散"
+        ],
+        "usphone": "mɛlt",
+        "ukphone": "melt"
+    },
+    {
+        "name": "membrane",
+        "trans": [
+            "薄膜； 细胞膜"
+        ],
+        "usphone": "'mɛmbren",
+        "ukphone": "'membreɪn"
+    },
+    {
+        "name": "memo",
+        "trans": [
+            "备忘录"
+        ],
+        "usphone": "'mɛmo",
+        "ukphone": "'memou"
+    },
+    {
+        "name": "memorize",
+        "trans": [
+            "记住， 记忆， 熟记"
+        ],
+        "usphone": "'mɛmə'raɪz",
+        "ukphone": "'meməraɪz"
+    },
+    {
+        "name": "mental",
+        "trans": [
+            "精神的； 智力的； 精神健康的"
+        ],
+        "usphone": "'mɛntl",
+        "ukphone": "'mentl"
+    },
+    {
+        "name": "mention",
+        "trans": [
+            "提及， 说起"
+        ],
+        "usphone": "'mɛnʃən",
+        "ukphone": "'menʃn"
+    },
+    {
+        "name": "mercantile",
+        "trans": [
+            "贸易的， 商业的； 重商主义的"
+        ],
+        "usphone": "'mɝkəntɪl",
+        "ukphone": "'mɜːrkəntaɪl"
+    },
+    {
+        "name": "merchandise",
+        "trans": [
+            "商品，货物",
+            "买卖， 经营"
+        ],
+        "usphone": "'mɝtʃəndaɪs",
+        "ukphone": "'mɜːrtʃəndaɪs"
+    },
+    {
+        "name": "merchant",
+        "trans": [
+            "商人"
+        ],
+        "usphone": "'mɝtʃənt",
+        "ukphone": "'mɜːrtʃənt"
+    },
+    {
+        "name": "mercury",
+        "trans": [
+            "[M-]水星； 水银， 汞"
+        ],
+        "usphone": "'mɝkjəri",
+        "ukphone": "'mɜːrkjəri"
+    },
+    {
+        "name": "mercy",
+        "trans": [
+            "宽恕； 仁慈； 恩惠， 幸运"
+        ],
+        "usphone": "'mɝsi",
+        "ukphone": "'mɜːrsi"
+    },
+    {
+        "name": "mere",
+        "trans": [
+            "仅仅的， 纯粹的"
+        ],
+        "usphone": "mɪr",
+        "ukphone": "mɪr"
+    },
+    {
+        "name": "meridian",
+        "trans": [
+            "子午线， 经线"
+        ],
+        "usphone": "mə'rɪdɪən",
+        "ukphone": "mə'rɪdiən"
+    },
+    {
+        "name": "mesmerize",
+        "trans": [
+            "施催眠术； 使入迷， 迷住"
+        ],
+        "usphone": "'mɛzməraɪz",
+        "ukphone": "'mezməraɪz"
+    },
+    {
+        "name": "Mesolithic",
+        "trans": [
+            "中石器时代的",
+            "中石器时代"
+        ],
+        "usphone": "ˌmiːzə(ʊ)ˈlɪθɪk",
+        "ukphone": "ˌmesə'liθik"
+    },
+    {
+        "name": "mess",
+        "trans": [
+            "肮脏，杂乱；混乱，困境",
+            "弄脏， 弄乱； 搞糟"
+        ],
+        "usphone": "mɛs",
+        "ukphone": "mes"
+    },
+    {
+        "name": "metabolic",
+        "trans": [
+            "新陈代谢的"
+        ],
+        "usphone": ",mɛtə'bɑlɪk",
+        "ukphone": "ˌmetə'bɑːlɪk"
+    },
+    {
+        "name": "metallic",
+        "trans": [
+            "金属般的； 金属制的； 含金属的"
+        ],
+        "usphone": "mə'tælɪk",
+        "ukphone": "mə'tælɪk"
+    },
+    {
+        "name": "metaphor",
+        "trans": [
+            "隐喻， 暗喻"
+        ],
+        "usphone": "'mɛtəfɚ",
+        "ukphone": "'metəfər"
+    },
+    {
+        "name": "meteor",
+        "trans": [
+            "流星"
+        ],
+        "usphone": "'mitɪɚ",
+        "ukphone": "'miːtiər"
+    },
+    {
+        "name": "meteorite",
+        "trans": [
+            "陨石"
+        ],
+        "usphone": "'mitɪəraɪt",
+        "ukphone": "'miːtiəraɪt"
+    },
+    {
+        "name": "meteorological",
+        "trans": [
+            "气象学的； 气象的"
+        ],
+        "usphone": ",mitɪərə'lɑdʒɪkl",
+        "ukphone": "ˌmiːtiərə'lɑːdʒɪkl"
+    },
+    {
+        "name": "meteorologist",
+        "trans": [
+            "气象学者"
+        ],
+        "usphone": "'mitɪə'rɑlədʒɪst",
+        "ukphone": "ˌmiːtiə'rɑːlədʒɪst"
+    },
+    {
+        "name": "meteorology",
+        "trans": [
+            "气象学"
+        ],
+        "usphone": ",mitɪə'rɑlədʒi",
+        "ukphone": "ˌmiːtiə'rɑːlədʒi"
+    },
+    {
+        "name": "methane",
+        "trans": [
+            "甲烷， 沼气"
+        ],
+        "usphone": "'mɛθen",
+        "ukphone": "'meθeɪn"
+    },
+    {
+        "name": "methanol",
+        "trans": [
+            "甲醇"
+        ],
+        "usphone": "'mɛθənɔl",
+        "ukphone": "'meθənɔːl"
+    },
+    {
+        "name": "method",
+        "trans": [
+            "方法， 办法， 措施； 秩序"
+        ],
+        "usphone": "'mɛθəd",
+        "ukphone": "'meθəd"
+    },
+    {
+        "name": "meticulous",
+        "trans": [
+            "细心的， 小心翼翼的"
+        ],
+        "usphone": "mə'tɪkjələs",
+        "ukphone": "mə'tɪkjələs"
+    },
+    {
+        "name": "metric",
+        "trans": [
+            "米制的； 公制的"
+        ],
+        "usphone": "'mɛtrɪk",
+        "ukphone": "'metrɪk"
+    },
+    {
+        "name": "metropolis",
+        "trans": [
+            "首府； 大都市"
+        ],
+        "usphone": "mə'trɑpəlɪs",
+        "ukphone": "mə'trɑːpəlɪs"
+    },
+    {
+        "name": "metropolitan",
+        "trans": [
+            "大都市的； 本土的"
+        ],
+        "usphone": ",mɛtrə'pɑlɪtən",
+        "ukphone": "ˌmetrə'pɑːlɪtən"
+    },
+    {
+        "name": "microbe",
+        "trans": [
+            "微生物， 细菌"
+        ],
+        "usphone": "'maɪkrob",
+        "ukphone": "'maɪkroub"
+    },
+    {
+        "name": "microorganism",
+        "trans": [
+            "微生物"
+        ],
+        "usphone": ",maɪkro'ɔrgən,ɪzəm",
+        "ukphone": "ˌmaɪkrou'ɔːrgənɪzəm"
+    },
+    {
+        "name": "microprocessor",
+        "trans": [
+            "微处理器"
+        ],
+        "usphone": ",maɪkro'prosɛsɚ",
+        "ukphone": "ˌmaɪkrou'prousesər"
+    },
+    {
+        "name": "microscope",
+        "trans": [
+            "显微镜"
+        ],
+        "usphone": "'maɪkrəskop",
+        "ukphone": "'maɪkrəskəup"
+    },
+    {
+        "name": "microscopic",
+        "trans": [
+            "用显微镜可见的； 极小的"
+        ],
+        "usphone": ",maɪkrə'skɑpɪk",
+        "ukphone": "ˌmaɪkrə'skɑːpɪk"
+    },
+    {
+        "name": "microwave",
+        "trans": [
+            "微波； 微波炉"
+        ],
+        "usphone": "'maɪkrə'wev",
+        "ukphone": "'maɪkrəweɪv"
+    },
+    {
+        "name": "middleman",
+        "trans": [
+            "中间人， 调解人； 经纪人"
+        ],
+        "usphone": "'mɪdl'mæn",
+        "ukphone": "'mɪdlmæn"
+    },
+    {
+        "name": "midterm",
+        "trans": [
+            "中间的，期中的",
+            "期中考试； 中期； 期中"
+        ],
+        "usphone": ",mɪd'tɝm",
+        "ukphone": "ˌmɪd'tɜːrm"
+    },
+    {
+        "name": "mighty",
+        "trans": [
+            "强有力的； 巨大的"
+        ],
+        "usphone": "'maɪti",
+        "ukphone": "'maɪti"
+    },
+    {
+        "name": "migrate",
+        "trans": [
+            "迁徙； 移居"
+        ],
+        "usphone": "'maɪɡret",
+        "ukphone": "'maɪgreɪt"
+    },
+    {
+        "name": "mild",
+        "trans": [
+            "轻微的； 温和的； 随和的"
+        ],
+        "usphone": "maɪld",
+        "ukphone": "maɪld"
+    },
+    {
+        "name": "milieu",
+        "trans": [
+            "出身背景； 社会环境"
+        ],
+        "usphone": "mi'ljɜː",
+        "ukphone": "miː'ljɜː"
+    },
+    {
+        "name": "militant",
+        "trans": [
+            "好战的，好暴力的",
+            "激进分子"
+        ],
+        "usphone": "'mɪlɪtənt",
+        "ukphone": "'mɪlɪtənt"
+    },
+    {
+        "name": "military",
+        "trans": [
+            "军事的",
+            "[the ～]军队， 军方"
+        ],
+        "usphone": "'mɪlətɛri",
+        "ukphone": "'mɪləteri"
+    },
+    {
+        "name": "millennium",
+        "trans": [
+            "一千年，千年期"
+        ],
+        "usphone": "məˈlɛniəm",
+        "ukphone": "mɪ'leniəm"
+    },
+    {
+        "name": "mime",
+        "trans": [
+            "模拟，模仿",
+            "喜剧； 哑剧； 哑剧演员； 模拟表演"
+        ],
+        "usphone": "maɪm",
+        "ukphone": "maɪm"
+    },
+    {
+        "name": "mimic",
+        "trans": [
+            "模仿的， 模拟的",
+            "模仿；像",
+            "模仿者；小丑"
+        ],
+        "usphone": "'mɪmɪk",
+        "ukphone": "'mɪmɪk"
+    },
+    {
+        "name": "mine",
+        "trans": [
+            "我的",
+            "开矿，采矿；在…布雷",
+            "矿， 矿井； 地雷， 水雷"
+        ],
+        "usphone": "maɪn",
+        "ukphone": "maɪn"
+    },
+    {
+        "name": "mingle",
+        "trans": [
+            "混合； 交往"
+        ],
+        "usphone": "'mɪŋɡl",
+        "ukphone": "'mɪŋgl"
+    },
+    {
+        "name": "minimal",
+        "trans": [
+            "最小的； 最低限度的"
+        ],
+        "usphone": "'mɪnɪməl",
+        "ukphone": "'mɪnɪməl"
+    },
+    {
+        "name": "minimize",
+        "trans": [
+            "将…减到最少， 使最小化； 降低， 贬低"
+        ],
+        "usphone": "'mɪnɪmaɪz",
+        "ukphone": "'mɪnɪmaɪz"
+    },
+    {
+        "name": "minimum",
+        "trans": [
+            "最小的，最低的",
+            "最小值， 最低限度"
+        ],
+        "usphone": "'mɪnɪməm",
+        "ukphone": "'mɪnɪməm"
+    },
+    {
+        "name": "minor",
+        "trans": [
+            "辅修",
+            "较小的；次要的",
+            "未成年人；辅修科目"
+        ],
+        "usphone": "'maɪnɚ",
+        "ukphone": "'maɪnər"
+    },
+    {
+        "name": "minority",
+        "trans": [
+            "少数； 少数民族"
+        ],
+        "usphone": "maɪ'nɔrəti",
+        "ukphone": "maɪ'nɔːrəti"
+    },
+    {
+        "name": "mint",
+        "trans": [
+            "铸造",
+            "薄荷； 造币厂； 大量的钱"
+        ],
+        "usphone": "mɪnt",
+        "ukphone": "mɪnt"
+    },
+    {
+        "name": "minus",
+        "trans": [
+            "减的，负的",
+            "减",
+            "负数；减号；不足"
+        ],
+        "usphone": "'maɪnəs",
+        "ukphone": "'maɪnəs"
+    },
+    {
+        "name": "minute",
+        "trans": [
+            "细微的， 极小的； 细致入微的， 详细的",
+            "分， 分钟； 一会儿， 片刻； 时刻"
+        ],
+        "usphone": "'mɪnɪt",
+        "ukphone": "'mɪnɪt"
+    },
+    {
+        "name": "miracle",
+        "trans": [
+            "奇事， 奇迹"
+        ],
+        "usphone": "'mɪrəkl",
+        "ukphone": "'mɪrəkl"
+    },
+    {
+        "name": "mischievous",
+        "trans": [
+            "恶作剧的， 顽皮的， 淘气的； 恶意的"
+        ],
+        "usphone": "'mɪstʃɪvəs",
+        "ukphone": "'mɪstʃɪvəs"
+    },
+    {
+        "name": "miserable",
+        "trans": [
+            "痛苦的； 可怜的； 令人不快的"
+        ],
+        "usphone": "'mɪzrəbl",
+        "ukphone": "'mɪzrəbl"
+    },
+    {
+        "name": "mismanage",
+        "trans": [
+            "对…管理不当， 处理不当"
+        ],
+        "usphone": "'mɪs'mænɪdʒ",
+        "ukphone": "ˌmɪs'mænɪdʒ"
+    },
+    {
+        "name": "missile",
+        "trans": [
+            "发射物； 导弹， 飞弹"
+        ],
+        "usphone": "'mɪsl",
+        "ukphone": "'mɪsl"
+    },
+    {
+        "name": "mission",
+        "trans": [
+            "代表团， 使团； 任务， 使命"
+        ],
+        "usphone": "'mɪʃən",
+        "ukphone": "'mɪʃn"
+    },
+    {
+        "name": "mobile",
+        "trans": [
+            "可移动的； 多变的",
+            "动的雕塑"
+        ],
+        "usphone": "ˈməʊbl;mobil",
+        "ukphone": "'moubl"
+    },
+    {
+        "name": "mock",
+        "trans": [
+            "嘲笑，嘲弄；模仿；蔑视，",
+            "模拟考试"
+        ],
+        "usphone": "mɑk",
+        "ukphone": "mɑːk"
+    },
+    {
+        "name": "mode",
+        "trans": [
+            "方式， 形式； 风格； 时尚"
+        ],
+        "usphone": "mod",
+        "ukphone": "moud"
+    },
+    {
+        "name": "modeling",
+        "trans": [
+            "立体感； 建模， 造型"
+        ],
+        "usphone": "'mɑdlɪŋ",
+        "ukphone": "'mɑːdlɪŋ"
+    },
+    {
+        "name": "modem",
+        "trans": [
+            "调制解调器"
+        ],
+        "usphone": "'mo'dɛm",
+        "ukphone": "'moudem"
+    },
+    {
+        "name": "moderate",
+        "trans": [
+            "适度的； 温和的； 普通的",
+            "缓和，使适中",
+            "持温和意见的人"
+        ],
+        "usphone": "ˈmɑdərɪt; (for v.,) ˈmɑdərˌeɪt",
+        "ukphone": "'mɒd(ə)rət"
+    },
+    {
+        "name": "modernity",
+        "trans": [
+            "现代性"
+        ],
+        "usphone": "mə'dɝnəti",
+        "ukphone": "mə'dɜːrnəti"
+    },
+    {
+        "name": "modest",
+        "trans": [
+            "谦虚的； 适度的"
+        ],
+        "usphone": "'mɑdɪst",
+        "ukphone": "'mɑːdɪst"
+    },
+    {
+        "name": "modify",
+        "trans": [
+            "修改， 更改； 缓和； 【语】修饰"
+        ],
+        "usphone": "'mɑdɪfaɪ",
+        "ukphone": "'mɑːdɪfaɪ"
+    },
+    {
+        "name": "modulate",
+        "trans": [
+            "调整， 调节； 调制"
+        ],
+        "usphone": "'mɑdʒəlet",
+        "ukphone": "'mɑːdʒəleɪt"
+    },
+    {
+        "name": "moist",
+        "trans": [
+            "潮湿的； 多雨的"
+        ],
+        "usphone": "mɔɪst",
+        "ukphone": "mɔɪst"
+    },
+    {
+        "name": "moisture",
+        "trans": [
+            "潮湿， 湿气"
+        ],
+        "usphone": "'mɔɪstʃɚ",
+        "ukphone": "'mɔɪstʃər"
+    },
+    {
+        "name": "mold",
+        "trans": [
+            "霉菌；模型",
+            "塑造"
+        ],
+        "usphone": "mold",
+        "ukphone": "mould"
+    },
+    {
+        "name": "molecular",
+        "trans": [
+            "分子的； 摩尔的； 由分子组成的"
+        ],
+        "usphone": "mə'lɛkjəlɚ",
+        "ukphone": "mə'lekjələr"
+    },
+    {
+        "name": "molecule",
+        "trans": [
+            "分子"
+        ],
+        "usphone": "'mɑlɪkjul",
+        "ukphone": "'mɑːlɪkjuːl"
+    },
+    {
+        "name": "molten",
+        "trans": [
+            "熔化的， 熔融的"
+        ],
+        "usphone": "'moltən",
+        "ukphone": "'moultən"
+    },
+    {
+        "name": "momentary",
+        "trans": [
+            "片刻的， 瞬间的， 暂时的"
+        ],
+        "usphone": "'moməntɛri",
+        "ukphone": "'moumənteri"
+    },
+    {
+        "name": "momentous",
+        "trans": [
+            "重大的， 重要的"
+        ],
+        "usphone": "mo'mɛntəs",
+        "ukphone": "mou'mentəs"
+    },
+    {
+        "name": "momentum",
+        "trans": [
+            "动量； 动力， 冲力； 势头"
+        ],
+        "usphone": "mo'mɛntəm",
+        "ukphone": "mou'mentəm"
+    },
+    {
+        "name": "monarch",
+        "trans": [
+            "君主， 帝王"
+        ],
+        "usphone": "'mɑnɚk",
+        "ukphone": "'mɑːnərk"
+    },
+    {
+        "name": "monarchy",
+        "trans": [
+            "君主制； 君主国"
+        ],
+        "usphone": "'mɑnɚki",
+        "ukphone": "'mɑːnərki"
+    },
+    {
+        "name": "monastery",
+        "trans": [
+            "男修道院， 寺院"
+        ],
+        "usphone": "'mɑnəstɛri",
+        "ukphone": "'mɑːnəsteri"
+    },
+    {
+        "name": "monetary",
+        "trans": [
+            "金钱的， 货币的"
+        ],
+        "usphone": "'mʌnɪtɛri",
+        "ukphone": "'mʌnɪteri"
+    },
+    {
+        "name": "monitor",
+        "trans": [
+            "监控；调节",
+            "显示器； 监视器； 班长"
+        ],
+        "usphone": "'mɔnɪtɚ",
+        "ukphone": "'mɑːnɪtər"
+    },
+    {
+        "name": "monogamous",
+        "trans": [
+            "一夫一妻制的； 单配的"
+        ],
+        "usphone": "mə'nɑɡəməs",
+        "ukphone": "mə'nɑːgəməs"
+    },
+    {
+        "name": "monogamy",
+        "trans": [
+            "一夫一妻制"
+        ],
+        "usphone": "mə'nɑɡəmi",
+        "ukphone": "mə'nɑːgəmi"
+    },
+    {
+        "name": "monopoly",
+        "trans": [
+            "垄断， 专卖； 垄断商品， 专卖商品； 独占， 专利"
+        ],
+        "usphone": "mə'nɑpəli",
+        "ukphone": "mə'nɑːpəli"
+    },
+    {
+        "name": "monotonous",
+        "trans": [
+            "单调的， 无聊的"
+        ],
+        "usphone": "mə'nɑtənəs",
+        "ukphone": "mə'nɑːtənəs"
+    },
+    {
+        "name": "monotony",
+        "trans": [
+            "单调， 千篇一律"
+        ],
+        "usphone": "mə'nɑtəni",
+        "ukphone": "mə'nɑːtəni"
+    },
+    {
+        "name": "monster",
+        "trans": [
+            "巨大的， 庞大的",
+            "怪物；庞然大物；恶魔"
+        ],
+        "usphone": "'mɑnstɚ",
+        "ukphone": "'mɑːnstər"
+    },
+    {
+        "name": "monument",
+        "trans": [
+            "纪念碑； 历史遗迹"
+        ],
+        "usphone": "'mɑnjumənt",
+        "ukphone": "'mɑːnjumənt"
+    },
+    {
+        "name": "monumental",
+        "trans": [
+            "纪念碑的； 不朽的"
+        ],
+        "usphone": ",mɑnju'mɛntl",
+        "ukphone": "ˌmɑːnju'mentl"
+    },
+    {
+        "name": "moor",
+        "trans": [
+            "停泊， 系泊",
+            "沼泽；旷野，荒野"
+        ],
+        "usphone": "",
+        "ukphone": "mur"
+    },
+    {
+        "name": "moral",
+        "trans": [
+            "道德的，道义上的；有道德的，品行端正的；精神的"
+        ],
+        "usphone": "'mɔrəl",
+        "ukphone": "'mɔːrəl"
+    },
+    {
+        "name": "morale",
+        "trans": [
+            "士气， 斗志"
+        ],
+        "usphone": "mə'ræl",
+        "ukphone": "mə'ræl"
+    },
+    {
+        "name": "morgue",
+        "trans": [
+            "停尸房， 太平间"
+        ],
+        "usphone": "mɔrɡ",
+        "ukphone": "mɔːrg"
+    },
+    {
+        "name": "morphology",
+        "trans": [
+            "形态学， 形态论"
+        ],
+        "usphone": "mɔr'fɑlədʒi",
+        "ukphone": "mɔːr'fɑːlədʒi"
+    },
+    {
+        "name": "mortality",
+        "trans": [
+            "死亡率"
+        ],
+        "usphone": "mɔr'tæləti",
+        "ukphone": "mɔːr'tæləti"
+    },
+    {
+        "name": "mortgage",
+        "trans": [
+            "抵押贷款，按揭；抵押证书",
+            "用…作抵押"
+        ],
+        "usphone": "'mɔrɡɪdʒ",
+        "ukphone": "'mɔːrgɪdʒ"
+    },
+    {
+        "name": "mortify",
+        "trans": [
+            "使蒙受屈辱， 使难堪"
+        ],
+        "usphone": "'mɔrtɪfaɪ",
+        "ukphone": "'mɔːrtɪfaɪ"
+    },
+    {
+        "name": "mosaic",
+        "trans": [
+            "马赛克； 镶嵌工艺"
+        ],
+        "usphone": "mo'zeɪk",
+        "ukphone": "mou'zeɪɪk"
+    },
+    {
+        "name": "mosquito",
+        "trans": [
+            "蚊子"
+        ],
+        "usphone": "məˈskiːtoʊ",
+        "ukphone": "mə'skiːtou"
+    },
+    {
+        "name": "moss",
+        "trans": [
+            "苔藓"
+        ],
+        "usphone": "mɔs",
+        "ukphone": "mɔːs"
+    },
+    {
+        "name": "moth",
+        "trans": [
+            "蛾"
+        ],
+        "usphone": "mɔθ",
+        "ukphone": "mɔːθ"
+    },
+    {
+        "name": "motif",
+        "trans": [
+            "主题， 主旨； 图形"
+        ],
+        "usphone": "mo'tif",
+        "ukphone": "mou'tiːf"
+    },
+    {
+        "name": "motion",
+        "trans": [
+            "做动作， 示意",
+            "运动，移动；动作；提议，动议"
+        ],
+        "usphone": "'moʃən",
+        "ukphone": "'mouʃn"
+    },
+    {
+        "name": "motivate",
+        "trans": [
+            "激励； 激发"
+        ],
+        "usphone": "'motə'vet",
+        "ukphone": "'moutɪveɪt"
+    },
+    {
+        "name": "motive",
+        "trans": [
+            "发动的； 导致运动的",
+            "动机，目的"
+        ],
+        "usphone": "'motɪv",
+        "ukphone": "'moutɪv"
+    },
+    {
+        "name": "motor",
+        "trans": [
+            "机动的；肌肉运动的",
+            "发动机， 电动机"
+        ],
+        "usphone": "'motɚ",
+        "ukphone": "'moutər"
+    },
+    {
+        "name": "mottled",
+        "trans": [
+            "有杂色的， 斑驳的"
+        ],
+        "usphone": "'mɑtld",
+        "ukphone": "'mɑːtld"
+    },
+    {
+        "name": "motto",
+        "trans": [
+            "座右铭； 箴言， 格言"
+        ],
+        "usphone": "'mɑto",
+        "ukphone": "'mɑːtou"
+    },
+    {
+        "name": "mound",
+        "trans": [
+            "土墩， 土丘； 堆， 垛"
+        ],
+        "usphone": "maʊnd",
+        "ukphone": "maund"
+    },
+    {
+        "name": "mount",
+        "trans": [
+            "增加；登上，攀登；骑上，乘上；发起，组织，开展",
+            "山， 山峰； 支架， 底座"
+        ],
+        "usphone": "maʊnt",
+        "ukphone": "maunt"
+    },
+    {
+        "name": "mountainous",
+        "trans": [
+            "多山的； 巨大的"
+        ],
+        "usphone": "'maʊntənəs",
+        "ukphone": "'mauntənəs"
+    },
+    {
+        "name": "muggy",
+        "trans": [
+            "闷热的"
+        ],
+        "usphone": "'mʌɡi",
+        "ukphone": "'mʌgi"
+    },
+    {
+        "name": "multiple",
+        "trans": [
+            "多样的；多重的",
+            "倍数"
+        ],
+        "usphone": "'mʌltəpl",
+        "ukphone": "'mʌltɪpl"
+    },
+    {
+        "name": "multiplicative",
+        "trans": [
+            "倍增的； 乘法的"
+        ],
+        "usphone": "'mʌltɪplɪketɪv",
+        "ukphone": "ˌmʌltɪplɪ'keɪtɪv"
+    },
+    {
+        "name": "multiply",
+        "trans": [
+            "增加； 繁殖； 乘"
+        ],
+        "usphone": "'mʌltɪplaɪ",
+        "ukphone": "'mʌltɪplaɪ"
+    },
+    {
+        "name": "multitude",
+        "trans": [
+            "大量， 众多； 群众， 民众； 人群"
+        ],
+        "usphone": "ˈmʌltɪˌtud, -ˌtjud",
+        "ukphone": "'mʌltɪtjuːd"
+    },
+    {
+        "name": "mundane",
+        "trans": [
+            "世俗的； 平凡的"
+        ],
+        "usphone": "mʌn'den",
+        "ukphone": "mʌn'deɪn"
+    },
+    {
+        "name": "municipal",
+        "trans": [
+            "市政的； 内政的； 地方性的"
+        ],
+        "usphone": "mju'nɪsɪpl",
+        "ukphone": "mjuː'nɪsɪpl"
+    },
+    {
+        "name": "mural",
+        "trans": [
+            "墙壁的； 在墙上的",
+            "壁画，壁饰"
+        ],
+        "usphone": "'mjʊrəl",
+        "ukphone": "'mjurəl"
+    },
+    {
+        "name": "muscle",
+        "trans": [
+            "肌肉； 体力， 力量， 实力； 影响力"
+        ],
+        "usphone": "'mʌsl",
+        "ukphone": "'mʌsl"
+    },
+    {
+        "name": "muscular",
+        "trans": [
+            "肌肉的； 肌肉发达的； 强健的， 强壮的"
+        ],
+        "usphone": "'mʌskjəlɚ",
+        "ukphone": "'mʌskjələr"
+    },
+    {
+        "name": "muse",
+        "trans": [
+            "沉思， 冥想",
+            "灵感"
+        ],
+        "usphone": "mjuz",
+        "ukphone": "mjuːz"
+    },
+    {
+        "name": "mushroom",
+        "trans": [
+            "迅速成长",
+            "蘑菇"
+        ],
+        "usphone": "'mʌʃrʊm",
+        "ukphone": "'mʌʃrum"
+    },
+    {
+        "name": "musical",
+        "trans": [
+            "音乐的；悦耳的；有音乐天赋的，爱好音乐的",
+            "音乐剧"
+        ],
+        "usphone": "'mjuzɪkl",
+        "ukphone": "'mjuːzɪkl"
+    },
+    {
+        "name": "musician",
+        "trans": [
+            "音乐家， 乐师"
+        ],
+        "usphone": "mjʊ'zɪʃən",
+        "ukphone": "mju'zɪʃn"
+    },
+    {
+        "name": "mutual",
+        "trans": [
+            "相互的； 共有的"
+        ],
+        "usphone": "'mjutʃuəl",
+        "ukphone": "'mjuːtʃuəl"
+    },
+    {
+        "name": "myopic",
+        "trans": [
+            "近视的； 缺乏远见的"
+        ],
+        "usphone": "maɪ'ɑpɪk",
+        "ukphone": "maɪ'oupiə"
+    },
+    {
+        "name": "myriad",
+        "trans": [
+            "无数的； 大量的",
+            "无数；大量"
+        ],
+        "usphone": "'miriəd",
+        "ukphone": "'mɪriəd"
+    },
+    {
+        "name": "mythology",
+        "trans": [
+            "神话； 神话学； 虚幻的想法"
+        ],
+        "usphone": "mɪ'θɑlədʒi",
+        "ukphone": "mɪ'θɑːlədʒi"
+    },
+    {
+        "name": "nail",
+        "trans": [
+            "指甲，爪；钉",
+            "将…钉牢， 钉住"
+        ],
+        "usphone": "nel",
+        "ukphone": "neɪl"
+    },
+    {
+        "name": "naive",
+        "trans": [
+            "天真的， 率真的， 质朴的； 幼稚的， 无知的， 轻信的； 稚拙派的"
+        ],
+        "usphone": "naɪ'iv",
+        "ukphone": "naɪ'iːv"
+    },
+    {
+        "name": "naked",
+        "trans": [
+            "裸露的， 无遮盖的； 直白的， 露骨的， 不加掩饰的"
+        ],
+        "usphone": "'nekɪd",
+        "ukphone": "'neɪkɪd"
+    },
+    {
+        "name": "nap",
+        "trans": [
+            "小睡， 打盹"
+        ],
+        "usphone": "næp",
+        "ukphone": "næp"
+    },
+    {
+        "name": "narrate",
+        "trans": [
+            "讲述， 叙述"
+        ],
+        "usphone": "næret",
+        "ukphone": "nə'reɪt"
+    },
+    {
+        "name": "narrative",
+        "trans": [
+            "叙述性的",
+            "叙述；记叙体，叙述技巧"
+        ],
+        "usphone": "'nærətɪv",
+        "ukphone": "'nærətɪv"
+    },
+    {
+        "name": "nationalism",
+        "trans": [
+            "国家主义； 民族主义， 民族优越感"
+        ],
+        "usphone": "'næʃnəlɪzəm",
+        "ukphone": "'næʃnəlɪzəm"
+    },
+    {
+        "name": "naturalist",
+        "trans": [
+            "自然主义者； 博物学家"
+        ],
+        "usphone": "'nætʃrəlɪst",
+        "ukphone": "'nætʃrəlɪst"
+    },
+    {
+        "name": "nauseous",
+        "trans": [
+            "恶心的； 令人作呕的， 令人厌恶的"
+        ],
+        "usphone": "'nɔʃəs",
+        "ukphone": "'nɔːʃəs"
+    },
+    {
+        "name": "naval",
+        "trans": [
+            "海军的"
+        ],
+        "usphone": "'nevl",
+        "ukphone": "'neɪvl"
+    },
+    {
+        "name": "navigate",
+        "trans": [
+            "航行， 横渡； 导航； 设法完成"
+        ],
+        "usphone": "'nævə'get",
+        "ukphone": "'nævɪgeɪt"
+    },
+    {
+        "name": "necessitate",
+        "trans": [
+            "需要， 使成为必要"
+        ],
+        "usphone": "nə'sɛsɪtet",
+        "ukphone": "nə'sesɪteɪt"
+    },
+    {
+        "name": "necessity",
+        "trans": [
+            "必需品； 必要， 需要； 必然性"
+        ],
+        "usphone": "nə'sɛsəti",
+        "ukphone": "nə'sesəti"
+    },
+    {
+        "name": "nectar",
+        "trans": [
+            "花蜜； 甘美的饮料， 琼浆玉液"
+        ],
+        "usphone": "'nɛktɚ",
+        "ukphone": "'nektər"
+    },
+    {
+        "name": "needy",
+        "trans": [
+            "贫穷的， 贫困的"
+        ],
+        "usphone": "'nidi",
+        "ukphone": "'niːdi"
+    },
+    {
+        "name": "negate",
+        "trans": [
+            "取消； 否定"
+        ],
+        "usphone": "nɪˈɡet",
+        "ukphone": "nɪ'geɪt"
+    },
+    {
+        "name": "neglect",
+        "trans": [
+            "忽略， 忽视； 疏忽"
+        ],
+        "usphone": "nɪ'glɛkt",
+        "ukphone": "nɪ'glekt"
+    },
+    {
+        "name": "negligent",
+        "trans": [
+            "忽略的； 疏忽的； 粗心大意的"
+        ],
+        "usphone": "'nɛɡlɪdʒənt",
+        "ukphone": "'neglɪdʒənt"
+    },
+    {
+        "name": "negligible",
+        "trans": [
+            "可以忽略的， 微不足道的； 无关紧要的"
+        ],
+        "usphone": "'nɛɡlɪdʒəbl",
+        "ukphone": "'neglɪdʒəbl"
+    },
+    {
+        "name": "negotiate",
+        "trans": [
+            "谈判， 商议； 商定， 达成； 通过， 越过"
+        ],
+        "usphone": "nɪ'ɡoʃɪet",
+        "ukphone": "nɪ'gouʃieɪt"
+    },
+    {
+        "name": "negotiation",
+        "trans": [
+            "商议， 谈判； 流通"
+        ],
+        "usphone": "nɪ,ɡoʃɪ'eʃən",
+        "ukphone": "nɪˌgouʃi'eɪʃn"
+    },
+    {
+        "name": "neoclassical",
+        "trans": [
+            "新古典主义的"
+        ],
+        "usphone": ",nio'klæsɪkl",
+        "ukphone": "ˌniːou'klæsɪkl"
+    },
+    {
+        "name": "Neolithic",
+        "trans": [
+            "新石器时代的"
+        ],
+        "usphone": "ˌniəˈlɪθɪk",
+        "ukphone": "ˌniːə'lɪθɪk"
+    },
+    {
+        "name": "neon",
+        "trans": [
+            "氖； 霓虹灯"
+        ],
+        "usphone": "'niɑn",
+        "ukphone": "'niːɑːn"
+    },
+    {
+        "name": "nest",
+        "trans": [
+            "做窝，筑巢",
+            "巢， 窝"
+        ],
+        "usphone": "nɛst",
+        "ukphone": "nest"
+    },
+    {
+        "name": "neuron",
+        "trans": [
+            "神经元， 神经细胞"
+        ],
+        "usphone": "'nʊrɑn",
+        "ukphone": "'nurɑːn"
+    },
+    {
+        "name": "neutral",
+        "trans": [
+            "中性的； 中立的"
+        ],
+        "usphone": "'nʊtrəl",
+        "ukphone": "'njuːtrəl"
+    },
+    {
+        "name": "neutron",
+        "trans": [
+            "中子"
+        ],
+        "usphone": "'nʊtrɑn",
+        "ukphone": "'njuːtrɑːn"
+    },
+    {
+        "name": "nevertheless",
+        "trans": [
+            "然而， 不过"
+        ],
+        "usphone": ",nɛvɚðə'lɛs",
+        "ukphone": "ˌnevərðə'les"
+    },
+    {
+        "name": "newsletter",
+        "trans": [
+            "时事通讯"
+        ],
+        "usphone": "'nuzlɛtɚ",
+        "ukphone": "'njuːzletər"
+    },
+    {
+        "name": "newsprint",
+        "trans": [
+            "新闻纸"
+        ],
+        "usphone": "'nuzprɪnt",
+        "ukphone": "'njuːzprɪnt"
+    },
+    {
+        "name": "niche",
+        "trans": [
+            "生态位； 壁龛"
+        ],
+        "usphone": "niʃ",
+        "ukphone": "niːʃ"
+    },
+    {
+        "name": "nickel",
+        "trans": [
+            "镍； 五分镍币"
+        ],
+        "usphone": "'nɪkl",
+        "ukphone": "'nɪkl"
+    },
+    {
+        "name": "nicotine",
+        "trans": [
+            "尼古丁"
+        ],
+        "usphone": "'nɪkətɪn",
+        "ukphone": "'nɪkətiːn"
+    },
+    {
+        "name": "nightmare",
+        "trans": [
+            "噩梦； 无法摆脱的恐惧； 可怕的事"
+        ],
+        "usphone": "'naɪt'mɛr",
+        "ukphone": "'naɪtmer"
+    },
+    {
+        "name": "nimble",
+        "trans": [
+            "敏捷的， 灵活的"
+        ],
+        "usphone": "'nɪmbl",
+        "ukphone": "'nɪmbl"
+    },
+    {
+        "name": "nitrogen",
+        "trans": [
+            "氮"
+        ],
+        "usphone": "'naɪtrədʒən",
+        "ukphone": "'naɪtrədʒən"
+    },
+    {
+        "name": "nocturnal",
+        "trans": [
+            "夜行性的； 夜间发生的"
+        ],
+        "usphone": "nɑk'tɝnl",
+        "ukphone": "nɑːk'tɜːrnl"
+    },
+    {
+        "name": "nomadic",
+        "trans": [
+            "游牧的； 流浪的"
+        ],
+        "usphone": "nəu'mædik, nɔ-",
+        "ukphone": "nou'mædɪk"
+    },
+    {
+        "name": "nominal",
+        "trans": [
+            "名义上的； 微不足道的"
+        ],
+        "usphone": "'nɑmɪnl",
+        "ukphone": "'nɑːmɪnl"
+    },
+    {
+        "name": "nominate",
+        "trans": [
+            "任命， 指定； 提名， 推荐"
+        ],
+        "usphone": "'nɑmɪnet",
+        "ukphone": "'nɑːmɪneɪt"
+    },
+    {
+        "name": "nominee",
+        "trans": [
+            "被提名者， 被任命者"
+        ],
+        "usphone": ",nɑmɪ'ni",
+        "ukphone": "ˌnɑːmɪ'niː"
+    },
+    {
+        "name": "nonetheless",
+        "trans": [
+            "虽然如此， 但是， 依然"
+        ],
+        "usphone": "'nʌnðə'lɛs",
+        "ukphone": "ˌnʌnðə'les"
+    },
+    {
+        "name": "nonsense",
+        "trans": [
+            "胡说， 废话； 冒失的行为"
+        ],
+        "usphone": "'nɑnsɛns",
+        "ukphone": "'nɑːnsens"
+    },
+    {
+        "name": "nonverbal",
+        "trans": [
+            "非语言的"
+        ],
+        "usphone": ",nɑn'vɝbl",
+        "ukphone": "'nɑːnvɜːrbl"
+    },
+    {
+        "name": "normally",
+        "trans": [
+            "通常地； 正常地"
+        ],
+        "usphone": "'nɔrmli",
+        "ukphone": "'nɔːrməli"
+    },
+    {
+        "name": "nostalgia",
+        "trans": [
+            "思乡病， 乡愁； 怀旧之情， 恋旧"
+        ],
+        "usphone": "nə'stældʒə",
+        "ukphone": "nə'stældʒə"
+    },
+    {
+        "name": "nostalgic",
+        "trans": [
+            "思乡的； 怀旧的"
+        ],
+        "usphone": "nɒ'stældʒɪk",
+        "ukphone": "nə'stældʒɪk"
+    },
+    {
+        "name": "nosy",
+        "trans": [
+            "爱管闲事的， 好打听的"
+        ],
+        "usphone": "'nozi",
+        "ukphone": "'nouzi"
+    },
+    {
+        "name": "notable",
+        "trans": [
+            "值得注意的，明显的；显著的；著名的；重要的",
+            "名人， 要人"
+        ],
+        "usphone": "'notəbl",
+        "ukphone": "'noutəbl"
+    },
+    {
+        "name": "notate",
+        "trans": [
+            "以符号表示， 把…写成记号"
+        ],
+        "usphone": "nəu'teit, 'nəuteit",
+        "ukphone": "'nouteɪt"
+    },
+    {
+        "name": "notation",
+        "trans": [
+            "符号， 记号"
+        ],
+        "usphone": "no'teʃən",
+        "ukphone": "nou'teɪʃn"
+    },
+    {
+        "name": "notch",
+        "trans": [
+            "等级，档次；"
+        ],
+        "usphone": "nɑtʃ",
+        "ukphone": "nɑːtʃ"
+    },
+    {
+        "name": "noted",
+        "trans": [
+            "著名的"
+        ],
+        "usphone": "'notɪd",
+        "ukphone": "'noutɪd"
+    },
+    {
+        "name": "noteworthy",
+        "trans": [
+            "显著的， 值得注目的"
+        ],
+        "usphone": "'notwɝði",
+        "ukphone": "'noutwɜːrði"
+    },
+    {
+        "name": "noticeable",
+        "trans": [
+            "明显的， 值得注意的"
+        ],
+        "usphone": "'notɪsəbl",
+        "ukphone": "'noutɪsəbl"
+    },
+    {
+        "name": "notify",
+        "trans": [
+            "通报"
+        ],
+        "usphone": "'notə'fai",
+        "ukphone": "'noutɪfaɪ"
+    },
+    {
+        "name": "notion",
+        "trans": [
+            "概念， 观念； 想法"
+        ],
+        "usphone": "'noʃən",
+        "ukphone": "'nouʃn"
+    },
+    {
+        "name": "notorious",
+        "trans": [
+            "臭名昭著的， 声名狼藉的"
+        ],
+        "usphone": "no'tɔrɪəs",
+        "ukphone": "nou'tɔːriəs"
+    },
+    {
+        "name": "notwithstanding",
+        "trans": [
+            "虽然， 尽管如此"
+        ],
+        "usphone": ",nɑtwɪθ'stændɪŋ",
+        "ukphone": "ˌnɑːtwɪθ'stændɪŋ"
+    },
+    {
+        "name": "nourish",
+        "trans": [
+            "滋养； 养育"
+        ],
+        "usphone": "'nɜrɪʃ",
+        "ukphone": "'nɜːrɪʃ"
+    },
+    {
+        "name": "nourishment",
+        "trans": [
+            "营养， 营养品"
+        ],
+        "usphone": "'nɝɪʃmənt",
+        "ukphone": "'nɜːrɪʃmənt"
+    },
+    {
+        "name": "novel",
+        "trans": [
+            "新颖的",
+            "小说"
+        ],
+        "usphone": "ˈnɑːvl",
+        "ukphone": "'nɑːvl"
+    },
+    {
+        "name": "novelty",
+        "trans": [
+            "新奇， 新颖； 新奇的事物"
+        ],
+        "usphone": "'nɑvlti",
+        "ukphone": "'nɑːvlti"
+    },
+    {
+        "name": "novice",
+        "trans": [
+            "生手， 新手； 新信徒"
+        ],
+        "usphone": "'nɑvɪs",
+        "ukphone": "'nɑːvɪs"
+    },
+    {
+        "name": "noxious",
+        "trans": [
+            "有害的； 有毒的"
+        ],
+        "usphone": "'nɑkʃəs",
+        "ukphone": "'nɑːkʃəs"
+    },
+    {
+        "name": "nucleus",
+        "trans": [
+            "(原子)核"
+        ],
+        "usphone": "'nuklɪəs",
+        "ukphone": "'njuːkliəs"
+    },
+    {
+        "name": "nude",
+        "trans": [
+            "裸体的"
+        ],
+        "usphone": "nud",
+        "ukphone": "nuːd"
+    },
+    {
+        "name": "numeric",
+        "trans": [
+            "数字的"
+        ],
+        "usphone": "nuː'merɪk",
+        "ukphone": "njuː'merɪk"
+    },
+    {
+        "name": "numerous",
+        "trans": [
+            "许多的； 无数的"
+        ],
+        "usphone": "'numərəs",
+        "ukphone": "'nuːmərəs"
+    },
+    {
+        "name": "nurture",
+        "trans": [
+            "养育，养护，培养；扶植，支持；滋长，助长",
+            "养育， 培养"
+        ],
+        "usphone": "'nɝtʃɚ",
+        "ukphone": "'nɜːrtʃər"
+    },
+    {
+        "name": "nutrient",
+        "trans": [
+            "滋养的， 有营养的",
+            "滋养物，营养品"
+        ],
+        "usphone": "'nutrɪənt",
+        "ukphone": "'nuːtriənt"
+    },
+    {
+        "name": "nutrition",
+        "trans": [
+            "营养； 营养学"
+        ],
+        "usphone": "nu'trɪʃən",
+        "ukphone": "nu'trɪʃn"
+    },
+    {
+        "name": "oak",
+        "trans": [
+            "橡树， 橡木"
+        ],
+        "usphone": "ok",
+        "ukphone": "ouk"
+    },
+    {
+        "name": "oasis",
+        "trans": [
+            "绿洲； 避风港"
+        ],
+        "usphone": "o'esɪs",
+        "ukphone": "ou'eɪsɪs"
+    },
+    {
+        "name": "obedience",
+        "trans": [
+            "服从， 顺从"
+        ],
+        "usphone": "ə'bidjəns",
+        "ukphone": "ou'biːdiəns"
+    },
+    {
+        "name": "obituary",
+        "trans": [
+            "讣闻， 讣告"
+        ],
+        "usphone": "o'bɪtʃuɛri",
+        "ukphone": "ou'bɪtʃueri"
+    },
+    {
+        "name": "objective",
+        "trans": [
+            "客观的",
+            "目标，目的"
+        ],
+        "usphone": "əb'dʒɛktɪv",
+        "ukphone": "əb'dʒektɪv"
+    },
+    {
+        "name": "obligate",
+        "trans": [
+            "使负义务， 强迫"
+        ],
+        "usphone": "'ɑblɪ,ɡeɪt",
+        "ukphone": "'ɑːblɪgeɪt"
+    },
+    {
+        "name": "obliterate",
+        "trans": [
+            "覆盖； 消灭； 忘却"
+        ],
+        "usphone": "ə'blɪtə'ret",
+        "ukphone": "ə'blɪtəreɪt"
+    },
+    {
+        "name": "oblivious",
+        "trans": [
+            "遗忘的； 未注意的， 不知不觉的"
+        ],
+        "usphone": "ə'blɪvɪəs",
+        "ukphone": "ə'blɪviəs"
+    },
+    {
+        "name": "oblong",
+        "trans": [
+            "矩形的，长方形的；椭圆形的",
+            "矩形， 长方形； 椭圆形"
+        ],
+        "usphone": "'ɑblɔŋ",
+        "ukphone": "'ɑːblɔːŋ"
+    },
+    {
+        "name": "obscene",
+        "trans": [
+            "淫秽的， 下流的； 骇人听闻的； 可憎的， 可恶的"
+        ],
+        "usphone": "əb'sin",
+        "ukphone": "əb'siːn"
+    },
+    {
+        "name": "obscure",
+        "trans": [
+            "暗的，模糊的，朦胧的；费解的，晦涩的；不著名的，不重要的",
+            "使变模糊； 使费解"
+        ],
+        "usphone": "əb'skjʊr",
+        "ukphone": "əb'skjur"
+    },
+    {
+        "name": "observatory",
+        "trans": [
+            "天文台， 天文观测站"
+        ],
+        "usphone": "əb'zɝvətɔri",
+        "ukphone": "əb'zɜːrvətɔːri"
+    },
+    {
+        "name": "observe",
+        "trans": [
+            "遵守， 奉行； 观察； 察觉， 看到； 评说， 评论"
+        ],
+        "usphone": "əb'zɝv",
+        "ukphone": "əb'zɜːrv"
+    },
+    {
+        "name": "obsess",
+        "trans": [
+            "迷住； 牵挂"
+        ],
+        "usphone": "əb'sɛs",
+        "ukphone": "əb'ses"
+    },
+    {
+        "name": "obsolete",
+        "trans": [
+            "过时的； 废弃的"
+        ],
+        "usphone": "ɑbsəˌlit",
+        "ukphone": "ˌɑːbsə'liːt"
+    },
+    {
+        "name": "obstacle",
+        "trans": [
+            "障碍， 妨害物"
+        ],
+        "usphone": "'ɑbstəkl",
+        "ukphone": "'ɑːbstəkl"
+    },
+    {
+        "name": "obstruct",
+        "trans": [
+            "妨碍， 阻挠； 阻塞"
+        ],
+        "usphone": "əb'strʌkt",
+        "ukphone": "əb'strʌkt"
+    },
+    {
+        "name": "obtain",
+        "trans": [
+            "获得； 通用， 流行"
+        ],
+        "usphone": "əb'ten",
+        "ukphone": "əb'teɪn"
+    },
+    {
+        "name": "occasional",
+        "trans": [
+            "偶然的， 不经常的； 临时的"
+        ],
+        "usphone": "ə'keʒənl",
+        "ukphone": "ə'keɪʒənl"
+    },
+    {
+        "name": "occupy",
+        "trans": [
+            "占用； 占据， 占领； 使忙于"
+        ],
+        "usphone": "'ɑkjupaɪ",
+        "ukphone": "'ɑːkjupaɪ"
+    },
+    {
+        "name": "occur",
+        "trans": [
+            "发生， 出现； 存在于"
+        ],
+        "usphone": "ə'kɝ",
+        "ukphone": "ə'kɜːr"
+    },
+    {
+        "name": "oceanographer",
+        "trans": [
+            "海洋学者"
+        ],
+        "usphone": ",oʃɪə'nɑgrəfɚ",
+        "ukphone": "ˌəuʃə'nɑːgrəfər"
+    },
+    {
+        "name": "octopus",
+        "trans": [
+            "章鱼"
+        ],
+        "usphone": "'ɑktəpəs",
+        "ukphone": "'ɑːktəpəs"
+    },
+    {
+        "name": "odd",
+        "trans": [
+            "单数的； 奇数的； 奇异的， 古怪的； 偶尔发生的"
+        ],
+        "usphone": "ɑd",
+        "ukphone": "ɑːd"
+    },
+    {
+        "name": "odorous",
+        "trans": [
+            "有气味的， 难闻的； 香的， 芬芳的"
+        ],
+        "usphone": "'odərəs",
+        "ukphone": "'oudərəs"
+    },
+    {
+        "name": "offensive",
+        "trans": [
+            "攻击性的；冒犯的，使人不快的；攻方的",
+            "进攻， 攻击； 攻势"
+        ],
+        "usphone": "ə'fɛnsɪv",
+        "ukphone": "ə'fensɪv"
+    },
+    {
+        "name": "offer",
+        "trans": [
+            "提供；自愿给予；提出，提议",
+            "提议； 报价， 出价； 特价"
+        ],
+        "usphone": "'ɔfɚ",
+        "ukphone": "'ɔːfər"
+    },
+    {
+        "name": "officious",
+        "trans": [
+            "爱发号施令的， 爱指手画脚的"
+        ],
+        "usphone": "ə'fɪʃəs",
+        "ukphone": "ə'fɪʃəs"
+    },
+    {
+        "name": "offset",
+        "trans": [
+            "分支；补偿；抵消",
+            "补偿； 抵消"
+        ],
+        "usphone": ",ɔf'sɛt",
+        "ukphone": "'ɔːfset"
+    },
+    {
+        "name": "offspring",
+        "trans": [
+            "子孙， 后代； 崽"
+        ],
+        "usphone": "'ɔfsprɪŋ",
+        "ukphone": "'ɔːfsprɪŋ"
+    },
+    {
+        "name": "olfactory",
+        "trans": [
+            "嗅觉的"
+        ],
+        "usphone": "ɑl'fæktəri",
+        "ukphone": "ɑːl'fæktəri"
+    },
+    {
+        "name": "omit",
+        "trans": [
+            "省略， 删去； 遗漏， 忽略"
+        ],
+        "usphone": "ə'mɪt",
+        "ukphone": "ə'mɪt"
+    },
+    {
+        "name": "ongoing",
+        "trans": [
+            "正在进行的；不间断的；继续存在的",
+            "前进， 发展"
+        ],
+        "usphone": "'ɑnɡoɪŋ",
+        "ukphone": "'ɑːngouɪŋ"
+    },
+    {
+        "name": "onslaught",
+        "trans": [
+            "冲击； 攻击， 猛攻"
+        ],
+        "usphone": "'ɑnslɔt",
+        "ukphone": "'ɑːnslɔːt"
+    },
+    {
+        "name": "ooze",
+        "trans": [
+            "渗出，慢慢流出；洋溢着，充满",
+            "泥浆； 缓慢渗出"
+        ],
+        "usphone": "uz",
+        "ukphone": "uːz"
+    },
+    {
+        "name": "opal",
+        "trans": [
+            "蛋白石"
+        ],
+        "usphone": "'opl",
+        "ukphone": "'oupl"
+    },
+    {
+        "name": "opaque",
+        "trans": [
+            "不透明的， 不透光的； 难懂的， 晦涩的"
+        ],
+        "usphone": "o'pek",
+        "ukphone": "ou'peɪk"
+    },
+    {
+        "name": "operant",
+        "trans": [
+            "运转中的；生效的；操作性的",
+            "起作用的人"
+        ],
+        "usphone": "'ɑpərənt",
+        "ukphone": "'ɑːpərænt"
+    },
+    {
+        "name": "operate",
+        "trans": [
+            "运转， 开动； 动手术； 经营， 管理； 起作用"
+        ],
+        "usphone": "'ɑpə'ret",
+        "ukphone": "'ɑːpəreɪt"
+    },
+    {
+        "name": "opponent",
+        "trans": [
+            "对立的， 反对的， 对抗的",
+            "敌手，对手，反对者"
+        ],
+        "usphone": "ə'ponənt",
+        "ukphone": "ə'pounənt"
+    },
+    {
+        "name": "opportunity",
+        "trans": [
+            "机会， 时机"
+        ],
+        "usphone": "ˌɑpɚˈtunətɪ",
+        "ukphone": "ˌɑːpər'tuːnəti"
+    },
+    {
+        "name": "oppose",
+        "trans": [
+            "反对， 对抗"
+        ],
+        "usphone": "ə'poz",
+        "ukphone": "ə'pouz"
+    },
+    {
+        "name": "opposed",
+        "trans": [
+            "反对的； 截然不同的"
+        ],
+        "usphone": "ə'pozd",
+        "ukphone": "ə'pouzd"
+    },
+    {
+        "name": "opposite",
+        "trans": [
+            "对面的；对立的；相反的",
+            "在…对面",
+            "对立面；对立物"
+        ],
+        "usphone": "ˈɑpəzɪt; ˈɑpəsɪt",
+        "ukphone": "'ɑːpəzət"
+    },
+    {
+        "name": "oppressive",
+        "trans": [
+            "压迫的， 压制的； 令人焦虑的"
+        ],
+        "usphone": "ə'prɛsɪv",
+        "ukphone": "ə'presɪv"
+    },
+    {
+        "name": "optic",
+        "trans": [
+            "眼的；视觉的；光学上的",
+            "光学仪器"
+        ],
+        "usphone": "'ɑptɪk",
+        "ukphone": "'ɑːptɪk"
+    },
+    {
+        "name": "optimal",
+        "trans": [
+            "最佳的， 最理想的"
+        ],
+        "usphone": "'ɑptəml",
+        "ukphone": "'ɑːptɪməl"
+    },
+    {
+        "name": "optimistic",
+        "trans": [
+            "乐观的"
+        ],
+        "usphone": ",ɑptɪ'mɪstɪk",
+        "ukphone": "ˌɑːptɪ'mɪstɪk"
+    },
+    {
+        "name": "optimize",
+        "trans": [
+            "使最优化； 充分利用"
+        ],
+        "usphone": "'ɑptɪmaɪz",
+        "ukphone": "'ɑːptɪmaɪz"
+    },
+    {
+        "name": "optional",
+        "trans": [
+            "可以任选的， 非强制的"
+        ],
+        "usphone": "'ɑpʃənl",
+        "ukphone": "'ɑːpʃənl"
+    },
+    {
+        "name": "oral",
+        "trans": [
+            "口头的， 口述的； 口腔的"
+        ],
+        "usphone": "'ɔrəl",
+        "ukphone": "'ɔːrəl"
+    },
+    {
+        "name": "oratorio",
+        "trans": [
+            "清唱剧， 宗教剧"
+        ],
+        "usphone": ",ɔrə'tɔrɪo",
+        "ukphone": "ˌɔːrə'tɔːriou"
+    },
+    {
+        "name": "orbit",
+        "trans": [
+            "作轨道运行",
+            "轨道；势力范围"
+        ],
+        "usphone": "'ɔrbɪt",
+        "ukphone": "'ɔːrbɪt"
+    },
+    {
+        "name": "orbital",
+        "trans": [
+            "轨道的"
+        ],
+        "usphone": "'ɔrbɪtl",
+        "ukphone": "'ɔːrbɪtl"
+    },
+    {
+        "name": "orchestra",
+        "trans": [
+            "管弦乐队"
+        ],
+        "usphone": "'ɔrkɪstrə",
+        "ukphone": "'ɔːrkɪstrə"
+    },
+    {
+        "name": "orchid",
+        "trans": [
+            "兰， 兰花"
+        ],
+        "usphone": "'ɔrkɪd",
+        "ukphone": "'ɔːrkɪd"
+    },
+    {
+        "name": "ordeal",
+        "trans": [
+            "折磨； 严峻考验"
+        ],
+        "usphone": "ɔr'dil",
+        "ukphone": "ɔːr'diːl"
+    },
+    {
+        "name": "ordinal",
+        "trans": [
+            "序数的；顺序的",
+            "序数词"
+        ],
+        "usphone": "'ɔrdənl",
+        "ukphone": "'ɔːrdənl"
+    },
+    {
+        "name": "ordinate",
+        "trans": [
+            "纵坐标"
+        ],
+        "usphone": "'ɔrdɪnət",
+        "ukphone": "'ɔːrdɪnət"
+    },
+    {
+        "name": "ore",
+        "trans": [
+            "矿； 矿物， 矿石"
+        ],
+        "usphone": "ɔr",
+        "ukphone": "ɔːr"
+    },
+    {
+        "name": "organic",
+        "trans": [
+            "有机的； 器官的； 有机体的"
+        ],
+        "usphone": "ɔr'gænɪk",
+        "ukphone": "ɔːr'gænɪk"
+    },
+    {
+        "name": "organism",
+        "trans": [
+            "生物， 有机物； 有机体"
+        ],
+        "usphone": "'ɔrɡənɪzəm",
+        "ukphone": "'ɔːrgənɪzəm"
+    },
+    {
+        "name": "orient",
+        "trans": [
+            "[O-]东方",
+            "使适应； 确定方向， 定位"
+        ],
+        "usphone": "'orɪənt",
+        "ukphone": "'ɔːriənt"
+    },
+    {
+        "name": "orientation",
+        "trans": [
+            "方向， 方位； 定位； 培训； 情况介绍"
+        ],
+        "usphone": "orɪɛn'teʃən",
+        "ukphone": "ˌɔːriən'teɪʃn"
+    },
+    {
+        "name": "origin",
+        "trans": [
+            "起源，由来；"
+        ],
+        "usphone": "'ɔrɪdʒɪn",
+        "ukphone": "'ɔːrɪdʒɪn"
+    },
+    {
+        "name": "originate",
+        "trans": [
+            "起源； 发起； 创立"
+        ],
+        "usphone": "əˈrɪdʒəˌnet",
+        "ukphone": "ə'rɪdʒɪneɪt"
+    },
+    {
+        "name": "ornament",
+        "trans": [
+            "装饰",
+            "装饰， 点缀"
+        ],
+        "usphone": "'ɔrnəmənt",
+        "ukphone": "'ɔːnəm(ə)nt"
+    },
+    {
+        "name": "ornamental",
+        "trans": [
+            "装饰性的，装饰用的",
+            "装饰物"
+        ],
+        "usphone": ",ɔrnə'mɛntl",
+        "ukphone": "ˌɔːrnə'mentl"
+    },
+    {
+        "name": "ornate",
+        "trans": [
+            "华丽的， 豪华的"
+        ],
+        "usphone": "ɔr'net",
+        "ukphone": "ɔːr'neɪt"
+    },
+    {
+        "name": "ornithology",
+        "trans": [
+            "鸟类学"
+        ],
+        "usphone": ",ɔrnɪ'θɑlədʒi",
+        "ukphone": "ˌɔːrnɪ'θɑːlədʒi"
+    },
+    {
+        "name": "orthodox",
+        "trans": [
+            "传统的； 正统的"
+        ],
+        "usphone": "'ɔrθədɑks",
+        "ukphone": "'ɔːrθədɑːks"
+    },
+    {
+        "name": "otherwise",
+        "trans": [
+            "另样，用别的方法；在其他方面",
+            "要不然， 否则"
+        ],
+        "usphone": "'ʌðɚwaɪz",
+        "ukphone": "'ʌðərwaɪz"
+    },
+    {
+        "name": "outbreak",
+        "trans": [
+            "发作； 爆发"
+        ],
+        "usphone": "'aʊtbrek",
+        "ukphone": "'autbreɪk"
+    },
+    {
+        "name": "outcome",
+        "trans": [
+            "结果， 成果"
+        ],
+        "usphone": "'aʊt'kʌm",
+        "ukphone": "'autkʌm"
+    },
+    {
+        "name": "outcry",
+        "trans": [
+            "大声疾呼， 强烈的抗议"
+        ],
+        "usphone": "'aʊtkraɪ",
+        "ukphone": "'autkraɪ"
+    },
+    {
+        "name": "outermost",
+        "trans": [
+            "最外面的， 离中心最远的"
+        ],
+        "usphone": "'aʊtɚ'most",
+        "ukphone": "'autərmoust"
+    },
+    {
+        "name": "outfit",
+        "trans": [
+            "全套装备； 全套服装"
+        ],
+        "usphone": "'aʊtfɪt",
+        "ukphone": "'autfɪt"
+    },
+    {
+        "name": "outgas",
+        "trans": [
+            "除去气"
+        ],
+        "usphone": "aʊt'gæs",
+        "ukphone": "ˌaut'gæs"
+    },
+    {
+        "name": "outlaw",
+        "trans": [
+            "宣布…为非法",
+            "罪犯， 歹徒， 亡命之徒； 被剥夺法律权益者"
+        ],
+        "usphone": "'aʊtlɔ",
+        "ukphone": "'autlɔː"
+    },
+    {
+        "name": "outline",
+        "trans": [
+            "轮廓； 概要， 大纲",
+            "描绘； 略述"
+        ],
+        "usphone": "'aʊtlaɪn",
+        "ukphone": "'autlaɪn"
+    },
+    {
+        "name": "outlive",
+        "trans": [
+            "比…长命， 比…耐久"
+        ],
+        "usphone": ",aʊt'lɪv",
+        "ukphone": "ˌaut'lɪv"
+    },
+    {
+        "name": "outlying",
+        "trans": [
+            "边远的， 偏僻的； 无关的， 题外的"
+        ],
+        "usphone": "'aʊtlaɪɪŋ",
+        "ukphone": "'autlaɪɪŋ"
+    },
+    {
+        "name": "output",
+        "trans": [
+            "产量； 输出； 产生"
+        ],
+        "usphone": "'aʊtpʊt",
+        "ukphone": "'autput"
+    },
+    {
+        "name": "outrage",
+        "trans": [
+            "暴行；"
+        ],
+        "usphone": "'aʊtredʒ",
+        "ukphone": "'autreɪdʒ"
+    },
+    {
+        "name": "outrageous",
+        "trans": [
+            "残暴的； 骇人的； 反常的， 过度的"
+        ],
+        "usphone": "aʊt'redʒəs",
+        "ukphone": "aut'reɪdʒəs"
+    },
+    {
+        "name": "outrageously",
+        "trans": [
+            "令人不能容忍地； 肆无忌惮地"
+        ],
+        "usphone": "aut'reidʒəsli",
+        "ukphone": "aut'reɪdʒəslɪ"
+    },
+    {
+        "name": "outspoken",
+        "trans": [
+            "直言不讳的， 坦率的"
+        ],
+        "usphone": "aʊt'spokən",
+        "ukphone": "aut'spoukən"
+    },
+    {
+        "name": "outstanding",
+        "trans": [
+            "优秀的， 杰出的， 出色的； 未解决的； 未偿付的"
+        ],
+        "usphone": "'aʊt'stændɪŋ",
+        "ukphone": "aut'stændɪŋ"
+    },
+    {
+        "name": "outweigh",
+        "trans": [
+            "超过"
+        ],
+        "usphone": "'aʊt'we",
+        "ukphone": "ˌaut'weɪ"
+    },
+    {
+        "name": "oval",
+        "trans": [
+            "卵形的，椭圆形的",
+            "卵形， 椭圆形"
+        ],
+        "usphone": "'ovl",
+        "ukphone": "'ouvl"
+    },
+    {
+        "name": "overact",
+        "trans": [
+            "把表演得过火； 表现做作"
+        ],
+        "usphone": "'ovɚ'ækt",
+        "ukphone": "ˌouvər'ækt"
+    },
+    {
+        "name": "overall",
+        "trans": [
+            "总共",
+            "全面的，综合的",
+            "工作服， 工装裤"
+        ],
+        "usphone": ",ovə'rɔl",
+        "ukphone": "'əʊvərɔːl"
+    },
+    {
+        "name": "overcharge",
+        "trans": [
+            "讨价过高，索价过高；过量装填；渲染，夸张",
+            "过高的要价； 超载"
+        ],
+        "usphone": ",ovɚ'tʃɑrdʒ",
+        "ukphone": "ˌouvər'tʃɑːrdʒ"
+    },
+    {
+        "name": "overcome",
+        "trans": [
+            "战胜， 克服"
+        ],
+        "usphone": ",ovɚ'kʌm",
+        "ukphone": "ˌouvər'kʌm"
+    },
+    {
+        "name": "overdue",
+        "trans": [
+            "过期未付的， 逾期的； 过度的， 过火的； 迟到的， 延误的"
+        ],
+        "usphone": "'ovɚ'dʊ",
+        "ukphone": "ˌouvər'duː"
+    },
+    {
+        "name": "overflow",
+        "trans": [
+            "泛滥， 溢出",
+            "溢出； 容纳不下的物"
+        ],
+        "usphone": ",ovɚ'flo",
+        "ukphone": "əʊvə'fləʊ"
+    },
+    {
+        "name": "overgraze",
+        "trans": [
+            "过度放牧"
+        ],
+        "usphone": ",əuvə'ɡreiz",
+        "ukphone": "ˌouvər'greɪz"
+    },
+    {
+        "name": "overhaul",
+        "trans": [
+            "仔细检查； 彻底检修",
+            "仔细检查； 彻底检修"
+        ],
+        "usphone": "'ovɚhɔl",
+        "ukphone": "əʊvə'hɔːl"
+    },
+    {
+        "name": "overlap",
+        "trans": [
+            "交叠， 部分重叠",
+            "重叠； 重叠的部分"
+        ],
+        "usphone": "'ovəlæp",
+        "ukphone": "əʊvə'læp"
+    },
+    {
+        "name": "overload",
+        "trans": [
+            "使超载， 使过载； 使超负荷； 给…增加负担",
+            "超载； 超负荷"
+        ],
+        "usphone": ",ovɚ'lod",
+        "ukphone": "əʊvə'ləʊd"
+    },
+    {
+        "name": "overlook",
+        "trans": [
+            "俯瞰， 眺望； 忽略； 对…不予考虑"
+        ],
+        "usphone": ",ovɚ'lʊk",
+        "ukphone": "ˌouvər'luk"
+    },
+    {
+        "name": "overnight",
+        "trans": [
+            "整夜； 一夜之间",
+            "通宵的， 一整夜的； 一夜之间的"
+        ],
+        "usphone": "'ovənaɪt",
+        "ukphone": "əʊvə'naɪt"
+    },
+    {
+        "name": "overrun",
+        "trans": [
+            "超过，溢出；泛滥；横行",
+            "泛滥； 超出的部分"
+        ],
+        "usphone": "'ovərʌn",
+        "ukphone": "ˌouvə'rʌn"
+    },
+    {
+        "name": "overseas",
+        "trans": [
+            "在海外，在国外",
+            "海外的， 国外的"
+        ],
+        "usphone": ",ovɚ'siz",
+        "ukphone": "ˌouvər'siːz"
+    },
+    {
+        "name": "oversleep",
+        "trans": [
+            "睡过头； 睡得过久"
+        ],
+        "usphone": "ovə'slip",
+        "ukphone": "ˌouvər'sliːp"
+    },
+    {
+        "name": "overt",
+        "trans": [
+            "公开的， 非秘密的"
+        ],
+        "usphone": "o'vɝt",
+        "ukphone": "ou'vɜːrt"
+    },
+    {
+        "name": "overtime",
+        "trans": [
+            "加班",
+            "超时的， 加班的"
+        ],
+        "usphone": ",ovə'taɪm",
+        "ukphone": "'ouvərtaɪm"
+    },
+    {
+        "name": "overview",
+        "trans": [
+            "梗概， 概述"
+        ],
+        "usphone": "'ovɚ'vjʊ",
+        "ukphone": "'ouvərvjuː"
+    },
+    {
+        "name": "overwhelm",
+        "trans": [
+            "淹没， 漫过； 压倒， 击败， 制服； 使难以忍受； 使应接不暇"
+        ],
+        "usphone": "ovɚˈhwɛlm",
+        "ukphone": "ˌouvər'welm"
+    },
+    {
+        "name": "owl",
+        "trans": [
+            "猫头鹰"
+        ],
+        "usphone": "aʊl",
+        "ukphone": "aul"
+    },
+    {
+        "name": "oxide",
+        "trans": [
+            "氧化物"
+        ],
+        "usphone": "'ɑksaɪd",
+        "ukphone": "'ɑːksaɪd"
+    },
+    {
+        "name": "oxygen",
+        "trans": [
+            "氧， 氧气"
+        ],
+        "usphone": "'ɑksɪdʒən",
+        "ukphone": "'ɑːksɪdʒən"
+    },
+    {
+        "name": "oyster",
+        "trans": [
+            "牡蛎， 蚝"
+        ],
+        "usphone": "'ɔɪstɚ",
+        "ukphone": "'ɔɪstər"
+    },
+    {
+        "name": "pack",
+        "trans": [
+            "收拾，打包；捆扎；塞满",
+            "包， 包裹"
+        ],
+        "usphone": "pæk",
+        "ukphone": "pæk"
+    },
+    {
+        "name": "packed",
+        "trans": [
+            "拥挤的； 压紧的"
+        ],
+        "usphone": "pækt",
+        "ukphone": "pækt"
+    },
+    {
+        "name": "pact",
+        "trans": [
+            "协议， 条约， 公约"
+        ],
+        "usphone": "pækt",
+        "ukphone": "pækt"
+    },
+    {
+        "name": "paddle",
+        "trans": [
+            "用桨划船； 涉水， 戏水",
+            "桨；桡足"
+        ],
+        "usphone": "'pædl",
+        "ukphone": "'pædl"
+    },
+    {
+        "name": "painstaking",
+        "trans": [
+            "煞费苦心的， 勤勉的"
+        ],
+        "usphone": "'penztekɪŋ",
+        "ukphone": "'peɪnzteɪkɪŋ"
+    },
+    {
+        "name": "palatable",
+        "trans": [
+            "美味的， 可口的； 合意的， 认可的"
+        ],
+        "usphone": "'pælətəbl",
+        "ukphone": "'pælətəbl"
+    },
+    {
+        "name": "palate",
+        "trans": [
+            "上腭； 味觉， 品尝力"
+        ],
+        "usphone": "'pælət",
+        "ukphone": "'pælət"
+    },
+    {
+        "name": "pale",
+        "trans": [
+            "变得苍白， 变得暗淡",
+            "苍白的；淡色的；暗淡的，微弱的"
+        ],
+        "usphone": "pel",
+        "ukphone": "peɪl"
+    },
+    {
+        "name": "Paleolithic",
+        "trans": [
+            "旧石器时代的",
+            "旧石器时代"
+        ],
+        "usphone": ",pelɪo'lɪθɪk",
+        "ukphone": "ˌpæliə'lɪθɪk"
+    },
+    {
+        "name": "pamphlet",
+        "trans": [
+            "小册子"
+        ],
+        "usphone": "ˈpæmflɪt",
+        "ukphone": "'pæmflət"
+    },
+    {
+        "name": "pancreas",
+        "trans": [
+            "胰腺"
+        ],
+        "usphone": "'pæŋkrɪəs",
+        "ukphone": "'pæŋkriəs"
+    },
+    {
+        "name": "panel",
+        "trans": [
+            "面板，镶板；仪表盘；专门小组",
+            "镶板"
+        ],
+        "usphone": "'pænl",
+        "ukphone": "'pænl"
+    },
+    {
+        "name": "panic",
+        "trans": [
+            "惊慌"
+        ],
+        "usphone": "'pænɪk",
+        "ukphone": "'pænɪk"
+    },
+    {
+        "name": "panorama",
+        "trans": [
+            "全景， 全貌； 概观， 综述"
+        ],
+        "usphone": ",pænə'ræmə",
+        "ukphone": "ˌpænə'ræmə"
+    },
+    {
+        "name": "pants",
+        "trans": [
+            "内裤， 短裤； 裤子"
+        ],
+        "usphone": "pænts",
+        "ukphone": "pænts"
+    },
+    {
+        "name": "parachute",
+        "trans": [
+            "跳伞； 空投",
+            "降落伞"
+        ],
+        "usphone": "'pærə'ʃʊt",
+        "ukphone": "'pærəʃuːt"
+    },
+    {
+        "name": "paradigm",
+        "trans": [
+            "范例， 典范"
+        ],
+        "usphone": "'pærə'daɪm",
+        "ukphone": "'pærədaɪm"
+    },
+    {
+        "name": "paradox",
+        "trans": [
+            "似非而是的论点； 自相矛盾的话"
+        ],
+        "usphone": "'pærədɑks",
+        "ukphone": "'pærədɑːks"
+    },
+    {
+        "name": "parallel",
+        "trans": [
+            "平行的；相似的",
+            "相似处；"
+        ],
+        "usphone": "'pærəlɛl",
+        "ukphone": "'pærəlel"
+    },
+    {
+        "name": "paralyze",
+        "trans": [
+            "使瘫痪， 使麻痹； 使无效"
+        ],
+        "usphone": "'pærə,laɪz",
+        "ukphone": "'pærəlaɪz"
+    },
+    {
+        "name": "parameter",
+        "trans": [
+            "参量， 参数； 界限， 范围"
+        ],
+        "usphone": "pə'ræmɪtɚ",
+        "ukphone": "pə'ræmɪtər"
+    },
+    {
+        "name": "paramount",
+        "trans": [
+            "至为重要的； 最高权力的， 至尊的"
+        ],
+        "usphone": "'pærəmaʊnt",
+        "ukphone": "'pærəmaunt"
+    },
+    {
+        "name": "paraphrase",
+        "trans": [
+            "解释； 改写",
+            "释义"
+        ],
+        "usphone": "ˈpærəfreɪz",
+        "ukphone": "'pærəfreɪz"
+    },
+    {
+        "name": "parasite",
+        "trans": [
+            "寄生物； 食客"
+        ],
+        "usphone": "'pærəsaɪt",
+        "ukphone": "'pærəsaɪt"
+    },
+    {
+        "name": "parking",
+        "trans": [
+            "机动车停放； 停车场"
+        ],
+        "usphone": "'pɑrkɪŋ",
+        "ukphone": "'pɑːrkɪŋ"
+    },
+    {
+        "name": "parliament",
+        "trans": [
+            "国会， 议会"
+        ],
+        "usphone": "'pɑrləmənt",
+        "ukphone": "'pɑːrləmənt"
+    },
+    {
+        "name": "part-time",
+        "trans": [
+            "兼职的； 部分时间的"
+        ],
+        "usphone": ",pɑrt'taɪm",
+        "ukphone": "'pɑːrtˌtaɪm"
+    },
+    {
+        "name": "partial",
+        "trans": [
+            "部分的， 不完全的； 偏爱的， 癖好的； 偏袒的"
+        ],
+        "usphone": "'pɑrʃəl",
+        "ukphone": "'pɑːrʃl"
+    },
+    {
+        "name": "participant",
+        "trans": [
+            "参与者； 参赛者"
+        ],
+        "usphone": "pɑr'tɪsəpənt",
+        "ukphone": "pɑːr'tɪsɪpənt"
+    },
+    {
+        "name": "participate",
+        "trans": [
+            "参与， 参加"
+        ],
+        "usphone": "pɑr'tɪsə'pet",
+        "ukphone": "pɑːr'tɪsɪpeɪt"
+    },
+    {
+        "name": "particle",
+        "trans": [
+            "微粒， 颗粒； 【语】小品词"
+        ],
+        "usphone": "'pɑrtɪkl",
+        "ukphone": "'pɑːrtɪkl"
+    },
+    {
+        "name": "particular",
+        "trans": [
+            "特定的；独特的；详细的；挑剔的",
+            "详情， 细目"
+        ],
+        "usphone": "pɚ'tɪkjəlɚ",
+        "ukphone": "pər'tɪkjələr"
+    },
+    {
+        "name": "partnership",
+        "trans": [
+            "合伙； 伙伴关系； 合伙人身份"
+        ],
+        "usphone": "'pɑrtnɚʃɪp",
+        "ukphone": "'pɑːrtnərʃɪp"
+    },
+    {
+        "name": "passion",
+        "trans": [
+            "激情， 热情"
+        ],
+        "usphone": "'pæʃən",
+        "ukphone": "'pæʃn"
+    },
+    {
+        "name": "passive",
+        "trans": [
+            "被动的， 消极的； 被动语态的"
+        ],
+        "usphone": "'pæsɪv",
+        "ukphone": "'pæsɪv"
+    },
+    {
+        "name": "paste",
+        "trans": [
+            "粘贴；拼贴",
+            "面团； 糨糊"
+        ],
+        "usphone": "pest",
+        "ukphone": "peɪst"
+    },
+    {
+        "name": "pastel",
+        "trans": [
+            "彩色蜡笔的；柔和的",
+            "彩色蜡笔"
+        ],
+        "usphone": "pæ'stɛl",
+        "ukphone": "pæ'stel"
+    },
+    {
+        "name": "pasture",
+        "trans": [
+            "牧场，草原；"
+        ],
+        "usphone": "'pæstʃɚ",
+        "ukphone": "'pæstʃər"
+    },
+    {
+        "name": "patch",
+        "trans": [
+            "修补，打补丁",
+            "小片， 小块； 补丁； 小块土地"
+        ],
+        "usphone": "pætʃ",
+        "ukphone": "pætʃ"
+    },
+    {
+        "name": "patent",
+        "trans": [
+            "有专利的； 显而易见的",
+            "取得专利权",
+            "专利权"
+        ],
+        "usphone": "'pætnt",
+        "ukphone": "'pæt(ə)nt; 'peɪt(ə)nt"
+    },
+    {
+        "name": "path",
+        "trans": [
+            "道路； 路线； 小路， 小径"
+        ],
+        "usphone": "pæθ",
+        "ukphone": "pæθ"
+    },
+    {
+        "name": "pathetic",
+        "trans": [
+            "可怜的， 引起怜悯的， 令人怜惜的"
+        ],
+        "usphone": "pə'θɛtɪk",
+        "ukphone": "pə'θetɪk"
+    },
+    {
+        "name": "pathological",
+        "trans": [
+            "病态的； 病理学的； 不理智的， 无道理的"
+        ],
+        "usphone": "'pæθə'lɑdʒɪkl",
+        "ukphone": "ˌpæθə'lɑːdʒɪkl"
+    },
+    {
+        "name": "pathology",
+        "trans": [
+            "反常， 变态； 病理学； 病状"
+        ],
+        "usphone": "pə'θɑlədʒi",
+        "ukphone": "pə'θɑːlədʒi"
+    },
+    {
+        "name": "patient",
+        "trans": [
+            "有耐心的，能忍耐的",
+            "病人， 患者"
+        ],
+        "usphone": "ˈpeʃənt",
+        "ukphone": "'peɪʃnt"
+    },
+    {
+        "name": "patriarch",
+        "trans": [
+            "家长， 族长"
+        ],
+        "usphone": "'petrɪɑrk",
+        "ukphone": "'peɪtriɑːrk"
+    },
+    {
+        "name": "patriarchic",
+        "trans": [
+            "家长的， 族长的； 德高望重的"
+        ],
+        "usphone": ",peitri'a:kik",
+        "ukphone": "'peɪtriɑːrkɪk"
+    },
+    {
+        "name": "patriarchy",
+        "trans": [
+            "父权制， 父系社会， 家长统治"
+        ],
+        "usphone": "'petrɪɑrki",
+        "ukphone": "'peɪtriɑːrki"
+    },
+    {
+        "name": "patriot",
+        "trans": [
+            "爱国者"
+        ],
+        "usphone": "'petrɪət",
+        "ukphone": "'peɪtriət"
+    },
+    {
+        "name": "patron",
+        "trans": [
+            "资助人， 赞助人； 老主顾， 顾客"
+        ],
+        "usphone": "'petrən",
+        "ukphone": "'peɪtrən"
+    },
+    {
+        "name": "patronize",
+        "trans": [
+            "以高人一等的态度对待； 光顾； 赞助， 资助"
+        ],
+        "usphone": "ˈpeɪtrəˌnaɪz;ˈpætrənˌaɪz",
+        "ukphone": "'peɪtrənaɪz"
+    },
+    {
+        "name": "pattern",
+        "trans": [
+            "模式，方式；样式，图案；样品，样本",
+            "仿制； 使形成， 促成"
+        ],
+        "usphone": "'pætɚn",
+        "ukphone": "'pætərn"
+    },
+    {
+        "name": "paucity",
+        "trans": [
+            "极小量， 少量"
+        ],
+        "usphone": "'pɔ:siti",
+        "ukphone": "'pɔːsəti"
+    },
+    {
+        "name": "pause",
+        "trans": [
+            "中止， 暂停"
+        ],
+        "usphone": "pɔz",
+        "ukphone": "pɔːz"
+    },
+    {
+        "name": "pave",
+        "trans": [
+            "铺； 密布"
+        ],
+        "usphone": "pev",
+        "ukphone": "peɪv"
+    },
+    {
+        "name": "peak",
+        "trans": [
+            "最高的，高峰的",
+            "最高点， 顶峰"
+        ],
+        "usphone": "pik",
+        "ukphone": "piːk"
+    },
+    {
+        "name": "pebble",
+        "trans": [
+            "小圆石， 鹅卵石"
+        ],
+        "usphone": "'pɛbl",
+        "ukphone": "'pebl"
+    },
+    {
+        "name": "peculiar",
+        "trans": [
+            "独特的； 罕见的； 奇怪的， 古怪的"
+        ],
+        "usphone": "pɪ'kjulɪɚ",
+        "ukphone": "pɪ'kjuːliər"
+    },
+    {
+        "name": "pedagogy",
+        "trans": [
+            "教育学， 教学法"
+        ],
+        "usphone": "'pɛdə'godʒi",
+        "ukphone": "'pedəgɑːdʒi"
+    },
+    {
+        "name": "pedestrian",
+        "trans": [
+            "徒步的； 缺乏想象力的",
+            "步行者，行人"
+        ],
+        "usphone": "pə'dɛstrɪən",
+        "ukphone": "pə'destriən"
+    },
+    {
+        "name": "penalty",
+        "trans": [
+            "处罚， 惩罚； 罚金； 犯规的处罚"
+        ],
+        "usphone": "'pɛnəlti",
+        "ukphone": "'penəlti"
+    },
+    {
+        "name": "pendant",
+        "trans": [
+            "垂饰， 下垂物"
+        ],
+        "usphone": "'pɛndənt",
+        "ukphone": "'pendənt"
+    },
+    {
+        "name": "penetrate",
+        "trans": [
+            "刺穿； 渗透； 洞察"
+        ],
+        "usphone": "'pɛnətret",
+        "ukphone": "'penətreɪt"
+    },
+    {
+        "name": "penicillin",
+        "trans": [
+            "青霉素， 盘尼西林"
+        ],
+        "usphone": ",pɛnɪ'sɪlɪn",
+        "ukphone": "ˌpenɪ'sɪlɪn"
+    },
+    {
+        "name": "peninsula",
+        "trans": [
+            "半岛"
+        ],
+        "usphone": "pə'nɪnsələ",
+        "ukphone": "pə'nɪnsələ"
+    },
+    {
+        "name": "penmanship",
+        "trans": [
+            "书法"
+        ],
+        "usphone": "'pɛnmən'ʃɪp",
+        "ukphone": "'penmənʃɪp"
+    },
+    {
+        "name": "pensive",
+        "trans": [
+            "沉思的； 忧虑的"
+        ],
+        "usphone": "'pɛnsɪv",
+        "ukphone": "'pensɪv"
+    },
+    {
+        "name": "pepper",
+        "trans": [
+            "胡椒；辣椒",
+            "撒胡椒粉； 大量给予"
+        ],
+        "usphone": "'pɛpɚ",
+        "ukphone": "'pepər"
+    },
+    {
+        "name": "perceive",
+        "trans": [
+            "感知， 察觉； 理解"
+        ],
+        "usphone": "pɚ'siv",
+        "ukphone": "pər'siːv"
+    },
+    {
+        "name": "perception",
+        "trans": [
+            "感知， 感觉； 认识， 观念； 洞察力"
+        ],
+        "usphone": "pɚ'sɛpʃən",
+        "ukphone": "pər'sepʃn"
+    },
+    {
+        "name": "perceptive",
+        "trans": [
+            "感知的， 知觉的； 有洞察力的， 理解力强的"
+        ],
+        "usphone": "pɚ'sɛptɪv",
+        "ukphone": "pər'septɪv"
+    },
+    {
+        "name": "perceptual",
+        "trans": [
+            "感知的， 知觉的"
+        ],
+        "usphone": "pɚ'sɛptʃuəl",
+        "ukphone": " pər 'septʃʊəl "
+    },
+    {
+        "name": "perch",
+        "trans": [
+            "栖息，停留；把…置于较高处；坐于",
+            "栖息处， 栖木； 高处， 较高的位置； 鲈鱼"
+        ],
+        "usphone": "pɝtʃ",
+        "ukphone": "pɜːrtʃ"
+    },
+    {
+        "name": "percolate",
+        "trans": [
+            "过滤；渗入，渗透；逐渐流传，传开",
+            "滤液"
+        ],
+        "usphone": "'pɝkəlet",
+        "ukphone": "'pɜːrkəleɪt"
+    },
+    {
+        "name": "percussion",
+        "trans": [
+            "打击乐器"
+        ],
+        "usphone": "pɚ'kʌʃən",
+        "ukphone": "pər'kʌʃn"
+    },
+    {
+        "name": "perfect",
+        "trans": [
+            "完美的， 理想的； 完全的， 十足的",
+            "使完美， 使熟练"
+        ],
+        "usphone": "ˈpɝfɪkt; (for v.) pɝˈfɛkt",
+        "ukphone": "ˈpɜ:fɪkt; (for v.) pəˈfekt"
+    },
+    {
+        "name": "perform",
+        "trans": [
+            "做， 履行， 完成； 表演， 演出； 执行"
+        ],
+        "usphone": "pɚ'fɔrm",
+        "ukphone": "pər'fɔːrm"
+    },
+    {
+        "name": "perfume",
+        "trans": [
+            "香味；香水",
+            "使充满香气； 洒香水于"
+        ],
+        "usphone": "pɚ'fjum",
+        "ukphone": "pər'fjuːm"
+    },
+    {
+        "name": "perimeter",
+        "trans": [
+            "周长； 外缘， 边缘"
+        ],
+        "usphone": "pə'rɪmɪtɚ",
+        "ukphone": "pə'rɪmɪtər"
+    },
+    {
+        "name": "periodic",
+        "trans": [
+            "周期的， 定期的"
+        ],
+        "usphone": ",pɪrɪ'ɑdɪk",
+        "ukphone": "ˌpɪri'ɑːdɪk"
+    },
+    {
+        "name": "periodical",
+        "trans": [
+            "周期的， 定期的",
+            "期刊，杂志"
+        ],
+        "usphone": ",pɪrɪ'ɑdɪkl",
+        "ukphone": "ˌpɪri'ɑːdɪkl"
+    },
+    {
+        "name": "peripheral",
+        "trans": [
+            "不重要的； 外围的"
+        ],
+        "usphone": "pə'rɪfərəl",
+        "ukphone": "pə'rɪfərəl"
+    },
+    {
+        "name": "periphery",
+        "trans": [
+            "外围， 边缘"
+        ],
+        "usphone": "pə'rɪfəri",
+        "ukphone": "pə'rɪfəri"
+    },
+    {
+        "name": "perish",
+        "trans": [
+            "灭亡； 湮灭， 毁灭； 老化"
+        ],
+        "usphone": "'pɛrɪʃ",
+        "ukphone": "'perɪʃ"
+    },
+    {
+        "name": "perishable",
+        "trans": [
+            "易腐的， 易变质的"
+        ],
+        "usphone": "'pɛrɪʃəbl",
+        "ukphone": "'perɪʃəbl"
+    },
+    {
+        "name": "permanence",
+        "trans": [
+            "永久， 持久"
+        ],
+        "usphone": "'pɝmənəns",
+        "ukphone": "'pɜːrmənəns"
+    },
+    {
+        "name": "permanent",
+        "trans": [
+            "持久的， 永久的； 固定不变的"
+        ],
+        "usphone": "'pɝmənənt",
+        "ukphone": "'pɜːrmənənt"
+    },
+    {
+        "name": "permeate",
+        "trans": [
+            "弥漫； 渗透"
+        ],
+        "usphone": "'pɝmɪet",
+        "ukphone": "'pɜːrmieɪt"
+    },
+    {
+        "name": "permission",
+        "trans": [
+            "允许， 同意； 许可证， 书面许可"
+        ],
+        "usphone": "pɚ'mɪʃən",
+        "ukphone": "pər'mɪʃn"
+    },
+    {
+        "name": "permit",
+        "trans": [
+            "允许， 许可",
+            "许可证， 执照"
+        ],
+        "usphone": "pɚ'mɪt",
+        "ukphone": "pə'mɪt"
+    },
+    {
+        "name": "pernicious",
+        "trans": [
+            "有害的， 恶性的"
+        ],
+        "usphone": "pɚ'nɪʃəs",
+        "ukphone": "pər'nɪʃəs"
+    },
+    {
+        "name": "perpendicular",
+        "trans": [
+            "成直角的，垂直的",
+            "垂直线"
+        ],
+        "usphone": "'pɝpən'dɪkjəlɚ",
+        "ukphone": "ˌpɜːrpən'dɪkjələr"
+    },
+    {
+        "name": "perpetual",
+        "trans": [
+            "连续不断的； 永久的， 长期的"
+        ],
+        "usphone": "pɚ'pɛtʃuəl",
+        "ukphone": "pər'petʃuəl"
+    },
+    {
+        "name": "perpetuate",
+        "trans": [
+            "使永存， 使持续"
+        ],
+        "usphone": "pɚ'pɛtʃuet",
+        "ukphone": "pər'petʃueɪt"
+    },
+    {
+        "name": "perquisite",
+        "trans": [
+            "津贴， 利益； 特权"
+        ],
+        "usphone": "'pɝkwəzɪt",
+        "ukphone": "'pɜːrkwɪzɪt"
+    },
+    {
+        "name": "persist",
+        "trans": [
+            "坚持； 持续"
+        ],
+        "usphone": "pɚ'sɪst",
+        "ukphone": "pər'sɪst"
+    },
+    {
+        "name": "persistent",
+        "trans": [
+            "坚持的， 百折不挠的； 持续的"
+        ],
+        "usphone": "pə'zɪstənt",
+        "ukphone": "pər'sɪstənt"
+    },
+    {
+        "name": "personal",
+        "trans": [
+            "个人的， 私人的； 亲自的"
+        ],
+        "usphone": "'pɝsənl",
+        "ukphone": "'pɜːrsənl"
+    },
+    {
+        "name": "personality",
+        "trans": [
+            "个性； 性格； 名人"
+        ],
+        "usphone": ",pɝsə'næləti",
+        "ukphone": "ˌpɜːrsə'næləti"
+    },
+    {
+        "name": "personnel",
+        "trans": [
+            "全体人员， 员工"
+        ],
+        "usphone": ",pɝsə'nɛl",
+        "ukphone": "ˌpɜːrsə'nel"
+    },
+    {
+        "name": "perspective",
+        "trans": [
+            "展望； 观点， 看法； 远景； 透视图， 透视法； 前途"
+        ],
+        "usphone": "pɚ'spɛktɪv",
+        "ukphone": "pər'spektɪv"
+    },
+    {
+        "name": "perspicuous",
+        "trans": [
+            "明白易懂的； 明了的"
+        ],
+        "usphone": "pə'spikjuəs",
+        "ukphone": "ˌpɜːr'spɪkjuəs"
+    },
+    {
+        "name": "persuasive",
+        "trans": [
+            "有说服力的， 让人信服的"
+        ],
+        "usphone": "pɚ'swesɪv",
+        "ukphone": "pər'sweɪsɪv"
+    },
+    {
+        "name": "pertain",
+        "trans": [
+            "存在； 适用"
+        ],
+        "usphone": "pɝ'ten",
+        "ukphone": "pər 'teɪn"
+    },
+    {
+        "name": "pertinent",
+        "trans": [
+            "相关的； 恰当的， 贴切的"
+        ],
+        "usphone": "'pɝtnənt",
+        "ukphone": "'pɜːrtnənt"
+    },
+    {
+        "name": "pervasive",
+        "trans": [
+            "普遍深入的； 遍及的， 弥漫的"
+        ],
+        "usphone": "pɚ'vesɪv",
+        "ukphone": "pər'veɪsɪv"
+    },
+    {
+        "name": "pest",
+        "trans": [
+            "害虫； 令人讨厌的人"
+        ],
+        "usphone": "pɛst",
+        "ukphone": "pest"
+    },
+    {
+        "name": "pesticide",
+        "trans": [
+            "杀虫剂， 农药"
+        ],
+        "usphone": "'pɛstɪsaɪd",
+        "ukphone": "'pestɪsaɪd"
+    },
+    {
+        "name": "petition",
+        "trans": [
+            "请愿， 正式请求",
+            "请愿；请愿书；诉状"
+        ],
+        "usphone": "pə'tɪʃən",
+        "ukphone": "pə'tɪʃn"
+    },
+    {
+        "name": "petroleum",
+        "trans": [
+            "石油"
+        ],
+        "usphone": "pə'trolɪəm",
+        "ukphone": "pə'trouliəm"
+    },
+    {
+        "name": "pharaoh",
+        "trans": [
+            "法老"
+        ],
+        "usphone": "'fεərəu",
+        "ukphone": "'ferou"
+    },
+    {
+        "name": "pharmacy",
+        "trans": [
+            "药店； 药剂学"
+        ],
+        "usphone": "'fɑrməsi",
+        "ukphone": "'fɑːrməsi"
+    },
+    {
+        "name": "phase",
+        "trans": [
+            "相位，月相；阶段，时期",
+            "分阶段实行， 逐步做"
+        ],
+        "usphone": "fez",
+        "ukphone": "feɪz"
+    },
+    {
+        "name": "phenomenon",
+        "trans": [
+            "现象， 迹象； 非凡的人"
+        ],
+        "usphone": "fə'nɑmɪnən",
+        "ukphone": "fə'nɑːmɪnən"
+    },
+    {
+        "name": "pheromone",
+        "trans": [
+            "信息素"
+        ],
+        "usphone": "'fɛrəmon",
+        "ukphone": "'ferəmoun"
+    },
+    {
+        "name": "philosophy",
+        "trans": [
+            "哲学； 哲学体系， 思想体系； 人生观， 人生哲学"
+        ],
+        "usphone": "fə'lɑsəfi",
+        "ukphone": "fə'lɑːsəfi"
+    },
+    {
+        "name": "photodissociation",
+        "trans": [
+            "光解"
+        ],
+        "usphone": ",fotodɪ,sosi'eʃɪn",
+        "ukphone": "ˌfoutou'dɪˌsouʃi'eɪʃn"
+    },
+    {
+        "name": "photograph",
+        "trans": [
+            "拍照",
+            "照片"
+        ],
+        "usphone": "'fotəɡræf",
+        "ukphone": "'foutəgræf"
+    },
+    {
+        "name": "photosynthesis",
+        "trans": [
+            "光合作用"
+        ],
+        "usphone": ",foto'sɪnθəsɪs",
+        "ukphone": "ˌfoutou'sɪnθəsɪs"
+    },
+    {
+        "name": "physical",
+        "trans": [
+            "物理的；物质的，有形的；身体的，肉体的",
+            "体检"
+        ],
+        "usphone": "'fɪzɪkl",
+        "ukphone": "'fɪzɪkl"
+    },
+    {
+        "name": "physician",
+        "trans": [
+            "内科医生"
+        ],
+        "usphone": "fɪ'zɪʃən",
+        "ukphone": "fɪ'zɪʃn"
+    },
+    {
+        "name": "physiology",
+        "trans": [
+            "生理学； 生理机能"
+        ],
+        "usphone": "'fɪzɪ'ɑlədʒi",
+        "ukphone": "ˌfɪzi'ɑːlədʒi"
+    },
+    {
+        "name": "picky",
+        "trans": [
+            "挑剔的， 难以取悦的"
+        ],
+        "usphone": "'pɪki",
+        "ukphone": "'pɪki"
+    },
+    {
+        "name": "pictorial",
+        "trans": [
+            "图示的，有图片的；绘画的，图画的",
+            "画报， 画刊"
+        ],
+        "usphone": "pɪk'tɔrɪəl",
+        "ukphone": "pɪk'tɔːriəl"
+    },
+    {
+        "name": "picturesque",
+        "trans": [
+            "如画的； 别致的； 生动的"
+        ],
+        "usphone": ",pɪktʃə'rɛsk",
+        "ukphone": "ˌpɪktʃə'resk"
+    },
+    {
+        "name": "pierce",
+        "trans": [
+            "刺穿， 刺破； 穿孔， 打眼"
+        ],
+        "usphone": "pɪrs",
+        "ukphone": "pɪrs"
+    },
+    {
+        "name": "pigeon",
+        "trans": [
+            "鸽子"
+        ],
+        "usphone": "'pɪdʒɪn",
+        "ukphone": "'pɪdʒɪn"
+    },
+    {
+        "name": "pigment",
+        "trans": [
+            "颜料； 色素"
+        ],
+        "usphone": "'pɪgmənt",
+        "ukphone": "'pɪgmənt"
+    },
+    {
+        "name": "pilot",
+        "trans": [
+            "试验性的",
+            "飞行员，领航员；领导人",
+            "驾驶， 领航； 试行， 试用； 使通过， 引导"
+        ],
+        "usphone": "'paɪlət",
+        "ukphone": "'paɪlət"
+    },
+    {
+        "name": "pin",
+        "trans": [
+            "钉住；固定",
+            "大头针； 钢钉； 胸针； 徽章"
+        ],
+        "usphone": "pɪn",
+        "ukphone": "pɪn"
+    },
+    {
+        "name": "pinch",
+        "trans": [
+            "捏，掐；夹痛；偷窃；逮捕",
+            "捏， 掐； 一撮， 微量"
+        ],
+        "usphone": "pɪntʃ",
+        "ukphone": "pɪntʃ"
+    },
+    {
+        "name": "pine",
+        "trans": [
+            "憔悴； 难过， 悲伤",
+            "松树"
+        ],
+        "usphone": "paɪn",
+        "ukphone": "paɪn"
+    },
+    {
+        "name": "pinnacle",
+        "trans": [
+            "山顶， 顶峰； 鼎盛时期； 小尖塔"
+        ],
+        "usphone": "'pɪnəkl",
+        "ukphone": "'pɪnəkl"
+    },
+    {
+        "name": "pinpoint",
+        "trans": [
+            "准确的， 精确的",
+            "精准定位；准确解释",
+            "极小的范围；光点"
+        ],
+        "usphone": "'pɪnpɔɪnt",
+        "ukphone": "'pɪnpɔɪnt"
+    },
+    {
+        "name": "pioneer",
+        "trans": [
+            "开拓，开创",
+            "开拓者， 创始人"
+        ],
+        "usphone": ",paɪə'nɪr",
+        "ukphone": "ˌpaɪə'nɪr"
+    },
+    {
+        "name": "pipe",
+        "trans": [
+            "用管道输送；用线路系统传输",
+            "管子， 管道； 烟斗"
+        ],
+        "usphone": "paɪp",
+        "ukphone": "paɪp"
+    },
+    {
+        "name": "pique",
+        "trans": [
+            "激怒；激起，引起",
+            "恼怒， 生气； 怨恨"
+        ],
+        "usphone": "pik",
+        "ukphone": "piːk"
+    },
+    {
+        "name": "piracy",
+        "trans": [
+            "海盗行为； 抢劫行为； 剽窃行为"
+        ],
+        "usphone": "'paɪrəsi",
+        "ukphone": "'paɪrəsi"
+    },
+    {
+        "name": "pit",
+        "trans": [
+            "使有坑，使…表面有斑点",
+            "大坑， 深坑； 矿井； 陷阱"
+        ],
+        "usphone": "pɪt",
+        "ukphone": "pɪt"
+    },
+    {
+        "name": "pitch",
+        "trans": [
+            "音高，音调；倾斜度；沥青，柏油；"
+        ],
+        "usphone": "pɪtʃ",
+        "ukphone": "pɪtʃ"
+    },
+    {
+        "name": "pivot",
+        "trans": [
+            "在枢轴上旋转",
+            "枢轴；中心点；核心"
+        ],
+        "usphone": "'pɪvət",
+        "ukphone": "'pɪvət"
+    },
+    {
+        "name": "placid",
+        "trans": [
+            "平静的， 安静的； 温和的， 文静的"
+        ],
+        "usphone": "'plæsɪd",
+        "ukphone": "'plæsɪd"
+    },
+    {
+        "name": "plague",
+        "trans": [
+            "困扰，使苦恼；纠缠",
+            "鼠疫； 传染病； 祸患， 灾害"
+        ],
+        "usphone": "pleɡ",
+        "ukphone": "pleɪg"
+    },
+    {
+        "name": "planet",
+        "trans": [
+            "行星"
+        ],
+        "usphone": "'plænɪt",
+        "ukphone": "'plænɪt"
+    },
+    {
+        "name": "planetary",
+        "trans": [
+            "行星的"
+        ],
+        "usphone": "'plænətɛri",
+        "ukphone": "'plænəteri"
+    },
+    {
+        "name": "plank",
+        "trans": [
+            "木板； 政策要点， 政纲的核心"
+        ],
+        "usphone": "plæŋk",
+        "ukphone": "plæŋk"
+    },
+    {
+        "name": "plankton",
+        "trans": [
+            "浮游生物"
+        ],
+        "usphone": "'plæŋktən",
+        "ukphone": "'plæŋktən"
+    },
+    {
+        "name": "plantation",
+        "trans": [
+            "种植园； 人造林"
+        ],
+        "usphone": "plæn'teʃən",
+        "ukphone": "plæn'teɪʃn"
+    },
+    {
+        "name": "plaque",
+        "trans": [
+            "匾额； 牙斑"
+        ],
+        "usphone": "plæk",
+        "ukphone": "plæk"
+    },
+    {
+        "name": "plasma",
+        "trans": [
+            "血浆； 等离子体"
+        ],
+        "usphone": "'plæzmə",
+        "ukphone": "'plæzmə"
+    },
+    {
+        "name": "plaster",
+        "trans": [
+            "在…上抹灰泥， 厚厚地涂",
+            "灰浆，灰泥，石膏"
+        ],
+        "usphone": "'plæstɚ",
+        "ukphone": "'plæstər"
+    },
+    {
+        "name": "plastic",
+        "trans": [
+            "塑料的； 可塑的； 做作的， 虚伪的",
+            "塑料"
+        ],
+        "usphone": "'plæstɪk",
+        "ukphone": "'plæstɪk"
+    },
+    {
+        "name": "plate",
+        "trans": [
+            "盘子；板条，板材；号码牌",
+            "镀， 电镀； 覆盖"
+        ],
+        "usphone": "pleɪt",
+        "ukphone": "pleɪt"
+    },
+    {
+        "name": "plateau",
+        "trans": [
+            "保持稳定水平",
+            "高原；稳定期，停滞期"
+        ],
+        "usphone": "plæ'to",
+        "ukphone": "plæ'tou"
+    },
+    {
+        "name": "platitude",
+        "trans": [
+            "陈词滥调， 老生常谈"
+        ],
+        "usphone": "'plætɪtud",
+        "ukphone": "'plætɪtjuːd"
+    },
+    {
+        "name": "plaudit",
+        "trans": [
+            "喝彩；赞美"
+        ],
+        "usphone": "'plɔ:dit",
+        "ukphone": "'plɔːdɪt"
+    },
+    {
+        "name": "plausible",
+        "trans": [
+            "似有道理的， 似乎正确的"
+        ],
+        "usphone": "'plɔzəbl",
+        "ukphone": "'plɔːzəbl"
+    },
+    {
+        "name": "playwright",
+        "trans": [
+            "剧作家"
+        ],
+        "usphone": "'pleraɪt",
+        "ukphone": "'pleɪraɪt"
+    },
+    {
+        "name": "pleasing",
+        "trans": [
+            "令人高兴的， 愉快的"
+        ],
+        "usphone": "'plizɪŋ",
+        "ukphone": "'pliːzɪŋ"
+    },
+    {
+        "name": "pliable",
+        "trans": [
+            "易弯曲的， 柔韧的； 易受影响的； 顺从的"
+        ],
+        "usphone": "'plaɪəbl",
+        "ukphone": "'plaɪəbl"
+    },
+    {
+        "name": "pliant",
+        "trans": [
+            "柔软的； 温顺的； 易受影响的"
+        ],
+        "usphone": "'plaɪənt",
+        "ukphone": "'plaɪənt"
+    },
+    {
+        "name": "plight",
+        "trans": [
+            "困境， 苦境"
+        ],
+        "usphone": "plaɪt",
+        "ukphone": "plaɪt"
+    },
+    {
+        "name": "plot",
+        "trans": [
+            "情节；阴谋，密谋；"
+        ],
+        "usphone": "plɑt",
+        "ukphone": "plɑːt"
+    },
+    {
+        "name": "plow",
+        "trans": [
+            "耕田， 犁田， 耕作",
+            "犁"
+        ],
+        "usphone": "plaʊ",
+        "ukphone": "plau"
+    },
+    {
+        "name": "plumage",
+        "trans": [
+            "鸟类羽毛"
+        ],
+        "usphone": "'plumɪdʒ",
+        "ukphone": "'pluːmɪdʒ"
+    },
+    {
+        "name": "plump",
+        "trans": [
+            "微胖的； 丰满的"
+        ],
+        "usphone": "plʌmp",
+        "ukphone": "plʌmp"
+    },
+    {
+        "name": "plunge",
+        "trans": [
+            "掉入；暴跌，突降",
+            "跳水； 猛跌， 骤降； 卷入"
+        ],
+        "usphone": "plʌndʒ",
+        "ukphone": "plʌndʒ"
+    },
+    {
+        "name": "pluralism",
+        "trans": [
+            "多元化， 多元性； 多元主义"
+        ],
+        "usphone": "'plʊər(ə)lɪz(ə)m",
+        "ukphone": "'plurəlɪzəm "
+    },
+    {
+        "name": "pocketbook",
+        "trans": [
+            "钱袋， 皮夹； 财政状况， 财力"
+        ],
+        "usphone": "'pɔkitbuk",
+        "ukphone": "'pɑːkɪtbuk"
+    },
+    {
+        "name": "podium",
+        "trans": [
+            "讲坛， 讲台； 指挥台"
+        ],
+        "usphone": "'podɪəm",
+        "ukphone": "'poudiəm"
+    },
+    {
+        "name": "poetic",
+        "trans": [
+            "诗歌的； 诗意的"
+        ],
+        "usphone": "po'ɛtɪk",
+        "ukphone": "pou'etɪk"
+    },
+    {
+        "name": "poetry",
+        "trans": [
+            "诗歌； 诗集； 诗意"
+        ],
+        "usphone": "'poətri",
+        "ukphone": "'pouətri"
+    },
+    {
+        "name": "pointed",
+        "trans": [
+            "尖的， 尖角的； 尖锐的， 尖刻的"
+        ],
+        "usphone": "'pɔɪntɪd",
+        "ukphone": "'pɔɪntɪd"
+    },
+    {
+        "name": "poisonous",
+        "trans": [
+            "有毒的， 有害的； 恶毒的"
+        ],
+        "usphone": "'pɔɪzənəs",
+        "ukphone": "'pɔɪzənəs"
+    },
+    {
+        "name": "polar",
+        "trans": [
+            "极的， 极地的； 磁极的； 正好相反的， 截然对立的"
+        ],
+        "usphone": "'polɚ",
+        "ukphone": "'poulər"
+    },
+    {
+        "name": "pole",
+        "trans": [
+            "地极； 磁极， 电极； 柱， 杆， 杖； 极端"
+        ],
+        "usphone": "pol",
+        "ukphone": "poul"
+    },
+    {
+        "name": "policy",
+        "trans": [
+            "政策， 方针； 原则； 保险单"
+        ],
+        "usphone": "'pɑləsi",
+        "ukphone": "'pɑːləsi"
+    },
+    {
+        "name": "polish",
+        "trans": [
+            "磨光， 擦亮； 修改， 润色",
+            "上光剂"
+        ],
+        "usphone": "'pɑlɪʃ",
+        "ukphone": "'pɑːlɪʃ"
+    },
+    {
+        "name": "politics",
+        "trans": [
+            "政治； 政纲， 政见； 政治事务； 权术； 政治学"
+        ],
+        "usphone": "'pɑlətɪks",
+        "ukphone": "'pɑːlətɪks"
+    },
+    {
+        "name": "pollen",
+        "trans": [
+            "花粉"
+        ],
+        "usphone": "'pɑlən",
+        "ukphone": "'pɑːlən"
+    },
+    {
+        "name": "pollinate",
+        "trans": [
+            "给…授粉"
+        ],
+        "usphone": "'pɑlənet",
+        "ukphone": "'pɑːləneɪt"
+    },
+    {
+        "name": "pollutant",
+        "trans": [
+            "污染物质， 有害物质"
+        ],
+        "usphone": "pə'lutənt",
+        "ukphone": "pə'luːtənt"
+    },
+    {
+        "name": "polygamous",
+        "trans": [
+            "一夫多妻的， 一妻多夫的"
+        ],
+        "usphone": "pə'lɪgəməs",
+        "ukphone": "pə'lɪgəməs"
+    },
+    {
+        "name": "polygamy",
+        "trans": [
+            "一夫多妻制， 一妻多夫制， 多配偶制"
+        ],
+        "usphone": "pə'lɪɡəmi",
+        "ukphone": "pə'lɪgəmi"
+    },
+    {
+        "name": "polygon",
+        "trans": [
+            "多角形， 多边形"
+        ],
+        "usphone": "'pɑlɪɡɑn",
+        "ukphone": "'pɑːligɑːn"
+    },
+    {
+        "name": "ponder",
+        "trans": [
+            "思索， 沉思"
+        ],
+        "usphone": "'pɑndɚ",
+        "ukphone": "'pɑːndər"
+    },
+    {
+        "name": "ponderous",
+        "trans": [
+            "笨重的； 笨拙的； 沉闷的"
+        ],
+        "usphone": "'pɑndərəs",
+        "ukphone": "'pɑːndərəs"
+    },
+    {
+        "name": "popular",
+        "trans": [
+            "通俗的； 受欢迎的； 流行的"
+        ],
+        "usphone": "'pɑpjəlɚ",
+        "ukphone": "'pɑːpjələ"
+    },
+    {
+        "name": "populate",
+        "trans": [
+            "居住于"
+        ],
+        "usphone": "'pɑpjulet",
+        "ukphone": "'pɑːpjuleɪt"
+    },
+    {
+        "name": "porcelain",
+        "trans": [
+            "瓷器， 瓷"
+        ],
+        "usphone": "ˈpɔrsələn",
+        "ukphone": "'pɔːrsəlɪn"
+    },
+    {
+        "name": "pore",
+        "trans": [
+            "仔细阅读，审阅；审视",
+            "气孔， 小孔"
+        ],
+        "usphone": "pɔr",
+        "ukphone": "pɔːr"
+    },
+    {
+        "name": "porous",
+        "trans": [
+            "有孔的， 多孔的； 能渗透的"
+        ],
+        "usphone": "'pɔrəs",
+        "ukphone": "'pɔːrəs"
+    },
+    {
+        "name": "portable",
+        "trans": [
+            "轻便的， 便携的， 手提式的"
+        ],
+        "usphone": "'pɔrtəbl",
+        "ukphone": "'pɔːrtəbl"
+    },
+    {
+        "name": "portion",
+        "trans": [
+            "部分；一份",
+            "划分， 分配"
+        ],
+        "usphone": "'pɔrʃən",
+        "ukphone": "'pɔːrʃn"
+    },
+    {
+        "name": "portrait",
+        "trans": [
+            "肖像， 画像； 描写， 描绘"
+        ],
+        "usphone": "'pɔrtrɪt",
+        "ukphone": "'pɔːrtrət"
+    },
+    {
+        "name": "portraiture",
+        "trans": [
+            "画像技法； 肖像， 画像"
+        ],
+        "usphone": "'pɔrtrətʃɚ",
+        "ukphone": "'pɔːrtrətʃər"
+    },
+    {
+        "name": "portray",
+        "trans": [
+            "描绘； 扮演， 饰演"
+        ],
+        "usphone": "pɔr'tre",
+        "ukphone": "pɔːr'treɪ"
+    },
+    {
+        "name": "pose",
+        "trans": [
+            "摆姿势；造成；提出",
+            "姿势"
+        ],
+        "usphone": "poz",
+        "ukphone": "pouz"
+    },
+    {
+        "name": "posit",
+        "trans": [
+            "安排； 假定"
+        ],
+        "usphone": "'pɑzɪt",
+        "ukphone": "'pɑːzɪt"
+    },
+    {
+        "name": "position",
+        "trans": [
+            "安置",
+            "位置； 职位； 立场； 姿势， 姿态； 见解"
+        ],
+        "usphone": "pə'zɪʃən",
+        "ukphone": "pə'zɪʃn"
+    },
+    {
+        "name": "positive",
+        "trans": [
+            "肯定的； 积极的； 确凿的； 自信的， 乐观的； 正电的"
+        ],
+        "usphone": "'pɑzətɪv",
+        "ukphone": "'pɑːzətɪv"
+    },
+    {
+        "name": "possess",
+        "trans": [
+            "具有， 拥有"
+        ],
+        "usphone": "pə'zɛs",
+        "ukphone": "pə'zes"
+    },
+    {
+        "name": "postage",
+        "trans": [
+            "邮资， 邮费"
+        ],
+        "usphone": "'postɪdʒ",
+        "ukphone": "'poustɪdʒ"
+    },
+    {
+        "name": "postcard",
+        "trans": [
+            "明信片"
+        ],
+        "usphone": "'post'kɑrd",
+        "ukphone": "'poustkɑːrd"
+    },
+    {
+        "name": "poster",
+        "trans": [
+            "海报， 招贴画； 发布消息的人"
+        ],
+        "usphone": "'postɚ",
+        "ukphone": "'poustər"
+    },
+    {
+        "name": "posthumous",
+        "trans": [
+            "死后的， 身后的"
+        ],
+        "usphone": "'pɑstʃəməs",
+        "ukphone": "'pɑːstʃəməs"
+    },
+    {
+        "name": "postpone",
+        "trans": [
+            "延期， 推迟"
+        ],
+        "usphone": "po'spon",
+        "ukphone": "ˌpoust'poun"
+    },
+    {
+        "name": "postulate",
+        "trans": [
+            "假定， 假设"
+        ],
+        "usphone": "'pɑstʃəlet",
+        "ukphone": "'pɑːstʃəleɪt"
+    },
+    {
+        "name": "potassium",
+        "trans": [
+            "钾"
+        ],
+        "usphone": "pə'tæsɪəm",
+        "ukphone": "pə'tæsiəm"
+    },
+    {
+        "name": "potency",
+        "trans": [
+            "影响力， 支配力； 效力"
+        ],
+        "usphone": "'potnsi",
+        "ukphone": "'poutnsi"
+    },
+    {
+        "name": "potential",
+        "trans": [
+            "潜在的； 可能的",
+            "潜能，潜力"
+        ],
+        "usphone": "pə'tɛnʃl",
+        "ukphone": "pə'tenʃl"
+    },
+    {
+        "name": "pottery",
+        "trans": [
+            "陶器； 陶器厂， 制陶作坊； 制陶工艺， 陶器制造术"
+        ],
+        "usphone": "'pɑtəri",
+        "ukphone": "'pɑːtəri"
+    },
+    {
+        "name": "pound",
+        "trans": [
+            "猛击；捣碎；怦怦跳",
+            "磅； 英镑"
+        ],
+        "usphone": "paʊnd",
+        "ukphone": "paund"
+    },
+    {
+        "name": "poverty",
+        "trans": [
+            "贫穷， 贫困"
+        ],
+        "usphone": "'pɑvɚti",
+        "ukphone": "'pɑːvərti"
+    },
+    {
+        "name": "powder",
+        "trans": [
+            "粉， 粉末； 散剂； 火药， 炸药"
+        ],
+        "usphone": "'paʊdɚ",
+        "ukphone": "'paudər"
+    },
+    {
+        "name": "practicable",
+        "trans": [
+            "能实行的， 可行的， 适用的"
+        ],
+        "usphone": "'præktɪkəbl",
+        "ukphone": "'præktɪkəbl"
+    },
+    {
+        "name": "practical",
+        "trans": [
+            "实用的； 实际的； 现实的"
+        ],
+        "usphone": "'præktɪkl",
+        "ukphone": "'præktɪkl"
+    },
+    {
+        "name": "pragmatic",
+        "trans": [
+            "务实的， 注重实效的， 实用的"
+        ],
+        "usphone": "præg'mætɪk",
+        "ukphone": "præg'mætɪk"
+    },
+    {
+        "name": "prairie",
+        "trans": [
+            "大草原"
+        ],
+        "usphone": "'prɛri",
+        "ukphone": "'preri"
+    },
+    {
+        "name": "preach",
+        "trans": [
+            "布道， 讲道； 竭力鼓吹， 宣讲， 宣传； 说教"
+        ],
+        "usphone": "pritʃ",
+        "ukphone": "priːtʃ"
+    },
+    {
+        "name": "precautionary",
+        "trans": [
+            "预防的"
+        ],
+        "usphone": "prɪ'kɔʃən,ɛri",
+        "ukphone": "prɪ'kɔːʃənerɪ"
+    },
+    {
+        "name": "precede",
+        "trans": [
+            "在…之前， 先于"
+        ],
+        "usphone": "prɪ'sid",
+        "ukphone": "prɪ'siːd"
+    },
+    {
+        "name": "precious",
+        "trans": [
+            "贵重的； 珍爱的"
+        ],
+        "usphone": "'prɛʃəs",
+        "ukphone": "'preʃəs"
+    },
+    {
+        "name": "precipitate",
+        "trans": [
+            "使…突然降临；加速；降水；使突然陷入；",
+            "仓促的， 鲁莽的"
+        ],
+        "usphone": "prɪ'sɪpɪtet",
+        "ukphone": "prɪ'sɪpɪteɪt"
+    },
+    {
+        "name": "precise",
+        "trans": [
+            "准确的， 精确的； 严谨的"
+        ],
+        "usphone": "prɪ'saɪs",
+        "ukphone": "prɪ'saɪs"
+    },
+    {
+        "name": "precursor",
+        "trans": [
+            "先驱； 先兆， 前兆； 前身"
+        ],
+        "usphone": "pri'kɝsɚ",
+        "ukphone": "priː'kɜːrsər"
+    },
+    {
+        "name": "predation",
+        "trans": [
+            "掠夺； 掠食"
+        ],
+        "usphone": "prɪ'deʃən",
+        "ukphone": "prɪ'deɪʃn"
+    },
+    {
+        "name": "predator",
+        "trans": [
+            "捕食性动物， 食肉动物； 掠夺者， 剥削者"
+        ],
+        "usphone": "'prɛdətɚ",
+        "ukphone": "'predətər"
+    },
+    {
+        "name": "predecessor",
+        "trans": [
+            "前辈； 前任； 原有事物"
+        ],
+        "usphone": "'prɛdəsɛsɚ",
+        "ukphone": "'predəsesər"
+    },
+    {
+        "name": "predict",
+        "trans": [
+            "预言， 预测"
+        ],
+        "usphone": "prɪ'dɪkt",
+        "ukphone": "prɪ'dɪkt"
+    },
+    {
+        "name": "predispose",
+        "trans": [
+            "事先影响某人； 易受感染"
+        ],
+        "usphone": "'pridɪ'spoz",
+        "ukphone": "ˌpriːdɪ'spouz"
+    },
+    {
+        "name": "predominant",
+        "trans": [
+            "占优势的， 主导的， 支配的； 显著的， 盛行的"
+        ],
+        "usphone": "prɪ'dɑmənənt",
+        "ukphone": "prɪ'dɑːmɪnənt"
+    },
+    {
+        "name": "predominate",
+        "trans": [
+            "统治， 支配， 占优势"
+        ],
+        "usphone": "prɪ'dɑmə'net",
+        "ukphone": "prɪ'dɑːmɪneɪt"
+    },
+    {
+        "name": "preeminent",
+        "trans": [
+            "卓越的， 杰出的"
+        ],
+        "usphone": "pri'ɛmɪnənt",
+        "ukphone": "prɪ'emɪnənt"
+    },
+    {
+        "name": "prefer",
+        "trans": [
+            "更喜欢， 宁愿"
+        ],
+        "usphone": "prɪ'fɝ",
+        "ukphone": "prɪ'fɜːr"
+    },
+    {
+        "name": "preference",
+        "trans": [
+            "偏爱； 优先"
+        ],
+        "usphone": "'prɛfrəns",
+        "ukphone": "'prefrəns"
+    },
+    {
+        "name": "prehistoric",
+        "trans": [
+            "史前的； 陈旧的"
+        ],
+        "usphone": ",prihɪ'stɔrɪk",
+        "ukphone": "ˌpriːhɪ'stɔːrɪk"
+    },
+    {
+        "name": "prejudice",
+        "trans": [
+            "偏见，成见",
+            "使产生偏见； 使…受到损害， 有损于"
+        ],
+        "usphone": "'prɛdʒədɪs",
+        "ukphone": "'predʒudɪs"
+    },
+    {
+        "name": "preliminary",
+        "trans": [
+            "预备的，初步的",
+            "初步做法， 起始行为"
+        ],
+        "usphone": "prɪ'lɪmɪnɛri",
+        "ukphone": "prɪ'lɪmɪneri"
+    },
+    {
+        "name": "preliterate",
+        "trans": [
+            "文字出现以前的， 没有文字的"
+        ],
+        "usphone": "pri'lɪtərɪt",
+        "ukphone": "ˌpriː'lɪtərət"
+    },
+    {
+        "name": "prelude",
+        "trans": [
+            "前奏曲， 序幕"
+        ],
+        "usphone": "'prɛljud",
+        "ukphone": "'preluːd"
+    },
+    {
+        "name": "premature",
+        "trans": [
+            "早熟的；过早的；不成熟的，仓促的",
+            "早产儿"
+        ],
+        "usphone": ",primə'tʃʊr",
+        "ukphone": "ˌpriːmə'tʃur"
+    },
+    {
+        "name": "premier",
+        "trans": [
+            "第一的， 首要的； 最著名的",
+            "首相，总理"
+        ],
+        "usphone": "prɪ'mɪr",
+        "ukphone": "prɪ'mɪr"
+    },
+    {
+        "name": "premise",
+        "trans": [
+            "房屋和地基， 经营场址； 前提， 假设"
+        ],
+        "usphone": "ˈpremɪs",
+        "ukphone": "'premɪs"
+    },
+    {
+        "name": "preoccupation",
+        "trans": [
+            "主要考虑因素； 全神贯注"
+        ],
+        "usphone": "prɪ,ɑkju'peʃən",
+        "ukphone": "priˌɑːkju'peɪʃn"
+    },
+    {
+        "name": "prepare",
+        "trans": [
+            "准备， 预备"
+        ],
+        "usphone": "prɪ'pɛr",
+        "ukphone": "prɪ'per"
+    },
+    {
+        "name": "preponderance",
+        "trans": [
+            "优势"
+        ],
+        "usphone": "prɪ'pɑndərəns",
+        "ukphone": "prɪ'pɑːndərəns"
+    },
+    {
+        "name": "prerequisite",
+        "trans": [
+            "必备的， 作为先决条件的",
+            "先决条件，前提"
+        ],
+        "usphone": ",pri'rɛkwəzɪt",
+        "ukphone": "ˌpriː'rekwəzɪt"
+    },
+    {
+        "name": "prescribe",
+        "trans": [
+            "开处方； 规定； 指示"
+        ],
+        "usphone": "prɪ'skraɪb",
+        "ukphone": "prɪ'skraɪb"
+    },
+    {
+        "name": "prescription",
+        "trans": [
+            "处方， 药方； 开处方， 开药方"
+        ],
+        "usphone": "prɪ'skrɪpʃən",
+        "ukphone": "prɪ'skrɪpʃn"
+    },
+    {
+        "name": "presentation",
+        "trans": [
+            "提供， 显示； 介绍， 陈述； 赠送； 表演"
+        ],
+        "usphone": ",prizɛn'teʃən",
+        "ukphone": "ˌpriːzen'teɪʃn"
+    },
+    {
+        "name": "preserve",
+        "trans": [
+            "保护， 维护； 保存， 保养"
+        ],
+        "usphone": "prɪ'zɝv",
+        "ukphone": "prɪ'zɜːrv"
+    },
+    {
+        "name": "preside",
+        "trans": [
+            "担任主席； 主持； 掌管"
+        ],
+        "usphone": "prɪ'zaɪd",
+        "ukphone": "prɪ'zaɪd"
+    },
+    {
+        "name": "presidency",
+        "trans": [
+            "职位； 任期"
+        ],
+        "usphone": "'prɛzɪdənsi",
+        "ukphone": "'prezɪdənsi"
+    },
+    {
+        "name": "president",
+        "trans": [
+            "总统， 校长， 主席"
+        ],
+        "usphone": "'prɛzɪdənt",
+        "ukphone": "'prezɪdənt"
+    },
+    {
+        "name": "press",
+        "trans": [
+            "压， 按， 挤； 压榨， 压迫； 催促， 逼迫",
+            "报刊；新闻界，新闻工作者；报道，评论；出版社；印刷厂；压，按，挤"
+        ],
+        "usphone": "prɛs",
+        "ukphone": "pres"
+    },
+    {
+        "name": "prestige",
+        "trans": [
+            "威望； 声望"
+        ],
+        "usphone": "prɛ'stidʒ",
+        "ukphone": "pre'stiːʒ"
+    },
+    {
+        "name": "pretension",
+        "trans": [
+            "要求， 主张； 自命不凡； 虚饰"
+        ],
+        "usphone": "prɪ'tɛnʃən",
+        "ukphone": "prɪ'tenʃn"
+    },
+    {
+        "name": "pretentious",
+        "trans": [
+            "自负的"
+        ],
+        "usphone": "prɪ'tɛnʃəs",
+        "ukphone": "prɪ'tenʃəs"
+    },
+    {
+        "name": "pretext",
+        "trans": [
+            "借口， 托词"
+        ],
+        "usphone": "'pritɛkst",
+        "ukphone": "'priːtekst"
+    },
+    {
+        "name": "prevail",
+        "trans": [
+            "盛行， 流行； 战胜， 压倒； 劝说"
+        ],
+        "usphone": "pri'vel",
+        "ukphone": "prɪ'veɪl"
+    },
+    {
+        "name": "prevailing",
+        "trans": [
+            "普遍的； 流行的； 一地常刮的， 盛行的"
+        ],
+        "usphone": "pri'velɪŋ",
+        "ukphone": "prɪ'veɪlɪŋ"
+    },
+    {
+        "name": "prevalent",
+        "trans": [
+            "流行的， 普遍的"
+        ],
+        "usphone": "'prɛvələnt",
+        "ukphone": "'prevələnt"
+    },
+    {
+        "name": "previous",
+        "trans": [
+            "先前的， 在前的"
+        ],
+        "usphone": "'privɪəs",
+        "ukphone": "'priːviəs"
+    },
+    {
+        "name": "prey",
+        "trans": [
+            "捕食，捕获",
+            "猎物； 受害者， 牺牲品"
+        ],
+        "usphone": "pre",
+        "ukphone": "preɪ"
+    },
+    {
+        "name": "primal",
+        "trans": [
+            "最初的； 主要的， 首要的"
+        ],
+        "usphone": "'praɪml",
+        "ukphone": "'praɪml"
+    },
+    {
+        "name": "primary",
+        "trans": [
+            "最初的； 首要的； 基本的"
+        ],
+        "usphone": "'praɪmɛri",
+        "ukphone": "'praɪmeri"
+    },
+    {
+        "name": "primate",
+        "trans": [
+            "灵长类， 灵长目动物； 大主教"
+        ],
+        "usphone": "'praɪmet",
+        "ukphone": "'praɪmeɪt"
+    },
+    {
+        "name": "prime",
+        "trans": [
+            "主要的；最初的；最好的；首先的",
+            "全盛时期，盛年",
+            "使准备好； 事先指点"
+        ],
+        "usphone": "praɪm",
+        "ukphone": "praɪm"
+    },
+    {
+        "name": "primitive",
+        "trans": [
+            "原始的，远古的；简单的，粗糙的",
+            "原始人； 原始事物"
+        ],
+        "usphone": "'prɪmətɪv",
+        "ukphone": "'prɪmətɪv"
+    },
+    {
+        "name": "primordial",
+        "trans": [
+            "原始的， 最初的； 基本的"
+        ],
+        "usphone": "praɪ'mɔrdɪəl",
+        "ukphone": "praɪ'mɔːrdiəl"
+    },
+    {
+        "name": "principal",
+        "trans": [
+            "主要的，最重要的",
+            "校长； 资本； 主角"
+        ],
+        "usphone": "'prɪnsəpl",
+        "ukphone": "'prɪnsəpl"
+    },
+    {
+        "name": "principle",
+        "trans": [
+            "原则； 原理； 道德准则， 行为规范； 信念"
+        ],
+        "usphone": "'prɪnsəpl",
+        "ukphone": "'prɪnsəpl"
+    },
+    {
+        "name": "prior",
+        "trans": [
+            "在…前的； 优先的"
+        ],
+        "usphone": "'praɪɚ",
+        "ukphone": "'praɪər"
+    },
+    {
+        "name": "prioritize",
+        "trans": [
+            "划分优先顺序； 优先处理"
+        ],
+        "usphone": "praɪ'ɔrətaɪz",
+        "ukphone": "praɪ'ɔːrətaɪz"
+    },
+    {
+        "name": "priority",
+        "trans": [
+            "优先权， 优先； 优先考虑的事， 最重要的事"
+        ],
+        "usphone": "praɪ'ɔrəti",
+        "ukphone": "praɪ'ɔːrəti"
+    },
+    {
+        "name": "privilege",
+        "trans": [
+            "给予特权，特别优待",
+            "特权， 特殊待遇； 特殊利益， 优惠； 荣耀， 荣幸"
+        ],
+        "usphone": "ˈprɪvəlɪdʒ",
+        "ukphone": "'prɪvəlɪdʒ"
+    },
+    {
+        "name": "prize",
+        "trans": [
+            "应获奖的； 优秀的， 典范性的",
+            "珍视",
+            "奖品；奖金；难能可贵的东西"
+        ],
+        "usphone": "praɪz",
+        "ukphone": "praɪz"
+    },
+    {
+        "name": "proactive",
+        "trans": [
+            "积极主动的； 先发制人的"
+        ],
+        "usphone": ",pro'æktɪv",
+        "ukphone": "ˌprou'æktɪv"
+    },
+    {
+        "name": "probe",
+        "trans": [
+            "探查，探测；盘问，追问",
+            "探针； 探测器； 探索， 调查"
+        ],
+        "usphone": "prob",
+        "ukphone": "proub"
+    },
+    {
+        "name": "procedure",
+        "trans": [
+            "程序， 手续， 步骤"
+        ],
+        "usphone": "prə'sidʒɚ",
+        "ukphone": "prə'siːdʒər"
+    },
+    {
+        "name": "proceed",
+        "trans": [
+            "进行下去， 继续做； 发生； 继续下去； 行进， 前往"
+        ],
+        "usphone": "pro'sid",
+        "ukphone": "prou'siːd"
+    },
+    {
+        "name": "process",
+        "trans": [
+            "加工，处理",
+            "过程； 程序， 手续； 工序， 制作法"
+        ],
+        "usphone": "proˈsɛs;(for n.)prɑsɛs",
+        "ukphone": "'prɑːses"
+    },
+    {
+        "name": "proclaim",
+        "trans": [
+            "宣布， 声明； 显示"
+        ],
+        "usphone": "prə'klem",
+        "ukphone": "prə'kleɪm"
+    },
+    {
+        "name": "prodigious",
+        "trans": [
+            "巨大的"
+        ],
+        "usphone": "prə'dɪdʒəs",
+        "ukphone": "prə'dɪdʒəs"
+    },
+    {
+        "name": "productive",
+        "trans": [
+            "生产的； 能产的， 多产的； 富有成效的"
+        ],
+        "usphone": "prə'dʌktɪv",
+        "ukphone": "prə'dʌktɪv"
+    },
+    {
+        "name": "productivity",
+        "trans": [
+            "生产力， 生产率"
+        ],
+        "usphone": ",prodʌk'tɪvəti",
+        "ukphone": "ˌprɑːdʌk'tɪvəti"
+    },
+    {
+        "name": "profession",
+        "trans": [
+            "职业； 同行； 专业； 宣称"
+        ],
+        "usphone": "prə'fɛʃən",
+        "ukphone": "prə'feʃn"
+    },
+    {
+        "name": "proficient",
+        "trans": [
+            "熟练的， 精通的"
+        ],
+        "usphone": "prə'fɪʃnt",
+        "ukphone": "prə'fɪʃnt"
+    },
+    {
+        "name": "profile",
+        "trans": [
+            "人物专访；概述，传略，人物简介；面部的侧影；轮廓，外形",
+            "扼要介绍， 概述"
+        ],
+        "usphone": "'profaɪl",
+        "ukphone": "'proufaɪl"
+    },
+    {
+        "name": "profound",
+        "trans": [
+            "巨大的， 深远的； 知识渊博的； 深奥的"
+        ],
+        "usphone": "prə'faʊnd",
+        "ukphone": "prə'faund"
+    },
+    {
+        "name": "progressive",
+        "trans": [
+            "进步的； 逐步的， 渐进的； 【语】进行时的"
+        ],
+        "usphone": "prə'ɡrɛsɪv",
+        "ukphone": "prə'gresɪv"
+    },
+    {
+        "name": "prohibit",
+        "trans": [
+            "禁止， 阻止"
+        ],
+        "usphone": "prə'hɪbɪt",
+        "ukphone": "prə'hɪbɪt"
+    },
+    {
+        "name": "prohibitive",
+        "trans": [
+            "禁止的， 抑制的； 高得令人难以承受的"
+        ],
+        "usphone": "prə'hɪbətɪv",
+        "ukphone": "prə'hɪbətɪv"
+    },
+    {
+        "name": "project",
+        "trans": [
+            "放映； 规划； 预测， 推想",
+            "方案； 课题， 项目； 工程"
+        ],
+        "usphone": "prəˈdʒɛkt; prɑdʒɛkt",
+        "ukphone": "prəˈdʒekt; ˈprɒdʒekt"
+    },
+    {
+        "name": "projector",
+        "trans": [
+            "放映机， 幻灯机， 投影仪"
+        ],
+        "usphone": "prə'dʒɛktɚ",
+        "ukphone": "prə'dʒektər"
+    },
+    {
+        "name": "proliferate",
+        "trans": [
+            "激增， 迅速繁殖"
+        ],
+        "usphone": "prə'lɪfə'ret",
+        "ukphone": "prə'lɪfəreɪt"
+    },
+    {
+        "name": "prolific",
+        "trans": [
+            "多产的； 富有创造力的"
+        ],
+        "usphone": "prə'lɪfɪk",
+        "ukphone": "prə'lɪfɪk"
+    },
+    {
+        "name": "prolong",
+        "trans": [
+            "拉长， 延长"
+        ],
+        "usphone": "prəˈlɑːŋ",
+        "ukphone": "prə'lɔːŋ"
+    },
+    {
+        "name": "prolonged",
+        "trans": [
+            "长期的， 持久的"
+        ],
+        "usphone": "pro'lɔŋd",
+        "ukphone": "prə'lɔːŋd"
+    },
+    {
+        "name": "prominent",
+        "trans": [
+            "卓著的， 杰出的； 突起的， 凸出的"
+        ],
+        "usphone": "'prɑmɪnənt",
+        "ukphone": "'prɑːmɪnənt"
+    },
+    {
+        "name": "promising",
+        "trans": [
+            "有希望的； 有前途的"
+        ],
+        "usphone": "'prɑmɪsɪŋ",
+        "ukphone": "'prɑːmɪsɪŋ"
+    },
+    {
+        "name": "promote",
+        "trans": [
+            "促进； 提升； 宣传， 推销"
+        ],
+        "usphone": "prə'mot",
+        "ukphone": "prə'mout"
+    },
+    {
+        "name": "prompt",
+        "trans": [
+            "敏捷的；及时的，迅速的",
+            "促进，推动；提示；鼓励",
+            "提词， 提示"
+        ],
+        "usphone": "prɑmpt",
+        "ukphone": "prɑːmpt"
+    },
+    {
+        "name": "prone",
+        "trans": [
+            "平卧的， 俯卧的； 易于做…的， 倾向于…的"
+        ],
+        "usphone": "pron",
+        "ukphone": "proun"
+    },
+    {
+        "name": "pronounced",
+        "trans": [
+            "显著的； 明确的"
+        ],
+        "usphone": "prə'naʊnst",
+        "ukphone": "prə'naunst"
+    },
+    {
+        "name": "proof",
+        "trans": [
+            "耐…的， 防…的",
+            "证据，证明；证词；检验，证实；校样"
+        ],
+        "usphone": "pruf",
+        "ukphone": "pruːf"
+    },
+    {
+        "name": "proofread",
+        "trans": [
+            "校对， 校正"
+        ],
+        "usphone": "'prufrid",
+        "ukphone": "'pruːfriːd"
+    },
+    {
+        "name": "propagate",
+        "trans": [
+            "繁殖； 散布， 传播"
+        ],
+        "usphone": "'prɑpə'get",
+        "ukphone": "'prɑːpəgeɪt"
+    },
+    {
+        "name": "propel",
+        "trans": [
+            "推进， 驱使； 激励"
+        ],
+        "usphone": "prə'pɛl",
+        "ukphone": "prə'pel"
+    },
+    {
+        "name": "propensity",
+        "trans": [
+            "倾向， 癖好"
+        ],
+        "usphone": "prə'pɛnsəti",
+        "ukphone": "prə'pensəti"
+    },
+    {
+        "name": "proper",
+        "trans": [
+            "正确的； 合乎体统的， 适当的； 固有的， 特有的"
+        ],
+        "usphone": "'prɑpɚ",
+        "ukphone": "'prɑːpər"
+    },
+    {
+        "name": "property",
+        "trans": [
+            "财产， 所有物； 所有权； 房产， 地产； 特性"
+        ],
+        "usphone": "'prɑpɚti",
+        "ukphone": "'prɑːpərti"
+    },
+    {
+        "name": "prophet",
+        "trans": [
+            "先知； 预言者； 拥护者， 鼓吹者"
+        ],
+        "usphone": "'prɑfɪt",
+        "ukphone": "'prɑːfɪt"
+    },
+    {
+        "name": "proponent",
+        "trans": [
+            "支持者； 倡导者"
+        ],
+        "usphone": "prə'ponənt",
+        "ukphone": "prə'pounənt"
+    },
+    {
+        "name": "proportion",
+        "trans": [
+            "比例； 部分； 均衡， 相称"
+        ],
+        "usphone": "prə'pɔrʃən",
+        "ukphone": "prə'pɔːrʃn"
+    },
+    {
+        "name": "proposal",
+        "trans": [
+            "提议， 建议； 求婚"
+        ],
+        "usphone": "prə'pozl",
+        "ukphone": "prə'pouzl"
+    },
+    {
+        "name": "propose",
+        "trans": [
+            "建议， 提议； 提名， 推荐； 打算， 计划； 求婚"
+        ],
+        "usphone": "prə'poz",
+        "ukphone": "prə'pouz"
+    },
+    {
+        "name": "proprietor",
+        "trans": [
+            "所有者， 业主"
+        ],
+        "usphone": "prə'praɪətɚ",
+        "ukphone": "prə'praɪətər"
+    },
+    {
+        "name": "prose",
+        "trans": [
+            "散文"
+        ],
+        "usphone": "proz",
+        "ukphone": "prouz"
+    },
+    {
+        "name": "prosecute",
+        "trans": [
+            "起诉， 控告， 检举； 担任控方律师； 继续从事"
+        ],
+        "usphone": "'prɑsɪ'kjʊt",
+        "ukphone": "'prɑːsɪkjuːt"
+    },
+    {
+        "name": "prospect",
+        "trans": [
+            "勘探， 勘察",
+            "前景，前途；可能性；景象；期望"
+        ],
+        "usphone": "'prɑspɛkt",
+        "ukphone": "'prɑːspekt"
+    },
+    {
+        "name": "prospector",
+        "trans": [
+            "勘探者， 采矿者"
+        ],
+        "usphone": "'prɑspɛktɚ",
+        "ukphone": "'prɑːspektər"
+    },
+    {
+        "name": "prosper",
+        "trans": [
+            "繁荣， 兴旺； 成功"
+        ],
+        "usphone": "'prɑspɚ",
+        "ukphone": "'prɑːspər"
+    },
+    {
+        "name": "prosperity",
+        "trans": [
+            "繁荣， 兴旺"
+        ],
+        "usphone": "prɑ'spɛrəti",
+        "ukphone": "prɑː'sperəti"
+    },
+    {
+        "name": "prostitution",
+        "trans": [
+            "卖淫； 出卖灵魂， 堕落； 滥用"
+        ],
+        "usphone": "'prɑstə'tʊʃən",
+        "ukphone": "ˌprɑːstə'tjuːʃn"
+    },
+    {
+        "name": "protagonist",
+        "trans": [
+            "主角， 主人公； 领导者， 倡导者"
+        ],
+        "usphone": "prə'tæɡənɪst",
+        "ukphone": "prə'tægənɪst"
+    },
+    {
+        "name": "protein",
+        "trans": [
+            "蛋白质"
+        ],
+        "usphone": "'protin",
+        "ukphone": "'proutiːn"
+    },
+    {
+        "name": "protest",
+        "trans": [
+            "抗议， 反对",
+            "抗议， 反对"
+        ],
+        "usphone": "prəˈtɛst;protɛst",
+        "ukphone": "prəˈtest;ˈprəʊtest"
+    },
+    {
+        "name": "prototype",
+        "trans": [
+            "原型， 雏形"
+        ],
+        "usphone": "'protə'taɪp",
+        "ukphone": "'proutətaɪp"
+    },
+    {
+        "name": "protrude",
+        "trans": [
+            "突出， 伸出"
+        ],
+        "usphone": "pro'trud",
+        "ukphone": "prou'truːd"
+    },
+    {
+        "name": "provincialism",
+        "trans": [
+            "地方主义， 乡土性"
+        ],
+        "usphone": "prə'vɪnʃə'lɪzəm",
+        "ukphone": "prə'vɪnʃlɪzəm"
+    },
+    {
+        "name": "provision",
+        "trans": [
+            "供应， 供应品； 条款； 准备， 预备"
+        ],
+        "usphone": "prə'vɪʒn",
+        "ukphone": "prə'vɪʒn"
+    },
+    {
+        "name": "provocative",
+        "trans": [
+            "挑衅的， 煽动性的； 惹人讨厌的； 挑逗的"
+        ],
+        "usphone": "prə'vɑkətɪv",
+        "ukphone": "prə'vɑːkətɪv"
+    },
+    {
+        "name": "provoke",
+        "trans": [
+            "挑动， 激怒， 挑衅； 引发， 引起"
+        ],
+        "usphone": "prə'vok",
+        "ukphone": "prə'vouk"
+    },
+    {
+        "name": "prudent",
+        "trans": [
+            "谨慎的； 深谋远虑的"
+        ],
+        "usphone": "'prʊdnt",
+        "ukphone": "'pruːdnt"
+    },
+    {
+        "name": "psychoanalysis",
+        "trans": [
+            "心理分析， 精神分析"
+        ],
+        "usphone": "'saɪkoə'næləsɪs",
+        "ukphone": "ˌsaɪkouə'næləsɪs"
+    },
+    {
+        "name": "psychology",
+        "trans": [
+            "心理学； 心理， 心理特征"
+        ],
+        "usphone": "saɪ'kɑlədʒi",
+        "ukphone": "saɪ'kɑːlədʒi"
+    },
+    {
+        "name": "publication",
+        "trans": [
+            "出版， 发行； 出版物； 公布， 发表"
+        ],
+        "usphone": ",pʌblɪ'keʃən",
+        "ukphone": "ˌpʌblɪ'keɪʃn"
+    },
+    {
+        "name": "publicize",
+        "trans": [
+            "宣传， 推广， 宣扬"
+        ],
+        "usphone": "'pʌblɪsaɪz",
+        "ukphone": "'pʌblɪsaɪz"
+    },
+    {
+        "name": "puddle",
+        "trans": [
+            "水坑， 水洼"
+        ],
+        "usphone": "'pʌdl",
+        "ukphone": "'pʌdl"
+    },
+    {
+        "name": "Pueblo",
+        "trans": [
+            "普韦布洛印第安人村落； 普韦布洛人"
+        ],
+        "usphone": "",
+        "ukphone": "'pweblou"
+    },
+    {
+        "name": "puff",
+        "trans": [
+            "喘气，喘息；喷出",
+            "吸； 一缕； 喘息"
+        ],
+        "usphone": "pʌf",
+        "ukphone": "pʌf"
+    },
+    {
+        "name": "pulp",
+        "trans": [
+            "使成浆状",
+            "纸浆； 浆状物"
+        ],
+        "usphone": "pʌlp",
+        "ukphone": "pʌlp"
+    },
+    {
+        "name": "pulse",
+        "trans": [
+            "脉搏， 脉率； 脉冲"
+        ],
+        "usphone": "pʌls",
+        "ukphone": "pʌls"
+    },
+    {
+        "name": "pump",
+        "trans": [
+            "泵",
+            "抽"
+        ],
+        "usphone": "pʌmp",
+        "ukphone": "pʌmp"
+    },
+    {
+        "name": "punch",
+        "trans": [
+            "拳打；打孔；按，压",
+            "重拳击打； 冲床， 打孔机"
+        ],
+        "usphone": "",
+        "ukphone": "pʌntʃ"
+    },
+    {
+        "name": "punctual",
+        "trans": [
+            "守时的"
+        ],
+        "usphone": "'pʌŋtʃʊəl",
+        "ukphone": "'pʌŋktʃuəl"
+    },
+    {
+        "name": "puncture",
+        "trans": [
+            "刺穿；泄气，挫伤",
+            "小孔； 刺伤"
+        ],
+        "usphone": "'pʌŋktʃɚ",
+        "ukphone": "'pʌŋktʃər"
+    },
+    {
+        "name": "pupil",
+        "trans": [
+            "小学生； 瞳孔"
+        ],
+        "usphone": "pjupl",
+        "ukphone": "'pjuːpl"
+    },
+    {
+        "name": "puppet",
+        "trans": [
+            "木偶； 玩偶； 傀儡， 受人操纵的人"
+        ],
+        "usphone": "'pʌpɪt",
+        "ukphone": "'pʌpɪt"
+    },
+    {
+        "name": "purchase",
+        "trans": [
+            "购买；购买的物品",
+            "购买"
+        ],
+        "usphone": "'pɝtʃəs",
+        "ukphone": "'pɜːrtʃəs"
+    },
+    {
+        "name": "pure",
+        "trans": [
+            "纯洁的； 纯净的； 完全的； 纯理论的， 抽象的"
+        ],
+        "usphone": "pjʊr",
+        "ukphone": "pjur"
+    },
+    {
+        "name": "puritanical",
+        "trans": [
+            "极守道德的"
+        ],
+        "usphone": "'pjʊrə'tænɪkl",
+        "ukphone": "ˌpjurɪ'tænɪkl"
+    },
+    {
+        "name": "purity",
+        "trans": [
+            "纯度； 纯洁， 纯净， 纯粹"
+        ],
+        "usphone": "'pjʊrəti",
+        "ukphone": "'pjurəti"
+    },
+    {
+        "name": "purple",
+        "trans": [
+            "紫色的",
+            "紫色"
+        ],
+        "usphone": "'pɝpl",
+        "ukphone": "'pɜːrpl"
+    },
+    {
+        "name": "pursue",
+        "trans": [
+            "继续； 从事于； 追击， 追踪； 追求"
+        ],
+        "usphone": "pə'sʊ",
+        "ukphone": "pər'sjuː"
+    },
+    {
+        "name": "pursuit",
+        "trans": [
+            "追求；"
+        ],
+        "usphone": "pɚ'sut",
+        "ukphone": "pər'suːt"
+    },
+    {
+        "name": "puzzle",
+        "trans": [
+            "难题，谜",
+            "迷惑， 使困惑"
+        ],
+        "usphone": "'pʌzl",
+        "ukphone": "'pʌzl"
+    },
+    {
+        "name": "pyramid",
+        "trans": [
+            "金字塔； 锥体； 金字塔形物； 金字塔式的组织"
+        ],
+        "usphone": "'pɪrəmɪd",
+        "ukphone": "'pɪrəmɪd"
+    },
+    {
+        "name": "quadruple",
+        "trans": [
+            "成四倍",
+            "四部分组成的；四倍的",
+            "四倍"
+        ],
+        "usphone": "kwɑ'drupl",
+        "ukphone": "kwɑː'druːpl"
+    },
+    {
+        "name": "quaint",
+        "trans": [
+            "古色古香的； 离奇有趣的"
+        ],
+        "usphone": "kwent",
+        "ukphone": "kweɪnt"
+    },
+    {
+        "name": "qualify",
+        "trans": [
+            "具有资格， 合格； 有权； 限定， 修饰"
+        ],
+        "usphone": "ˈkwɑləˌfaɪ",
+        "ukphone": "'kwɑːlɪfaɪ"
+    },
+    {
+        "name": "quality",
+        "trans": [
+            "优良的， 优质的",
+            "质，质量；品德，品质；性质，特性"
+        ],
+        "usphone": "'kwɑləti",
+        "ukphone": "'kwɑːləti"
+    },
+    {
+        "name": "quantify",
+        "trans": [
+            "以数量表示， 量化"
+        ],
+        "usphone": "'kwɑntɪfaɪ",
+        "ukphone": "'kwɑːntɪfaɪ"
+    },
+    {
+        "name": "quantitative",
+        "trans": [
+            "数量的， 定量的"
+        ],
+        "usphone": "'kwɑntətetɪv",
+        "ukphone": "'kwɑːntəteɪtɪv"
+    },
+    {
+        "name": "quantum",
+        "trans": [
+            "量子"
+        ],
+        "usphone": "'kwɑntəm",
+        "ukphone": "'kwɑːntəm"
+    },
+    {
+        "name": "quarry",
+        "trans": [
+            "采石； 采集",
+            "采石场，石矿；猎物，追捕的对象"
+        ],
+        "usphone": "'kwɔri",
+        "ukphone": "'kwɔːri"
+    },
+    {
+        "name": "quarterly",
+        "trans": [
+            "按季度，一季一次",
+            "季度的， 每季一次的",
+            "季刊"
+        ],
+        "usphone": "'kwɔrtɚli",
+        "ukphone": "'kwɔːrtərli"
+    },
+    {
+        "name": "quartz",
+        "trans": [
+            "石英"
+        ],
+        "usphone": "kwɔrts",
+        "ukphone": "kwɔːrts"
+    },
+    {
+        "name": "quasar",
+        "trans": [
+            "类星体"
+        ],
+        "usphone": "'kwezɑr",
+        "ukphone": "'kweɪzɑːr"
+    },
+    {
+        "name": "quash",
+        "trans": [
+            "撤销， 废止； 镇压； 平息"
+        ],
+        "usphone": "kwɑʃ",
+        "ukphone": "kwɑːʃ"
+    },
+    {
+        "name": "quell",
+        "trans": [
+            "制止， 镇压； 缓解， 减轻"
+        ],
+        "usphone": "kwɛl",
+        "ukphone": "kwel"
+    },
+    {
+        "name": "quench",
+        "trans": [
+            "扑灭， 熄灭； 解"
+        ],
+        "usphone": "kwɛntʃ",
+        "ukphone": "kwentʃ"
+    },
+    {
+        "name": "query",
+        "trans": [
+            "向…提问； 对…表示怀疑",
+            "疑问，问题"
+        ],
+        "usphone": "'kwɪri",
+        "ukphone": "'kwɪri"
+    },
+    {
+        "name": "questionnaire",
+        "trans": [
+            "问卷， 调查表"
+        ],
+        "usphone": "ˌkwɛstʃənˈɛr",
+        "ukphone": "ˌkwestʃə'ner"
+    },
+    {
+        "name": "quiescent",
+        "trans": [
+            "静止的， 寂静的； 静态的"
+        ],
+        "usphone": "kwɪ'ɛsnt",
+        "ukphone": "kwi'esnt"
+    },
+    {
+        "name": "quilt",
+        "trans": [
+            "缝被；缝制",
+            "被褥"
+        ],
+        "usphone": "kwɪlt",
+        "ukphone": "kwɪlt"
+    },
+    {
+        "name": "quit",
+        "trans": [
+            "停止； 放弃； 离开； 辞"
+        ],
+        "usphone": "kwɪt",
+        "ukphone": "kwɪt"
+    },
+    {
+        "name": "quiver",
+        "trans": [
+            "颤动， 抖动",
+            "颤抖；箭筒"
+        ],
+        "usphone": "'kwɪvɚ",
+        "ukphone": "'kwɪvər"
+    },
+    {
+        "name": "quiz",
+        "trans": [
+            "小测验；智力竞赛",
+            "测验； 盘问， 查问， 询问"
+        ],
+        "usphone": "kwɪz",
+        "ukphone": "kwɪz"
+    },
+    {
+        "name": "quota",
+        "trans": [
+            "配额， 限额， 定额"
+        ],
+        "usphone": "'kwotə",
+        "ukphone": "'kwoutə"
+    },
+    {
+        "name": "quotation",
+        "trans": [
+            "引文， 引语， 语录； 报价"
+        ],
+        "usphone": "kwo'teʃən",
+        "ukphone": "kwou'teɪʃn"
+    },
+    {
+        "name": "quote",
+        "trans": [
+            "引用；"
+        ],
+        "usphone": "kwot",
+        "ukphone": "kwout"
+    },
+    {
+        "name": "quotient",
+        "trans": [
+            "商； 份额"
+        ],
+        "usphone": "'kwoʃnt",
+        "ukphone": "'kwouʃnt"
+    },
+    {
+        "name": "racing",
+        "trans": [
+            "比赛的",
+            "比赛， 竞赛"
+        ],
+        "usphone": "'resɪŋ",
+        "ukphone": "'reɪsɪŋ"
+    },
+    {
+        "name": "racism",
+        "trans": [
+            "种族主义， 种族歧视"
+        ],
+        "usphone": "'resɪzəm",
+        "ukphone": "'reɪsɪzəm "
+    },
+    {
+        "name": "racket",
+        "trans": [
+            "球拍； 喧嚷， 吵闹； 勒索， 诈骗"
+        ],
+        "usphone": "'rækɪt",
+        "ukphone": "'rækɪt"
+    },
+    {
+        "name": "radar",
+        "trans": [
+            "雷达"
+        ],
+        "usphone": "'redɑr",
+        "ukphone": "'reɪdɑːr"
+    },
+    {
+        "name": "radiate",
+        "trans": [
+            "辐射， 发射； 流露， 显示； 自中心向各方伸展"
+        ],
+        "usphone": "'redɪet",
+        "ukphone": "'reɪdieɪt"
+    },
+    {
+        "name": "radiation",
+        "trans": [
+            "放射； 辐射； 放射物， 放射线； 辐射的热"
+        ],
+        "usphone": ",redɪ'eʃən",
+        "ukphone": "ˌreɪdi'eɪʃn"
+    },
+    {
+        "name": "radical",
+        "trans": [
+            "根本的；激进的，极端的；全新的，不同凡响的",
+            "激进分子； 游离基， 自由基"
+        ],
+        "usphone": "'rædɪkl",
+        "ukphone": "'rædɪkl"
+    },
+    {
+        "name": "radioactive",
+        "trans": [
+            "放射性的， 有辐射的"
+        ],
+        "usphone": "'redɪo'æktɪv",
+        "ukphone": "'reɪdiou'æktɪv"
+    },
+    {
+        "name": "radius",
+        "trans": [
+            "半径； 周围， 范围"
+        ],
+        "usphone": "'redɪəs",
+        "ukphone": "'reɪdiəs"
+    },
+    {
+        "name": "raft",
+        "trans": [
+            "用筏运送； 乘筏渡河",
+            "筏，木排；充气船"
+        ],
+        "usphone": "ræft",
+        "ukphone": "ræft"
+    },
+    {
+        "name": "rage",
+        "trans": [
+            "猛烈地继续，激烈进行；发怒，怒斥；迅速蔓延，猖獗",
+            "风靡一时的事物， 时尚； 狂怒"
+        ],
+        "usphone": "redʒ",
+        "ukphone": "reɪdʒ"
+    },
+    {
+        "name": "rainbow",
+        "trans": [
+            "彩虹"
+        ],
+        "usphone": "'renbo",
+        "ukphone": "'reɪnbou"
+    },
+    {
+        "name": "rainfall",
+        "trans": [
+            "降雨； 降雨量"
+        ],
+        "usphone": "'ren'fɔl",
+        "ukphone": "'reɪnfɔːl"
+    },
+    {
+        "name": "raise",
+        "trans": [
+            "举起，提升；直立；增加；募集；饲养，养育；引起；提出",
+            "提升， 增加"
+        ],
+        "usphone": "rez",
+        "ukphone": "reɪz"
+    },
+    {
+        "name": "rally",
+        "trans": [
+            "集合，召集；恢复，重新振作",
+            "集会， 大会"
+        ],
+        "usphone": "'ræli",
+        "ukphone": "'ræli"
+    },
+    {
+        "name": "ramble",
+        "trans": [
+            "漫游；漫谈，闲聊",
+            "漫步"
+        ],
+        "usphone": "'ræmbl",
+        "ukphone": "'ræmbl"
+    },
+    {
+        "name": "rampant",
+        "trans": [
+            "猖獗的， 肆虐的； 蔓生的"
+        ],
+        "usphone": "'ræmpənt",
+        "ukphone": "'ræmpənt"
+    },
+    {
+        "name": "ranch",
+        "trans": [
+            "大牧场， 饲养场"
+        ],
+        "usphone": "ræntʃ",
+        "ukphone": "ræntʃ"
+    },
+    {
+        "name": "rancher",
+        "trans": [
+            "牧场主； 大农场工人"
+        ],
+        "usphone": "'ræntʃɚ",
+        "ukphone": "'ræntʃər"
+    },
+    {
+        "name": "rancorous",
+        "trans": [
+            "怨恨的， 满怀恶意的"
+        ],
+        "usphone": "'ræŋkərəs",
+        "ukphone": "'ræŋkərəs"
+    },
+    {
+        "name": "random",
+        "trans": [
+            "随机的，任意的",
+            "随机， 随意"
+        ],
+        "usphone": "'rændəm",
+        "ukphone": "'rændəm"
+    },
+    {
+        "name": "range",
+        "trans": [
+            "变动； 散布； 漫游",
+            "范围；山脉；一系列；射程，距离"
+        ],
+        "usphone": "rendʒ",
+        "ukphone": "reɪndʒ"
+    },
+    {
+        "name": "rank",
+        "trans": [
+            "属于某等级， 归类",
+            "等级；头衔"
+        ],
+        "usphone": "ræŋk",
+        "ukphone": "ræŋk"
+    },
+    {
+        "name": "rape",
+        "trans": [
+            "强奸； 肆意破坏"
+        ],
+        "usphone": "rep",
+        "ukphone": "reɪp"
+    },
+    {
+        "name": "rare",
+        "trans": [
+            "稀有的， 罕见的； 半熟的"
+        ],
+        "usphone": "rɛr",
+        "ukphone": "rer"
+    },
+    {
+        "name": "rash",
+        "trans": [
+            "鲁莽的，轻率的",
+            "疹， 皮疹； 一连串令人不快的事物"
+        ],
+        "usphone": "ræʃ",
+        "ukphone": "ræʃ"
+    },
+    {
+        "name": "rate",
+        "trans": [
+            "估价； 评级， 评价； 把…列为",
+            "率，比率；速度；价格；等级"
+        ],
+        "usphone": "ret",
+        "ukphone": "reɪt"
+    },
+    {
+        "name": "ratify",
+        "trans": [
+            "正式批准， 使正式生效"
+        ],
+        "usphone": "'rætɪfaɪ",
+        "ukphone": "'rætɪfaɪ"
+    },
+    {
+        "name": "ratio",
+        "trans": [
+            "比， 比率"
+        ],
+        "usphone": "'reʃɪo",
+        "ukphone": "'reɪʃiou"
+    },
+    {
+        "name": "ration",
+        "trans": [
+            "配给量，定量；给养，口粮",
+            "配给， 定量供应"
+        ],
+        "usphone": "'ræʃən",
+        "ukphone": "'ræʃn"
+    },
+    {
+        "name": "rationality",
+        "trans": [
+            "理性； 合理性"
+        ],
+        "usphone": ",ræʃən'æləti",
+        "ukphone": "ˌræʃə'næləti"
+    },
+    {
+        "name": "rattle",
+        "trans": [
+            "发出咔嗒声；使紧张，使恐惧",
+            "咔嗒声； 拨浪鼓"
+        ],
+        "usphone": "'rætl",
+        "ukphone": "'rætl"
+    },
+    {
+        "name": "ravage",
+        "trans": [
+            "毁坏； 抢劫， 掠夺"
+        ],
+        "usphone": "'rævɪdʒ",
+        "ukphone": "'rævɪdʒ"
+    },
+    {
+        "name": "raven",
+        "trans": [
+            "乌黑光亮的",
+            "渡鸦"
+        ],
+        "usphone": "'revən",
+        "ukphone": "'reɪvn"
+    },
+    {
+        "name": "ravine",
+        "trans": [
+            "沟壑， 溪谷"
+        ],
+        "usphone": "rə'vin",
+        "ukphone": "rə'viːn"
+    },
+    {
+        "name": "raw",
+        "trans": [
+            "生的， 未烹制的； 自然状态的， 未经加工的； 生疏的， 无经验的； 粗犷的； 原始的， 未经处理的"
+        ],
+        "usphone": "rɔ",
+        "ukphone": "rɔː"
+    },
+    {
+        "name": "rayon",
+        "trans": [
+            "人造丝， 人造纤维"
+        ],
+        "usphone": "'reɑn",
+        "ukphone": "'reɪɑːn"
+    },
+    {
+        "name": "reactor",
+        "trans": [
+            "反应堆"
+        ],
+        "usphone": "rɪ'æktɚ",
+        "ukphone": "ri'æktər"
+    },
+    {
+        "name": "readability",
+        "trans": [
+            "可读性"
+        ],
+        "usphone": ",ri:də'biləti",
+        "ukphone": "ˌriːdə'bɪləti"
+    },
+    {
+        "name": "readily",
+        "trans": [
+            "欣然地； 容易地"
+        ],
+        "usphone": "'rɛdɪli",
+        "ukphone": "'redɪli"
+    },
+    {
+        "name": "realistic",
+        "trans": [
+            "现实的； 逼真的"
+        ],
+        "usphone": ",riə'lɪstɪk",
+        "ukphone": "ˌriːə'lɪstɪk"
+    },
+    {
+        "name": "realization",
+        "trans": [
+            "实现； 意识"
+        ],
+        "usphone": ",riələ'zeʃən",
+        "ukphone": "ˌriːəlaɪ'zeɪʃn"
+    },
+    {
+        "name": "realm",
+        "trans": [
+            "王国， 国度； 界， 范围， 领域"
+        ],
+        "usphone": "rɛlm",
+        "ukphone": "relm"
+    },
+    {
+        "name": "realtor",
+        "trans": [
+            "房地产经纪人"
+        ],
+        "usphone": "'riəltə, -tɔ:",
+        "ukphone": "'riːəltər"
+    },
+    {
+        "name": "reapply",
+        "trans": [
+            "再申请； 再利用"
+        ],
+        "usphone": ",riə'plaɪ",
+        "ukphone": "ˌriːə'plaɪ"
+    },
+    {
+        "name": "rear",
+        "trans": [
+            "后部的， 后面的",
+            "养育，抚养，培养；饲养",
+            "后部，后方；臀部"
+        ],
+        "usphone": "rɪr",
+        "ukphone": "rɪr"
+    },
+    {
+        "name": "reasonable",
+        "trans": [
+            "合理的， 适当的； 通情达理的； 公道的"
+        ],
+        "usphone": "'riznəbl",
+        "ukphone": "'riːznəbl"
+    },
+    {
+        "name": "rebate",
+        "trans": [
+            "回扣， 折扣； 退还款"
+        ],
+        "usphone": "'ribet",
+        "ukphone": "'riːbeɪt"
+    },
+    {
+        "name": "rebel",
+        "trans": [
+            "造反， 起义， 反抗",
+            "叛逆者， 起义者"
+        ],
+        "usphone": "rɪ'bɛl",
+        "ukphone": "'reb(ə)l"
+    },
+    {
+        "name": "rebellious",
+        "trans": [
+            "反叛的， 叛逆的； 叛乱的"
+        ],
+        "usphone": "rɪ'bɛljəs",
+        "ukphone": "rɪ'beljəs"
+    },
+    {
+        "name": "recall",
+        "trans": [
+            "回忆起，回想起；召回，叫回；收回，撤销",
+            "记忆力， 记性； 召回"
+        ],
+        "usphone": "'rikɔl",
+        "ukphone": "rɪ'kɔːl"
+    },
+    {
+        "name": "recede",
+        "trans": [
+            "退， 后退； 渐渐远去； 逐渐减弱"
+        ],
+        "usphone": "rɪ'sid",
+        "ukphone": "rɪ'siːd"
+    },
+    {
+        "name": "receiver",
+        "trans": [
+            "接收器； 听筒； 接收者； 官方接管人"
+        ],
+        "usphone": "rɪ'sivɚ",
+        "ukphone": "rɪ'siːvər"
+    },
+    {
+        "name": "receptacle",
+        "trans": [
+            "容器； 插座"
+        ],
+        "usphone": "rɪ'sɛptəkl",
+        "ukphone": "rɪ'septəkl"
+    },
+    {
+        "name": "reception",
+        "trans": [
+            "招待会； 反响； 接纳， 接待； 接收"
+        ],
+        "usphone": "rɪ'sɛpʃən",
+        "ukphone": "rɪ'sepʃn"
+    },
+    {
+        "name": "receptive",
+        "trans": [
+            "接受得快的； 善于接受的， 能接纳的"
+        ],
+        "usphone": "rɪ'sɛptɪv",
+        "ukphone": "rɪ'septɪv"
+    },
+    {
+        "name": "receptor",
+        "trans": [
+            "感受器； 受体"
+        ],
+        "usphone": "rɪ'sɛptɚ",
+        "ukphone": "rɪ'septər"
+    },
+    {
+        "name": "recess",
+        "trans": [
+            "休会期；休庭；暂停；凹室，"
+        ],
+        "usphone": "'risɛs",
+        "ukphone": "rɪ'ses"
+    },
+    {
+        "name": "recession",
+        "trans": [
+            "衰退， 衰退时期， 萧条时期； 撤回， 退回"
+        ],
+        "usphone": "rɪ'sɛʃən",
+        "ukphone": "rɪ'seʃn"
+    },
+    {
+        "name": "recessive",
+        "trans": [
+            "隐性的"
+        ],
+        "usphone": "rɪ'sɛsɪv",
+        "ukphone": "rɪ'sesɪv"
+    },
+    {
+        "name": "recharge",
+        "trans": [
+            "充电； 休整； 再装弹药"
+        ],
+        "usphone": "ri:'tʃɑ:dʒ, 'ri:tʃɑ:dʒ",
+        "ukphone": "ˌriː'tʃɑːrdʒ"
+    },
+    {
+        "name": "recipe",
+        "trans": [
+            "食谱； 方法， 秘诀， 诀窍"
+        ],
+        "usphone": "'rɛsəpi",
+        "ukphone": "'resəpi"
+    },
+    {
+        "name": "recipient",
+        "trans": [
+            "接受者， 收受者"
+        ],
+        "usphone": "rɪ'sɪpɪənt",
+        "ukphone": "rɪ'sɪpiənt"
+    },
+    {
+        "name": "reciprocal",
+        "trans": [
+            "相互的；互惠的；相应的；"
+        ],
+        "usphone": "rɪ'sɪprəkl",
+        "ukphone": "rɪ'sɪprəkl"
+    },
+    {
+        "name": "reciprocity",
+        "trans": [
+            "互惠， 互助； 互惠主义"
+        ],
+        "usphone": ",rɛsɪ'prɑsəti",
+        "ukphone": "ˌresɪ'prɑːsəti"
+    },
+    {
+        "name": "recital",
+        "trans": [
+            "音乐演奏会； 诗歌朗诵会； 赘述"
+        ],
+        "usphone": "rɪ'saɪtl",
+        "ukphone": "rɪ'saɪtl"
+    },
+    {
+        "name": "reckless",
+        "trans": [
+            "轻率的， 鲁莽的， 无所顾忌的"
+        ],
+        "usphone": "'rɛkləs",
+        "ukphone": "'rekləs"
+    },
+    {
+        "name": "recline",
+        "trans": [
+            "向后倚靠， 斜倚"
+        ],
+        "usphone": "rɪ'klaɪn",
+        "ukphone": "rɪ'klaɪn"
+    },
+    {
+        "name": "recognition",
+        "trans": [
+            "承认， 认同； 认出， 识别， 辨认； 赏识"
+        ],
+        "usphone": ",rɛkəɡ'nɪʃən",
+        "ukphone": "ˌrekəg'nɪʃn"
+    },
+    {
+        "name": "recognize",
+        "trans": [
+            "认出， 识别； 认可"
+        ],
+        "usphone": "ˈrɛkəɡˌnaɪz",
+        "ukphone": "'rekəgnaɪz"
+    },
+    {
+        "name": "recoil",
+        "trans": [
+            "弹回；后退，退缩；产生后坐力",
+            "后退， 退缩； 反冲， 后坐力"
+        ],
+        "usphone": "'rikɔɪl",
+        "ukphone": "rɪ'kɔɪl"
+    },
+    {
+        "name": "recollection",
+        "trans": [
+            "记忆力； 回忆， 记忆； 回想起来的事"
+        ],
+        "usphone": ",rɛkə'lɛkʃən",
+        "ukphone": "ˌrekə'lekʃn"
+    },
+    {
+        "name": "recommend",
+        "trans": [
+            "推荐； 建议"
+        ],
+        "usphone": "'rɛkə'mɛnd",
+        "ukphone": "ˌrekə'mend"
+    },
+    {
+        "name": "reconcile",
+        "trans": [
+            "使协调； 使和解； 使顺从"
+        ],
+        "usphone": "'rɛkənsaɪl",
+        "ukphone": "'rekənsaɪl"
+    },
+    {
+        "name": "reconstruction",
+        "trans": [
+            "复兴； 改造， 再建"
+        ],
+        "usphone": ",rikən'strʌkʃən",
+        "ukphone": "ˌriːkən'strʌkʃn"
+    },
+    {
+        "name": "recount",
+        "trans": [
+            "讲述， 描述； 重新清点， 重计"
+        ],
+        "usphone": "rɪ'kaʊnt",
+        "ukphone": "rɪ'kaunt"
+    },
+    {
+        "name": "recoup",
+        "trans": [
+            "收回， 弥补"
+        ],
+        "usphone": "ri'ku:p",
+        "ukphone": "rɪ'kuːp"
+    },
+    {
+        "name": "recover",
+        "trans": [
+            "复原， 恢复； 重新获得； 收回"
+        ],
+        "usphone": "rɪ'kʌvɚ",
+        "ukphone": "rɪ'kʌvər"
+    },
+    {
+        "name": "recreation",
+        "trans": [
+            "娱乐， 消遣"
+        ],
+        "usphone": ",rɛkrɪ'eʃən",
+        "ukphone": "ˌrekri'eɪʃn"
+    },
+    {
+        "name": "recruit",
+        "trans": [
+            "招募，征募",
+            "新兵； 新成员"
+        ],
+        "usphone": "rɪ'krut",
+        "ukphone": "rɪ'kruːt"
+    },
+    {
+        "name": "rectangle",
+        "trans": [
+            "长方形， 矩形"
+        ],
+        "usphone": "'rɛktæŋɡl",
+        "ukphone": "'rektæŋgl"
+    },
+    {
+        "name": "rectify",
+        "trans": [
+            "矫正， 纠正； 整顿"
+        ],
+        "usphone": "'rɛktɪfaɪ",
+        "ukphone": "'rektɪfaɪ"
+    },
+    {
+        "name": "recurring",
+        "trans": [
+            "往复的， 反复的， 再次发生的"
+        ],
+        "usphone": "rɪ'kɝɪŋ",
+        "ukphone": "rɪ'kɜːrɪŋ"
+    },
+    {
+        "name": "recycle",
+        "trans": [
+            "回收利用， 再应用"
+        ],
+        "usphone": ",ri'saɪkl",
+        "ukphone": "ˌriː'saɪkl"
+    },
+    {
+        "name": "reddish",
+        "trans": [
+            "微红的"
+        ],
+        "usphone": "'rɛdɪʃ",
+        "ukphone": "'redɪʃ"
+    },
+    {
+        "name": "redeem",
+        "trans": [
+            "赎回； 偿清， 付清； 兑换； 弥补， 补偿； 履行， 遵守"
+        ],
+        "usphone": "rɪ'dim",
+        "ukphone": "rɪ'diːm"
+    },
+    {
+        "name": "redundant",
+        "trans": [
+            "多余的； 累赘的"
+        ],
+        "usphone": "rɪ'dʌndənt",
+        "ukphone": "rɪ'dʌndənt"
+    },
+    {
+        "name": "reef",
+        "trans": [
+            "礁， 暗礁"
+        ],
+        "usphone": "rif",
+        "ukphone": "riːf"
+    },
+    {
+        "name": "refer",
+        "trans": [
+            "提到， 谈及； 查阅， 参考"
+        ],
+        "usphone": "rɪ'fɝ",
+        "ukphone": "rɪ'fɜːr"
+    },
+    {
+        "name": "reference",
+        "trans": [
+            "提到， 论及， 涉及； 引文， 参考； 介绍"
+        ],
+        "usphone": "'rɛfrəns",
+        "ukphone": "'refrəns"
+    },
+    {
+        "name": "refine",
+        "trans": [
+            "精炼， 精制； 使完善； 净化， 提纯"
+        ],
+        "usphone": "rɪ'faɪn",
+        "ukphone": "rɪ'faɪn"
+    },
+    {
+        "name": "reflect",
+        "trans": [
+            "反射， 映现； 显示， 表明； 仔细考虑， 深思"
+        ],
+        "usphone": "rɪ'flɛkt",
+        "ukphone": "rɪ'flekt"
+    },
+    {
+        "name": "reflection",
+        "trans": [
+            "反映； 映像； 深思， 考虑； 回忆； 记录， 描述"
+        ],
+        "usphone": "rɪ'flɛkʃən",
+        "ukphone": "rɪ'flekʃn"
+    },
+    {
+        "name": "reform",
+        "trans": [
+            "改革， 改造， 革新； 改正， 改过自新"
+        ],
+        "usphone": "rɪ'fɔrm",
+        "ukphone": "rɪ'fɔːrm"
+    },
+    {
+        "name": "refraction",
+        "trans": [
+            "折射"
+        ],
+        "usphone": "rɪ'frækʃən",
+        "ukphone": "rɪ'frækʃn"
+    },
+    {
+        "name": "refrain",
+        "trans": [
+            "抑制； 戒除",
+            "反复句，副歌"
+        ],
+        "usphone": "rɪ'fren",
+        "ukphone": "rɪ'freɪn"
+    },
+    {
+        "name": "refreshing",
+        "trans": [
+            "使人耳目一新的； 提神的， 使人精神振作的"
+        ],
+        "usphone": "ri'frɛʃɪŋ",
+        "ukphone": "rɪ'freʃɪŋ"
+    },
+    {
+        "name": "refrigerate",
+        "trans": [
+            "冷冻， 冷藏； 使冷却， 使变冷"
+        ],
+        "usphone": "rɪ'frɪdʒəret",
+        "ukphone": "rɪ'frɪdʒəreɪt"
+    },
+    {
+        "name": "refund",
+        "trans": [
+            "偿还额； 退款",
+            "退还， 偿付"
+        ],
+        "usphone": "ˈrifʌnd",
+        "ukphone": "ˈriːfʌnd"
+    },
+    {
+        "name": "refurbish",
+        "trans": [
+            "再装修， 重新装饰"
+        ],
+        "usphone": ",ri'fɝbɪʃ",
+        "ukphone": "ˌriː'fɜːrbɪʃ"
+    },
+    {
+        "name": "refute",
+        "trans": [
+            "反驳， 驳斥"
+        ],
+        "usphone": "ri'fjʊt",
+        "ukphone": "rɪ'fjuːt"
+    },
+    {
+        "name": "regardless",
+        "trans": [
+            "不顾， 不管"
+        ],
+        "usphone": "rɪ'ɡɑrdləs",
+        "ukphone": "rɪ'gɑːrdləs"
+    },
+    {
+        "name": "regenerate",
+        "trans": [
+            "复兴， 振兴； 再生"
+        ],
+        "usphone": "rɪ'dʒɛnəret",
+        "ukphone": "rɪ'dʒenəreɪt"
+    },
+    {
+        "name": "regiment",
+        "trans": [
+            "团；"
+        ],
+        "usphone": "'rɛdʒɪmənt",
+        "ukphone": "'redʒɪmənt"
+    },
+    {
+        "name": "region",
+        "trans": [
+            "层； 地区， 区域； 范围"
+        ],
+        "usphone": "'ridʒən",
+        "ukphone": "'riːdʒən"
+    },
+    {
+        "name": "register",
+        "trans": [
+            "登记， 注册"
+        ],
+        "usphone": "'rɛdʒɪstɚ",
+        "ukphone": "'redʒɪstər"
+    },
+    {
+        "name": "regular",
+        "trans": [
+            "规则的， 有规律的； 整齐的， 匀称的； 频繁的， 经常的； 正常的； 经常的； 正规的， 正式的"
+        ],
+        "usphone": "'rɛgjəlɚ",
+        "ukphone": "'regjələr"
+    },
+    {
+        "name": "regulate",
+        "trans": [
+            "管理， 控制； 调整， 调节； 校准"
+        ],
+        "usphone": "'rɛɡjulet",
+        "ukphone": "'regjuleɪt"
+    },
+    {
+        "name": "rehabilitate",
+        "trans": [
+            "使恢复原状， 修复； 改造， 使恢复正常生活； 恢复…的名誉"
+        ],
+        "usphone": ",riə'bɪlə,tet",
+        "ukphone": "ˌriːə'bɪlɪteɪt"
+    },
+    {
+        "name": "rehearse",
+        "trans": [
+            "预演， 排练； 默诵； 照搬， 重复"
+        ],
+        "usphone": "rɪ'hɝs",
+        "ukphone": "rɪ'hɜːrs"
+    },
+    {
+        "name": "reign",
+        "trans": [
+            "统治，支配；"
+        ],
+        "usphone": "ren",
+        "ukphone": "reɪn"
+    },
+    {
+        "name": "reinforce",
+        "trans": [
+            "加固， 加强； 增援"
+        ],
+        "usphone": ",riɪn'fɔrs",
+        "ukphone": "ˌriːɪn'fɔːrs"
+    },
+    {
+        "name": "reiterate",
+        "trans": [
+            "反复说， 重申"
+        ],
+        "usphone": "rɪ'ɪtəret",
+        "ukphone": "ri'ɪtəreɪt"
+    },
+    {
+        "name": "reject",
+        "trans": [
+            "拒绝， 抵制； 抛弃， 摈弃， ， 丢弃； 拒收， 不录用； 排斥",
+            "被拒货品， 不合格产品"
+        ],
+        "usphone": "rɪ'dʒɛkt",
+        "ukphone": "rɪ'dʒekt"
+    },
+    {
+        "name": "rejuvenate",
+        "trans": [
+            "使年轻； 使恢复活力"
+        ],
+        "usphone": "rɪ'dʒuvənet",
+        "ukphone": "rɪ'dʒuːvəneɪt"
+    },
+    {
+        "name": "rekindle",
+        "trans": [
+            "重新点燃； 使振作"
+        ],
+        "usphone": ",ri'kɪndl",
+        "ukphone": "ˌriː'kɪndl"
+    },
+    {
+        "name": "relate",
+        "trans": [
+            "叙述， 讲述； 有关联"
+        ],
+        "usphone": "rɪ'let",
+        "ukphone": "rɪ'leɪt"
+    },
+    {
+        "name": "relative",
+        "trans": [
+            "相对的；有关的",
+            "亲属， 亲戚"
+        ],
+        "usphone": "'rɛlətɪv",
+        "ukphone": "'relətɪv"
+    },
+    {
+        "name": "relay",
+        "trans": [
+            "转播； 传达， 转述",
+            "接替人员， 轮换者； 接力赛； 中继设备"
+        ],
+        "usphone": "rɪ'le",
+        "ukphone": "'riːleɪ"
+    },
+    {
+        "name": "release",
+        "trans": [
+            "释放； 发布， 公开； 发泄"
+        ],
+        "usphone": "rɪ'lis",
+        "ukphone": "rɪ'liːs"
+    },
+    {
+        "name": "relegate",
+        "trans": [
+            "使贬职， 使降级； 放逐， 贬谪"
+        ],
+        "usphone": "'rɛlɪɡet",
+        "ukphone": "'relɪgeɪt"
+    },
+    {
+        "name": "relevance",
+        "trans": [
+            "有关， 相关； 中肯， 适当； 重大关系， 意义； 实用性"
+        ],
+        "usphone": "'rɛləvəns",
+        "ukphone": "'reləvəns"
+    },
+    {
+        "name": "relevant",
+        "trans": [
+            "相关的， 有关的； 中肯的， 贴切的； 有价值的， 有意义的"
+        ],
+        "usphone": "'rɛləvənt",
+        "ukphone": "'reləvənt"
+    },
+    {
+        "name": "reliable",
+        "trans": [
+            "可靠的， 可信赖的"
+        ],
+        "usphone": "rɪ'laɪəbl",
+        "ukphone": "rɪ'laɪəbl"
+    },
+    {
+        "name": "reliance",
+        "trans": [
+            "依靠， 依赖； 信任"
+        ],
+        "usphone": "rɪ'laɪəns",
+        "ukphone": "rɪ'laɪəns"
+    },
+    {
+        "name": "relic",
+        "trans": [
+            "遗物， 遗迹， 遗风"
+        ],
+        "usphone": "'rɛlɪk",
+        "ukphone": "'relɪk"
+    },
+    {
+        "name": "relief",
+        "trans": [
+            "缓解， 减轻， 轻松； 援救， 救济； 宽慰； 浮雕"
+        ],
+        "usphone": "rɪ'lif",
+        "ukphone": "rɪ'liːf"
+    },
+    {
+        "name": "relieve",
+        "trans": [
+            "缓解， 减轻； 使轻松， 使宽慰； 调剂； 接替， 换班"
+        ],
+        "usphone": "rɪ'liv",
+        "ukphone": "rɪ'liːv"
+    },
+    {
+        "name": "reliever",
+        "trans": [
+            "救济者； 缓解物"
+        ],
+        "usphone": "rɪ'livɚ",
+        "ukphone": "rɪ'liːvər"
+    },
+    {
+        "name": "religion",
+        "trans": [
+            "宗教； 宗教信仰； 宗派， 教派"
+        ],
+        "usphone": "rɪ'lɪdʒən",
+        "ukphone": "rɪ'lɪdʒən"
+    },
+    {
+        "name": "reluctant",
+        "trans": [
+            "不情愿的， 勉强的"
+        ],
+        "usphone": "rɪ'lʌktənt",
+        "ukphone": "rɪ'lʌktənt"
+    },
+    {
+        "name": "rely",
+        "trans": [
+            "依赖， 依靠； 信赖， 信任"
+        ],
+        "usphone": "rɪ'laɪ",
+        "ukphone": "rɪ'laɪ"
+    },
+    {
+        "name": "remainder",
+        "trans": [
+            "剩余物， 残余； 其他的人； 差数， 余数"
+        ],
+        "usphone": "rɪ'mendɚ",
+        "ukphone": "rɪ'meɪndər"
+    },
+    {
+        "name": "remains",
+        "trans": [
+            "剩余物， 残留物； 古代遗物， 遗迹， 遗址； 遗骸"
+        ],
+        "usphone": "rɪ'menz",
+        "ukphone": "rɪ'meɪnz"
+    },
+    {
+        "name": "remark",
+        "trans": [
+            "评论；谈论；察觉",
+            "评论， 评语； 注释"
+        ],
+        "usphone": "rɪ'mɑrk",
+        "ukphone": "rɪ'mɑːrk"
+    },
+    {
+        "name": "remarkable",
+        "trans": [
+            "显著的， 值得注意的； 非凡的"
+        ],
+        "usphone": "rɪ'mɑrkəbl",
+        "ukphone": "rɪ'mɑːrkəbl"
+    },
+    {
+        "name": "remind",
+        "trans": [
+            "提醒； 使想起； 使发生联想"
+        ],
+        "usphone": "rɪ'maɪnd",
+        "ukphone": "rɪ'maɪnd"
+    },
+    {
+        "name": "remnant",
+        "trans": [
+            "残余物； 布头； 遗迹"
+        ],
+        "usphone": "'rɛmnənt",
+        "ukphone": "'remnənt"
+    },
+    {
+        "name": "remodel",
+        "trans": [
+            "重新塑造， 改造； 改编； 改变"
+        ],
+        "usphone": ",ri'mɑdl",
+        "ukphone": "ˌriː'mɑːdl"
+    },
+    {
+        "name": "remote",
+        "trans": [
+            "偏僻的， 偏远的； 久远的； 远程的； 关系远的； 微乎其微的； 冷漠的"
+        ],
+        "usphone": "rɪ'mot",
+        "ukphone": "rɪ'mout"
+    },
+    {
+        "name": "removal",
+        "trans": [
+            "除去； 移动， 搬迁"
+        ],
+        "usphone": "rɪ'muvl",
+        "ukphone": "rɪ'muːvl"
+    },
+    {
+        "name": "renaissance",
+        "trans": [
+            "[the R-] 文艺复兴， 文艺复兴时期； 复兴， 再生"
+        ],
+        "usphone": "ˈrenəsɑ:ns; ˌrɛnəˈsɑns",
+        "ukphone": "'renəsɑːns"
+    },
+    {
+        "name": "render",
+        "trans": [
+            "给予， 提供； 致使； 递交， 呈献； 表达； 翻译"
+        ],
+        "usphone": "'rɛndɚ",
+        "ukphone": "'rendər"
+    },
+    {
+        "name": "rendition",
+        "trans": [
+            "表演， 演唱； 提供， 给予； 翻译"
+        ],
+        "usphone": "rɛn'dɪʃən",
+        "ukphone": "ren'dɪʃn"
+    },
+    {
+        "name": "renew",
+        "trans": [
+            "使…续期； 重新开始； 重申； 修复"
+        ],
+        "usphone": "rɪ'nʊ",
+        "ukphone": "rɪ'njuː"
+    },
+    {
+        "name": "renovate",
+        "trans": [
+            "修复； 更新， 翻新"
+        ],
+        "usphone": "'rɛnəvet",
+        "ukphone": "'renəveɪt"
+    },
+    {
+        "name": "renown",
+        "trans": [
+            "名望， 声誉"
+        ],
+        "usphone": "rɪ'naʊn",
+        "ukphone": "rɪ'naun"
+    },
+    {
+        "name": "rental",
+        "trans": [
+            "租用的；出租的",
+            "租金额； 租赁， 出租"
+        ],
+        "usphone": "'rɛntl",
+        "ukphone": "'rentl"
+    },
+    {
+        "name": "repel",
+        "trans": [
+            "击退， 驱逐； 排斥； 抵制， 拒绝； 使反感， 使厌恶"
+        ],
+        "usphone": "rɪ'pɛl",
+        "ukphone": "rɪ'pel"
+    },
+    {
+        "name": "repertoire",
+        "trans": [
+            "常备剧目， 保留剧目； 可表演节目； 全部才能"
+        ],
+        "usphone": "'rɛpɚ'twɑr",
+        "ukphone": "'repərtwɑːr"
+    },
+    {
+        "name": "repertory",
+        "trans": [
+            "保留剧目； 保留剧目轮演； 库存， 储备； 仓库"
+        ],
+        "usphone": "'rɛpɚtɔri",
+        "ukphone": "'repərtɔːri"
+    },
+    {
+        "name": "repetition",
+        "trans": [
+            "重复， 反复； 重复的事"
+        ],
+        "usphone": "'rɛpə'tɪʃən",
+        "ukphone": "ˌrepə'tɪʃn"
+    },
+    {
+        "name": "replace",
+        "trans": [
+            "替换， 取代； 归还， 把…放回原处"
+        ],
+        "usphone": "rɪ'ples",
+        "ukphone": "rɪ'pleɪs"
+    },
+    {
+        "name": "replenish",
+        "trans": [
+            "添加， 补充"
+        ],
+        "usphone": "rɪ'plɛnɪʃ",
+        "ukphone": "rɪ'plenɪʃ"
+    },
+    {
+        "name": "replica",
+        "trans": [
+            "复制品"
+        ],
+        "usphone": "'rɛplɪkə",
+        "ukphone": "'replɪkə"
+    },
+    {
+        "name": "replicate",
+        "trans": [
+            "复制； 再制， 再生"
+        ],
+        "usphone": "'rɛplɪket",
+        "ukphone": "'replɪkeɪt"
+    },
+    {
+        "name": "represent",
+        "trans": [
+            "代表； 表现； 描绘； 象征"
+        ],
+        "usphone": ",rɛprɪ'zɛnt",
+        "ukphone": "ˌreprɪ'zent"
+    },
+    {
+        "name": "representative",
+        "trans": [
+            "典型的， 有代表性的",
+            "代表，代理人"
+        ],
+        "usphone": "'rɛprɪ'zɛntətɪv",
+        "ukphone": "ˌreprɪ'zentətɪv"
+    },
+    {
+        "name": "repress",
+        "trans": [
+            "克制， 抑制； 镇压， 压制"
+        ],
+        "usphone": "rɪ'prɛs",
+        "ukphone": "rɪ'pres"
+    },
+    {
+        "name": "reproach",
+        "trans": [
+            "指责， 斥责， 批评"
+        ],
+        "usphone": "rɪ'protʃ",
+        "ukphone": "rɪ'proutʃ"
+    },
+    {
+        "name": "reproduce",
+        "trans": [
+            "繁殖， 生育； 复制； 再现"
+        ],
+        "usphone": ",riprə'dus",
+        "ukphone": "ˌriːprə'duːs"
+    },
+    {
+        "name": "reptile",
+        "trans": [
+            "爬行动物， 爬虫类； 卑鄙的人"
+        ],
+        "usphone": "'rɛptaɪl",
+        "ukphone": "'reptaɪl"
+    },
+    {
+        "name": "republic",
+        "trans": [
+            "共和国； 共和政体"
+        ],
+        "usphone": "rɪ'pʌblɪk",
+        "ukphone": "rɪ'pʌblɪk"
+    },
+    {
+        "name": "reputation",
+        "trans": [
+            "名声， 声望， 名誉"
+        ],
+        "usphone": ",rɛpju'teʃən",
+        "ukphone": "ˌrepju'teɪʃn"
+    },
+    {
+        "name": "repute",
+        "trans": [
+            "称为，认为",
+            "名声， 名誉"
+        ],
+        "usphone": "rɪ'pjut",
+        "ukphone": "rɪ'pjuːt"
+    },
+    {
+        "name": "request",
+        "trans": [
+            "要求， 请求"
+        ],
+        "usphone": "rɪ'kwɛst",
+        "ukphone": "rɪ'kwest"
+    },
+    {
+        "name": "require",
+        "trans": [
+            "需要； 要求， 命令"
+        ],
+        "usphone": "rɪ'kwaɪr",
+        "ukphone": "rɪ'kwaɪər"
+    },
+    {
+        "name": "reschedule",
+        "trans": [
+            "重新计划， 重订…的时间表"
+        ],
+        "usphone": ",ri'skɛdʒul",
+        "ukphone": "ˌriː'skedʒuːl"
+    },
+    {
+        "name": "rescue",
+        "trans": [
+            "营救， 搭救"
+        ],
+        "usphone": "'rɛskju",
+        "ukphone": "'reskjuː"
+    },
+    {
+        "name": "resemble",
+        "trans": [
+            "与…相似， 像"
+        ],
+        "usphone": "rɪ'zɛmbl",
+        "ukphone": "rɪ'zembl"
+    },
+    {
+        "name": "resent",
+        "trans": [
+            "憎恶， 愤恨， 怨恨"
+        ],
+        "usphone": "rɪ'zɛnt",
+        "ukphone": "rɪ'zent"
+    },
+    {
+        "name": "reservation",
+        "trans": [
+            "预约， 预订； 保留意见， 疑惑； 居留地"
+        ],
+        "usphone": ",rɛzɚ'veʃən",
+        "ukphone": "ˌrezər'veɪʃn"
+    },
+    {
+        "name": "reserve",
+        "trans": [
+            "储备；自然保护区；谨慎；替补队员；后备部队",
+            "保留； 预订"
+        ],
+        "usphone": "rɪ'zɝv",
+        "ukphone": "rɪ'zɜːrv"
+    },
+    {
+        "name": "reservoir",
+        "trans": [
+            "水库， 蓄水池； 储备， 储藏"
+        ],
+        "usphone": "'rɛzɚ,vɔr",
+        "ukphone": "'rezərvwɑːr"
+    },
+    {
+        "name": "reside",
+        "trans": [
+            "居住于， 定居； 存在， 在于"
+        ],
+        "usphone": "rɪ'zaɪd",
+        "ukphone": "rɪ'zaɪd"
+    },
+    {
+        "name": "resident",
+        "trans": [
+            "常驻的；居住的",
+            "居民； 住宿者， 旅客； 住院实习医生"
+        ],
+        "usphone": "'rɛzɪdənt",
+        "ukphone": "'rezɪdənt"
+    },
+    {
+        "name": "residue",
+        "trans": [
+            "剩余物， 残余物"
+        ],
+        "usphone": "'rɛzɪdu",
+        "ukphone": "'rezɪduː"
+    },
+    {
+        "name": "resign",
+        "trans": [
+            "辞去， 辞职； 放弃； 顺从， 听从"
+        ],
+        "usphone": "rɪ'zaɪn",
+        "ukphone": "rɪ'zaɪn"
+    },
+    {
+        "name": "resilience",
+        "trans": [
+            "弹力， 弹性； 复原力； 适应力"
+        ],
+        "usphone": "rɪˈzɪliəns",
+        "ukphone": "rɪ'zɪliəns"
+    },
+    {
+        "name": "resin",
+        "trans": [
+            "树脂"
+        ],
+        "usphone": "'rɛzn",
+        "ukphone": "'rezn"
+    },
+    {
+        "name": "resist",
+        "trans": [
+            "抵抗； 耐， 抗"
+        ],
+        "usphone": "rɪ'zɪst",
+        "ukphone": "rɪ'zɪst"
+    },
+    {
+        "name": "resistant",
+        "trans": [
+            "抵抗的， 有抵抗力的； 抵制的； 抗…的， 耐…的"
+        ],
+        "usphone": "rɪ'zɪstənt",
+        "ukphone": "rɪ'zɪstənt"
+    },
+    {
+        "name": "resolute",
+        "trans": [
+            "坚决的， 果断的"
+        ],
+        "usphone": "'rɛzəlut",
+        "ukphone": "'rezəluːt"
+    },
+    {
+        "name": "resolve",
+        "trans": [
+            "解决；决定，决心；分解；显现",
+            "决心， 决议"
+        ],
+        "usphone": "rɪ'zɑlv",
+        "ukphone": "rɪ'zɑːlv"
+    },
+    {
+        "name": "resonance",
+        "trans": [
+            "共振， 共鸣； 回声， 反响"
+        ],
+        "usphone": "'rɛznəns",
+        "ukphone": "'rezənəns"
+    },
+    {
+        "name": "resort",
+        "trans": [
+            "求助",
+            "度假胜地； 手段"
+        ],
+        "usphone": "rɪ'zɔrt",
+        "ukphone": "rɪ'zɔːrt"
+    },
+    {
+        "name": "resource",
+        "trans": [
+            "资源〔指土地、矿产等〕",
+            "向…提供资源"
+        ],
+        "usphone": "'risɔrs",
+        "ukphone": "'riːsɔːrs"
+    },
+    {
+        "name": "respect",
+        "trans": [
+            "尊重，尊敬；遵守",
+            "尊敬， 尊重； 重视； 方面"
+        ],
+        "usphone": "rɪ'spɛkt",
+        "ukphone": "rɪ'spekt"
+    },
+    {
+        "name": "respective",
+        "trans": [
+            "分别的， 各自的"
+        ],
+        "usphone": "rɪ'spɛktɪv",
+        "ukphone": "rɪ'spektɪv"
+    },
+    {
+        "name": "respire",
+        "trans": [
+            "呼吸"
+        ],
+        "usphone": "rɪ'spaɪɚ",
+        "ukphone": "rɪ'spaɪər"
+    },
+    {
+        "name": "respond",
+        "trans": [
+            "回答， 答复； 作出反应； 响应"
+        ],
+        "usphone": "rɪ'spɑnd",
+        "ukphone": "rɪ'spɑːnd"
+    },
+    {
+        "name": "respondent",
+        "trans": [
+            "回答的",
+            "回答者，响应者；调查对象；被告"
+        ],
+        "usphone": "rɪ'spɑndənt",
+        "ukphone": "rɪ'spɑːndənt"
+    },
+    {
+        "name": "response",
+        "trans": [
+            "回答； 反应， 响应"
+        ],
+        "usphone": "rɪ'spɑns",
+        "ukphone": "rɪ'spɑːns"
+    },
+    {
+        "name": "responsible",
+        "trans": [
+            "有责任感的， 负责的； 需负责任的； 责任重大的， 重要的"
+        ],
+        "usphone": "rɪ'spɑnsəbl",
+        "ukphone": "rɪ'spɑːnsəbl"
+    },
+    {
+        "name": "restoration",
+        "trans": [
+            "恢复； 整修， 修复； 复位， 复原； 归还"
+        ],
+        "usphone": "'rɛstə'reʃən",
+        "ukphone": "ˌrestə'reɪʃn"
+    },
+    {
+        "name": "restore",
+        "trans": [
+            "恢复； 修复； 归还， 交还"
+        ],
+        "usphone": "rɪ'stɔr",
+        "ukphone": "rɪ'stɔːr"
+    },
+    {
+        "name": "restraint",
+        "trans": [
+            "抑制， 克制； 限制； 约束力； 管制措施"
+        ],
+        "usphone": "rɪ'strent",
+        "ukphone": "rɪ'streɪnt"
+    },
+    {
+        "name": "restrict",
+        "trans": [
+            "限制， 约束"
+        ],
+        "usphone": "rɪ'strɪkt",
+        "ukphone": "rɪ'strɪkt"
+    },
+    {
+        "name": "resume",
+        "trans": [
+            "重新开始， 继续"
+        ],
+        "usphone": "",
+        "ukphone": "rɪ'zuːm"
+    },
+    {
+        "name": "retail",
+        "trans": [
+            "以零售方式",
+            "零售；以…价格销售",
+            "零售"
+        ],
+        "usphone": "'ritel",
+        "ukphone": "'riːteɪl"
+    },
+    {
+        "name": "retain",
+        "trans": [
+            "保持， 保留"
+        ],
+        "usphone": "rɪ'ten",
+        "ukphone": "rɪ'teɪn"
+    },
+    {
+        "name": "retire",
+        "trans": [
+            "退休， 引退， 退役； 退出； 撤退； 就寝"
+        ],
+        "usphone": "rɪ'taɪɚ",
+        "ukphone": "rɪ'taɪər"
+    },
+    {
+        "name": "retract",
+        "trans": [
+            "收回， 撤销； 缩回"
+        ],
+        "usphone": "rɪ'trækt",
+        "ukphone": "rɪ'trækt"
+    },
+    {
+        "name": "retreat",
+        "trans": [
+            "退却，撤退；退缩",
+            "退却， 撤退； 隐退处"
+        ],
+        "usphone": "rɪ'trit",
+        "ukphone": "rɪ'triːt"
+    },
+    {
+        "name": "retrieval",
+        "trans": [
+            "数据检索； 取回， 索回"
+        ],
+        "usphone": "rɪ'trivl",
+        "ukphone": "rɪ'triːvl"
+    },
+    {
+        "name": "retrieve",
+        "trans": [
+            "取回， 索回； 挽回， 扭转颓势； 检索"
+        ],
+        "usphone": "rɪ'triv",
+        "ukphone": "rɪ'triːv"
+    },
+    {
+        "name": "retrospect",
+        "trans": [
+            "回顾， 反顾"
+        ],
+        "usphone": "'rɛtrəspɛkt",
+        "ukphone": "'retrəspekt"
+    },
+    {
+        "name": "retrospective",
+        "trans": [
+            "回顾的， 追想的； 有追溯效力的"
+        ],
+        "usphone": ",rɛtrə'spɛktɪv",
+        "ukphone": "ˌretrə'spektɪv"
+    },
+    {
+        "name": "reunion",
+        "trans": [
+            "团圆， 重聚"
+        ],
+        "usphone": "",
+        "ukphone": "ˌriː'juːniən"
+    },
+    {
+        "name": "reveal",
+        "trans": [
+            "暴露， 揭露； 展现"
+        ],
+        "usphone": "rɪ'vil",
+        "ukphone": "rɪ'viːl"
+    },
+    {
+        "name": "revenue",
+        "trans": [
+            "收入； 税收"
+        ],
+        "usphone": "'rɛvənu",
+        "ukphone": "'revənjuː"
+    },
+    {
+        "name": "revere",
+        "trans": [
+            "尊敬， 敬畏"
+        ],
+        "usphone": "rɪ'vɪr",
+        "ukphone": "rɪ'vɪr"
+    },
+    {
+        "name": "reverse",
+        "trans": [
+            "反转；彻底转变，颠倒；撤销，废除；交换；",
+            "相反的"
+        ],
+        "usphone": "rɪ'vɝs",
+        "ukphone": "rɪ'vɜːrs"
+    },
+    {
+        "name": "reversible",
+        "trans": [
+            "可逆的， 可翻转的； 正反两用的； 可恢复原状的"
+        ],
+        "usphone": "rɪ'vɝsəbl",
+        "ukphone": "rɪ'vɜːrsəbl"
+    },
+    {
+        "name": "revert",
+        "trans": [
+            "恢复； 归还， 归属"
+        ],
+        "usphone": "rɪ'vɝt",
+        "ukphone": "rɪ'vɜːrt"
+    },
+    {
+        "name": "review",
+        "trans": [
+            "审查； 复习； 回顾； 评论； 检阅"
+        ],
+        "usphone": "rɪ'vju",
+        "ukphone": "rɪ'vjuː"
+    },
+    {
+        "name": "revise",
+        "trans": [
+            "修订， 修改； 复习"
+        ],
+        "usphone": "rɪ'vaɪz",
+        "ukphone": "rɪ'vaɪz"
+    },
+    {
+        "name": "revitalize",
+        "trans": [
+            "使恢复生机， 使再生； 使更强壮"
+        ],
+        "usphone": ",ri'vaɪtəlaɪz",
+        "ukphone": "ˌriː'vaɪtəlaɪz"
+    },
+    {
+        "name": "revival",
+        "trans": [
+            "复兴， 再流行； 复苏； 苏醒， 复活； 重演"
+        ],
+        "usphone": "rɪ'vaɪvl",
+        "ukphone": "rɪ'vaɪvl"
+    },
+    {
+        "name": "revive",
+        "trans": [
+            "恢复； 苏醒； 重新利用"
+        ],
+        "usphone": "rɪ'vaɪv",
+        "ukphone": "rɪ'vaɪv"
+    },
+    {
+        "name": "revoke",
+        "trans": [
+            "撤销， 撤回； 取消， 废除"
+        ],
+        "usphone": "rɪ'vok",
+        "ukphone": "rɪ'vouk"
+    },
+    {
+        "name": "revolt",
+        "trans": [
+            "反叛，反抗；违抗；厌恶，反感",
+            "起义， 叛乱， 反抗"
+        ],
+        "usphone": "rɪ'volt",
+        "ukphone": "rɪ'voult"
+    },
+    {
+        "name": "revolution",
+        "trans": [
+            "革命； 巨变； 旋转"
+        ],
+        "usphone": "'rɛvə'lʊʃən",
+        "ukphone": "ˌrevə'luːʃn"
+    },
+    {
+        "name": "reward",
+        "trans": [
+            "报答，奖赏，报酬",
+            "奖赏， 奖励， 给以报酬"
+        ],
+        "usphone": "rɪ'wɔrd",
+        "ukphone": "rɪ'wɔːrd"
+    },
+    {
+        "name": "rhinoceros",
+        "trans": [
+            "犀牛"
+        ],
+        "usphone": "raɪ'nɑsərəs",
+        "ukphone": "raɪ'nɑːsərəs"
+    },
+    {
+        "name": "rhyme",
+        "trans": [
+            "押韵；和…同韵",
+            "押韵； 同韵词， 押韵词"
+        ],
+        "usphone": "raɪm",
+        "ukphone": "raɪm"
+    },
+    {
+        "name": "rhythm",
+        "trans": [
+            "节奏， 韵律"
+        ],
+        "usphone": "'rɪðəm",
+        "ukphone": "'rɪðəm"
+    },
+    {
+        "name": "ribbon",
+        "trans": [
+            "带状物； 丝带， 缎带； 绶带； 色带"
+        ],
+        "usphone": "'rɪbən",
+        "ukphone": "'rɪbən"
+    },
+    {
+        "name": "riddle",
+        "trans": [
+            "谜；谜语；难解之谜；粗筛",
+            "使布满窟窿"
+        ],
+        "usphone": "'rɪdl",
+        "ukphone": "'rɪdl"
+    },
+    {
+        "name": "ridge",
+        "trans": [
+            "脊； 山脊， 山脉； 高压脊； 隆起物"
+        ],
+        "usphone": "rɪdʒ",
+        "ukphone": "rɪdʒ"
+    },
+    {
+        "name": "ridicule",
+        "trans": [
+            "嘲笑，奚落",
+            "嘲笑， 奚落"
+        ],
+        "usphone": "'rɪdɪ'kjʊl",
+        "ukphone": "'rɪdɪkjuːl"
+    },
+    {
+        "name": "ridiculous",
+        "trans": [
+            "荒唐的， 可笑的"
+        ],
+        "usphone": "rɪ'dɪkjələs",
+        "ukphone": "rɪ'dɪkjələs"
+    },
+    {
+        "name": "righteous",
+        "trans": [
+            "正直的， 公正的； 正义的， 正当的"
+        ],
+        "usphone": "'raɪtʃəs",
+        "ukphone": "'raɪtʃəs"
+    },
+    {
+        "name": "rigid",
+        "trans": [
+            "严格的； 刚硬的， 不易弯曲的； 死板的， 刻板的； 僵硬的"
+        ],
+        "usphone": "'rɪdʒɪd",
+        "ukphone": "'rɪdʒɪd"
+    },
+    {
+        "name": "rigor",
+        "trans": [
+            "严格； 严酷"
+        ],
+        "usphone": "'rɪgɚ",
+        "ukphone": "'rɪgər"
+    },
+    {
+        "name": "rigorous",
+        "trans": [
+            "缜密的， 谨慎的； 严格的， 严厉的"
+        ],
+        "usphone": "'rɪɡərəs",
+        "ukphone": "'rɪgərəs"
+    },
+    {
+        "name": "rim",
+        "trans": [
+            "边，轮缘；边界",
+            "给…镶边"
+        ],
+        "usphone": "rɪm",
+        "ukphone": "rɪm"
+    },
+    {
+        "name": "rinse",
+        "trans": [
+            "冲洗，漂洗，冲刷",
+            "漂洗， 冲洗， 洗涤； 染发剂"
+        ],
+        "usphone": "rɪns",
+        "ukphone": "rɪns"
+    },
+    {
+        "name": "rip",
+        "trans": [
+            "扯破，撕坏",
+            "裂口， 裂缝"
+        ],
+        "usphone": "rɪp",
+        "ukphone": "rɪp"
+    },
+    {
+        "name": "ripe",
+        "trans": [
+            "熟的； 成熟的"
+        ],
+        "usphone": "raɪp",
+        "ukphone": "raɪp"
+    },
+    {
+        "name": "ripen",
+        "trans": [
+            "成熟"
+        ],
+        "usphone": "'raɪpən",
+        "ukphone": "'raɪpən"
+    },
+    {
+        "name": "ripple",
+        "trans": [
+            "起涟漪； 扩散",
+            "细浪，涟漪"
+        ],
+        "usphone": "'rɪpl",
+        "ukphone": "'rɪpl"
+    },
+    {
+        "name": "rite",
+        "trans": [
+            "仪式， 典礼"
+        ],
+        "usphone": "raɪt",
+        "ukphone": "raɪt"
+    },
+    {
+        "name": "ritual",
+        "trans": [
+            "仪式的； 习惯的， 例行的",
+            "典礼，仪式；例行公事，老规矩"
+        ],
+        "usphone": "'rɪtʃuəl",
+        "ukphone": "'rɪtʃuəl"
+    },
+    {
+        "name": "rival",
+        "trans": [
+            "竞争的， 对抗的",
+            "与…相匹敌，比得上",
+            "竞争对手"
+        ],
+        "usphone": "'raɪvl",
+        "ukphone": "'raɪvl"
+    },
+    {
+        "name": "rivalry",
+        "trans": [
+            "竞争 ； 敌对"
+        ],
+        "usphone": "'raɪvlri",
+        "ukphone": "'raɪvlri"
+    },
+    {
+        "name": "roam",
+        "trans": [
+            "漫游，漫步，闲逛",
+            "漫步， 漫游"
+        ],
+        "usphone": "rom",
+        "ukphone": "roum"
+    },
+    {
+        "name": "rob",
+        "trans": [
+            "抢夺， 抢掠； 剥夺， 使失去"
+        ],
+        "usphone": "rɑb",
+        "ukphone": "rɑːb"
+    },
+    {
+        "name": "robust",
+        "trans": [
+            "健壮的， 强壮的"
+        ],
+        "usphone": "ro'bʌst",
+        "ukphone": "rou'bʌst"
+    },
+    {
+        "name": "rod",
+        "trans": [
+            "杆， 棒"
+        ],
+        "usphone": "rɑd",
+        "ukphone": "rɑːd"
+    },
+    {
+        "name": "rodent",
+        "trans": [
+            "啮齿目的； 咬的",
+            "啮齿目动物"
+        ],
+        "usphone": "'rodnt",
+        "ukphone": "'roudnt"
+    },
+    {
+        "name": "rodeo",
+        "trans": [
+            "牛仔竞技表演"
+        ],
+        "usphone": "'rodɪo",
+        "ukphone": "'roudiou"
+    },
+    {
+        "name": "roe",
+        "trans": [
+            "鱼卵"
+        ],
+        "usphone": "ro",
+        "ukphone": "rou"
+    },
+    {
+        "name": "roll",
+        "trans": [
+            "滚动，转动；卷，绕；摇摆，摇晃",
+            "卷； 卷形物； 名单， 花名册"
+        ],
+        "usphone": "rol",
+        "ukphone": "roul"
+    },
+    {
+        "name": "romantic",
+        "trans": [
+            "爱情的； 浪漫的， 富有情调的； 多情的； 不切实际的， 幻想的； [R-]浪漫主义的"
+        ],
+        "usphone": "ro'mæntɪk",
+        "ukphone": "rou'mæntɪk"
+    },
+    {
+        "name": "roost",
+        "trans": [
+            "栖息",
+            "栖息处， 鸟巢"
+        ],
+        "usphone": "rust",
+        "ukphone": "ruːst"
+    },
+    {
+        "name": "rotate",
+        "trans": [
+            "转动， 旋转； 轮流"
+        ],
+        "usphone": "'rotet",
+        "ukphone": "'routeɪt"
+    },
+    {
+        "name": "rotational",
+        "trans": [
+            "旋转的； 轮流的"
+        ],
+        "usphone": "ro'teʃənl",
+        "ukphone": "rou'teɪʃnl"
+    },
+    {
+        "name": "rough",
+        "trans": [
+            "粗糙不平的；粗暴的；艰难的",
+            "高低不平的地面"
+        ],
+        "usphone": "rʌf",
+        "ukphone": "rʌf"
+    },
+    {
+        "name": "rouse",
+        "trans": [
+            "唤起， 唤醒； 激起， 鼓舞； 激怒"
+        ],
+        "usphone": "raʊz",
+        "ukphone": "rauz"
+    },
+    {
+        "name": "routine",
+        "trans": [
+            "例行的； 常规的",
+            "例行公事；惯例，常规"
+        ],
+        "usphone": "rʊ'tin",
+        "ukphone": "ruː'tiːn"
+    },
+    {
+        "name": "rub",
+        "trans": [
+            "擦， 摩擦"
+        ],
+        "usphone": "rʌb",
+        "ukphone": "rʌb"
+    },
+    {
+        "name": "rudimentary",
+        "trans": [
+            "未充分发展的， 原始的； 基本的， 基础的"
+        ],
+        "usphone": ",rudɪ'mɛntri",
+        "ukphone": "ˌruːdɪ'mentri"
+    },
+    {
+        "name": "rug",
+        "trans": [
+            "地毯； 围毯"
+        ],
+        "usphone": "rʌɡ",
+        "ukphone": "rʌg"
+    },
+    {
+        "name": "rugged",
+        "trans": [
+            "崎岖的， 凹凸不平的； 艰难的； 粗犷的； 结实的， 耐用的； 粗野的， 不文雅的"
+        ],
+        "usphone": "'rʌɡɪd",
+        "ukphone": "'rʌgɪd"
+    },
+    {
+        "name": "ruin",
+        "trans": [
+            "破坏，毁灭；使破产",
+            "毁灭，毁坏；"
+        ],
+        "usphone": "'ruɪn",
+        "ukphone": "'ruːɪn"
+    },
+    {
+        "name": "rumor",
+        "trans": [
+            "传闻， 谣言"
+        ],
+        "usphone": "'rʊmɚ",
+        "ukphone": "'ruːmər"
+    },
+    {
+        "name": "rupture",
+        "trans": [
+            "破裂； 决裂， 断绝"
+        ],
+        "usphone": "'rʌptʃɚ",
+        "ukphone": "'rʌptʃər"
+    },
+    {
+        "name": "rural",
+        "trans": [
+            "乡村的， 农村的； 田园的"
+        ],
+        "usphone": "'rʊrəl",
+        "ukphone": "'rurəl"
+    },
+    {
+        "name": "rush",
+        "trans": [
+            "冲，突进；奔，急速流动；仓促从事；突袭",
+            "冲，急速行进；匆忙；"
+        ],
+        "usphone": "rʌʃ",
+        "ukphone": "rʌʃ"
+    },
+    {
+        "name": "rust",
+        "trans": [
+            "生锈",
+            "锈， 铁锈； 锈病"
+        ],
+        "usphone": "rʌst",
+        "ukphone": "rʌst"
+    },
+    {
+        "name": "rustic",
+        "trans": [
+            "乡村的； 淳朴的； 用粗糙木材制作的"
+        ],
+        "usphone": "'rʌstɪk",
+        "ukphone": "'rʌstɪk"
+    },
+    {
+        "name": "rustproof",
+        "trans": [
+            "不锈的"
+        ],
+        "usphone": "'rʌstpruf",
+        "ukphone": "'rʌstpruːf"
+    },
+    {
+        "name": "ruthless",
+        "trans": [
+            "无情的， 残酷的， 冷酷的； 坚决的， 彻底的"
+        ],
+        "usphone": "'rʊθləs",
+        "ukphone": "'ruːθləs"
+    },
+    {
+        "name": "sac",
+        "trans": [
+            "囊， 液囊"
+        ],
+        "usphone": "sæk",
+        "ukphone": "sæk"
+    },
+    {
+        "name": "sacred",
+        "trans": [
+            "宗教的； 上帝的， 神圣的"
+        ],
+        "usphone": "'sekrɪd",
+        "ukphone": "'seɪkrɪd"
+    },
+    {
+        "name": "sacrifice",
+        "trans": [
+            "牺牲，献出；以…做祭献",
+            "牺牲， 献身； 献祭， 祭品"
+        ],
+        "usphone": "'sækrɪfaɪs",
+        "ukphone": "'sækrɪfaɪs"
+    },
+    {
+        "name": "sacrificial",
+        "trans": [
+            "供奉的， 献祭的， 牺牲的"
+        ],
+        "usphone": ",sækrɪ'fɪʃl",
+        "ukphone": "ˌsækrɪ'fɪʃl"
+    },
+    {
+        "name": "saddle",
+        "trans": [
+            "马鞍；车座",
+            "给…备鞍"
+        ],
+        "usphone": "'sædl",
+        "ukphone": "'sædl"
+    },
+    {
+        "name": "sage",
+        "trans": [
+            "贤明的；审慎的",
+            "智者， 圣人"
+        ],
+        "usphone": "sedʒ",
+        "ukphone": "seɪdʒ"
+    },
+    {
+        "name": "sake",
+        "trans": [
+            "缘故， 理由； 好处"
+        ],
+        "usphone": "sek",
+        "ukphone": "seɪk"
+    },
+    {
+        "name": "salamander",
+        "trans": [
+            "火蜥蜴； 火蛇"
+        ],
+        "usphone": "'sæləmændɚ",
+        "ukphone": "'sæləmændər"
+    },
+    {
+        "name": "salient",
+        "trans": [
+            "显著的， 突出的"
+        ],
+        "usphone": "'selɪənt",
+        "ukphone": "'seɪliənt"
+    },
+    {
+        "name": "salmon",
+        "trans": [
+            "鲑鱼， 大马哈鱼"
+        ],
+        "usphone": "'sæmən",
+        "ukphone": "'sæmən"
+    },
+    {
+        "name": "salon",
+        "trans": [
+            "营业性的厅； 沙龙； 客厅， 会客厅"
+        ],
+        "usphone": "sə'lɑn",
+        "ukphone": "sə'lɑːn"
+    },
+    {
+        "name": "sample",
+        "trans": [
+            "样品，标本",
+            "抽样调查； 品尝， 体验"
+        ],
+        "usphone": "'sæmpl",
+        "ukphone": "'sæmpl"
+    },
+    {
+        "name": "sanction",
+        "trans": [
+            "同意，许可；惩罚，实施制裁",
+            "同意， 许可； 约束； 制裁"
+        ],
+        "usphone": "'sæŋkʃən",
+        "ukphone": "'sæŋkʃn"
+    },
+    {
+        "name": "sanctuary",
+        "trans": [
+            "禁猎区， 动物保护区； 庇护所， 避难所； 圣所， 圣殿"
+        ],
+        "usphone": "'sæŋktʃuɛri",
+        "ukphone": "'sæŋktʃueri"
+    },
+    {
+        "name": "sanitation",
+        "trans": [
+            "卫生； 卫生设施， 卫生设备"
+        ],
+        "usphone": ",sænɪ'teʃən",
+        "ukphone": "ˌsænɪ'teɪʃn"
+    },
+    {
+        "name": "sap",
+        "trans": [
+            "使衰竭；削弱，逐渐破坏",
+            "液， 汁； 精力； 笨蛋"
+        ],
+        "usphone": "sæp",
+        "ukphone": "sæp"
+    },
+    {
+        "name": "sapphire",
+        "trans": [
+            "天蓝色， 蔚蓝色的",
+            "蓝宝石，青石；蔚蓝色"
+        ],
+        "usphone": "'sæfaɪɚ",
+        "ukphone": "'sæfaɪər"
+    },
+    {
+        "name": "sardonic",
+        "trans": [
+            "嘲笑的， 讥讽的"
+        ],
+        "usphone": "sɑːrˈdɑːnɪk",
+        "ukphone": "sɑːr'dɑːnɪk"
+    },
+    {
+        "name": "satellite",
+        "trans": [
+            "卫星； 人造卫星"
+        ],
+        "usphone": "'sætəlaɪt",
+        "ukphone": "'sætəlaɪt"
+    },
+    {
+        "name": "satire",
+        "trans": [
+            "讽刺文学， 讽刺作品； 讽刺"
+        ],
+        "usphone": "'sætaɪɚ",
+        "ukphone": "'sætaɪər"
+    },
+    {
+        "name": "satiric",
+        "trans": [
+            "讽刺的， 嘲讽的"
+        ],
+        "usphone": "sə'tɪrɪk",
+        "ukphone": "sə'tɪrɪk"
+    },
+    {
+        "name": "saturate",
+        "trans": [
+            "使湿透； 使饱和"
+        ],
+        "usphone": "'sætʃərɪt",
+        "ukphone": "'sætʃəreɪt"
+    },
+    {
+        "name": "saturation",
+        "trans": [
+            "饱和； 饱和度"
+        ],
+        "usphone": "'sætʃə'reʃən",
+        "ukphone": "ˌsætʃə'reɪʃn"
+    },
+    {
+        "name": "Saturn",
+        "trans": [
+            "土星"
+        ],
+        "usphone": "'sætɝn",
+        "ukphone": "'sætɜːrn"
+    },
+    {
+        "name": "sauce",
+        "trans": [
+            "调味汁， 佐料"
+        ],
+        "usphone": "sɔs",
+        "ukphone": "sɔːs"
+    },
+    {
+        "name": "saucy",
+        "trans": [
+            "无礼的； 俏皮的； 漂亮的"
+        ],
+        "usphone": "'sɔsi",
+        "ukphone": "'sɔːsi"
+    },
+    {
+        "name": "saunter",
+        "trans": [
+            "闲逛， 漫步"
+        ],
+        "usphone": "'sɔntɚ",
+        "ukphone": "'sɔːntər"
+    },
+    {
+        "name": "savage",
+        "trans": [
+            "凶残的；野蛮的，未开化的",
+            "野蛮人，未开化的人",
+            "残害； 激烈抨击"
+        ],
+        "usphone": "'sævɪdʒ",
+        "ukphone": "'sævɪdʒ"
+    },
+    {
+        "name": "scale",
+        "trans": [
+            "鳞；规模；比例；刻度；【音】音阶；等级，级别",
+            "攀登"
+        ],
+        "usphone": "skel",
+        "ukphone": "skeɪl"
+    },
+    {
+        "name": "scan",
+        "trans": [
+            "细察，审视；扫描；粗略地看，浏览",
+            "扫描检查； 浏览"
+        ],
+        "usphone": "skæn",
+        "ukphone": "skæn"
+    },
+    {
+        "name": "scandal",
+        "trans": [
+            "丑事， 丑闻； 恶意诽谤， 流言蜚语； 可耻的行为"
+        ],
+        "usphone": "'skændl",
+        "ukphone": "'skændl"
+    },
+    {
+        "name": "scar",
+        "trans": [
+            "给…留下疤痕；给…留下精神创伤；损害…的外观",
+            "疤痕； 创伤"
+        ],
+        "usphone": "skɑr",
+        "ukphone": "skɑːr"
+    },
+    {
+        "name": "scarce",
+        "trans": [
+            "缺乏的； 稀有的， 罕见的"
+        ],
+        "usphone": "skɛrs",
+        "ukphone": "skers"
+    },
+    {
+        "name": "scarf",
+        "trans": [
+            "围巾， 披巾， 头巾"
+        ],
+        "usphone": "skɑrf",
+        "ukphone": "skɑːrf"
+    },
+    {
+        "name": "scatter",
+        "trans": [
+            "使分散， 驱散， 散开； 撒播"
+        ],
+        "usphone": "'skætɚ",
+        "ukphone": "'skætər"
+    },
+    {
+        "name": "scavenger",
+        "trans": [
+            "捡破烂的人， 拾荒者； 食腐动物"
+        ],
+        "usphone": "'skævɪndʒɚ",
+        "ukphone": "'skævɪndʒər"
+    },
+    {
+        "name": "scene",
+        "trans": [
+            "地点， 现场； 景色； 一场， 一个镜头； 场面； 活动领域， 圈子"
+        ],
+        "usphone": "sin",
+        "ukphone": "siːn"
+    },
+    {
+        "name": "scent",
+        "trans": [
+            "香味，香气；气味；踪迹，线索；香水",
+            "闻出； 察觉"
+        ],
+        "usphone": "sɛnt",
+        "ukphone": "sent"
+    },
+    {
+        "name": "schedule",
+        "trans": [
+            "安排，预定",
+            "时刻表， 日程表； 清单， 明细表"
+        ],
+        "usphone": "ˈskedʒʊl; skɛdʒʊl",
+        "ukphone": "'skedʒuːl"
+    },
+    {
+        "name": "schematic",
+        "trans": [
+            "图解的； 纲要的； 严谨的"
+        ],
+        "usphone": "ski'mætɪk",
+        "ukphone": "skiː'mætɪk"
+    },
+    {
+        "name": "scheme",
+        "trans": [
+            "密谋， 秘密策划， 图谋",
+            "计划，方案；阴谋；体系，体制"
+        ],
+        "usphone": "skim",
+        "ukphone": "skiːm"
+    },
+    {
+        "name": "scholar",
+        "trans": [
+            "学者； 奖学金获得者"
+        ],
+        "usphone": "'skɑlɚ",
+        "ukphone": "'skɑːlər"
+    },
+    {
+        "name": "scholarship",
+        "trans": [
+            "奖学金； 学问， 学识"
+        ],
+        "usphone": "'skɑlɚʃɪp",
+        "ukphone": "'skɑːlərʃɪp"
+    },
+    {
+        "name": "scientific",
+        "trans": [
+            "科学的； 细致严谨的"
+        ],
+        "usphone": ",saɪən'tɪfɪk",
+        "ukphone": "ˌsaɪən'tɪfɪk"
+    },
+    {
+        "name": "scoff",
+        "trans": [
+            "嘲笑， 讥笑"
+        ],
+        "usphone": "skɔf",
+        "ukphone": "skɔːf"
+    },
+    {
+        "name": "scope",
+        "trans": [
+            "范围， 界限； 眼界， 见识； 余地， 机会"
+        ],
+        "usphone": "skop",
+        "ukphone": "skoup"
+    },
+    {
+        "name": "scorch",
+        "trans": [
+            "烧焦；枯萎，枯黄",
+            "焦痕"
+        ],
+        "usphone": "skɔrtʃ",
+        "ukphone": "skɔːrtʃ"
+    },
+    {
+        "name": "score",
+        "trans": [
+            "评分；划；获胜，成功",
+            "得分， 分数； 乐谱； 抓痕， 划痕； 二十"
+        ],
+        "usphone": "skɔ",
+        "ukphone": "skɔː"
+    },
+    {
+        "name": "scorn",
+        "trans": [
+            "轻蔑， 鄙视； 不屑于",
+            "轻蔑，鄙视"
+        ],
+        "usphone": "skɔrn",
+        "ukphone": "skɔːrn"
+    },
+    {
+        "name": "scornful",
+        "trans": [
+            "轻蔑的， 鄙视的"
+        ],
+        "usphone": "'skɔ:nful",
+        "ukphone": "'skɔːrnfl"
+    },
+    {
+        "name": "scourge",
+        "trans": [
+            "鞭笞；使受苦，折磨",
+            "鞭子； 祸害； 鞭笞"
+        ],
+        "usphone": "skɝdʒ",
+        "ukphone": "skɜːrdʒ"
+    },
+    {
+        "name": "scout",
+        "trans": [
+            "侦察；寻找；搜索",
+            "侦察员； 侦察机； 童子军"
+        ],
+        "usphone": "skaʊt",
+        "ukphone": "skaut"
+    },
+    {
+        "name": "scrape",
+        "trans": [
+            "刮掉，擦掉；发出刺耳的刮擦声；"
+        ],
+        "usphone": "skrep",
+        "ukphone": "skreɪp"
+    },
+    {
+        "name": "scratch",
+        "trans": [
+            "刮擦，划；抓，搔",
+            "划痕； 挠痒"
+        ],
+        "usphone": "skrætʃ",
+        "ukphone": "skrætʃ"
+    },
+    {
+        "name": "screen",
+        "trans": [
+            "掩蔽；审查；筛选",
+            "屏幕"
+        ],
+        "usphone": "skrin",
+        "ukphone": "skriːn"
+    },
+    {
+        "name": "script",
+        "trans": [
+            "剧本，脚本，广播稿；笔迹；字母表",
+            "为电影写剧本"
+        ],
+        "usphone": "skrɪpt",
+        "ukphone": "skrɪpt"
+    },
+    {
+        "name": "scroll",
+        "trans": [
+            "卷轴； 纸卷， 画卷； 名册"
+        ],
+        "usphone": "skrol",
+        "ukphone": "skroul"
+    },
+    {
+        "name": "scrub",
+        "trans": [
+            "擦洗；取消",
+            "灌木丛； 丛林地带"
+        ],
+        "usphone": "skrʌb",
+        "ukphone": "skrʌb"
+    },
+    {
+        "name": "scruffy",
+        "trans": [
+            "不整洁的， 邋遢的"
+        ],
+        "usphone": "'skrʌfi",
+        "ukphone": "'skrʌfi"
+    },
+    {
+        "name": "scruple",
+        "trans": [
+            "踌躇， 顾忌， 顾虑"
+        ],
+        "usphone": "'skrupl",
+        "ukphone": "'skruːpl"
+    },
+    {
+        "name": "scrupulous",
+        "trans": [
+            "多顾虑的， 谨慎的； 一丝不苟的， 严谨的； 审慎正直的， 恪守道德规范的"
+        ],
+        "usphone": "'skrupjələs",
+        "ukphone": "'skruːpjələs"
+    },
+    {
+        "name": "scrutinize",
+        "trans": [
+            "仔细检查， 细察"
+        ],
+        "usphone": "'skrutənaɪz",
+        "ukphone": "'skruːtənaɪz"
+    },
+    {
+        "name": "scuba",
+        "trans": [
+            "水中呼吸器， 水肺"
+        ],
+        "usphone": "'skjʊbə",
+        "ukphone": "'skuːbə"
+    },
+    {
+        "name": "scuffle",
+        "trans": [
+            "扭打， 混战"
+        ],
+        "usphone": "'skʌfl",
+        "ukphone": "'skʌfl"
+    },
+    {
+        "name": "sculpt",
+        "trans": [
+            "雕刻"
+        ],
+        "usphone": "skʌlpt",
+        "ukphone": "skʌlpt"
+    },
+    {
+        "name": "sculpture",
+        "trans": [
+            "雕像， 雕塑品； 雕刻术"
+        ],
+        "usphone": "'skʌlptʃɚ",
+        "ukphone": "'skʌlptʃər"
+    },
+    {
+        "name": "scurry",
+        "trans": [
+            "急跑， 疾行"
+        ],
+        "usphone": "'skɝi",
+        "ukphone": "'skɜːri"
+    },
+    {
+        "name": "seal",
+        "trans": [
+            "密封；确定，使成定局",
+            "海豹； 封铅， 封条； 印， 图章"
+        ],
+        "usphone": "sil",
+        "ukphone": "siːl"
+    },
+    {
+        "name": "seashore",
+        "trans": [
+            "海岸， 海滨"
+        ],
+        "usphone": "'siʃɔr",
+        "ukphone": "'siːʃɔːr"
+    },
+    {
+        "name": "season",
+        "trans": [
+            "季节； 时节； 时期"
+        ],
+        "usphone": "'sizn",
+        "ukphone": "'siːzn"
+    },
+    {
+        "name": "seasoning",
+        "trans": [
+            "调味品， 调料"
+        ],
+        "usphone": "'sizənɪŋ",
+        "ukphone": "'siːzənɪŋ"
+    },
+    {
+        "name": "secede",
+        "trans": [
+            "正式脱离， 退出"
+        ],
+        "usphone": "sɪ'sid",
+        "ukphone": "sɪ'siːd"
+    },
+    {
+        "name": "seclusion",
+        "trans": [
+            "独处， 隐居； 隔离； 与世隔绝， 归隐"
+        ],
+        "usphone": "sɪ'klʊʒən",
+        "ukphone": "sɪ'kluːʒn"
+    },
+    {
+        "name": "second",
+        "trans": [
+            "第二的；次等的，二等的",
+            "赞成，附和",
+            "第二",
+            "秒；瞬间，片刻"
+        ],
+        "usphone": "'sɛkənd",
+        "ukphone": "'sekənd"
+    },
+    {
+        "name": "secrete",
+        "trans": [
+            "分泌； 藏匿， 躲藏"
+        ],
+        "usphone": "sɪ'krit",
+        "ukphone": "sɪ'kriːt"
+    },
+    {
+        "name": "section",
+        "trans": [
+            "部分； 地区； 部门； 段落， 章节； 截面， 剖面"
+        ],
+        "usphone": "'sɛkʃən",
+        "ukphone": "'sekʃn"
+    },
+    {
+        "name": "secular",
+        "trans": [
+            "现世的； 世俗的； 非宗教的"
+        ],
+        "usphone": "'sɛkjəlɚ",
+        "ukphone": "'sekjələr"
+    },
+    {
+        "name": "secure",
+        "trans": [
+            "安全的，有保障的；可靠的；确定的；"
+        ],
+        "usphone": "sə'kjʊr",
+        "ukphone": "sə'kjur"
+    },
+    {
+        "name": "sedentary",
+        "trans": [
+            "久坐的， 固定不动的； 土生的， 不迁徙的； 沉积的"
+        ],
+        "usphone": "'sɛdntɛri",
+        "ukphone": "'sednteri"
+    },
+    {
+        "name": "sediment",
+        "trans": [
+            "沉淀物， 沉积物"
+        ],
+        "usphone": "sɛdəmənt",
+        "ukphone": "'sedɪmənt"
+    },
+    {
+        "name": "sedimentary",
+        "trans": [
+            "沉积的， 沉淀性的"
+        ],
+        "usphone": ",sɛdɪ'mɛntri",
+        "ukphone": "ˌsedɪ'mentri"
+    },
+    {
+        "name": "seem",
+        "trans": [
+            "好像， 似乎"
+        ],
+        "usphone": "sim",
+        "ukphone": "siːm"
+    },
+    {
+        "name": "seep",
+        "trans": [
+            "漏出， 渗漏"
+        ],
+        "usphone": "sip",
+        "ukphone": "siːp"
+    },
+    {
+        "name": "segment",
+        "trans": [
+            "音段； 段， 部分"
+        ],
+        "usphone": "'sɛɡmənt",
+        "ukphone": "'segmənt"
+    },
+    {
+        "name": "segregate",
+        "trans": [
+            "隔离， 使分开"
+        ],
+        "usphone": "'sɛɡrɪɡet",
+        "ukphone": "'segrɪgeɪt"
+    },
+    {
+        "name": "seismic",
+        "trans": [
+            "地震的， 地震引起的； 影响深远的， 重大的"
+        ],
+        "usphone": "'saɪzmɪk",
+        "ukphone": "'saɪzmɪk"
+    },
+    {
+        "name": "seismograph",
+        "trans": [
+            "地震仪， 测震仪"
+        ],
+        "usphone": "'saɪzməɡræf",
+        "ukphone": "'saɪzməgræf"
+    },
+    {
+        "name": "seismology",
+        "trans": [
+            "地震学"
+        ],
+        "usphone": "saɪz'mɑlədʒi",
+        "ukphone": "saɪz'mɑːlədʒi"
+    },
+    {
+        "name": "selection",
+        "trans": [
+            "选择， 挑选； 精选； 被挑选出来的人， 精选品； 可供选择的事物"
+        ],
+        "usphone": "sɪ'lɛkʃən",
+        "ukphone": "sɪ'lekʃn"
+    },
+    {
+        "name": "selective",
+        "trans": [
+            "选择的， 选择性的； 精挑细选的"
+        ],
+        "usphone": "sɪ'lɛktɪv",
+        "ukphone": "sɪ'lektɪv"
+    },
+    {
+        "name": "semantic",
+        "trans": [
+            "语义的"
+        ],
+        "usphone": "sɪ'mæntɪk",
+        "ukphone": "sɪ'mæntɪk"
+    },
+    {
+        "name": "semester",
+        "trans": [
+            "学期"
+        ],
+        "usphone": "səˈmɛstɚ",
+        "ukphone": "sɪ'mestər"
+    },
+    {
+        "name": "seminar",
+        "trans": [
+            "研讨会； 研讨班"
+        ],
+        "usphone": "'sɛmɪnɑr",
+        "ukphone": "'semɪnɑːr"
+    },
+    {
+        "name": "semiotics",
+        "trans": [
+            "符号学"
+        ],
+        "usphone": ",si:mi'ɔtiks, -mai-, ,semi-, ,semai-",
+        "ukphone": "ˌsemi'ɑːtɪks"
+    },
+    {
+        "name": "senate",
+        "trans": [
+            "参议院； 上院"
+        ],
+        "usphone": "'sɛnət",
+        "ukphone": "'senət"
+    },
+    {
+        "name": "senator",
+        "trans": [
+            "参议员"
+        ],
+        "usphone": "'sɛnətɚ",
+        "ukphone": "'senətər"
+    },
+    {
+        "name": "senior",
+        "trans": [
+            "地位较高的；"
+        ],
+        "usphone": "'sinɪɚ",
+        "ukphone": "'siːniər"
+    },
+    {
+        "name": "sensational",
+        "trans": [
+            "轰动性的， 引起哗然的， 耸人听闻的； 〈口〉极好的， 绝妙的"
+        ],
+        "usphone": "sɛn'seʃənl",
+        "ukphone": "sen'seɪʃənl"
+    },
+    {
+        "name": "sense",
+        "trans": [
+            "觉得， 意识到",
+            "感官，官能；感觉；判断力；意义，意思"
+        ],
+        "usphone": "sɛns",
+        "ukphone": "sens"
+    },
+    {
+        "name": "sensible",
+        "trans": [
+            "可察觉的， 可感知的； 明智的； 切合实际的； 意识到的"
+        ],
+        "usphone": "'sɛnsəbl",
+        "ukphone": "'sensəbl"
+    },
+    {
+        "name": "sensitive",
+        "trans": [
+            "敏感的； 灵敏的"
+        ],
+        "usphone": "'sɛnsətɪv",
+        "ukphone": "'sensətɪv"
+    },
+    {
+        "name": "sensory",
+        "trans": [
+            "感觉的， 感官的"
+        ],
+        "usphone": "'sɛnsəri",
+        "ukphone": "'sensəri"
+    },
+    {
+        "name": "sensual",
+        "trans": [
+            "感觉的， 感官的； 肉欲的； 耽于感官享受的"
+        ],
+        "usphone": "'sɛnʃuəl",
+        "ukphone": "'senʃuəl"
+    },
+    {
+        "name": "sentimental",
+        "trans": [
+            "情感的； 伤感的， 多愁善感的"
+        ],
+        "usphone": "'sɛntə'mɛntl",
+        "ukphone": "ˌsentɪ'mentl"
+    },
+    {
+        "name": "separate",
+        "trans": [
+            "分离； 划分； 区别； 分居",
+            "分离的； 个别的"
+        ],
+        "usphone": "(for v.) sɛpəˌret; (for adj.) sɛprɪt",
+        "ukphone": "(for v.) ˈsepəreɪt; (for adj.) ˈseprət"
+    },
+    {
+        "name": "sequence",
+        "trans": [
+            "一系列，一连串；顺序，次序，序列",
+            "按顺序排列"
+        ],
+        "usphone": "'sikwəns",
+        "ukphone": "'siːkwəns"
+    },
+    {
+        "name": "sequential",
+        "trans": [
+            "序列的； 连续的； 随之而来的"
+        ],
+        "usphone": "sɪ'kwɛnʃl",
+        "ukphone": "sɪ'kwenʃl"
+    },
+    {
+        "name": "sequoia",
+        "trans": [
+            "美洲杉， 红杉"
+        ],
+        "usphone": "sɪ'kwɔɪə",
+        "ukphone": "sɪ'kwɔɪə"
+    },
+    {
+        "name": "series",
+        "trans": [
+            "系列， 连续； 连续剧"
+        ],
+        "usphone": "'sɪriz",
+        "ukphone": "'sɪriːz"
+    },
+    {
+        "name": "session",
+        "trans": [
+            "会议； 开庭； 开庭期； 一节"
+        ],
+        "usphone": "'sɛʃən",
+        "ukphone": "'seʃn"
+    },
+    {
+        "name": "setback",
+        "trans": [
+            "挫折， 阻碍； 倒退"
+        ],
+        "usphone": "'sɛtbæk",
+        "ukphone": "'setbæk"
+    },
+    {
+        "name": "setting",
+        "trans": [
+            "环境； 背景； 布景； 曲； 底座， 底板"
+        ],
+        "usphone": "'sɛtɪŋ",
+        "ukphone": "'setɪŋ"
+    },
+    {
+        "name": "settle",
+        "trans": [
+            "安定， 安顿， 定居； 结束， 解决； 决定， 确定； 平静下来； 支付， 结算； 飞落， 停留"
+        ],
+        "usphone": "'sɛtl",
+        "ukphone": "'setl"
+    },
+    {
+        "name": "severe",
+        "trans": [
+            "严重的； 严厉的； 剧烈的； 严峻的， 艰巨的； 朴素的， 不加装饰的"
+        ],
+        "usphone": "səˈvɪr",
+        "ukphone": "sɪ'vɪr"
+    },
+    {
+        "name": "sew",
+        "trans": [
+            "缝， 做针线活； 缝补， 缝上"
+        ],
+        "usphone": "so",
+        "ukphone": "sou"
+    },
+    {
+        "name": "sewage",
+        "trans": [
+            "污水， 污物"
+        ],
+        "usphone": "'sʊɪdʒ",
+        "ukphone": "'suːɪdʒ"
+    },
+    {
+        "name": "sewerage",
+        "trans": [
+            "排水系统； 污水处理； 污水"
+        ],
+        "usphone": "'suərɪdʒ",
+        "ukphone": "'suːərɪdʒ"
+    },
+    {
+        "name": "sexism",
+        "trans": [
+            "性别歧视"
+        ],
+        "usphone": "'sɛk'sɪzəm",
+        "ukphone": "'seksɪzəm"
+    },
+    {
+        "name": "shade",
+        "trans": [
+            "阴凉处，遮光物；阴暗；色度；差别",
+            "遮蔽， 遮光"
+        ],
+        "usphone": "ʃed",
+        "ukphone": "ʃeɪd"
+    },
+    {
+        "name": "shallow",
+        "trans": [
+            "浅的；"
+        ],
+        "usphone": "'ʃælo",
+        "ukphone": "'ʃælou"
+    },
+    {
+        "name": "shame",
+        "trans": [
+            "羞耻，羞愧，耻辱；可耻的人",
+            "使羞愧； 玷辱"
+        ],
+        "usphone": "ʃem",
+        "ukphone": "ʃeɪm"
+    },
+    {
+        "name": "shape",
+        "trans": [
+            "形状，外形，样子；体形，身材；形式；幻象；情况，状况",
+            "使成为…形状， 塑造； 决定…的形成"
+        ],
+        "usphone": "ʃep",
+        "ukphone": "ʃeɪp"
+    },
+    {
+        "name": "sharpen",
+        "trans": [
+            "削尖， 磨快； 使敏锐； 变得清晰"
+        ],
+        "usphone": "'ʃɑrpən",
+        "ukphone": "'ʃɑːrpən"
+    },
+    {
+        "name": "sharply",
+        "trans": [
+            "急剧地； 猛烈地； 尖刻地； 鲜明地"
+        ],
+        "usphone": "'ʃɑrpli",
+        "ukphone": "'ʃɑːrpli"
+    },
+    {
+        "name": "shatter",
+        "trans": [
+            "粉碎， 破碎； 破灭； 散开， 吹散； 给予极大打击"
+        ],
+        "usphone": "'ʃætɚ",
+        "ukphone": "'ʃætər"
+    },
+    {
+        "name": "shear",
+        "trans": [
+            "剪； 切断， 剪切"
+        ],
+        "usphone": "ʃɪr",
+        "ukphone": "ʃɪr"
+    },
+    {
+        "name": "sheath",
+        "trans": [
+            "鞘， 外壳； 套； 护皮； 紧身连衣裙"
+        ],
+        "usphone": "ʃiθ",
+        "ukphone": "ʃiːθ"
+    },
+    {
+        "name": "shed",
+        "trans": [
+            "抛弃；摆脱；流出；散发；发出；脱落",
+            "小屋"
+        ],
+        "usphone": "ʃɛd",
+        "ukphone": "ʃed"
+    },
+    {
+        "name": "sheer",
+        "trans": [
+            "垂直地，陡峭地",
+            "急转， 偏离",
+            "陡峭的；完全的，十足的，全然的；绝对的；极薄的"
+        ],
+        "usphone": "ʃɪr",
+        "ukphone": "ʃɪr"
+    },
+    {
+        "name": "shell",
+        "trans": [
+            "壳，外壳；壳状物；骨架，框架；外表；炮弹",
+            "给…去壳； 炮击"
+        ],
+        "usphone": "ʃɛl",
+        "ukphone": "ʃel"
+    },
+    {
+        "name": "shellfish",
+        "trans": [
+            "贝类， 有壳的水生动物"
+        ],
+        "usphone": "'ʃɛl'fɪʃ",
+        "ukphone": "'ʃelfɪʃ"
+    },
+    {
+        "name": "shelter",
+        "trans": [
+            "掩蔽处，庇护所；居所，住所；掩蔽，保护",
+            "保护， 掩蔽； 躲避"
+        ],
+        "usphone": "'ʃɛltɚ",
+        "ukphone": "'ʃeltər"
+    },
+    {
+        "name": "shield",
+        "trans": [
+            "防护物；盾",
+            "保护"
+        ],
+        "usphone": "ʃild",
+        "ukphone": "ʃiːld"
+    },
+    {
+        "name": "shift",
+        "trans": [
+            "转移；改变",
+            "转移； 改变； 轮班"
+        ],
+        "usphone": "ʃɪft",
+        "ukphone": "ʃɪft"
+    },
+    {
+        "name": "shipwright",
+        "trans": [
+            "造船者， 造船工人； 修船工"
+        ],
+        "usphone": "'ʃɪp,raɪt",
+        "ukphone": "'ʃɪpraɪt"
+    },
+    {
+        "name": "shirk",
+        "trans": [
+            "逃避， 规避"
+        ],
+        "usphone": "ʃə:k",
+        "ukphone": "ʃɜːrk"
+    },
+    {
+        "name": "shore",
+        "trans": [
+            "滨，岸",
+            "支撑， 支持"
+        ],
+        "usphone": "ʃɔr",
+        "ukphone": "ʃɔːr"
+    },
+    {
+        "name": "shortage",
+        "trans": [
+            "不足， 缺乏"
+        ],
+        "usphone": "'ʃɔrtɪdʒ",
+        "ukphone": "'ʃɔːrtɪdʒ"
+    },
+    {
+        "name": "shortly",
+        "trans": [
+            "不久； 简要地； 不耐烦地"
+        ],
+        "usphone": "'ʃɔrtli",
+        "ukphone": "'ʃɔːrtli"
+    },
+    {
+        "name": "shovel",
+        "trans": [
+            "铲；把…大量投入",
+            "铲， 铁铲； 挖掘机"
+        ],
+        "usphone": "'ʃʌvl",
+        "ukphone": "'ʃʌvl"
+    },
+    {
+        "name": "shower",
+        "trans": [
+            "淋浴； 下阵雨； 洒落， 纷纷降落； 抛撒",
+            "阵雨，暴雨；淋浴；一阵，一大批"
+        ],
+        "usphone": "'ʃaʊɚ",
+        "ukphone": "'ʃauər"
+    },
+    {
+        "name": "shred",
+        "trans": [
+            "碎片，细条；些许，少量",
+            "切碎， 撕碎"
+        ],
+        "usphone": "ʃrɛd",
+        "ukphone": "ʃred"
+    },
+    {
+        "name": "shrewd",
+        "trans": [
+            "敏捷的， 机灵的； 精明的"
+        ],
+        "usphone": "ʃrud",
+        "ukphone": "ʃruːd"
+    },
+    {
+        "name": "shrimp",
+        "trans": [
+            "小虾"
+        ],
+        "usphone": "ʃrɪmp",
+        "ukphone": "ʃrɪmp"
+    },
+    {
+        "name": "shrink",
+        "trans": [
+            "收缩， 缩小； 退缩， 畏缩"
+        ],
+        "usphone": "ʃrɪŋk",
+        "ukphone": "ʃrɪŋk"
+    },
+    {
+        "name": "shrivel",
+        "trans": [
+            "枯萎"
+        ],
+        "usphone": "'ʃrɪvl",
+        "ukphone": "'ʃrɪvl"
+    },
+    {
+        "name": "shroud",
+        "trans": [
+            "隐藏，遮蔽",
+            "裹尸布， 寿衣； 遮蔽物"
+        ],
+        "usphone": "ʃraʊd",
+        "ukphone": "ʃraud"
+    },
+    {
+        "name": "shrub",
+        "trans": [
+            "灌木"
+        ],
+        "usphone": "ʃrʌb",
+        "ukphone": "ʃrʌb"
+    },
+    {
+        "name": "shuffle",
+        "trans": [
+            "拖着脚走； 洗； 蒙混； 搅乱"
+        ],
+        "usphone": "'ʃʌfl",
+        "ukphone": "'ʃʌfl"
+    },
+    {
+        "name": "shuttle",
+        "trans": [
+            "穿梭往返；短程往返运送",
+            "航天飞机； 梭子； 航班"
+        ],
+        "usphone": "'ʃʌtl",
+        "ukphone": "'ʃʌtl"
+    },
+    {
+        "name": "sidebar",
+        "trans": [
+            "补充报道"
+        ],
+        "usphone": "'saɪdbɑr",
+        "ukphone": "'saɪdbɑːr"
+    },
+    {
+        "name": "sidewalk",
+        "trans": [
+            "人行道"
+        ],
+        "usphone": "'saɪdwɔk",
+        "ukphone": "'saɪdwɔːk"
+    },
+    {
+        "name": "siege",
+        "trans": [
+            "包围， 围困； 封锁"
+        ],
+        "usphone": "sidʒ",
+        "ukphone": "siːdʒ"
+    },
+    {
+        "name": "sieve",
+        "trans": [
+            "筛子；漏勺",
+            "筛， 滤"
+        ],
+        "usphone": "sɪv",
+        "ukphone": "sɪv"
+    },
+    {
+        "name": "signal",
+        "trans": [
+            "发信号，示意；标志",
+            "显要的， 重大的",
+            "信号，暗号；标志"
+        ],
+        "usphone": "'sɪgnl",
+        "ukphone": "'sɪgnəl"
+    },
+    {
+        "name": "significant",
+        "trans": [
+            "有重大意义的， 重要的， 显著的； 意味深长的"
+        ],
+        "usphone": "sɪɡ'nɪfɪkənt",
+        "ukphone": "sɪg'nɪfɪkənt"
+    },
+    {
+        "name": "signify",
+        "trans": [
+            "意味； 表示， 预示； 要紧， 有重要性"
+        ],
+        "usphone": "'sɪɡnɪfaɪ",
+        "ukphone": "'sɪgnɪfaɪ"
+    },
+    {
+        "name": "silica",
+        "trans": [
+            "硅石， 硅土； 二氧化硅"
+        ],
+        "usphone": "'sɪlɪkə",
+        "ukphone": "'sɪlɪkə"
+    },
+    {
+        "name": "silicate",
+        "trans": [
+            "硅酸盐"
+        ],
+        "usphone": "'sɪlɪket",
+        "ukphone": "'sɪlɪkeɪt"
+    },
+    {
+        "name": "silicon",
+        "trans": [
+            "硅"
+        ],
+        "usphone": "'sɪlɪkən",
+        "ukphone": "'sɪlɪkən"
+    },
+    {
+        "name": "silt",
+        "trans": [
+            "阻塞",
+            "淤泥"
+        ],
+        "usphone": "sɪlt",
+        "ukphone": "sɪlt"
+    },
+    {
+        "name": "silversmith",
+        "trans": [
+            "银匠； 银器商人"
+        ],
+        "usphone": "'sɪlvɚsmɪθ",
+        "ukphone": "'sɪlvərsmɪθ"
+    },
+    {
+        "name": "similar",
+        "trans": [
+            "相似的， 类似的"
+        ],
+        "usphone": "'sɪməlɚ",
+        "ukphone": "'sɪmələr"
+    },
+    {
+        "name": "simile",
+        "trans": [
+            "明喻"
+        ],
+        "usphone": "'sɪməli",
+        "ukphone": "'sɪməli"
+    },
+    {
+        "name": "simmer",
+        "trans": [
+            "充满；煨，炖",
+            "煨， 炖"
+        ],
+        "usphone": "'sɪmɚ",
+        "ukphone": "'sɪmər"
+    },
+    {
+        "name": "simplicity",
+        "trans": [
+            "简单， 容易； 朴素， 质朴"
+        ],
+        "usphone": "sɪm'plɪsəti",
+        "ukphone": "sɪm'plɪsəti"
+    },
+    {
+        "name": "simplify",
+        "trans": [
+            "简化， 使简单， 使单纯"
+        ],
+        "usphone": "'sɪmplɪfaɪ",
+        "ukphone": "'sɪmplɪfaɪ"
+    },
+    {
+        "name": "simply",
+        "trans": [
+            "简单地， 简明地； 简直； 仅仅， 只； 朴素地， 简朴地"
+        ],
+        "usphone": "'sɪmpli",
+        "ukphone": "'sɪmpli"
+    },
+    {
+        "name": "simulate",
+        "trans": [
+            "模仿， 模拟； 假装， 伪装"
+        ],
+        "usphone": "'sɪmjulet",
+        "ukphone": "'sɪmjuleɪt"
+    },
+    {
+        "name": "simultaneous",
+        "trans": [
+            "同时的， 同步的"
+        ],
+        "usphone": ",saɪml'tenɪəs",
+        "ukphone": "ˌsaɪml'teɪniəs"
+    },
+    {
+        "name": "singular",
+        "trans": [
+            "单数的； 突出的， 卓越的； 异常的"
+        ],
+        "usphone": "'sɪŋɡjəlɚ",
+        "ukphone": "'sɪŋgjələr"
+    },
+    {
+        "name": "sinuous",
+        "trans": [
+            "蜿蜒的； 迂回的"
+        ],
+        "usphone": "'sɪnjʊəs",
+        "ukphone": "'sɪnjuəs"
+    },
+    {
+        "name": "situated",
+        "trans": [
+            "坐落在…的； 处于…境地的"
+        ],
+        "usphone": "'sɪtʃuetɪd",
+        "ukphone": "'sɪtʃueɪtɪd"
+    },
+    {
+        "name": "skeletal",
+        "trans": [
+            "骨骼的， 骸骨的； 梗概的； 轮廓的"
+        ],
+        "usphone": "'skɛlətl",
+        "ukphone": "'skelətl"
+    },
+    {
+        "name": "skeleton",
+        "trans": [
+            "梗概， 提纲； 骨架， 骨骼； 框架"
+        ],
+        "usphone": "'skɛlɪtn",
+        "ukphone": "'skelɪtn"
+    },
+    {
+        "name": "skeptical",
+        "trans": [
+            "怀疑的"
+        ],
+        "usphone": "'skɛptɪkl",
+        "ukphone": "'skeptɪkl"
+    },
+    {
+        "name": "skim",
+        "trans": [
+            "撇去； 掠过， 擦过； 浏览， 略读"
+        ],
+        "usphone": "skɪm",
+        "ukphone": "skɪm"
+    },
+    {
+        "name": "skip",
+        "trans": [
+            "跳；跳过，略过，漏过；不出席",
+            "跳； 跳过"
+        ],
+        "usphone": "skɪp",
+        "ukphone": "skɪp"
+    },
+    {
+        "name": "skull",
+        "trans": [
+            "颅骨， 头骨； 脑袋； 头脑"
+        ],
+        "usphone": "skʌl",
+        "ukphone": "skʌl"
+    },
+    {
+        "name": "skyscraper",
+        "trans": [
+            "摩天楼"
+        ],
+        "usphone": "'skaɪ'skrepɚ",
+        "ukphone": "'skaɪskreɪpər"
+    },
+    {
+        "name": "slacken",
+        "trans": [
+            "松弛， 放松； 减缓， 放慢"
+        ],
+        "usphone": "'slækən",
+        "ukphone": "'slækən"
+    },
+    {
+        "name": "slander",
+        "trans": [
+            "诽谤，中伤，诋毁",
+            "诽谤， 诋毁"
+        ],
+        "usphone": "'slændɚ",
+        "ukphone": "'slændər"
+    },
+    {
+        "name": "slash",
+        "trans": [
+            "砍；大幅削减",
+            "砍痕， 伤痕； 斜线号"
+        ],
+        "usphone": "slæʃ",
+        "ukphone": "slæʃ"
+    },
+    {
+        "name": "sled",
+        "trans": [
+            "乘雪橇， 用雪橇运",
+            "雪橇；摘棉机"
+        ],
+        "usphone": "slɛd",
+        "ukphone": "sled"
+    },
+    {
+        "name": "sledding",
+        "trans": [
+            "进展"
+        ],
+        "usphone": "'slɛdɪŋ",
+        "ukphone": "'sledɪŋ"
+    },
+    {
+        "name": "sleek",
+        "trans": [
+            "光滑而有光泽的；线条流畅的；时髦的",
+            "使平整光亮"
+        ],
+        "usphone": "slik",
+        "ukphone": "sliːk"
+    },
+    {
+        "name": "sleigh",
+        "trans": [
+            "雪橇"
+        ],
+        "usphone": "sle",
+        "ukphone": "sleɪ"
+    },
+    {
+        "name": "slender",
+        "trans": [
+            "细长的； 苗条的， 纤细的； 微薄的， 不足的"
+        ],
+        "usphone": "'slɛndɚ",
+        "ukphone": "'slendər"
+    },
+    {
+        "name": "slice",
+        "trans": [
+            "薄片；部分，份额",
+            "把…切成片"
+        ],
+        "usphone": "slaɪs",
+        "ukphone": "slaɪs"
+    },
+    {
+        "name": "slick",
+        "trans": [
+            "光滑的； 熟练的； 圆滑的， 口齿伶俐的； 精巧的， 巧妙的"
+        ],
+        "usphone": "slɪk",
+        "ukphone": "slɪk"
+    },
+    {
+        "name": "slide",
+        "trans": [
+            "滑动",
+            "滑动； 滑坡， 滑道； 幻灯片"
+        ],
+        "usphone": "slaɪd",
+        "ukphone": "slaɪd"
+    },
+    {
+        "name": "slight",
+        "trans": [
+            "轻微的，微小的",
+            "侮慢；轻视，冷落"
+        ],
+        "usphone": "slaɪt",
+        "ukphone": "slaɪt"
+    },
+    {
+        "name": "slip",
+        "trans": [
+            "滑倒，失足；滑落；悄悄疾行，溜；摆脱；下降，跌落；陷入",
+            "差错， 纰漏； 滑倒； 纸片"
+        ],
+        "usphone": "slɪp",
+        "ukphone": "slɪp"
+    },
+    {
+        "name": "slog",
+        "trans": [
+            "艰难行进； 埋头苦干； 猛击"
+        ],
+        "usphone": "slɑɡ",
+        "ukphone": "slɑːg"
+    },
+    {
+        "name": "slogan",
+        "trans": [
+            "标语， 口号； 广告语"
+        ],
+        "usphone": "'slogən",
+        "ukphone": "'slougən"
+    },
+    {
+        "name": "slope",
+        "trans": [
+            "倾斜",
+            "斜坡，斜面；斜度"
+        ],
+        "usphone": "slop",
+        "ukphone": "sloup"
+    },
+    {
+        "name": "sloth",
+        "trans": [
+            "树懒； 懒散， 怠惰"
+        ],
+        "usphone": "sloθ",
+        "ukphone": "slouθ"
+    },
+    {
+        "name": "slough",
+        "trans": [
+            "使脱落",
+            "泥坑， 沼泽； 绝境"
+        ],
+        "usphone": "slʌf; slaʊ; slu",
+        "ukphone": "slʌf；slaʊ"
+    },
+    {
+        "name": "sluggish",
+        "trans": [
+            "行动迟缓的； 不活泼的； 无精打采的， 怠惰的"
+        ],
+        "usphone": "'slʌɡɪʃ",
+        "ukphone": "'slʌgɪʃ"
+    },
+    {
+        "name": "slumber",
+        "trans": [
+            "睡眠， 安睡"
+        ],
+        "usphone": "'slʌmbɚ",
+        "ukphone": "'slʌmbər"
+    },
+    {
+        "name": "smear",
+        "trans": [
+            "胡乱涂抹；弄脏；诽谤，诋毁",
+            "污迹， 污斑； 诽谤， 诋毁； 涂片"
+        ],
+        "usphone": "smɪr",
+        "ukphone": "smɪr"
+    },
+    {
+        "name": "smelting",
+        "trans": [
+            "冶炼， 熔炼"
+        ],
+        "usphone": "'smeltiŋ",
+        "ukphone": "'smeltɪŋ"
+    },
+    {
+        "name": "smirk",
+        "trans": [
+            "假笑， 得意地笑"
+        ],
+        "usphone": "smɝk",
+        "ukphone": "smɜːrk"
+    },
+    {
+        "name": "smoothly",
+        "trans": [
+            "顺利地； 平稳地； 平静地"
+        ],
+        "usphone": "'smʊðli",
+        "ukphone": "'smuːðli"
+    },
+    {
+        "name": "smother",
+        "trans": [
+            "使窒息而死； 厚厚地覆盖； 抑制， 扼杀； 把闷熄"
+        ],
+        "usphone": "'smʌðɚ",
+        "ukphone": "'smʌðər"
+    },
+    {
+        "name": "snack",
+        "trans": [
+            "快餐， 小吃， 点心"
+        ],
+        "usphone": "snæk",
+        "ukphone": "snæk"
+    },
+    {
+        "name": "snap",
+        "trans": [
+            "猛咬；折断，断裂；打开，关上；呵斥，厉声说；拍照",
+            "仓促的， 匆忙的",
+            "啪嗒声；照片"
+        ],
+        "usphone": "snæp",
+        "ukphone": "snæp"
+    },
+    {
+        "name": "sneaker",
+        "trans": [
+            "鬼鬼祟祟的人， 卑鄙者； 运动鞋"
+        ],
+        "usphone": "'snikɚ",
+        "ukphone": "'sniːkər"
+    },
+    {
+        "name": "sneaky",
+        "trans": [
+            "偷偷摸摸的， 鬼鬼祟祟的"
+        ],
+        "usphone": "'sniki",
+        "ukphone": "'sniːki"
+    },
+    {
+        "name": "snide",
+        "trans": [
+            "伪造的； 不诚实的； 讽刺的， 挖苦的， 含沙射影的"
+        ],
+        "usphone": "snaɪd",
+        "ukphone": "snaɪd"
+    },
+    {
+        "name": "snowflake",
+        "trans": [
+            "雪花， 雪片"
+        ],
+        "usphone": "'snoflek",
+        "ukphone": "'snoufleɪk"
+    },
+    {
+        "name": "so-called",
+        "trans": [
+            "所谓的"
+        ],
+        "usphone": ",so'kɔld",
+        "ukphone": "ˌsou'kɔːld"
+    },
+    {
+        "name": "soak",
+        "trans": [
+            "浸泡， 浸湿， 浸透"
+        ],
+        "usphone": "sok",
+        "ukphone": "souk"
+    },
+    {
+        "name": "sober",
+        "trans": [
+            "清醒的，未醉的；持重的，冷静的；素净的",
+            "清醒； 变得冷静"
+        ],
+        "usphone": "'sobɚ",
+        "ukphone": "'soubər"
+    },
+    {
+        "name": "soccer",
+        "trans": [
+            "足球"
+        ],
+        "usphone": "'sɑkɚ",
+        "ukphone": "'sɑːkər"
+    },
+    {
+        "name": "sociable",
+        "trans": [
+            "好交际的， 合群的； 友善的， 友好的"
+        ],
+        "usphone": "'soʃəbl",
+        "ukphone": "'souʃəbl"
+    },
+    {
+        "name": "sociology",
+        "trans": [
+            "社会学"
+        ],
+        "usphone": ",sosɪ'ɑlədʒi",
+        "ukphone": "ˌsousi'ɑːlədʒi"
+    },
+    {
+        "name": "soda",
+        "trans": [
+            "苏打， 纯碱"
+        ],
+        "usphone": "'sodə",
+        "ukphone": "'soudə"
+    },
+    {
+        "name": "sodium",
+        "trans": [
+            "钠"
+        ],
+        "usphone": "'sodɪəm",
+        "ukphone": "'soudiəm"
+    },
+    {
+        "name": "soft",
+        "trans": [
+            "柔软的； 柔和的； 不强烈的； 心肠软的； 软性的"
+        ],
+        "usphone": "sɔft",
+        "ukphone": "sɔːft"
+    },
+    {
+        "name": "solar",
+        "trans": [
+            "太阳的， 日光的； 太阳能的"
+        ],
+        "usphone": "'solɚ",
+        "ukphone": "'soulər"
+    },
+    {
+        "name": "solder",
+        "trans": [
+            "焊接",
+            "焊料， 焊锡"
+        ],
+        "usphone": "'sɑdɚ",
+        "ukphone": "'sɑːdər"
+    },
+    {
+        "name": "sole",
+        "trans": [
+            "单独的；唯一的",
+            "鞋底， 脚底"
+        ],
+        "usphone": "sol",
+        "ukphone": "soul"
+    },
+    {
+        "name": "solemn",
+        "trans": [
+            "庄严的， 严肃的； 隆重的"
+        ],
+        "usphone": "'sɑləm",
+        "ukphone": "'sɑːləm"
+    },
+    {
+        "name": "solicit",
+        "trans": [
+            "恳请； 乞求； 征求； 勾引； 招揽"
+        ],
+        "usphone": "sə'lɪsɪt",
+        "ukphone": "sə'lɪsɪt"
+    },
+    {
+        "name": "solid",
+        "trans": [
+            "固体的；实心的；结实的，稳固的；可靠的；连续的",
+            "固体"
+        ],
+        "usphone": "'sɑlɪd",
+        "ukphone": "'sɑːlɪd"
+    },
+    {
+        "name": "solitary",
+        "trans": [
+            "孤独的； 单独的， 独自的； 单个的； 唯一的， 仅有的"
+        ],
+        "usphone": "'sɑlətɛri",
+        "ukphone": "'sɑːləteri"
+    },
+    {
+        "name": "solitude",
+        "trans": [
+            "孤独， 单独； 独处， 独居； 隐居处"
+        ],
+        "usphone": "'sɑlətud",
+        "ukphone": "'sɑːlətjuːd"
+    },
+    {
+        "name": "solo",
+        "trans": [
+            "独自，单独地",
+            "单独的；独唱的，独奏的",
+            "独唱， 独奏， 独舞"
+        ],
+        "usphone": "'solo",
+        "ukphone": "'soulou"
+    },
+    {
+        "name": "soloist",
+        "trans": [
+            "独奏者， 独唱者， 单独表演者"
+        ],
+        "usphone": "'soloɪst",
+        "ukphone": "'soulouɪst"
+    },
+    {
+        "name": "soluble",
+        "trans": [
+            "可溶的； 可解决的"
+        ],
+        "usphone": "'sɑljəbl",
+        "ukphone": "'sɑːljəbl"
+    },
+    {
+        "name": "solution",
+        "trans": [
+            "溶液； 解答， 解决"
+        ],
+        "usphone": "sə'luʃən",
+        "ukphone": "sə'luːʃn"
+    },
+    {
+        "name": "solvent",
+        "trans": [
+            "有溶解力的； 有偿付能力的",
+            "溶剂"
+        ],
+        "usphone": "'sɑlvənt",
+        "ukphone": "'sɑːlvənt"
+    },
+    {
+        "name": "somber",
+        "trans": [
+            "昏暗的； 忧郁的"
+        ],
+        "usphone": "ˈsɑːmbər",
+        "ukphone": "'sɑːmbər"
+    },
+    {
+        "name": "somewhat",
+        "trans": [
+            "稍微， 有点"
+        ],
+        "usphone": "'sʌmwʌt",
+        "ukphone": "'sʌmwʌt"
+    },
+    {
+        "name": "soothe",
+        "trans": [
+            "缓和， 减轻； 抚慰， 安慰"
+        ],
+        "usphone": "sʊð",
+        "ukphone": "suːð"
+    },
+    {
+        "name": "sophisticated",
+        "trans": [
+            "老练的， 见多识广的； 精密的； 复杂的， 先进的； 高雅的， 有教养的"
+        ],
+        "usphone": "sə'fɪstɪketɪd",
+        "ukphone": "sə'fɪstɪkeɪtɪd"
+    },
+    {
+        "name": "soprano",
+        "trans": [
+            "女高音"
+        ],
+        "usphone": "sə'prɑno",
+        "ukphone": "sə'prɑːnou"
+    },
+    {
+        "name": "sore",
+        "trans": [
+            "疼痛的；恼火的",
+            "疮口， 痛处"
+        ],
+        "usphone": "sɔr",
+        "ukphone": "sɔːr"
+    },
+    {
+        "name": "sound",
+        "trans": [
+            "可靠的；健康的，完好无损的；合理的",
+            "似乎； 测量…的深度"
+        ],
+        "usphone": "saʊnd",
+        "ukphone": "saund"
+    },
+    {
+        "name": "sour",
+        "trans": [
+            "变酸；变馊；变坏，恶化",
+            "酸的； 馊的； 乖戾的， 尖酸刻薄的； 酸痛的"
+        ],
+        "usphone": "'saʊɚ",
+        "ukphone": "'sauər"
+    },
+    {
+        "name": "source",
+        "trans": [
+            "源， 源泉； 来源， 出处； 信息来源"
+        ],
+        "usphone": "sɔrs",
+        "ukphone": "sɔːrs"
+    },
+    {
+        "name": "souvenir",
+        "trans": [
+            "纪念品， 纪念物"
+        ],
+        "usphone": ",suvə'nɪr",
+        "ukphone": "ˌsuːvə'nɪr"
+    },
+    {
+        "name": "sovereign",
+        "trans": [
+            "君主的；至高无上的；独立自主的",
+            "君主， 元首， 最高统治者"
+        ],
+        "usphone": "sɑvrɪn",
+        "ukphone": "'sɑːvrən"
+    },
+    {
+        "name": "sow",
+        "trans": [
+            "播种， 种； 灌输； 煽动"
+        ],
+        "usphone": "so",
+        "ukphone": "sou"
+    },
+    {
+        "name": "soybean",
+        "trans": [
+            "大豆"
+        ],
+        "usphone": "'sɔɪ,bin",
+        "ukphone": "'sɔɪbiːn"
+    },
+    {
+        "name": "spacecraft",
+        "trans": [
+            "航天器， 宇宙飞船"
+        ],
+        "usphone": "'speskræft",
+        "ukphone": "'speɪskræft"
+    },
+    {
+        "name": "spaghetti",
+        "trans": [
+            "意大利式细面条"
+        ],
+        "usphone": "spə'ɡɛti",
+        "ukphone": "spə'geti"
+    },
+    {
+        "name": "span",
+        "trans": [
+            "跨度；持续时间",
+            "跨越； 持续， 贯穿； 包括"
+        ],
+        "usphone": "spæn",
+        "ukphone": "spæn"
+    },
+    {
+        "name": "spare",
+        "trans": [
+            "备用的；空闲的",
+            "抽出；免除",
+            "备用品"
+        ],
+        "usphone": "spɛr",
+        "ukphone": "sper"
+    },
+    {
+        "name": "spark",
+        "trans": [
+            "激发，引发，触发；"
+        ],
+        "usphone": "spɑrk",
+        "ukphone": "spɑːrk"
+    },
+    {
+        "name": "sparse",
+        "trans": [
+            "稀疏的， 稀少的； 贫乏的"
+        ],
+        "usphone": "spɑrs",
+        "ukphone": "spɑːrs"
+    },
+    {
+        "name": "spatial",
+        "trans": [
+            "空间的"
+        ],
+        "usphone": "'speʃl",
+        "ukphone": "'speɪʃl"
+    },
+    {
+        "name": "spawn",
+        "trans": [
+            "产卵；产生，促成",
+            "卵"
+        ],
+        "usphone": "spɔn",
+        "ukphone": "spɔːn"
+    },
+    {
+        "name": "spear",
+        "trans": [
+            "刺，戳",
+            "矛， 枪； 嫩叶"
+        ],
+        "usphone": "spɪr",
+        "ukphone": "spɪr"
+    },
+    {
+        "name": "spearhead",
+        "trans": [
+            "先锋，前锋，先头部队",
+            "为…作先锋； 带头做"
+        ],
+        "usphone": "'spɪr'hɛd",
+        "ukphone": "'spɪrhed"
+    },
+    {
+        "name": "specialize",
+        "trans": [
+            "专攻； 专用于"
+        ],
+        "usphone": "'spɛʃəlaɪz",
+        "ukphone": "'speʃəlaɪz"
+    },
+    {
+        "name": "species",
+        "trans": [
+            "种类， 类群"
+        ],
+        "usphone": "'spiʃiz",
+        "ukphone": "'spiːsiːz"
+    },
+    {
+        "name": "specific",
+        "trans": [
+            "明确的， 具体的； 特定的， 特有的"
+        ],
+        "usphone": "spɪ'sɪfɪk",
+        "ukphone": "spə'sɪfɪk"
+    },
+    {
+        "name": "specify",
+        "trans": [
+            "使具体化； 明确规定， 详细说明"
+        ],
+        "usphone": "'spɛsɪfaɪ",
+        "ukphone": "'spesɪfaɪ"
+    },
+    {
+        "name": "specimen",
+        "trans": [
+            "标本， 样本； 范例； 抽样"
+        ],
+        "usphone": "'spɛsəmən",
+        "ukphone": "'spesɪmən"
+    },
+    {
+        "name": "speckle",
+        "trans": [
+            "弄上斑点；点缀",
+            "斑点； 色斑"
+        ],
+        "usphone": "'spɛkl",
+        "ukphone": "'spekl"
+    },
+    {
+        "name": "spectacle",
+        "trans": [
+            "精彩的表演；壮观的场面；奇观；壮丽的景象；"
+        ],
+        "usphone": "'spɛktəkl",
+        "ukphone": "'spektəkl"
+    },
+    {
+        "name": "spectacular",
+        "trans": [
+            "壮观的，引人注目的",
+            "壮观的场面； 壮观的演出"
+        ],
+        "usphone": "spɛk'tækjəlɚ",
+        "ukphone": "spek'tækjələr"
+    },
+    {
+        "name": "spectator",
+        "trans": [
+            "观众； 旁观者"
+        ],
+        "usphone": "'spɛktetɚ",
+        "ukphone": "'spekteɪtər"
+    },
+    {
+        "name": "spectrum",
+        "trans": [
+            "谱， 光谱， 频谱； 范围， 幅度"
+        ],
+        "usphone": "'spɛktrəm",
+        "ukphone": "'spektrəm"
+    },
+    {
+        "name": "speculate",
+        "trans": [
+            "推测； 深思， 沉思； 投机， 做投机买卖"
+        ],
+        "usphone": "'spɛkjə'let",
+        "ukphone": "'spekjuleɪt"
+    },
+    {
+        "name": "spellbind",
+        "trans": [
+            "用妖术迷惑； 迷住， 使入迷"
+        ],
+        "usphone": "'spɛl,baɪnd",
+        "ukphone": "'spelbaɪnd"
+    },
+    {
+        "name": "spew",
+        "trans": [
+            "喷涌；射出；呕吐，呕出",
+            "喷出物"
+        ],
+        "usphone": "spju",
+        "ukphone": "spjuː"
+    },
+    {
+        "name": "sphere",
+        "trans": [
+            "球； 范围， 领域； 阶层"
+        ],
+        "usphone": "sfɪr",
+        "ukphone": "sfɪr"
+    },
+    {
+        "name": "spherical",
+        "trans": [
+            "球形的， 球状的"
+        ],
+        "usphone": "'sfɪrɪkəl",
+        "ukphone": "'sferɪkl"
+    },
+    {
+        "name": "spheroid",
+        "trans": [
+            "球状体， 椭球体"
+        ],
+        "usphone": "'sfɪrɔɪd",
+        "ukphone": "'sfɪrɔɪd"
+    },
+    {
+        "name": "spice",
+        "trans": [
+            "香料，调味品；趣味，情趣",
+            "加香料于； 给…增添趣味"
+        ],
+        "usphone": "spaɪs",
+        "ukphone": "spaɪs"
+    },
+    {
+        "name": "spike",
+        "trans": [
+            "长钉， 大钉； 猛增， 急升"
+        ],
+        "usphone": "spaɪk",
+        "ukphone": "spaɪk"
+    },
+    {
+        "name": "spill",
+        "trans": [
+            "溢出，溅出；蜂拥而出",
+            "溢出， 泄漏"
+        ],
+        "usphone": "spɪl",
+        "ukphone": "spɪl"
+    },
+    {
+        "name": "spin",
+        "trans": [
+            "快速旋转；纺纱；吐丝；甩干衣服",
+            "旋转"
+        ],
+        "usphone": "spɪn",
+        "ukphone": "spɪn"
+    },
+    {
+        "name": "spinet",
+        "trans": [
+            "小型立式钢琴"
+        ],
+        "usphone": "ˈspɪnɪt",
+        "ukphone": "'spɪnət"
+    },
+    {
+        "name": "spinning",
+        "trans": [
+            "旋转的",
+            "纺纱"
+        ],
+        "usphone": "'spɪnɪŋ",
+        "ukphone": "'spɪnɪŋ"
+    },
+    {
+        "name": "spiny",
+        "trans": [
+            "长满刺的， 多刺的， 带刺的； 棘手的"
+        ],
+        "usphone": "'spaɪni",
+        "ukphone": "'spaɪni"
+    },
+    {
+        "name": "spiral",
+        "trans": [
+            "盘旋；盘旋上升；急剧增长",
+            "螺旋形的",
+            "螺旋形； 螺旋式的上升"
+        ],
+        "usphone": "'spaɪrəl",
+        "ukphone": "'spaɪrəl"
+    },
+    {
+        "name": "splash",
+        "trans": [
+            "溅， 泼",
+            "重点文章；溅上的液体；斑点"
+        ],
+        "usphone": "splæʃ",
+        "ukphone": "splæʃ"
+    },
+    {
+        "name": "split",
+        "trans": [
+            "分开，分裂；撕裂；分担，分享；断绝关系，分手",
+            "裂口； 分化， 分裂"
+        ],
+        "usphone": "splɪt",
+        "ukphone": "splɪt"
+    },
+    {
+        "name": "spoil",
+        "trans": [
+            "破坏； 宠坏， 溺爱； 变质"
+        ],
+        "usphone": "spɔɪl",
+        "ukphone": "spɔɪl"
+    },
+    {
+        "name": "sponge",
+        "trans": [
+            "用海绵擦， 揩",
+            "海绵；寄生虫"
+        ],
+        "usphone": "spʌndʒ",
+        "ukphone": "spʌndʒ"
+    },
+    {
+        "name": "sponsor",
+        "trans": [
+            "主办；赞助",
+            "发起者； 赞助者"
+        ],
+        "usphone": "'spɑnsɚ",
+        "ukphone": "'spɑːnsər"
+    },
+    {
+        "name": "spontaneity",
+        "trans": [
+            "自发性； 自发行为"
+        ],
+        "usphone": ",spɑntə'neəti",
+        "ukphone": "ˌspɑːntə'neɪəti"
+    },
+    {
+        "name": "spontaneous",
+        "trans": [
+            "自发的， 自然产生的； 自然的， 无雕饰的"
+        ],
+        "usphone": "spɑn'tenɪəs",
+        "ukphone": "spɑːn'teɪniəs"
+    },
+    {
+        "name": "sporadic",
+        "trans": [
+            "偶发的， 间或出现的， 零星的"
+        ],
+        "usphone": "spə'rædɪk",
+        "ukphone": "spə'rædɪk"
+    },
+    {
+        "name": "spot",
+        "trans": [
+            "认出，发现",
+            "地点； 斑点； 少量"
+        ],
+        "usphone": "spɑt",
+        "ukphone": "spɑːt"
+    },
+    {
+        "name": "sprain",
+        "trans": [
+            "扭伤"
+        ],
+        "usphone": "spren",
+        "ukphone": "spreɪn"
+    },
+    {
+        "name": "sprawl",
+        "trans": [
+            "伸开四肢坐；扩展，蔓延",
+            "扩展， 蔓延； 蔓延物"
+        ],
+        "usphone": "sprɔl",
+        "ukphone": "sprɔːl"
+    },
+    {
+        "name": "spray",
+        "trans": [
+            "浪花；飞沫；"
+        ],
+        "usphone": "spreɪ",
+        "ukphone": "spreɪ"
+    },
+    {
+        "name": "spread",
+        "trans": [
+            "展开；蔓延，扩散；散布；涂，敷",
+            "传播， 蔓延； 涉及幅度， 活动范围"
+        ],
+        "usphone": "sprɛd",
+        "ukphone": "spred"
+    },
+    {
+        "name": "spring",
+        "trans": [
+            "跳跃；涌现，突然出现；突然提出",
+            "泉； 弹簧， 发条； 春天； 跳， 跃"
+        ],
+        "usphone": "sprɪŋ",
+        "ukphone": "sprɪŋ"
+    },
+    {
+        "name": "sprinkle",
+        "trans": [
+            "撒，洒，喷",
+            "少量"
+        ],
+        "usphone": "'sprɪŋkl",
+        "ukphone": "'sprɪŋkl"
+    },
+    {
+        "name": "sprout",
+        "trans": [
+            "发芽，抽条，生长；迅速出现，涌现出",
+            "新芽， 嫩枝， 苗"
+        ],
+        "usphone": "spraʊt",
+        "ukphone": "spraut"
+    },
+    {
+        "name": "spun",
+        "trans": [
+            "拉成丝的"
+        ],
+        "usphone": "spʌn",
+        "ukphone": "spʌn"
+    },
+    {
+        "name": "spur",
+        "trans": [
+            "刺激；激励；马刺",
+            "激励， 鼓舞； 刺激， 促进"
+        ],
+        "usphone": "spɝ",
+        "ukphone": "spɜːr"
+    },
+    {
+        "name": "spurn",
+        "trans": [
+            "拒绝； 摈弃"
+        ],
+        "usphone": "spə:n",
+        "ukphone": "spɜːrn"
+    },
+    {
+        "name": "squabble",
+        "trans": [
+            "发生口角，"
+        ],
+        "usphone": "'skwɑbl",
+        "ukphone": "'skwɑːbl"
+    },
+    {
+        "name": "squander",
+        "trans": [
+            "浪费， 挥霍"
+        ],
+        "usphone": "'skwɑndɚ",
+        "ukphone": "'skwɑːndər"
+    },
+    {
+        "name": "square",
+        "trans": [
+            "正方形的；成直角的，方的；平方的",
+            "正方形；广场；平方",
+            "使成正方形； 求平方； 使打成平局"
+        ],
+        "usphone": "skwɛr",
+        "ukphone": "skwer"
+    },
+    {
+        "name": "squash",
+        "trans": [
+            "压碎，挤压；挤进，塞入；制止",
+            "软式墙网球， 壁球； 果汁汽水"
+        ],
+        "usphone": "skwɔʃ",
+        "ukphone": "skwɑːʃ"
+    },
+    {
+        "name": "squeeze",
+        "trans": [
+            "挤压；挤入；挤过，塞入；压榨，榨取；"
+        ],
+        "usphone": "skwiz",
+        "ukphone": "skwiːz"
+    },
+    {
+        "name": "squid",
+        "trans": [
+            "鱿鱼， 枪乌贼"
+        ],
+        "usphone": "skwɪd",
+        "ukphone": "skwɪd"
+    },
+    {
+        "name": "squirrel",
+        "trans": [
+            "松鼠"
+        ],
+        "usphone": "ˈskwɜ:rəl; skwɝ​əl",
+        "ukphone": "'skwɜːrəl"
+    },
+    {
+        "name": "squirt",
+        "trans": [
+            "喷射，喷；向…喷射",
+            "喷射； 〈口， 贬〉无名小辈"
+        ],
+        "usphone": "skwɝt",
+        "ukphone": "skwɜːrt"
+    },
+    {
+        "name": "stable",
+        "trans": [
+            "稳定的，安定的；牢固的；沉稳的",
+            "马厩"
+        ],
+        "usphone": "'stebl",
+        "ukphone": "'steɪbl"
+    },
+    {
+        "name": "stack",
+        "trans": [
+            "堆积， 堆放",
+            "堆"
+        ],
+        "usphone": "stæk",
+        "ukphone": "stæk"
+    },
+    {
+        "name": "stadium",
+        "trans": [
+            "竞走场； 运动场"
+        ],
+        "usphone": "'stedɪəm",
+        "ukphone": "'steɪdiəm"
+    },
+    {
+        "name": "staff",
+        "trans": [
+            "全体职工；行政人员；棍棒",
+            "为…配备人员； 任职于"
+        ],
+        "usphone": "stæf",
+        "ukphone": "stæf"
+    },
+    {
+        "name": "stage",
+        "trans": [
+            "阶段；步骤；舞台；戏剧",
+            "上演； 筹划"
+        ],
+        "usphone": "stedʒ",
+        "ukphone": "steɪdʒ"
+    },
+    {
+        "name": "stagecoach",
+        "trans": [
+            "公共马车， 驿站马车"
+        ],
+        "usphone": "'stedʒkotʃ",
+        "ukphone": "'steɪdʒkoutʃ"
+    },
+    {
+        "name": "staggered",
+        "trans": [
+            "交错的， 错开的； 震惊的"
+        ],
+        "usphone": "'stæɡɚd",
+        "ukphone": "'stægərd"
+    },
+    {
+        "name": "staggering",
+        "trans": [
+            "巨大的； 势不可挡的； 惊人的， 令人吃惊的"
+        ],
+        "usphone": "'stæɡərɪŋ",
+        "ukphone": "'stægərɪŋ"
+    },
+    {
+        "name": "stagnant",
+        "trans": [
+            "不景气的； 停滞的； 迟钝的； 因不流动而污浊的"
+        ],
+        "usphone": "'stægnənt",
+        "ukphone": "'stægnənt"
+    },
+    {
+        "name": "stain",
+        "trans": [
+            "沾污；留下污渍",
+            "污点， 污渍"
+        ],
+        "usphone": "sten",
+        "ukphone": "steɪn"
+    },
+    {
+        "name": "stake",
+        "trans": [
+            "股份；赌注；利害关系",
+            "以…打赌， 拿…冒险"
+        ],
+        "usphone": "stek",
+        "ukphone": "steɪk"
+    },
+    {
+        "name": "stalk",
+        "trans": [
+            "偷偷接近； 跟踪； 趾高气扬地走",
+            "茎，梗，柄"
+        ],
+        "usphone": "stɔk",
+        "ukphone": "stɔːk"
+    },
+    {
+        "name": "stampede",
+        "trans": [
+            "狂奔，涌向；使仓促行事",
+            "逃窜， 狂奔； 热潮， 风尚"
+        ],
+        "usphone": "stæm'pid",
+        "ukphone": "stæm'piːd"
+    },
+    {
+        "name": "standard",
+        "trans": [
+            "标准的",
+            "标准，准则"
+        ],
+        "usphone": "'stændɚd",
+        "ukphone": "'stændərd"
+    },
+    {
+        "name": "stanza",
+        "trans": [
+            "节， 段"
+        ],
+        "usphone": "'stænzə",
+        "ukphone": "'stænzə"
+    },
+    {
+        "name": "staple",
+        "trans": [
+            "主要产品；原材料；主食；订书钉"
+        ],
+        "usphone": "'stepl",
+        "ukphone": "'steɪpl"
+    },
+    {
+        "name": "starch",
+        "trans": [
+            "淀粉；"
+        ],
+        "usphone": "stɑrtʃ",
+        "ukphone": "stɑːrtʃ"
+    },
+    {
+        "name": "stardom",
+        "trans": [
+            "明星的身份"
+        ],
+        "usphone": "'stɑrdəm",
+        "ukphone": "'stɑːrdəm"
+    },
+    {
+        "name": "stark",
+        "trans": [
+            "十足",
+            "赤裸的；严酷的，严峻的；明显的，鲜明的；十足的，极端的"
+        ],
+        "usphone": "stɑrk",
+        "ukphone": "stɑːrk"
+    },
+    {
+        "name": "startling",
+        "trans": [
+            "惊人的， 令人吃惊的"
+        ],
+        "usphone": "'stɑrtlɪŋ",
+        "ukphone": "'stɑːrtlɪŋ"
+    },
+    {
+        "name": "stash",
+        "trans": [
+            "隐藏，藏匿",
+            "贮藏物"
+        ],
+        "usphone": "stæʃ",
+        "ukphone": "stæʃ"
+    },
+    {
+        "name": "state",
+        "trans": [
+            "陈述， 说明， 声明； 规定",
+            "情况，状况；国家；州"
+        ],
+        "usphone": "stet",
+        "ukphone": "steɪt"
+    },
+    {
+        "name": "statesman",
+        "trans": [
+            "政治家"
+        ],
+        "usphone": "'stetsmən",
+        "ukphone": "'steɪtsmən"
+    },
+    {
+        "name": "static",
+        "trans": [
+            "静态的， 静止的； 静电的； 静力的",
+            "静电噪音；静电；[-s]静力学"
+        ],
+        "usphone": "'stætɪk",
+        "ukphone": "'stætɪk"
+    },
+    {
+        "name": "station",
+        "trans": [
+            "所；站；台；岗位；身份，地位",
+            "安置； 派驻， 驻扎"
+        ],
+        "usphone": "ˈsteɪʃən",
+        "ukphone": "'steɪʃn"
+    },
+    {
+        "name": "stationary",
+        "trans": [
+            "静止的； 固定的， 稳定的， 不变的"
+        ],
+        "usphone": "'steʃənɛri",
+        "ukphone": "'steɪʃəneri"
+    },
+    {
+        "name": "statistic",
+        "trans": [
+            "统计数字，统计资料；"
+        ],
+        "usphone": "stə'tɪstɪk",
+        "ukphone": "stə'tɪstɪk"
+    },
+    {
+        "name": "statue",
+        "trans": [
+            "雕像"
+        ],
+        "usphone": "'stætʃu",
+        "ukphone": "'stætʃuː"
+    },
+    {
+        "name": "stature",
+        "trans": [
+            "身材， 身高； 地位， 声望， 名望"
+        ],
+        "usphone": "'stætʃɚ",
+        "ukphone": "'stætʃər"
+    },
+    {
+        "name": "status",
+        "trans": [
+            "身份， 地位； 情况"
+        ],
+        "usphone": "ˈstetəs",
+        "ukphone": "'steɪtəs"
+    },
+    {
+        "name": "staunch",
+        "trans": [
+            "坚定的， 忠诚的"
+        ],
+        "usphone": "stɔntʃ",
+        "ukphone": "stɔːntʃ"
+    },
+    {
+        "name": "steady",
+        "trans": [
+            "牢固的；稳定的；沉稳的，"
+        ],
+        "usphone": "'stɛdi",
+        "ukphone": "'stedi"
+    },
+    {
+        "name": "steep",
+        "trans": [
+            "陡的，陡峭的；急剧的；过高的",
+            "浸泡； 沉浸"
+        ],
+        "usphone": "stip",
+        "ukphone": "stiːp"
+    },
+    {
+        "name": "steer",
+        "trans": [
+            "驾驶，为…操舵；引导",
+            "食用公牛"
+        ],
+        "usphone": "stɪr",
+        "ukphone": "stɪr"
+    },
+    {
+        "name": "stellar",
+        "trans": [
+            "星的， 恒星的， 星球的； 精彩的； 优秀的"
+        ],
+        "usphone": "ˈstelər",
+        "ukphone": "'stelər"
+    },
+    {
+        "name": "stem",
+        "trans": [
+            "阻止，遏制；起源",
+            "茎， 干"
+        ],
+        "usphone": "stɛm",
+        "ukphone": "stem"
+    },
+    {
+        "name": "stereo",
+        "trans": [
+            "立体声的",
+            "立体声"
+        ],
+        "usphone": "'stɛrɪo",
+        "ukphone": "'steriou"
+    },
+    {
+        "name": "stereotype",
+        "trans": [
+            "陈规；固定形式，老套；刻板印象",
+            "对…形成固定看法"
+        ],
+        "usphone": "'stɛrɪətaɪp",
+        "ukphone": "'steriətaɪp"
+    },
+    {
+        "name": "sterile",
+        "trans": [
+            "不育的； 贫瘠的； 无菌的； 无结果的， 没有实际价值的； 刻板的"
+        ],
+        "usphone": "'stɛrəl",
+        "ukphone": "'sterəl"
+    },
+    {
+        "name": "stew",
+        "trans": [
+            "炖， 煨； 思考； 不安， 担忧",
+            "炖菜；不安，担忧"
+        ],
+        "usphone": "stu, stju",
+        "ukphone": "stjuː"
+    },
+    {
+        "name": "stick",
+        "trans": [
+            "刺，戳，插；粘住，粘贴；放置；卡住",
+            "棍， 棒； 手杖"
+        ],
+        "usphone": "stɪk",
+        "ukphone": "stɪk"
+    },
+    {
+        "name": "sticky",
+        "trans": [
+            "黏的， 黏性的； 闷热的； 棘手的"
+        ],
+        "usphone": "'stɪki",
+        "ukphone": "'stɪki"
+    },
+    {
+        "name": "stiff",
+        "trans": [
+            "极其， 非常； 僵硬地",
+            "硬的，僵直的；呆板的；拘谨的；艰难的，费劲的；强烈的"
+        ],
+        "usphone": "stɪf",
+        "ukphone": "stɪf"
+    },
+    {
+        "name": "stiffen",
+        "trans": [
+            "变僵硬； 变坚定， 变强硬"
+        ],
+        "usphone": "'stɪfn",
+        "ukphone": "'stɪfn"
+    },
+    {
+        "name": "stigma",
+        "trans": [
+            "污点， 耻辱； 烙印； 特征"
+        ],
+        "usphone": "'stɪɡmə",
+        "ukphone": "'stɪgmə"
+    },
+    {
+        "name": "stimulate",
+        "trans": [
+            "刺激； 激励， 激发"
+        ],
+        "usphone": "'stɪmjə'let",
+        "ukphone": "'stɪmjuleɪt"
+    },
+    {
+        "name": "stimulus",
+        "trans": [
+            "刺激（物）；促进因素"
+        ],
+        "usphone": "'stɪmjələs",
+        "ukphone": "'stɪmjələs"
+    },
+    {
+        "name": "sting",
+        "trans": [
+            "刺，蜇；感觉刺痛",
+            "尾刺； 刺痛"
+        ],
+        "usphone": "stɪŋ",
+        "ukphone": "stɪŋ"
+    },
+    {
+        "name": "stingy",
+        "trans": [
+            "吝啬的， 小气的"
+        ],
+        "usphone": "'stɪndʒi",
+        "ukphone": "'stɪndʒi"
+    },
+    {
+        "name": "stipulate",
+        "trans": [
+            "规定， 明确要求； 约定"
+        ],
+        "usphone": "'stɪpjulet",
+        "ukphone": "'stɪpjuleɪt"
+    },
+    {
+        "name": "stir",
+        "trans": [
+            "搅拌；煽动；激发，打动；行动，活动",
+            "搅拌， 搅动； 激动， 震动"
+        ],
+        "usphone": "stɝ",
+        "ukphone": "stɜːr"
+    },
+    {
+        "name": "stock",
+        "trans": [
+            "储备，储存",
+            "库存，现货；备用物；股份，股票；世系，血统；家畜，"
+        ],
+        "usphone": "stɑk",
+        "ukphone": "stɑːk"
+    },
+    {
+        "name": "storage",
+        "trans": [
+            "库房； 贮藏； 存储"
+        ],
+        "usphone": "'stɔrɪdʒ",
+        "ukphone": "'stɔːrɪdʒ"
+    },
+    {
+        "name": "stout",
+        "trans": [
+            "结实的， 强壮的； 肥胖的； 顽强的"
+        ],
+        "usphone": "staʊt",
+        "ukphone": "staut"
+    },
+    {
+        "name": "strain",
+        "trans": [
+            "拉力，压力，张力；"
+        ],
+        "usphone": "stren",
+        "ukphone": "streɪn"
+    },
+    {
+        "name": "strand",
+        "trans": [
+            "股，缕；部分，方面",
+            "使滞留； 使搁浅"
+        ],
+        "usphone": "strænd",
+        "ukphone": "strænd"
+    },
+    {
+        "name": "strap",
+        "trans": [
+            "带",
+            "用带捆扎， 束牢； 用绷带包扎"
+        ],
+        "usphone": "stræp",
+        "ukphone": "stræp"
+    },
+    {
+        "name": "strategic",
+        "trans": [
+            "对全局有重要意义的， 关键的； 战略性的"
+        ],
+        "usphone": "strə'tidʒɪk",
+        "ukphone": "strə'tiːdʒɪk"
+    },
+    {
+        "name": "strategy",
+        "trans": [
+            "战略， 策略"
+        ],
+        "usphone": "'strætədʒi",
+        "ukphone": "'strætədʒi"
+    },
+    {
+        "name": "stratigraphy",
+        "trans": [
+            "地层学； 地层中的岩石组成"
+        ],
+        "usphone": "strə'tɪgrəfi",
+        "ukphone": "strə'tɪgrəfɪ"
+    },
+    {
+        "name": "stratum",
+        "trans": [
+            "岩层；地层"
+        ],
+        "usphone": "'stretəm",
+        "ukphone": "'streɪtəm"
+    },
+    {
+        "name": "stray",
+        "trans": [
+            "迷路；分心，走神；离题",
+            "迷路的；"
+        ],
+        "usphone": "stre",
+        "ukphone": "streɪ"
+    },
+    {
+        "name": "stream",
+        "trans": [
+            "涌",
+            "溪流； 串， 股"
+        ],
+        "usphone": "strim",
+        "ukphone": "striːm"
+    },
+    {
+        "name": "strenuous",
+        "trans": [
+            "费劲的， 费力的， 艰苦的； 精力充沛的； 奋力的"
+        ],
+        "usphone": "'strɛnjuəs",
+        "ukphone": "'strenjuəs"
+    },
+    {
+        "name": "stress",
+        "trans": [
+            "强调； 重读； 焦虑不安",
+            "压力；强调；精神压力，紧张；重音，重读"
+        ],
+        "usphone": "strɛs",
+        "ukphone": "stres"
+    },
+    {
+        "name": "stretch",
+        "trans": [
+            "延伸， 拉长",
+            "一段路程；延伸"
+        ],
+        "usphone": "strɛtʃ",
+        "ukphone": "stretʃ"
+    },
+    {
+        "name": "stride",
+        "trans": [
+            "大步；步法；"
+        ],
+        "usphone": "straɪd",
+        "ukphone": "straɪd"
+    },
+    {
+        "name": "strike",
+        "trans": [
+            "碰，撞，撞击；侵袭；突然想到；给…以深刻印象；罢工；敲响",
+            "罢工； 袭击"
+        ],
+        "usphone": "straɪk",
+        "ukphone": "straɪk"
+    },
+    {
+        "name": "string",
+        "trans": [
+            "用线串； 悬挂",
+            "细绳，带子；一串；一系列；弦"
+        ],
+        "usphone": "strɪŋ",
+        "ukphone": "strɪŋ"
+    },
+    {
+        "name": "strip",
+        "trans": [
+            "剥夺，剥掉；脱去…的衣服",
+            "条， 带状物； 条纹"
+        ],
+        "usphone": "strɪp",
+        "ukphone": "strɪp"
+    },
+    {
+        "name": "stripe",
+        "trans": [
+            "条纹， 斑纹"
+        ],
+        "usphone": "straɪp",
+        "ukphone": "straɪp"
+    },
+    {
+        "name": "strive",
+        "trans": [
+            "奋斗， 努力； 力求"
+        ],
+        "usphone": "straɪv",
+        "ukphone": "straɪv"
+    },
+    {
+        "name": "stubborn",
+        "trans": [
+            "顽固的， 倔强的； 难对付的"
+        ],
+        "usphone": "'stʌbɚn",
+        "ukphone": "'stʌbərn"
+    },
+    {
+        "name": "studio",
+        "trans": [
+            "工作室， 画室； 摄影室， 演播室， 录音室； 练习室； 电影公司"
+        ],
+        "usphone": "'studɪo",
+        "ukphone": "'stjuːdiou"
+    },
+    {
+        "name": "stuff",
+        "trans": [
+            "原料，材料",
+            "填满， 塞满； 让…吃饱"
+        ],
+        "usphone": "stʌf",
+        "ukphone": "stʌf"
+    },
+    {
+        "name": "stumble",
+        "trans": [
+            "绊脚； 蹒跚而行； 结巴"
+        ],
+        "usphone": "'stʌmbl",
+        "ukphone": "'stʌmbl"
+    },
+    {
+        "name": "stun",
+        "trans": [
+            "使昏迷； 使震惊； 使…目瞪口呆， 给以深刻印象"
+        ],
+        "usphone": "stʌn",
+        "ukphone": "stʌn"
+    },
+    {
+        "name": "stunt",
+        "trans": [
+            "阻碍生长；遏制",
+            "特技表演； 噱头； 愚蠢行为"
+        ],
+        "usphone": "stʌnt",
+        "ukphone": "stʌnt"
+    },
+    {
+        "name": "sturdy",
+        "trans": [
+            "健壮的， 结实的； 稳固的； 顽强的"
+        ],
+        "usphone": "'stɝdi",
+        "ukphone": "'stɜːrdi"
+    },
+    {
+        "name": "stylish",
+        "trans": [
+            "漂亮的， 时髦的； 高雅的， 有格调的"
+        ],
+        "usphone": "'staɪlɪʃ",
+        "ukphone": "'staɪlɪʃ"
+    },
+    {
+        "name": "stylistic",
+        "trans": [
+            "风格上的， 文体上的"
+        ],
+        "usphone": "staɪ'lɪstɪk",
+        "ukphone": "staɪ'lɪstɪk"
+    },
+    {
+        "name": "stylized",
+        "trans": [
+            "非写实的； 程式化的"
+        ],
+        "usphone": "'stailaizd",
+        "ukphone": "'staɪlaɪzd"
+    },
+    {
+        "name": "subconscious",
+        "trans": [
+            "下意识的， 潜意识的",
+            "下意识，潜意识"
+        ],
+        "usphone": ",sʌb'kɑnʃəs",
+        "ukphone": "ˌsʌb'kɑːnʃəs"
+    },
+    {
+        "name": "subculture",
+        "trans": [
+            "亚文化行为观念， 次文化"
+        ],
+        "usphone": "'sʌbkʌltʃɚ",
+        "ukphone": "'sʌbkʌltʃər"
+    },
+    {
+        "name": "subdivide",
+        "trans": [
+            "再分， 细分"
+        ],
+        "usphone": "'sʌbdɪvaɪd",
+        "ukphone": "'sʌbdɪvaɪd"
+    },
+    {
+        "name": "subdue",
+        "trans": [
+            "制服， 征服； 抑制， 克制"
+        ],
+        "usphone": "səb'du",
+        "ukphone": "səb'duː"
+    },
+    {
+        "name": "subject",
+        "trans": [
+            "受…支配的",
+            "主题；对象",
+            "使服从"
+        ],
+        "usphone": "ˈsʌbdʒɪkt;(for adj.)ˈsʌbdʒɪkt;(for v.)səbˈdʒɛkt",
+        "ukphone": "ˈsʌbdʒɪkt;(for adj.)ˈsʌbdʒɪkt;(for v.)səbˈdʒekt"
+    },
+    {
+        "name": "subjective",
+        "trans": [
+            "主观的， 个人的"
+        ],
+        "usphone": "səb'dʒɛktɪv",
+        "ukphone": "səb'dʒektɪv"
+    },
+    {
+        "name": "subjugate",
+        "trans": [
+            "征服， 制伏， 使服从"
+        ],
+        "usphone": "'sʌbdʒuɡet",
+        "ukphone": "'sʌbdʒugeɪt"
+    },
+    {
+        "name": "subliminal",
+        "trans": [
+            "下意识的， 潜意识的"
+        ],
+        "usphone": ",sʌb'lɪmɪnl",
+        "ukphone": "ˌsʌb'lɪmɪnl"
+    },
+    {
+        "name": "submarine",
+        "trans": [
+            "水下的， 海底的",
+            "潜水艇"
+        ],
+        "usphone": ",sʌbmə'rin",
+        "ukphone": "ˌsʌbmə'riːn"
+    },
+    {
+        "name": "submerge",
+        "trans": [
+            "浸没， 淹没"
+        ],
+        "usphone": "səb'mɝdʒ",
+        "ukphone": "səb'mɜːrdʒ"
+    },
+    {
+        "name": "submission",
+        "trans": [
+            "屈服， 服从； 提交， 呈递； 提交物； 看法， 意见"
+        ],
+        "usphone": "səb'mɪʃən",
+        "ukphone": "səb'mɪʃn"
+    },
+    {
+        "name": "submit",
+        "trans": [
+            "提交， 呈递； 屈从； 主张， 建议"
+        ],
+        "usphone": "səb'mɪt",
+        "ukphone": "səb'mɪt"
+    },
+    {
+        "name": "subordinate",
+        "trans": [
+            "次要的；下级的",
+            "使处于次要地位， 使从属于",
+            "部属， 下属"
+        ],
+        "usphone": "səˈbɔːdɪnɪt (for n. &adj.) ; səˈbɔːdɪˌnet (for v.)",
+        "ukphone": "sə'bɔːdɪnət"
+    },
+    {
+        "name": "suborn",
+        "trans": [
+            "收买， 买通， 唆使"
+        ],
+        "usphone": "sə'bɔrn",
+        "ukphone": "sə'bɔːrn"
+    },
+    {
+        "name": "subscribe",
+        "trans": [
+            "订购， 订阅； 申请， 预订； 捐助， 赞助"
+        ],
+        "usphone": "səb'skraɪb",
+        "ukphone": "səb'skraɪb"
+    },
+    {
+        "name": "subsequent",
+        "trans": [
+            "随后的； 并发的"
+        ],
+        "usphone": "'sʌbsɪkwənt",
+        "ukphone": "'sʌbsɪkwənt"
+    },
+    {
+        "name": "subsidiary",
+        "trans": [
+            "次要的； 辅助的， 附设的； 附属的",
+            "子公司；附属机构；支流"
+        ],
+        "usphone": "səb'sɪdɪɛri",
+        "ukphone": "səb'sɪdieri"
+    },
+    {
+        "name": "subsidy",
+        "trans": [
+            "补助金， 津贴"
+        ],
+        "usphone": "'sʌbsədi",
+        "ukphone": "'sʌbsədi"
+    },
+    {
+        "name": "subsist",
+        "trans": [
+            "存活， 生存"
+        ],
+        "usphone": "səb'sɪst",
+        "ukphone": "səb'sɪst"
+    },
+    {
+        "name": "subsistence",
+        "trans": [
+            "生存， 生计"
+        ],
+        "usphone": "səb'sɪstəns",
+        "ukphone": "səb'sɪstəns"
+    },
+    {
+        "name": "subspecies",
+        "trans": [
+            "亚种"
+        ],
+        "usphone": "sʌb'spiʃiz",
+        "ukphone": "sʌb'spiːʃiːz"
+    },
+    {
+        "name": "substance",
+        "trans": [
+            "物质； 主旨， 实质； 根据； 重要性"
+        ],
+        "usphone": "'sʌbstəns",
+        "ukphone": "'sʌbstəns"
+    },
+    {
+        "name": "substantial",
+        "trans": [
+            "实质的； 坚固的； 可观的， 大量的"
+        ],
+        "usphone": "səbˈstænʃəl",
+        "ukphone": "sʌb'stænʃl"
+    },
+    {
+        "name": "substantiate",
+        "trans": [
+            "证实， 证明"
+        ],
+        "usphone": "səb'stænʃɪet",
+        "ukphone": "səb'stænʃieɪt"
+    },
+    {
+        "name": "substitute",
+        "trans": [
+            "代替",
+            "代替者，代替品"
+        ],
+        "usphone": "'sʌbstɪtut",
+        "ukphone": "'sʌbstɪtuːt"
+    },
+    {
+        "name": "subtle",
+        "trans": [
+            "细微的， 微妙的； 精巧的， 巧妙的； 狡猾的； 敏锐的"
+        ],
+        "usphone": "'sʌtl",
+        "ukphone": "'sʌtl"
+    },
+    {
+        "name": "subtract",
+        "trans": [
+            "减去"
+        ],
+        "usphone": "səb'trækt",
+        "ukphone": "səb'trækt"
+    },
+    {
+        "name": "suburb",
+        "trans": [
+            "市郊， 郊区"
+        ],
+        "usphone": "'sʌbɝb",
+        "ukphone": "'sʌbɜːrb"
+    },
+    {
+        "name": "subversive",
+        "trans": [
+            "颠覆性的，破坏性的",
+            "颠覆分子"
+        ],
+        "usphone": "sʌb'vɝsɪv",
+        "ukphone": "səb'vɜːrsɪv"
+    },
+    {
+        "name": "subway",
+        "trans": [
+            "地铁"
+        ],
+        "usphone": "'sʌbwe",
+        "ukphone": "'sʌbweɪ"
+    },
+    {
+        "name": "successive",
+        "trans": [
+            "接替的， 继承的； 接连的， 连续的"
+        ],
+        "usphone": "sək'sɛsɪv",
+        "ukphone": "sək'sesɪv"
+    },
+    {
+        "name": "succumb",
+        "trans": [
+            "屈服， 屈从； 死亡"
+        ],
+        "usphone": "sə'kʌm",
+        "ukphone": "sə'kʌm"
+    },
+    {
+        "name": "suction",
+        "trans": [
+            "吸， 抽吸； 吸力"
+        ],
+        "usphone": "'sʌkʃən",
+        "ukphone": "'sʌkʃn"
+    },
+    {
+        "name": "sufficient",
+        "trans": [
+            "足够的， 充分的"
+        ],
+        "usphone": "səˈfɪʃənt",
+        "ukphone": "sə'fɪʃnt"
+    },
+    {
+        "name": "suffragist",
+        "trans": [
+            "妇女政权论者"
+        ],
+        "usphone": "",
+        "ukphone": "'sʌfrədʒɪst"
+    },
+    {
+        "name": "suitcase",
+        "trans": [
+            "手提箱， 衣箱"
+        ],
+        "usphone": "'sutkes",
+        "ukphone": "'suːtkeɪs"
+    },
+    {
+        "name": "suite",
+        "trans": [
+            "套， 组； 套房"
+        ],
+        "usphone": "sut; swit",
+        "ukphone": "swiːt"
+    },
+    {
+        "name": "sulfur",
+        "trans": [
+            "硫； 硫黄"
+        ],
+        "usphone": "'sʌlfɚ",
+        "ukphone": "'sʌlfər"
+    },
+    {
+        "name": "sum",
+        "trans": [
+            "共计， 合计， 总计",
+            "和，总数；金额，数额；算术"
+        ],
+        "usphone": "sʌm",
+        "ukphone": "sʌm"
+    },
+    {
+        "name": "summarize",
+        "trans": [
+            "概括， 总结"
+        ],
+        "usphone": "'sʌməraɪz",
+        "ukphone": "'sʌməraɪz"
+    },
+    {
+        "name": "summary",
+        "trans": [
+            "概括的， 概要的； 即刻的， 立即的",
+            "摘要，概要"
+        ],
+        "usphone": "'sʌməri",
+        "ukphone": "'sʌməri"
+    },
+    {
+        "name": "summit",
+        "trans": [
+            "最高点， 峰顶， 极点； 峰会"
+        ],
+        "usphone": "'sʌmɪt",
+        "ukphone": "'sʌmɪt"
+    },
+    {
+        "name": "summon",
+        "trans": [
+            "传唤， 传讯； 召集， 召开； 鼓起， 振作"
+        ],
+        "usphone": "'sʌmən",
+        "ukphone": "'sʌmən"
+    },
+    {
+        "name": "sumptuous",
+        "trans": [
+            "奢华的， 豪华的"
+        ],
+        "usphone": "'sʌmptʃuəs",
+        "ukphone": "'sʌmptʃuəs"
+    },
+    {
+        "name": "sunlit",
+        "trans": [
+            "阳光照射的"
+        ],
+        "usphone": "'sʌnlɪt",
+        "ukphone": "'sʌnlɪt"
+    },
+    {
+        "name": "sunset",
+        "trans": [
+            "日落， 傍晚"
+        ],
+        "usphone": "'sʌnsɛt",
+        "ukphone": "'sʌnset"
+    },
+    {
+        "name": "superb",
+        "trans": [
+            "极好的， 高质量的， 上乘的； 华丽的"
+        ],
+        "usphone": "suːˈpɜːrb",
+        "ukphone": "suː'pɜːrb"
+    },
+    {
+        "name": "superficial",
+        "trans": [
+            "肤浅的， 浅薄的； 表面的， 外表的， 外层的"
+        ],
+        "usphone": ",supɚ'fɪʃl",
+        "ukphone": "ˌsuːpər'fɪʃl"
+    },
+    {
+        "name": "superimpose",
+        "trans": [
+            "使重叠， 使叠加； 添加"
+        ],
+        "usphone": ",supərɪm'poz",
+        "ukphone": "ˌsuːpərɪm'pouz"
+    },
+    {
+        "name": "superintendent",
+        "trans": [
+            "主管， 负责人； 指挥者， 管理者； 警长"
+        ],
+        "usphone": ",supərɪn'tɛndənt",
+        "ukphone": "ˌsuːpərɪn'tendənt"
+    },
+    {
+        "name": "superior",
+        "trans": [
+            "较高的；更好的；有优越感的，高傲的；超群的",
+            "上级， 长官"
+        ],
+        "usphone": "sʊˈpɪrɪɚ",
+        "ukphone": "suː'pɪriər"
+    },
+    {
+        "name": "supersonic",
+        "trans": [
+            "超音速的，超声波的",
+            "超音速， 超声波"
+        ],
+        "usphone": ",supɚ'sɑnɪk",
+        "ukphone": "ˌsuːpər'sɑːnɪk"
+    },
+    {
+        "name": "superstitious",
+        "trans": [
+            "迷信的， 受迷信思想支配的"
+        ],
+        "usphone": "'sʊpɚ'stɪʃəs",
+        "ukphone": "ˌsuːpər'stɪʃəs"
+    },
+    {
+        "name": "supervise",
+        "trans": [
+            "监督； 指导"
+        ],
+        "usphone": "'sʊpɚ'vaɪz",
+        "ukphone": "'suːpərvaɪz"
+    },
+    {
+        "name": "supplant",
+        "trans": [
+            "取代， 代替"
+        ],
+        "usphone": "sə'plænt",
+        "ukphone": "sə'plænt"
+    },
+    {
+        "name": "supplement",
+        "trans": [
+            "补充， 增补； 增刊； 补遗， 附录",
+            "补充， 增补"
+        ],
+        "usphone": "'sʌplɪmənt",
+        "ukphone": "'sʌplɪm(ə)nt"
+    },
+    {
+        "name": "supplier",
+        "trans": [
+            "供应者， 供应商， 供货方"
+        ],
+        "usphone": "sə'plaɪɚ",
+        "ukphone": "sə'plaɪər"
+    },
+    {
+        "name": "supply",
+        "trans": [
+            "供应；储备；补给",
+            "供给， 供应； 满足， 弥补"
+        ],
+        "usphone": "sə'plaɪ",
+        "ukphone": "sə'plaɪ"
+    },
+    {
+        "name": "suppose",
+        "trans": [
+            "假设， 推测； 认为， 料想； 要不"
+        ],
+        "usphone": "sə'poz",
+        "ukphone": "sə'pouz"
+    },
+    {
+        "name": "suppress",
+        "trans": [
+            "抑制， 阻止； 镇压， 压制； 禁止发表， 查禁； 阻止…的生长"
+        ],
+        "usphone": "sə'prɛs",
+        "ukphone": "sə'pres"
+    },
+    {
+        "name": "supreme",
+        "trans": [
+            "至高无上的"
+        ],
+        "usphone": "suˈprim",
+        "ukphone": "suː'priːm"
+    },
+    {
+        "name": "surcharge",
+        "trans": [
+            "额外费用，增收费，附加费",
+            "收取额外费用"
+        ],
+        "usphone": "'sɝtʃɑrdʒ",
+        "ukphone": "'sɜːrtʃɑːrdʒ"
+    },
+    {
+        "name": "surge",
+        "trans": [
+            "涌动；蜂拥而出；飞涨，"
+        ],
+        "usphone": "sɝdʒ",
+        "ukphone": "sɜːrdʒ"
+    },
+    {
+        "name": "surgeon",
+        "trans": [
+            "外科医师"
+        ],
+        "usphone": "'sɝdʒən",
+        "ukphone": "'sɜːrdʒən"
+    },
+    {
+        "name": "surgery",
+        "trans": [
+            "外科手术； 外科学； 手术室， 诊疗室"
+        ],
+        "usphone": "'sɝdʒəri",
+        "ukphone": "'sɜːrdʒəri"
+    },
+    {
+        "name": "surmise",
+        "trans": [
+            "推测， 猜测",
+            "推测， 猜测"
+        ],
+        "usphone": "sɝ'maɪz",
+        "ukphone": "sə'maɪz"
+    },
+    {
+        "name": "surpass",
+        "trans": [
+            "超过， 超越， 胜过"
+        ],
+        "usphone": "sə'pæs",
+        "ukphone": "sər'pæs"
+    },
+    {
+        "name": "surplus",
+        "trans": [
+            "过剩的， 多余的",
+            "过剩，剩余；盈余，顺差"
+        ],
+        "usphone": "'sɝpləs",
+        "ukphone": "'sɜːrpləs"
+    },
+    {
+        "name": "surrender",
+        "trans": [
+            "投降；放弃，交出",
+            "投降； 屈服， 屈从； 放弃"
+        ],
+        "usphone": "sə'rɛndɚ",
+        "ukphone": "sə'rendər"
+    },
+    {
+        "name": "surround",
+        "trans": [
+            "包围， 圈住； 围绕， 环绕"
+        ],
+        "usphone": "sə'raʊnd",
+        "ukphone": "sə'raund"
+    },
+    {
+        "name": "survey",
+        "trans": [
+            "调查； 概述",
+            "调查； 概述"
+        ],
+        "usphone": "ˈsɝˌve; (for v.) sɝˈve",
+        "ukphone": "ˈsəːveɪ; (for v.) səˈveɪ"
+    },
+    {
+        "name": "survive",
+        "trans": [
+            "幸免， 幸存； 继续存在， 存货； 艰难度过； 比…长命"
+        ],
+        "usphone": "sɚ'vaɪv",
+        "ukphone": "sər'vaɪv"
+    },
+    {
+        "name": "susceptible",
+        "trans": [
+            "易受感染的； 易受影响的； 过敏的； 感情丰富的； 能经受…的， 容许…的"
+        ],
+        "usphone": "sə'sɛptəbl",
+        "ukphone": "sə'septəbl"
+    },
+    {
+        "name": "suspect",
+        "trans": [
+            "怀疑， 猜想",
+            "可疑的；不信任的",
+            "嫌疑犯， 可疑分子"
+        ],
+        "usphone": "sʌspɛkt; (for v.) səˈspɛkt",
+        "ukphone": "ˈsʌspekt; (for v.) səˈspekt"
+    },
+    {
+        "name": "suspend",
+        "trans": [
+            "吊， 悬挂； 暂缓， 暂停， 中止"
+        ],
+        "usphone": "sə'spɛnd",
+        "ukphone": "sə'spend"
+    },
+    {
+        "name": "suspense",
+        "trans": [
+            "担心， 焦虑； 悬念， 不确定"
+        ],
+        "usphone": "sə'spɛns",
+        "ukphone": "sə'spens"
+    },
+    {
+        "name": "suspension",
+        "trans": [
+            "暂停； 暂缓， 推迟， 延期； 悬架； 悬浮液"
+        ],
+        "usphone": "sə'spɛnʃən",
+        "ukphone": "sə'spenʃn"
+    },
+    {
+        "name": "suspicious",
+        "trans": [
+            "可疑的， 令人怀疑的； 不信任的， 猜疑的， 多疑的"
+        ],
+        "usphone": "sə'spɪʃəs",
+        "ukphone": "sə'spɪʃəs"
+    },
+    {
+        "name": "sustain",
+        "trans": [
+            "保持， 维持； 支持， 支撑； 经受， 承受"
+        ],
+        "usphone": "sə'sten",
+        "ukphone": "sə'steɪn"
+    },
+    {
+        "name": "sustainable",
+        "trans": [
+            "不破坏生态平衡的， 可持续的； 足可支撑的； 可忍受的"
+        ],
+        "usphone": "sə'stenəbl",
+        "ukphone": "sə'steɪnəbl"
+    },
+    {
+        "name": "sustenance",
+        "trans": [
+            "食物； 生计； 维持"
+        ],
+        "usphone": "'sʌstənəns",
+        "ukphone": "'sʌstənəns"
+    },
+    {
+        "name": "swallow",
+        "trans": [
+            "吞，咽；吞没，侵吞；轻信，轻易接受；默默忍受；使不流露，抑制",
+            "燕子； 吞， 咽"
+        ],
+        "usphone": "'swɑlo",
+        "ukphone": "'swɑːlou"
+    },
+    {
+        "name": "swamp",
+        "trans": [
+            "沼泽地，湿地",
+            "使陷入， 淹没； 使应接不暇， 使疲于应对"
+        ],
+        "usphone": "swɑmp",
+        "ukphone": "swɑːmp"
+    },
+    {
+        "name": "swampy",
+        "trans": [
+            "沼泽的， 湿地的； 松软的"
+        ],
+        "usphone": "'swɔmpi",
+        "ukphone": "'swɑːmpi"
+    },
+    {
+        "name": "swap",
+        "trans": [
+            "交换，掉换",
+            "交换， 掉换； 交换物， 被调换者"
+        ],
+        "usphone": "swɑp",
+        "ukphone": "swɑːp"
+    },
+    {
+        "name": "swarm",
+        "trans": [
+            "云集",
+            "密集， 云集； 成群地飞行",
+            "群，一大群"
+        ],
+        "usphone": "swɔrm",
+        "ukphone": "swɔːrm"
+    },
+    {
+        "name": "swear",
+        "trans": [
+            "诅咒； 宣誓， 发誓"
+        ],
+        "usphone": "swɛr",
+        "ukphone": "swer"
+    },
+    {
+        "name": "sweat",
+        "trans": [
+            "出汗",
+            "汗；一身汗"
+        ],
+        "usphone": "swɛt",
+        "ukphone": "swet"
+    },
+    {
+        "name": "sweep",
+        "trans": [
+            "打扫；席卷，横扫；挥动，舞动；迅速传播；"
+        ],
+        "usphone": "swip",
+        "ukphone": "swiːp"
+    },
+    {
+        "name": "sweeping",
+        "trans": [
+            "彻底的，广泛的；〈贬〉笼统的，一概而论的",
+            "清扫， 扫除； 垃圾"
+        ],
+        "usphone": "'swipɪŋ",
+        "ukphone": "'swiːpɪŋ"
+    },
+    {
+        "name": "swell",
+        "trans": [
+            "增加，扩大；膨胀，肿胀",
+            "波浪的涌动； 隆起； 增强， 增加"
+        ],
+        "usphone": "swɛl",
+        "ukphone": "swel"
+    },
+    {
+        "name": "swift",
+        "trans": [
+            "敏捷的，速度快的",
+            "雨燕"
+        ],
+        "usphone": "swɪft",
+        "ukphone": "swɪft"
+    },
+    {
+        "name": "swindle",
+        "trans": [
+            "诈骗， 骗取"
+        ],
+        "usphone": "swɪndl",
+        "ukphone": "'swɪndl"
+    },
+    {
+        "name": "swing",
+        "trans": [
+            "摆动，摇荡；突然转向，突然转身",
+            "摆动， 摇摆； 秋千"
+        ],
+        "usphone": "swɪŋ",
+        "ukphone": "swɪŋ"
+    },
+    {
+        "name": "swirl",
+        "trans": [
+            "打旋， 旋转",
+            "漩涡；螺旋形"
+        ],
+        "usphone": "swɝl",
+        "ukphone": "swɜːrl"
+    },
+    {
+        "name": "switch",
+        "trans": [
+            "转变， 改变； 交换， 掉换",
+            "开关，电闸；转换，改变；枝条，鞭子"
+        ],
+        "usphone": "swɪtʃ",
+        "ukphone": "swɪtʃ"
+    },
+    {
+        "name": "swoon",
+        "trans": [
+            "昏厥， 昏倒； 痴迷"
+        ],
+        "usphone": "swu:n",
+        "ukphone": "swuːn"
+    },
+    {
+        "name": "swoop",
+        "trans": [
+            "猛扑； 突然袭击",
+            "突然行动"
+        ],
+        "usphone": "swup",
+        "ukphone": "swuːp"
+    },
+    {
+        "name": "syllable",
+        "trans": [
+            "音节"
+        ],
+        "usphone": "'sɪləbl",
+        "ukphone": "'sɪləbl"
+    },
+    {
+        "name": "syllabus",
+        "trans": [
+            "教学大纲， 课程提纲"
+        ],
+        "usphone": "'sɪləbəs",
+        "ukphone": "'sɪləbəs"
+    },
+    {
+        "name": "symbol",
+        "trans": [
+            "符号， 标志； 象征"
+        ],
+        "usphone": "'sɪmbl",
+        "ukphone": "'sɪmbl"
+    },
+    {
+        "name": "symmetry",
+        "trans": [
+            "对称； 相似， 相仿"
+        ],
+        "usphone": "'sɪmətri",
+        "ukphone": "'sɪmətri"
+    },
+    {
+        "name": "sympathetic",
+        "trans": [
+            "感应的， 交感的； 有同情心的； 体谅的"
+        ],
+        "usphone": ",sɪmpə'θɛtɪk",
+        "ukphone": "ˌsɪmpə'θetɪk"
+    },
+    {
+        "name": "sympathy",
+        "trans": [
+            "同情， 同情心； 赞同， 支持"
+        ],
+        "usphone": "'sɪmpəθi",
+        "ukphone": "'sɪmpəθi"
+    },
+    {
+        "name": "symphony",
+        "trans": [
+            "交响乐， 交响曲； 和谐， 协调"
+        ],
+        "usphone": "'sɪmfəni",
+        "ukphone": "'sɪmfəni"
+    },
+    {
+        "name": "symptom",
+        "trans": [
+            "症状； 征兆"
+        ],
+        "usphone": "'sɪmptəm",
+        "ukphone": "'sɪmptəm"
+    },
+    {
+        "name": "synchronize",
+        "trans": [
+            "同步， 同时发生"
+        ],
+        "usphone": "'sɪŋkrənaɪz",
+        "ukphone": "'sɪŋkrənaɪz"
+    },
+    {
+        "name": "synchronizer",
+        "trans": [
+            "同步装置"
+        ],
+        "usphone": "'siŋkrənaizə, 'sin-",
+        "ukphone": "'sɪŋkrənaɪzər"
+    },
+    {
+        "name": "syndrome",
+        "trans": [
+            "综合征； 典型表现"
+        ],
+        "usphone": "'sɪndrəm",
+        "ukphone": "'sɪndroum"
+    },
+    {
+        "name": "synonym",
+        "trans": [
+            "同义词"
+        ],
+        "usphone": "ˈsɪnənɪm",
+        "ukphone": "'sɪnənɪm"
+    },
+    {
+        "name": "syntactic",
+        "trans": [
+            "句法的； 按照句法的"
+        ],
+        "usphone": "sɪn'tæktɪk",
+        "ukphone": "sɪn'tæktɪk"
+    },
+    {
+        "name": "synthesize",
+        "trans": [
+            "合成； 综合"
+        ],
+        "usphone": "'sɪnθəsaɪz",
+        "ukphone": "'sɪnθəsaɪz"
+    },
+    {
+        "name": "synthetic",
+        "trans": [
+            "合成的，综合的；人造的"
+        ],
+        "usphone": "sɪn'θɛtɪk",
+        "ukphone": "sɪn'θetɪk"
+    },
+    {
+        "name": "syrup",
+        "trans": [
+            "糖浆"
+        ],
+        "usphone": "'sɪrəp",
+        "ukphone": "'sɪrəp"
+    },
+    {
+        "name": "systematic",
+        "trans": [
+            "系统的， 体系的"
+        ],
+        "usphone": "'sɪstə'mætɪk",
+        "ukphone": "ˌsɪstə'mætɪk"
+    },
+    {
+        "name": "systematize",
+        "trans": [
+            "使系统化， 使条理化， 使成体系"
+        ],
+        "usphone": "'sɪstəmətaɪz",
+        "ukphone": "'sɪstəmətaɪz"
+    },
+    {
+        "name": "tableland",
+        "trans": [
+            "高原， 台地"
+        ],
+        "usphone": "'tebllænd",
+        "ukphone": "'teɪbllænd"
+    },
+    {
+        "name": "taboo",
+        "trans": [
+            "忌讳的",
+            "禁忌，忌讳；禁止，避讳"
+        ],
+        "usphone": "tə'bu",
+        "ukphone": "tə'buː"
+    },
+    {
+        "name": "tackle",
+        "trans": [
+            "对付，处理；阻截；抢球",
+            "拦截； 用具"
+        ],
+        "usphone": "'tækl",
+        "ukphone": "'tækl"
+    },
+    {
+        "name": "tactic",
+        "trans": [
+            "手段，策略；"
+        ],
+        "usphone": "'tæktɪk",
+        "ukphone": "'tæktɪk"
+    },
+    {
+        "name": "tactile",
+        "trans": [
+            "触觉的； 有触觉的； 可感触的"
+        ],
+        "usphone": "'tæktl",
+        "ukphone": "'tæktaɪl"
+    },
+    {
+        "name": "talent",
+        "trans": [
+            "天赋； 才干； 人才"
+        ],
+        "usphone": "'tælənt",
+        "ukphone": "'tælənt"
+    },
+    {
+        "name": "tally",
+        "trans": [
+            "吻合",
+            "记录；账"
+        ],
+        "usphone": "'tæli",
+        "ukphone": "'tæli"
+    },
+    {
+        "name": "tame",
+        "trans": [
+            "驯服的；沉闷的，乏味的",
+            "驯化； 控制并利用"
+        ],
+        "usphone": "teɪm",
+        "ukphone": "teɪm"
+    },
+    {
+        "name": "tangent",
+        "trans": [
+            "切线的， 相切的",
+            "切线；正切"
+        ],
+        "usphone": "'tændʒənt",
+        "ukphone": "'tændʒənt"
+    },
+    {
+        "name": "tangible",
+        "trans": [
+            "可触摸的， 可感知的； 明确的， 确凿的； 有形的， 实际的"
+        ],
+        "usphone": "'tændʒəbl",
+        "ukphone": "'tændʒəbl"
+    },
+    {
+        "name": "tangle",
+        "trans": [
+            "缠结， 纠结",
+            "混乱；纠纷，不和"
+        ],
+        "usphone": "'tæŋɡl",
+        "ukphone": "'tæŋgl"
+    },
+    {
+        "name": "tantalizing",
+        "trans": [
+            "诱人的"
+        ],
+        "usphone": "'tæntəlaɪzɪŋ",
+        "ukphone": "'tæntəlaɪzɪŋ"
+    },
+    {
+        "name": "target",
+        "trans": [
+            "目标，对象；靶子",
+            "把…作为目标"
+        ],
+        "usphone": "'tɑrɡɪt",
+        "ukphone": "'tɑːrgɪt"
+    },
+    {
+        "name": "tariff",
+        "trans": [
+            "关税； 价目表， 收费表"
+        ],
+        "usphone": "'tærɪf",
+        "ukphone": "'tærɪf"
+    },
+    {
+        "name": "tarnish",
+        "trans": [
+            "失去光泽；玷污，败坏",
+            "污点； 瑕疵"
+        ],
+        "usphone": "'tɑrnɪʃ",
+        "ukphone": "'tɑːrnɪʃ"
+    },
+    {
+        "name": "taut",
+        "trans": [
+            "绷紧的； 肌肉结实的； 结构严谨的， 紧凑的"
+        ],
+        "usphone": "tɔt",
+        "ukphone": "tɔːt"
+    },
+    {
+        "name": "tavern",
+        "trans": [
+            "小旅馆， 客栈； 小酒店"
+        ],
+        "usphone": "'tævɚn",
+        "ukphone": "'tævərn"
+    },
+    {
+        "name": "technical",
+        "trans": [
+            "技术的， 工艺的； 专业的"
+        ],
+        "usphone": "'tɛknɪkl",
+        "ukphone": "'teknɪkl"
+    },
+    {
+        "name": "technological",
+        "trans": [
+            "技术的， 工艺的"
+        ],
+        "usphone": "tɛknə'lɑdʒɪkl",
+        "ukphone": "ˌteknə'lɑːdʒɪkl"
+    },
+    {
+        "name": "tectonic",
+        "trans": [
+            "地壳构造的"
+        ],
+        "usphone": "tɛk'tɑnɪk",
+        "ukphone": "tek'tɑːnɪk"
+    },
+    {
+        "name": "tectonics",
+        "trans": [
+            "构造地质学"
+        ],
+        "usphone": "tɛk'tɑnɪks",
+        "ukphone": "tek'tɑːnɪks"
+    },
+    {
+        "name": "tedious",
+        "trans": [
+            "单调乏味的， 令人厌烦的"
+        ],
+        "usphone": "'tidɪəs",
+        "ukphone": "'tiːdiəs"
+    },
+    {
+        "name": "tedium",
+        "trans": [
+            "单调， 乏味"
+        ],
+        "usphone": "'tidɪəm",
+        "ukphone": "'tiːdiəm"
+    },
+    {
+        "name": "teem",
+        "trans": [
+            "充满， 到处都是"
+        ],
+        "usphone": "tim",
+        "ukphone": "tiːm"
+    },
+    {
+        "name": "telecommunication",
+        "trans": [
+            "电信"
+        ],
+        "usphone": ",tɛlɪkə,mjʊnə'keʃən",
+        "ukphone": "ˌtelikəˌmjuːnɪ'keɪʃn"
+    },
+    {
+        "name": "telegraph",
+        "trans": [
+            "打电报， 发电报",
+            "电报；电报机"
+        ],
+        "usphone": "'tɛlɪɡræf",
+        "ukphone": "'telɪgræf"
+    },
+    {
+        "name": "telescope",
+        "trans": [
+            "望远镜"
+        ],
+        "usphone": "'tɛləˌskop",
+        "ukphone": "'telɪskoup"
+    },
+    {
+        "name": "temper",
+        "trans": [
+            "脾气，性情",
+            "缓和， 调节"
+        ],
+        "usphone": "'tɛmpɚ",
+        "ukphone": "'tempər"
+    },
+    {
+        "name": "temperate",
+        "trans": [
+            "气候温和的， 温带的； 温和的， 自我克制的"
+        ],
+        "usphone": "'tɛmpərət",
+        "ukphone": "'tempərət"
+    },
+    {
+        "name": "template",
+        "trans": [
+            "模板， 样板"
+        ],
+        "usphone": "'tɛmplet",
+        "ukphone": "'templeɪt"
+    },
+    {
+        "name": "temple",
+        "trans": [
+            "寺庙， 教堂； 太阳穴"
+        ],
+        "usphone": "'tɛmpl",
+        "ukphone": "'templ"
+    },
+    {
+        "name": "tempo",
+        "trans": [
+            "速度， 节奏； 行进速度"
+        ],
+        "usphone": "'tɛmpo",
+        "ukphone": "'tempou"
+    },
+    {
+        "name": "temporary",
+        "trans": [
+            "暂时的， 临时的"
+        ],
+        "usphone": "ˈtempəreri",
+        "ukphone": "'tempəreri"
+    },
+    {
+        "name": "tempt",
+        "trans": [
+            "引诱， 诱惑； 吸引"
+        ],
+        "usphone": "tɛmpt",
+        "ukphone": "tempt"
+    },
+    {
+        "name": "tenant",
+        "trans": [
+            "房客，承租人",
+            "居住"
+        ],
+        "usphone": "'tɛnənt",
+        "ukphone": "'tenənt"
+    },
+    {
+        "name": "tend",
+        "trans": [
+            "趋于， 易于； 照料， 看护"
+        ],
+        "usphone": "tɛnd",
+        "ukphone": "tend"
+    },
+    {
+        "name": "tender",
+        "trans": [
+            "嫩的；脆弱的；温柔的，亲切的",
+            "提出；投标",
+            "投标"
+        ],
+        "usphone": "'tɛndɚ",
+        "ukphone": "'tendər"
+    },
+    {
+        "name": "tendon",
+        "trans": [
+            "腱"
+        ],
+        "usphone": "'tɛndən",
+        "ukphone": "'tendən"
+    },
+    {
+        "name": "tenement",
+        "trans": [
+            "廉租公寓"
+        ],
+        "usphone": "'tɛnəmənt",
+        "ukphone": "'tenəmənt"
+    },
+    {
+        "name": "tenet",
+        "trans": [
+            "原则； 信条； 教义"
+        ],
+        "usphone": "'tɛnɪt",
+        "ukphone": "'tenɪt"
+    },
+    {
+        "name": "tension",
+        "trans": [
+            "紧张； 拉紧； 张力"
+        ],
+        "usphone": "'tɛnʃən",
+        "ukphone": "'tenʃn"
+    },
+    {
+        "name": "tentacle",
+        "trans": [
+            "触角， 触须， 触手"
+        ],
+        "usphone": "'tɛntəkl",
+        "ukphone": "'tentəkl"
+    },
+    {
+        "name": "tentative",
+        "trans": [
+            "试验性的； 不确定的， 暂定的； 犹豫的"
+        ],
+        "usphone": "'tɛntətɪv",
+        "ukphone": "'tentətɪv"
+    },
+    {
+        "name": "tenuous",
+        "trans": [
+            "纤细的； 稀薄的； 脆弱的"
+        ],
+        "usphone": "'tɛnjuəs",
+        "ukphone": "'tenjuəs"
+    },
+    {
+        "name": "term",
+        "trans": [
+            "学期；期限，期间；条件，条款；术语",
+            "把…称为"
+        ],
+        "usphone": "tɝm",
+        "ukphone": "tɜːrm"
+    },
+    {
+        "name": "terminal",
+        "trans": [
+            "末端的",
+            "终点站；终点；航站楼"
+        ],
+        "usphone": "tɝ​mənl",
+        "ukphone": "'tɜːrmɪnl"
+    },
+    {
+        "name": "terminate",
+        "trans": [
+            "停止， 结束"
+        ],
+        "usphone": "'tɝmɪnet",
+        "ukphone": "'tɜːrmɪneɪt"
+    },
+    {
+        "name": "terminology",
+        "trans": [
+            "专门用语， 术语； 术语学"
+        ],
+        "usphone": ",tɝmə'nɑlədʒi",
+        "ukphone": "ˌtɜːrmə'nɑːlədʒi"
+    },
+    {
+        "name": "terminus",
+        "trans": [
+            "终点站"
+        ],
+        "usphone": "'tɝmɪnəs",
+        "ukphone": "'tɜːrmɪnəs"
+    },
+    {
+        "name": "terrain",
+        "trans": [
+            "地势， 地形； 地带"
+        ],
+        "usphone": "tɛˈren",
+        "ukphone": "tə'reɪn"
+    },
+    {
+        "name": "terrestrial",
+        "trans": [
+            "陆地的， 陆生的， 陆栖的； 地球的"
+        ],
+        "usphone": "tə'rɛstrɪəl",
+        "ukphone": "tə'restriəl"
+    },
+    {
+        "name": "terrific",
+        "trans": [
+            "极好的； 非常的， 极度的； 可怕的"
+        ],
+        "usphone": "tə'rɪfɪk",
+        "ukphone": "tə'rɪfɪk"
+    },
+    {
+        "name": "territory",
+        "trans": [
+            "领土， 版图； 领域， 地盘"
+        ],
+        "usphone": "'tɛrətɔri",
+        "ukphone": "'terətɔːri"
+    },
+    {
+        "name": "terrorism",
+        "trans": [
+            "恐怖主义"
+        ],
+        "usphone": "'tɛrərɪzəm",
+        "ukphone": "'terərɪzəm"
+    },
+    {
+        "name": "testimony",
+        "trans": [
+            "证词； 证据， 证明"
+        ],
+        "usphone": "'tɛstə'moni",
+        "ukphone": "'testɪmouni"
+    },
+    {
+        "name": "textile",
+        "trans": [
+            "纺织品"
+        ],
+        "usphone": "'tɛkstaɪl",
+        "ukphone": "'tekstaɪl"
+    },
+    {
+        "name": "texture",
+        "trans": [
+            "质地； 纹理； 结构"
+        ],
+        "usphone": "'tɛkstʃɚ",
+        "ukphone": "'tekstʃər"
+    },
+    {
+        "name": "thaw",
+        "trans": [
+            "融化，解冻；化冻；变暖；变得友善",
+            "解冻时期； 缓和"
+        ],
+        "usphone": "θɔ",
+        "ukphone": "θɔː"
+    },
+    {
+        "name": "theoretical",
+        "trans": [
+            "不切实际的； 理论的"
+        ],
+        "usphone": ",θiə'rɛtɪkəl",
+        "ukphone": "ˌθiːə'retɪkl"
+    },
+    {
+        "name": "theory",
+        "trans": [
+            "理论， 原理； 学说； 见解， 看法"
+        ],
+        "usphone": "'θiəri",
+        "ukphone": "'θɪəri"
+    },
+    {
+        "name": "therapy",
+        "trans": [
+            "治疗， 疗法"
+        ],
+        "usphone": "'θɛrəpi",
+        "ukphone": "'θerəpi"
+    },
+    {
+        "name": "thereby",
+        "trans": [
+            "因此， 从而"
+        ],
+        "usphone": ",ðɛr'baɪ",
+        "ukphone": "ˌðer'baɪ"
+    },
+    {
+        "name": "therefore",
+        "trans": [
+            "因此，从而",
+            "因此"
+        ],
+        "usphone": "'ðɛrfɔr",
+        "ukphone": "'ðerfɔːr"
+    },
+    {
+        "name": "thermal",
+        "trans": [
+            "热的，热量的；保暖的，防寒的",
+            "上升的热气流"
+        ],
+        "usphone": "'θɝml",
+        "ukphone": "'θɜːrml"
+    },
+    {
+        "name": "thesis",
+        "trans": [
+            "论文； 论题， 论点"
+        ],
+        "usphone": "'θisɪs",
+        "ukphone": "'θiːsɪs"
+    },
+    {
+        "name": "thorn",
+        "trans": [
+            "刺， 荆棘； 带刺小灌木"
+        ],
+        "usphone": "θɔrn",
+        "ukphone": "θɔːrn"
+    },
+    {
+        "name": "thorough",
+        "trans": [
+            "彻底的； 详尽的； 一丝不苟的"
+        ],
+        "usphone": "ˈθʌrəʊ; θʌro",
+        "ukphone": "'θɜːrou"
+    },
+    {
+        "name": "thread",
+        "trans": [
+            "穿；穿过，通过",
+            "线； 线索； 思路"
+        ],
+        "usphone": "θrɛd",
+        "ukphone": "θred"
+    },
+    {
+        "name": "threat",
+        "trans": [
+            "恐吓， 威胁； 坏兆头， 危险迹象"
+        ],
+        "usphone": "θrɛt",
+        "ukphone": "θret"
+    },
+    {
+        "name": "thrifty",
+        "trans": [
+            "节省的， 节俭的"
+        ],
+        "usphone": "'θrɪfti",
+        "ukphone": "'θrɪfti"
+    },
+    {
+        "name": "thrive",
+        "trans": [
+            "茂盛； 茁壮成长； 兴旺， 繁荣"
+        ],
+        "usphone": "θraɪv",
+        "ukphone": "θraɪv"
+    },
+    {
+        "name": "throng",
+        "trans": [
+            "群集， 拥向",
+            "一大群人"
+        ],
+        "usphone": "θrɔŋ",
+        "ukphone": "θrɔːŋ"
+    },
+    {
+        "name": "through",
+        "trans": [
+            "从头到尾，自始至终；直达，径直；彻底，完全",
+            "完成的， 结束的； 直达的， 直通的",
+            "穿过，通过；从头到尾，自始至终；经由，以；因为，由于"
+        ],
+        "usphone": "θru",
+        "ukphone": "θruː"
+    },
+    {
+        "name": "throw",
+        "trans": [
+            "投，掷，抛；丢，扔；使陷入，使处于；使困惑，使吃惊",
+            "投， 掷， 抛； 投掷的距离"
+        ],
+        "usphone": "θro",
+        "ukphone": "θrou"
+    },
+    {
+        "name": "thrust",
+        "trans": [
+            "挤；插；戳，刺",
+            "戳， 刺； 要旨； 驱动力"
+        ],
+        "usphone": "θrʌst",
+        "ukphone": "θrʌst"
+    },
+    {
+        "name": "thwart",
+        "trans": [
+            "阻碍； 使…受挫"
+        ],
+        "usphone": "θwɔrt",
+        "ukphone": "θwɔːrt"
+    },
+    {
+        "name": "tickle",
+        "trans": [
+            "发痒；使高兴，逗乐",
+            "痒"
+        ],
+        "usphone": "'tɪkl",
+        "ukphone": "'tɪkl"
+    },
+    {
+        "name": "tide",
+        "trans": [
+            "涨落",
+            "潮， 潮汐； 潮流， 趋势"
+        ],
+        "usphone": "taɪd",
+        "ukphone": "taɪd"
+    },
+    {
+        "name": "tile",
+        "trans": [
+            "铺瓦；铺地砖",
+            "瓦片； 地砖"
+        ],
+        "usphone": "taɪl",
+        "ukphone": "taɪl"
+    },
+    {
+        "name": "timber",
+        "trans": [
+            "木材， 木料"
+        ],
+        "usphone": "'tɪmbɚ",
+        "ukphone": "'tɪmbər"
+    },
+    {
+        "name": "tinker",
+        "trans": [
+            "做焊锅匠；做拙劣修补",
+            "补锅匠"
+        ],
+        "usphone": "'tɪŋkɚ",
+        "ukphone": "'tɪŋkər"
+    },
+    {
+        "name": "tissue",
+        "trans": [
+            "纸巾，面巾纸"
+        ],
+        "usphone": "'tɪʃu",
+        "ukphone": "'tɪʃuː"
+    },
+    {
+        "name": "toady",
+        "trans": [
+            "谄媚，奉承",
+            "谄媚者， 马屁精"
+        ],
+        "usphone": "'todi",
+        "ukphone": "'toudi"
+    },
+    {
+        "name": "toed",
+        "trans": [
+            "有趾的"
+        ],
+        "usphone": "tod",
+        "ukphone": "toud"
+    },
+    {
+        "name": "token",
+        "trans": [
+            "象征性的",
+            "表示，标志，象征；记号；信物；代币；礼券，代价券"
+        ],
+        "usphone": "'tokən",
+        "ukphone": "'toukən"
+    },
+    {
+        "name": "tolerable",
+        "trans": [
+            "可忍受的， 可容忍的； 尚好的， 过得去的"
+        ],
+        "usphone": "'tɑlərəbl",
+        "ukphone": "'tɑːlərəbl"
+    },
+    {
+        "name": "tolerant",
+        "trans": [
+            "宽容的； 容忍的"
+        ],
+        "usphone": "'tɑlərənt",
+        "ukphone": "'tɑːlərənt"
+    },
+    {
+        "name": "tolerate",
+        "trans": [
+            "忍受； 容许， 承认"
+        ],
+        "usphone": "'tɑləret",
+        "ukphone": "'tɑːləreɪt"
+    },
+    {
+        "name": "topography",
+        "trans": [
+            "地形学； 地形， 地貌"
+        ],
+        "usphone": "tə'pɑgrəfi",
+        "ukphone": "tə'pɑːgrəfi"
+    },
+    {
+        "name": "topsoil",
+        "trans": [
+            "表层土"
+        ],
+        "usphone": "'tɑp'sɔɪl",
+        "ukphone": "'tɑːpsɔɪl"
+    },
+    {
+        "name": "tornado",
+        "trans": [
+            "飓风， 龙卷风"
+        ],
+        "usphone": "tɔr'nedo",
+        "ukphone": "tɔːr'neɪdou"
+    },
+    {
+        "name": "torpor",
+        "trans": [
+            "迟钝； 死气沉沉"
+        ],
+        "usphone": "'tɔrpɚ",
+        "ukphone": "'tɔːrpər"
+    },
+    {
+        "name": "torrent",
+        "trans": [
+            "洪流， 急流； 爆发， 迸发"
+        ],
+        "usphone": "'tɔrənt",
+        "ukphone": "'tɔːrənt"
+    },
+    {
+        "name": "tortuous",
+        "trans": [
+            "折磨人的， 令人痛苦的； 曲折的， 蜿蜒的； 含混不清的， 拐弯抹角的"
+        ],
+        "usphone": "'tɔrtʃuəs",
+        "ukphone": "'tɔːrtʃuəs"
+    },
+    {
+        "name": "tough",
+        "trans": [
+            "坚韧的； 棘手的， 困难的； 强健的， 吃苦耐劳的； 粗暴的； 严格的； 老的"
+        ],
+        "usphone": "tʌf",
+        "ukphone": "tʌf"
+    },
+    {
+        "name": "tournament",
+        "trans": [
+            "比赛； 锦标赛"
+        ],
+        "usphone": "ˈtɝ​nəmənt",
+        "ukphone": "'tɜːrnəmənt"
+    },
+    {
+        "name": "tout",
+        "trans": [
+            "吹捧； 兜售"
+        ],
+        "usphone": "taʊt",
+        "ukphone": "taut"
+    },
+    {
+        "name": "tow",
+        "trans": [
+            "拖， 牵引"
+        ],
+        "usphone": "to",
+        "ukphone": "tou"
+    },
+    {
+        "name": "towering",
+        "trans": [
+            "高耸的； 杰出的"
+        ],
+        "usphone": "'taʊərɪŋ",
+        "ukphone": "'tauərɪŋ"
+    },
+    {
+        "name": "toxic",
+        "trans": [
+            "有毒的； 中毒的"
+        ],
+        "usphone": "'tɑksɪk",
+        "ukphone": "'tɑːksɪk"
+    },
+    {
+        "name": "trace",
+        "trans": [
+            "查出，找到；追溯；探索；描摹；追述",
+            "痕迹； 微量， 少许； 扫描线"
+        ],
+        "usphone": "tres",
+        "ukphone": "treɪs"
+    },
+    {
+        "name": "track",
+        "trans": [
+            "跟踪， 追踪",
+            "跑道；小路；轨迹；足迹"
+        ],
+        "usphone": "træk",
+        "ukphone": "træk"
+    },
+    {
+        "name": "tract",
+        "trans": [
+            "地域； 领域； 传单， 小册子； 大片"
+        ],
+        "usphone": "trækt",
+        "ukphone": "trækt"
+    },
+    {
+        "name": "trade",
+        "trans": [
+            "交易， 买卖； 互相交换",
+            "贸易，商业；交易；职业，行业"
+        ],
+        "usphone": "tred",
+        "ukphone": "treɪd"
+    },
+    {
+        "name": "traditional",
+        "trans": [
+            "传统的， 惯例的； 口传的， 传说的"
+        ],
+        "usphone": "trə'dɪʃənl",
+        "ukphone": "trə'dɪʃənl"
+    },
+    {
+        "name": "tragedy",
+        "trans": [
+            "惨事， 灾难； 悲剧"
+        ],
+        "usphone": "'trædʒədi",
+        "ukphone": "'trædʒədi"
+    },
+    {
+        "name": "tragic",
+        "trans": [
+            "悲惨的； 悲剧的"
+        ],
+        "usphone": "'trædʒɪk",
+        "ukphone": "'trædʒɪk"
+    },
+    {
+        "name": "trait",
+        "trans": [
+            "特性， 特点"
+        ],
+        "usphone": "tret",
+        "ukphone": "treɪt"
+    },
+    {
+        "name": "trample",
+        "trans": [
+            "踩碎； 践踏， 摧残"
+        ],
+        "usphone": "'træmpl",
+        "ukphone": "'træmpl"
+    },
+    {
+        "name": "trance",
+        "trans": [
+            "恍惚； 昏睡状态"
+        ],
+        "usphone": "træns",
+        "ukphone": "træns"
+    },
+    {
+        "name": "tranquil",
+        "trans": [
+            "安静的， 平静的"
+        ],
+        "usphone": "ˈtræŋkwəl",
+        "ukphone": "'træŋkwɪl"
+    },
+    {
+        "name": "transact",
+        "trans": [
+            "交易； 执行， 处理"
+        ],
+        "usphone": "træn'zækt",
+        "ukphone": "træn'zækt"
+    },
+    {
+        "name": "transaction",
+        "trans": [
+            "交易， 业务； 办理， 处理"
+        ],
+        "usphone": "træn'zækʃən",
+        "ukphone": "træn'zækʃn"
+    },
+    {
+        "name": "transcend",
+        "trans": [
+            "超越"
+        ],
+        "usphone": "træn'sɛnd",
+        "ukphone": "træn'send"
+    },
+    {
+        "name": "transcendent",
+        "trans": [
+            "卓越的， 出众的"
+        ],
+        "usphone": "træn'sɛndənt",
+        "ukphone": "træn'sendənt"
+    },
+    {
+        "name": "transcribe",
+        "trans": [
+            "记录， 抄录； 转录； 改编"
+        ],
+        "usphone": "træn'skraɪb",
+        "ukphone": "træn'skraɪb"
+    },
+    {
+        "name": "transfer",
+        "trans": [
+            "转移；转学；转让；换乘",
+            "转移； 转学； 转让； 换乘"
+        ],
+        "usphone": "træns'fɝ",
+        "ukphone": "'trænsˌfɜːr"
+    },
+    {
+        "name": "transform",
+        "trans": [
+            "使变形； 改造， 改革； 转换"
+        ],
+        "usphone": "træns'fɔrm",
+        "ukphone": "træns'fɔːrm"
+    },
+    {
+        "name": "transient",
+        "trans": [
+            "短暂的， 转瞬即逝的； 临时的"
+        ],
+        "usphone": "ˈtrænʃnt; trænʃənt",
+        "ukphone": "'trænziənt"
+    },
+    {
+        "name": "transit",
+        "trans": [
+            "运输， 运送； 中转； 转变； 交通运输系统"
+        ],
+        "usphone": "'træzɪt",
+        "ukphone": "'trænzɪt"
+    },
+    {
+        "name": "transition",
+        "trans": [
+            "过渡， 过渡时期； 转变"
+        ],
+        "usphone": "træn'zɪʃən",
+        "ukphone": "træn'zɪʃn"
+    },
+    {
+        "name": "translation",
+        "trans": [
+            "翻译； 译文， 译本"
+        ],
+        "usphone": "træns'leʃən",
+        "ukphone": "træns'leɪʃn"
+    },
+    {
+        "name": "translucent",
+        "trans": [
+            "半透明的"
+        ],
+        "usphone": "træns'lusnt",
+        "ukphone": "træns'luːsnt"
+    },
+    {
+        "name": "transmit",
+        "trans": [
+            "传送， 传递， 输送； 传播， 传染"
+        ],
+        "usphone": "trænzˈmɪt",
+        "ukphone": "træns'mɪt"
+    },
+    {
+        "name": "transparent",
+        "trans": [
+            "透明的； 明显的， 显而易见的； 直率的"
+        ],
+        "usphone": "træns'pærənt",
+        "ukphone": "træns'pærənt"
+    },
+    {
+        "name": "transplant",
+        "trans": [
+            "移植； 使迁移， 使移居； 移栽， 移种",
+            "移植"
+        ],
+        "usphone": "træns'plænt",
+        "ukphone": "træns'plɑːnt; trɑːns-; -nz-"
+    },
+    {
+        "name": "transport",
+        "trans": [
+            "运输； 运输系统， 运载工具",
+            "运输； 传播"
+        ],
+        "usphone": "'trænspɔrt",
+        "ukphone": "træn'spɔːt; trɑːn-"
+    },
+    {
+        "name": "transportation",
+        "trans": [
+            "运输； 运输系统， 运输工具"
+        ],
+        "usphone": ",trænspɔr'teʃən",
+        "ukphone": "ˌtrænspɔːr'teɪʃn"
+    },
+    {
+        "name": "trash",
+        "trans": [
+            "无价值之物，废物；拙劣的文学作品；没用的人",
+            "捣毁， 破坏"
+        ],
+        "usphone": "træʃ",
+        "ukphone": "træʃ"
+    },
+    {
+        "name": "trauma",
+        "trans": [
+            "精神创伤； 外伤； 痛苦经历"
+        ],
+        "usphone": "'traʊmə",
+        "ukphone": "'traumə"
+    },
+    {
+        "name": "traverse",
+        "trans": [
+            "横穿， 横渡"
+        ],
+        "usphone": "trə'vɝs",
+        "ukphone": "trə'vɜːrs"
+    },
+    {
+        "name": "tread",
+        "trans": [
+            "踏，践踏；行走",
+            "轮胎面； 脚步声； 步法"
+        ],
+        "usphone": "trɛd",
+        "ukphone": "tred"
+    },
+    {
+        "name": "treadmill",
+        "trans": [
+            "踏车； 枯燥乏味的工作"
+        ],
+        "usphone": "'trɛdmɪl",
+        "ukphone": "'tredmɪl"
+    },
+    {
+        "name": "trek",
+        "trans": [
+            "艰苦跋涉"
+        ],
+        "usphone": "trɛk",
+        "ukphone": "trek"
+    },
+    {
+        "name": "tremendous",
+        "trans": [
+            "惊人的； 巨大的"
+        ],
+        "usphone": "trə'mɛndəs",
+        "ukphone": "trə'mendəs"
+    },
+    {
+        "name": "tremulous",
+        "trans": [
+            "发抖的， 颤抖的； 害怕的"
+        ],
+        "usphone": "'trɛmjələs",
+        "ukphone": "'tremjələs"
+    },
+    {
+        "name": "trench",
+        "trans": [
+            "挖沟",
+            "沟渠，壕沟；战壕"
+        ],
+        "usphone": "trɛntʃ",
+        "ukphone": "trentʃ"
+    },
+    {
+        "name": "trend",
+        "trans": [
+            "趋势， 倾向"
+        ],
+        "usphone": "trɛnd",
+        "ukphone": "trend"
+    },
+    {
+        "name": "trial",
+        "trans": [
+            "审讯； 试验， 试用； 令人伤脑筋的人"
+        ],
+        "usphone": "'traɪəl",
+        "ukphone": "'traɪəl"
+    },
+    {
+        "name": "triangle",
+        "trans": [
+            "三角形； 三角形物体"
+        ],
+        "usphone": "'traɪæŋɡl",
+        "ukphone": "'traɪæŋgl"
+    },
+    {
+        "name": "tribal",
+        "trans": [
+            "部落的， 宗族的； 种族的"
+        ],
+        "usphone": "'traɪbl",
+        "ukphone": "'traɪbl"
+    },
+    {
+        "name": "tributary",
+        "trans": [
+            "支流；"
+        ],
+        "usphone": "'trɪbjə'tɛri",
+        "ukphone": "'trɪbjəteri"
+    },
+    {
+        "name": "tribute",
+        "trans": [
+            "贡品； 颂词， 称赞； 悼念， 致哀； 礼物"
+        ],
+        "usphone": "'trɪbjut",
+        "ukphone": "'trɪbjuːt"
+    },
+    {
+        "name": "trifle",
+        "trans": [
+            "不认真对待， 怠慢",
+            "少许；琐事，小事；无价值的东西"
+        ],
+        "usphone": "'traɪfl",
+        "ukphone": "'traɪfl"
+    },
+    {
+        "name": "trigger",
+        "trans": [
+            "引发，导致",
+            "扳机"
+        ],
+        "usphone": "'trɪɡɚ",
+        "ukphone": "'trɪgər"
+    },
+    {
+        "name": "trilogy",
+        "trans": [
+            "三部剧， 三部曲"
+        ],
+        "usphone": "'trɪlədʒi",
+        "ukphone": "'trɪlədʒi"
+    },
+    {
+        "name": "triple",
+        "trans": [
+            "增至三倍",
+            "三部分的； 三方的； 三倍的"
+        ],
+        "usphone": "'trɪpl",
+        "ukphone": "'trɪpl"
+    },
+    {
+        "name": "triumph",
+        "trans": [
+            "获胜， 成功",
+            "狂喜；胜利，成功"
+        ],
+        "usphone": "ˈtraɪəmf",
+        "ukphone": "'traɪʌmf"
+    },
+    {
+        "name": "trivial",
+        "trans": [
+            "琐碎的， 微不足道的"
+        ],
+        "usphone": "'trɪvɪəl",
+        "ukphone": "'trɪviəl"
+    },
+    {
+        "name": "trivialize",
+        "trans": [
+            "使显得琐碎； 轻视"
+        ],
+        "usphone": "'trɪvɪəlaɪz",
+        "ukphone": "'trɪviəlaɪz"
+    },
+    {
+        "name": "tropic",
+        "trans": [
+            "热带的",
+            "回归线；热带地区"
+        ],
+        "usphone": "'trɑpɪk",
+        "ukphone": "'trɑːpɪk"
+    },
+    {
+        "name": "troposphere",
+        "trans": [
+            "对流层"
+        ],
+        "usphone": "'tropəsfɪr",
+        "ukphone": "'troupəsfɪr"
+    },
+    {
+        "name": "troupe",
+        "trans": [
+            "剧团； 马戏团； 芭蕾舞团"
+        ],
+        "usphone": "trʊp",
+        "ukphone": "truːp"
+    },
+    {
+        "name": "trumpet",
+        "trans": [
+            "鼓吹，宣扬",
+            "小号， 喇叭"
+        ],
+        "usphone": "'trʌmpɪt",
+        "ukphone": "'trʌmpɪt"
+    },
+    {
+        "name": "tube",
+        "trans": [
+            "管； 管状物； 管状器官"
+        ],
+        "usphone": "tub",
+        "ukphone": "tjuːb"
+    },
+    {
+        "name": "tug",
+        "trans": [
+            "拖，"
+        ],
+        "usphone": "tʌɡ",
+        "ukphone": "tʌg"
+    },
+    {
+        "name": "tuition",
+        "trans": [
+            "学费； 教学， 讲授"
+        ],
+        "usphone": "tʊ'ɪʃən",
+        "ukphone": "tu'ɪʃn"
+    },
+    {
+        "name": "tundra",
+        "trans": [
+            "苔原， 冻原， 冻土地带"
+        ],
+        "usphone": "'tʌndrə",
+        "ukphone": "'tʌndrə"
+    },
+    {
+        "name": "tunnel",
+        "trans": [
+            "开凿隧道； 挖地道",
+            "隧道；地道"
+        ],
+        "usphone": "'tʌnl",
+        "ukphone": "'tʌnl"
+    },
+    {
+        "name": "turbulent",
+        "trans": [
+            "动乱的； 狂暴的， 汹涌的"
+        ],
+        "usphone": "'tɝbjələnt",
+        "ukphone": "'tɜːrbjələnt"
+    },
+    {
+        "name": "turkey",
+        "trans": [
+            "火鸡； 失败"
+        ],
+        "usphone": "'tɝki",
+        "ukphone": "'tɜːrki"
+    },
+    {
+        "name": "turmoil",
+        "trans": [
+            "骚动， 混乱； 焦虑"
+        ],
+        "usphone": "'tɝmɔɪl",
+        "ukphone": "'tɜːrmɔɪl"
+    },
+    {
+        "name": "turnout",
+        "trans": [
+            "出席人数； 产量， 产额"
+        ],
+        "usphone": "'tɝnaʊt",
+        "ukphone": "'tɜːrnaut"
+    },
+    {
+        "name": "turnpike",
+        "trans": [
+            "收费公路"
+        ],
+        "usphone": "'tɝn'paɪk",
+        "ukphone": "'tɜːrnpaɪk"
+    },
+    {
+        "name": "turtle",
+        "trans": [
+            "龟， 海龟"
+        ],
+        "usphone": "'tɝtl",
+        "ukphone": "'tɜːrtl"
+    },
+    {
+        "name": "tutor",
+        "trans": [
+            "辅导",
+            "导师；家庭教师"
+        ],
+        "usphone": "'tʊtɚ",
+        "ukphone": "'tuːtər"
+    },
+    {
+        "name": "twig",
+        "trans": [
+            "嫩枝， 小枝"
+        ],
+        "usphone": "twɪɡ",
+        "ukphone": "twɪg"
+    },
+    {
+        "name": "twine",
+        "trans": [
+            "缠绕， 盘绕， 围绕",
+            "细绳"
+        ],
+        "usphone": "twaɪn",
+        "ukphone": "twaɪn"
+    },
+    {
+        "name": "twinkling",
+        "trans": [
+            "闪光的",
+            "瞬间，一眨眼"
+        ],
+        "usphone": "'twɪŋklɪŋ",
+        "ukphone": "'twɪŋklɪŋ"
+    },
+    {
+        "name": "twist",
+        "trans": [
+            "缠绕，扭曲；曲解，歪曲",
+            "转折， 突然变化； 卷曲物"
+        ],
+        "usphone": "twɪst",
+        "ukphone": "twɪst"
+    },
+    {
+        "name": "tycoon",
+        "trans": [
+            "巨头， 大亨"
+        ],
+        "usphone": "taɪ'kun",
+        "ukphone": "taɪ'kuːn"
+    },
+    {
+        "name": "typical",
+        "trans": [
+            "典型的， 有代表性的"
+        ],
+        "usphone": "'tɪpɪkl",
+        "ukphone": "'tɪpɪkl"
+    },
+    {
+        "name": "typify",
+        "trans": [
+            "是…的典范； 成为…的特征"
+        ],
+        "usphone": "'tɪpɪfaɪ",
+        "ukphone": "'tɪpɪfaɪ"
+    },
+    {
+        "name": "tyrannical",
+        "trans": [
+            "专制的， 残暴的， 专横的"
+        ],
+        "usphone": "tɪ'rænɪkl",
+        "ukphone": "tɪ'rænɪkl"
+    },
+    {
+        "name": "ultimate",
+        "trans": [
+            "最后的，最终的；根本的",
+            "最好的事物； 最大的或最先进的事物"
+        ],
+        "usphone": "ˈʌltəmɪt",
+        "ukphone": "'ʌltɪmət"
+    },
+    {
+        "name": "ultimatum",
+        "trans": [
+            "最后通牒"
+        ],
+        "usphone": ",ʌltɪ'metəm",
+        "ukphone": "ˌʌltɪ'meɪtəm"
+    },
+    {
+        "name": "ultraviolet",
+        "trans": [
+            "紫外的"
+        ],
+        "usphone": ",ʌltrə'vaɪələt",
+        "ukphone": "ˌʌltrə'vaɪələt"
+    },
+    {
+        "name": "unadorned",
+        "trans": [
+            "未装饰的， 朴实的"
+        ],
+        "usphone": "'ʌnə'dɔ:nd",
+        "ukphone": "ˌʌnə'dɔːrnd"
+    },
+    {
+        "name": "unaided",
+        "trans": [
+            "未受协助的， 独立的"
+        ],
+        "usphone": "ʌn'edɪd",
+        "ukphone": "ʌn'eɪdɪd"
+    },
+    {
+        "name": "unanimous",
+        "trans": [
+            "全体一致的， 一致同意的"
+        ],
+        "usphone": "jʊ'nænəməs",
+        "ukphone": "ju'nænɪməs"
+    },
+    {
+        "name": "unbridgeable",
+        "trans": [
+            "不能架桥的； 不能逾越的"
+        ],
+        "usphone": "'ʌn'bridʒəbl",
+        "ukphone": "ʌn'brɪdʒəbl"
+    },
+    {
+        "name": "uncanny",
+        "trans": [
+            "神秘的； 易乎寻常的"
+        ],
+        "usphone": "ʌn'kæni",
+        "ukphone": "ʌn'kæni"
+    },
+    {
+        "name": "unconsolidated",
+        "trans": [
+            "松散的， 疏松的"
+        ],
+        "usphone": "'ʌnkən'sɔlideitid",
+        "ukphone": "ˌʌnkən'sɑːlɪdeɪtɪd"
+    },
+    {
+        "name": "undergo",
+        "trans": [
+            "经历； 遭受"
+        ],
+        "usphone": ",ʌndɚ'ɡo",
+        "ukphone": "ˌʌndər'gou"
+    },
+    {
+        "name": "undergraduate",
+        "trans": [
+            "大学肄业生； 大学本科生"
+        ],
+        "usphone": ",ʌndɚ'ɡrædʒuət",
+        "ukphone": "ˌʌndər'grædʒət"
+    },
+    {
+        "name": "underground",
+        "trans": [
+            "在地下， 往地下； 秘密地， 不公开地",
+            "地下的； 秘密的， 不公开的 记 组合词： under + ground → 地下的"
+        ],
+        "usphone": "ʌndɚˈɡraʊnd",
+        "ukphone": "ʌndə'graʊnd"
+    },
+    {
+        "name": "underlying",
+        "trans": [
+            "潜在的； 基础的"
+        ],
+        "usphone": ",ʌndɚ'laɪɪŋ",
+        "ukphone": "ˌʌndər'laɪɪŋ"
+    },
+    {
+        "name": "underneath",
+        "trans": [
+            "在下面",
+            "在…下面"
+        ],
+        "usphone": ",ʌndɚ'niθ",
+        "ukphone": "ˌʌndər'niːθ"
+    },
+    {
+        "name": "underscore",
+        "trans": [
+            "强调； 在…之下画线",
+            "底线"
+        ],
+        "usphone": ",ʌndɚ'skɔr",
+        "ukphone": "ʌndə'skɔː"
+    },
+    {
+        "name": "understate",
+        "trans": [
+            "轻描淡写， 避重就轻地说"
+        ],
+        "usphone": "'ʌndɚ'stet",
+        "ukphone": "ˌʌndər'steɪt"
+    },
+    {
+        "name": "undertake",
+        "trans": [
+            "承担； 进行， 从事"
+        ],
+        "usphone": ",ʌndɚ'tek",
+        "ukphone": "ˌʌndər'teɪk"
+    },
+    {
+        "name": "undertaking",
+        "trans": [
+            "任务， 项目； 事业， 企业； 承诺， 保证"
+        ],
+        "usphone": "'ʌndɚ'tekɪŋ",
+        "ukphone": "ˌʌndər'teɪkɪŋ"
+    },
+    {
+        "name": "unearth",
+        "trans": [
+            "掘出， 发掘； 揭露"
+        ],
+        "usphone": "ʌn'ɝθ",
+        "ukphone": "ʌn'ɜːrθ"
+    },
+    {
+        "name": "unequal",
+        "trans": [
+            "不同的， 不相等的； 不平等的， 不相称的； 不胜任的"
+        ],
+        "usphone": "ʌn'ikwəl",
+        "ukphone": "ʌn'iːkwəl"
+    },
+    {
+        "name": "uneven",
+        "trans": [
+            "不平均的； 不平坦的； 不规则的； 不势均力敌的； 不公平的"
+        ],
+        "usphone": "ʌn'ivən",
+        "ukphone": "ʌn'iːvn"
+    },
+    {
+        "name": "uniform",
+        "trans": [
+            "统一的； 均匀的",
+            "制服"
+        ],
+        "usphone": "junəˌfɔrm",
+        "ukphone": "'juːnɪfɔːrm"
+    },
+    {
+        "name": "uniformity",
+        "trans": [
+            "同样， 一致； 一致性"
+        ],
+        "usphone": ",jʊnə'fɔrməti",
+        "ukphone": "ˌjuːnɪ'fɔːməti"
+    },
+    {
+        "name": "unify",
+        "trans": [
+            "统一， 联合"
+        ],
+        "usphone": "'junɪfaɪ",
+        "ukphone": "'juːnɪfaɪ"
+    },
+    {
+        "name": "unique",
+        "trans": [
+            "唯一的； 独特的， 罕见的； 特有的"
+        ],
+        "usphone": "jʊ'nik",
+        "ukphone": "ju'niːk"
+    },
+    {
+        "name": "unity",
+        "trans": [
+            "团结一致， 统一， 联合； 协调； 统一体"
+        ],
+        "usphone": "'junəti",
+        "ukphone": "'juːnəti"
+    },
+    {
+        "name": "universal",
+        "trans": [
+            "普遍的， 全体的； 通用的， 万能的； 宇宙的， 全世界的"
+        ],
+        "usphone": "'jʊnə'vɝsl",
+        "ukphone": "ˌjuːnɪ'vɜːrsl"
+    },
+    {
+        "name": "universe",
+        "trans": [
+            "宇宙； 世界"
+        ],
+        "usphone": "'junɪvɝs",
+        "ukphone": "'juːnɪvɜːrs"
+    },
+    {
+        "name": "unparalleled",
+        "trans": [
+            "空前的， 无比的"
+        ],
+        "usphone": "ʌn'pærəlɛld",
+        "ukphone": "ʌn'pærəleld"
+    },
+    {
+        "name": "unprecedented",
+        "trans": [
+            "空前的"
+        ],
+        "usphone": "ʌn'prɛsɪdɛntɪd",
+        "ukphone": "ʌn'presɪdentɪd"
+    },
+    {
+        "name": "unpredictable",
+        "trans": [
+            "不可预知的； 无法预言的"
+        ],
+        "usphone": ",ʌnprɪ'dɪktəbl",
+        "ukphone": "ˌʌnprɪ'dɪktəbl"
+    },
+    {
+        "name": "unravel",
+        "trans": [
+            "澄清； 解体， 瓦解； 解开"
+        ],
+        "usphone": "ʌn'rævl",
+        "ukphone": "ʌn'rævl"
+    },
+    {
+        "name": "unsubstantiated",
+        "trans": [
+            "未经证实的， 无事实根据的"
+        ],
+        "usphone": ",ʌnsəb'stænʃɪetɪd",
+        "ukphone": "ˌʌnsəb'stænʃieɪtɪd"
+    },
+    {
+        "name": "untamed",
+        "trans": [
+            "未驯服的， 难驾驭的"
+        ],
+        "usphone": ",ʌn'temd",
+        "ukphone": "ˌʌn'teɪmd"
+    },
+    {
+        "name": "untapped",
+        "trans": [
+            "未开发的， 未使用的"
+        ],
+        "usphone": ",ʌn'tæpt",
+        "ukphone": "ˌʌn'tæpt"
+    },
+    {
+        "name": "upheaval",
+        "trans": [
+            "剧变， 动乱， 大变动"
+        ],
+        "usphone": "ʌp'hivl",
+        "ukphone": "ʌp'hiːvl"
+    },
+    {
+        "name": "uphold",
+        "trans": [
+            "支持， 维护； 维持"
+        ],
+        "usphone": "ʌpˈhoʊld",
+        "ukphone": "ʌp'hould"
+    },
+    {
+        "name": "uppermost",
+        "trans": [
+            "在最上面， 在最重要的位置",
+            "最高的，最上面的；最重要的"
+        ],
+        "usphone": "'ʌpɚmost",
+        "ukphone": "'ʌpərmoust"
+    },
+    {
+        "name": "uproot",
+        "trans": [
+            "根除； 离开家园"
+        ],
+        "usphone": ",ʌp'rut",
+        "ukphone": "ˌʌp'ruːt"
+    },
+    {
+        "name": "upset",
+        "trans": [
+            "心烦意乱的； 不适的",
+            "使心烦意乱； 颠覆， 推翻； 搅乱",
+            "困扰， 麻烦； 出乎意料的结局； 苦恼"
+        ],
+        "usphone": "ʌp'sɛt",
+        "ukphone": "ʌp'set"
+    },
+    {
+        "name": "upsurge",
+        "trans": [
+            "高涨； 激增"
+        ],
+        "usphone": "'ʌpsɝdʒ",
+        "ukphone": "'ʌpsɜːrdʒ"
+    },
+    {
+        "name": "urban",
+        "trans": [
+            "城市的， 市内的"
+        ],
+        "usphone": "'ɝbən",
+        "ukphone": "'ɜːrbən"
+    },
+    {
+        "name": "urbanization",
+        "trans": [
+            "都市化"
+        ],
+        "usphone": ",ɝbənɪ'zeʃən",
+        "ukphone": "ˌɜːrbənaɪ'zeɪʃn"
+    },
+    {
+        "name": "urge",
+        "trans": [
+            "促进，力劝；驱赶，驱策",
+            "强烈的欲望， 冲动"
+        ],
+        "usphone": "ɝdʒ",
+        "ukphone": "ɜːrdʒ"
+    },
+    {
+        "name": "urgent",
+        "trans": [
+            "急迫的， 紧迫的"
+        ],
+        "usphone": "'ɝdʒənt",
+        "ukphone": "'ɜːrdʒənt"
+    },
+    {
+        "name": "usher",
+        "trans": [
+            "引领， 引导",
+            "领座员，招待员"
+        ],
+        "usphone": "'ʌʃɚ",
+        "ukphone": "'ʌʃər"
+    },
+    {
+        "name": "utensil",
+        "trans": [
+            "用具； 器皿"
+        ],
+        "usphone": "jʊ'tɛnsl",
+        "ukphone": "juː'tensl"
+    },
+    {
+        "name": "utilitarian",
+        "trans": [
+            "实用的；功利主义的",
+            "功利主义者"
+        ],
+        "usphone": ",jutɪlɪ'tɛrɪən",
+        "ukphone": "ˌjuːtɪlɪ'teriən"
+    },
+    {
+        "name": "utility",
+        "trans": [
+            "功用， 效用； 公用事业"
+        ],
+        "usphone": "ju'tɪləti",
+        "ukphone": "juː'tɪləti"
+    },
+    {
+        "name": "utilize",
+        "trans": [
+            "利用"
+        ],
+        "usphone": "'juːtəlaɪz",
+        "ukphone": "'juːtəlaɪz"
+    },
+    {
+        "name": "utmost",
+        "trans": [
+            "最大限度的",
+            "最大限度； 最大量"
+        ],
+        "usphone": "'ʌt'most",
+        "ukphone": "'ʌtmoust"
+    },
+    {
+        "name": "utter",
+        "trans": [
+            "完全的",
+            "出声；说"
+        ],
+        "usphone": "'ʌtɚ",
+        "ukphone": "'ʌtər"
+    },
+    {
+        "name": "vacancy",
+        "trans": [
+            "空房间； 空位， 空缺； 空虚"
+        ],
+        "usphone": "'vekənsi",
+        "ukphone": "'veɪkənsi"
+    },
+    {
+        "name": "vacant",
+        "trans": [
+            "空的； 闲置的； 茫然的， 空虚的"
+        ],
+        "usphone": "'vekənt",
+        "ukphone": "'veɪkənt"
+    },
+    {
+        "name": "vacate",
+        "trans": [
+            "腾出， 空出； 离， 退"
+        ],
+        "usphone": "ˈveɪˌkeɪt; veɪˈkeɪt",
+        "ukphone": "və'keɪt"
+    },
+    {
+        "name": "vacation",
+        "trans": [
+            "度假",
+            "假期"
+        ],
+        "usphone": "veˈkeʃən",
+        "ukphone": "veɪ'keɪʃn"
+    },
+    {
+        "name": "vaccine",
+        "trans": [
+            "疫苗"
+        ],
+        "usphone": "væk'sin",
+        "ukphone": "væk'siːn"
+    },
+    {
+        "name": "vacuum",
+        "trans": [
+            "真空；真空状态，空白，"
+        ],
+        "usphone": "'vækjʊəm",
+        "ukphone": "'vækjuəm"
+    },
+    {
+        "name": "vagrant",
+        "trans": [
+            "漂泊的",
+            "无业游民，流浪者"
+        ],
+        "usphone": "'veɡrənt",
+        "ukphone": "'veɪgrənt"
+    },
+    {
+        "name": "vague",
+        "trans": [
+            "模糊的； 不明确的"
+        ],
+        "usphone": "veɡ",
+        "ukphone": "veɪg"
+    },
+    {
+        "name": "vain",
+        "trans": [
+            "徒然的， 无效的； 自负的， 虚荣的"
+        ],
+        "usphone": "ven",
+        "ukphone": "veɪn"
+    },
+    {
+        "name": "valid",
+        "trans": [
+            "有根据的， 合理的； 有效的"
+        ],
+        "usphone": "'vælɪd",
+        "ukphone": "'vælɪd"
+    },
+    {
+        "name": "validate",
+        "trans": [
+            "使有效， 使生效； 证实"
+        ],
+        "usphone": "'vælɪdet",
+        "ukphone": "'vælɪdeɪt"
+    },
+    {
+        "name": "validity",
+        "trans": [
+            "合法性； 符合逻辑"
+        ],
+        "usphone": "və'lɪdəti",
+        "ukphone": "və'lɪdəti"
+    },
+    {
+        "name": "vanish",
+        "trans": [
+            "消失； 灭绝"
+        ],
+        "usphone": "'vænɪʃ",
+        "ukphone": "'vænɪʃ"
+    },
+    {
+        "name": "vapor",
+        "trans": [
+            "蒸气， 潮气"
+        ],
+        "usphone": "ˈveɪpər",
+        "ukphone": "'veɪpər"
+    },
+    {
+        "name": "vaporize",
+        "trans": [
+            "蒸发， 汽化"
+        ],
+        "usphone": "'vepə'raɪz",
+        "ukphone": "'veɪpəraɪz"
+    },
+    {
+        "name": "variable",
+        "trans": [
+            "易变的；"
+        ],
+        "usphone": "'vɛrɪəbl",
+        "ukphone": "'veriəbl"
+    },
+    {
+        "name": "variant",
+        "trans": [
+            "不同的， 变异的",
+            "变体，变形"
+        ],
+        "usphone": "'vɛrɪənt",
+        "ukphone": "'veriənt"
+    },
+    {
+        "name": "varied",
+        "trans": [
+            "各式各样的"
+        ],
+        "usphone": "'vɛrɪd",
+        "ukphone": "'verid"
+    },
+    {
+        "name": "varnish",
+        "trans": [
+            "上清漆",
+            "清漆"
+        ],
+        "usphone": "'vɑrnɪʃ",
+        "ukphone": "'vɑːrnɪʃ"
+    },
+    {
+        "name": "vary",
+        "trans": [
+            "改变， 变化"
+        ],
+        "usphone": "ˈveri",
+        "ukphone": "'veri"
+    },
+    {
+        "name": "vascular",
+        "trans": [
+            "血管的， 脉管的"
+        ],
+        "usphone": "'væskjəlɚ",
+        "ukphone": "'væskjələr"
+    },
+    {
+        "name": "vast",
+        "trans": [
+            "巨大的； 大量的； 范围广的"
+        ],
+        "usphone": "væst",
+        "ukphone": "væst"
+    },
+    {
+        "name": "vault",
+        "trans": [
+            "跳过",
+            "拱顶；金库，保险库；撑杆跳"
+        ],
+        "usphone": "vɔlt",
+        "ukphone": "vɔːlt"
+    },
+    {
+        "name": "vegetarian",
+        "trans": [
+            "素食者的",
+            "素食者"
+        ],
+        "usphone": "ˌvɛdʒəˈtɛrɪən",
+        "ukphone": "ˌvedʒə'teriən"
+    },
+    {
+        "name": "vegetation",
+        "trans": [
+            "植物； 植被"
+        ],
+        "usphone": "'vɛdʒə'teʃən",
+        "ukphone": "ˌvedʒə'teɪʃn"
+    },
+    {
+        "name": "vegetative",
+        "trans": [
+            "植物的； 有生长力的"
+        ],
+        "usphone": "'vɛdʒə'tetɪv",
+        "ukphone": "'vedʒɪteɪtɪv"
+    },
+    {
+        "name": "vehicle",
+        "trans": [
+            "交通工具， 车辆； 工具， 手段"
+        ],
+        "usphone": "ˈviəkəl",
+        "ukphone": "'viːəkl"
+    },
+    {
+        "name": "veil",
+        "trans": [
+            "面纱；遮蔽物",
+            "以面纱掩盖； 掩饰"
+        ],
+        "usphone": "vel",
+        "ukphone": "veɪl"
+    },
+    {
+        "name": "vein",
+        "trans": [
+            "静脉； 叶脉； 纹理， 纹路； 方式， 风格"
+        ],
+        "usphone": "ven",
+        "ukphone": "veɪn"
+    },
+    {
+        "name": "velocity",
+        "trans": [
+            "速度， 速率； 迅速"
+        ],
+        "usphone": "vəˈlɑsəti",
+        "ukphone": "və'lɑːsəti"
+    },
+    {
+        "name": "venom",
+        "trans": [
+            "毒液； 恶意， 怨恨"
+        ],
+        "usphone": "'vɛnəm",
+        "ukphone": "'venəm"
+    },
+    {
+        "name": "venomous",
+        "trans": [
+            "有毒的， 分泌毒液的； 恶意的， 狠毒的"
+        ],
+        "usphone": "'vɛnəməs",
+        "ukphone": "'venəməs"
+    },
+    {
+        "name": "vent",
+        "trans": [
+            "通风口；出口",
+            "表达， 发泄"
+        ],
+        "usphone": "vɛnt",
+        "ukphone": "vent"
+    },
+    {
+        "name": "ventilation",
+        "trans": [
+            "通风设备； 空气流通"
+        ],
+        "usphone": ",vɛntl'eʃən",
+        "ukphone": "ˌventɪ'leɪʃn"
+    },
+    {
+        "name": "venture",
+        "trans": [
+            "敢于去； 冒险",
+            "冒险，投机；投机活动，风险项目"
+        ],
+        "usphone": "'vɛntʃɚ",
+        "ukphone": "'ventʃər"
+    },
+    {
+        "name": "venturesome",
+        "trans": [
+            "敢于冒险的； 有危险的"
+        ],
+        "usphone": "'vɛntʃɚsəm",
+        "ukphone": "'ventʃərsəm"
+    },
+    {
+        "name": "verbal",
+        "trans": [
+            "口头的； 言辞的； 动词的"
+        ],
+        "usphone": "'vɝbl",
+        "ukphone": "'vɜːrbl"
+    },
+    {
+        "name": "verbalize",
+        "trans": [
+            "用言语表达"
+        ],
+        "usphone": "'vɝbəlaɪz",
+        "ukphone": "'vɜːrbəlaɪz"
+    },
+    {
+        "name": "verbiage",
+        "trans": [
+            "冗词， 赘言， 废话"
+        ],
+        "usphone": "'vɝbɪɪdʒ",
+        "ukphone": "'vɜːrbiɪdʒ"
+    },
+    {
+        "name": "verdict",
+        "trans": [
+            "裁定； 判断； 意见"
+        ],
+        "usphone": "'vɝdɪkt",
+        "ukphone": "'vɜːrdɪkt"
+    },
+    {
+        "name": "verge",
+        "trans": [
+            "接近，濒临",
+            "草地"
+        ],
+        "usphone": "vɝdʒ",
+        "ukphone": "vɜːrdʒ"
+    },
+    {
+        "name": "verifiable",
+        "trans": [
+            "可证实的， 可核实的"
+        ],
+        "usphone": "'vɛrə,faɪəbl",
+        "ukphone": "'verɪfaɪəbl"
+    },
+    {
+        "name": "verify",
+        "trans": [
+            "检验， 核实"
+        ],
+        "usphone": "'vɛrɪfaɪ",
+        "ukphone": "'verɪfaɪ"
+    },
+    {
+        "name": "versatile",
+        "trans": [
+            "多才多艺的； 多用途的"
+        ],
+        "usphone": "'vɝsətl",
+        "ukphone": "'vɜːrsətl"
+    },
+    {
+        "name": "verse",
+        "trans": [
+            "诗歌； 韵文； 诗节"
+        ],
+        "usphone": "vɝs",
+        "ukphone": "vɜːrs"
+    },
+    {
+        "name": "version",
+        "trans": [
+            "译文， 译本； 版本"
+        ],
+        "usphone": "'vɝʒn",
+        "ukphone": "'vɜːrʒn"
+    },
+    {
+        "name": "versus",
+        "trans": [
+            "对， 对抗； 与…相对， 与…相比"
+        ],
+        "usphone": "'vɝsəs",
+        "ukphone": "'vɜːrsəs"
+    },
+    {
+        "name": "vertebrate",
+        "trans": [
+            "有脊椎的",
+            "脊椎动物"
+        ],
+        "usphone": "'vɝtɪbrət",
+        "ukphone": "'vɜːrtɪbrət"
+    },
+    {
+        "name": "vertical",
+        "trans": [
+            "垂直的，竖直的",
+            "垂直线"
+        ],
+        "usphone": "'vɝtɪkl",
+        "ukphone": "'vɜːrtɪkl"
+    },
+    {
+        "name": "vestige",
+        "trans": [
+            "遗迹， 残余； 丝毫， 一点儿"
+        ],
+        "usphone": "'vɛstɪdʒ",
+        "ukphone": "'vestɪdʒ"
+    },
+    {
+        "name": "veto",
+        "trans": [
+            "否决权；禁止",
+            "否决； 禁止"
+        ],
+        "usphone": "'vito",
+        "ukphone": "'viːtou"
+    },
+    {
+        "name": "viable",
+        "trans": [
+            "可行的， 可实施的； 可生长发育的"
+        ],
+        "usphone": "'vaiəbl",
+        "ukphone": "'vaɪəbl"
+    },
+    {
+        "name": "vibrant",
+        "trans": [
+            "振动的； 活泼的， 充满生气的"
+        ],
+        "usphone": "'vaɪbrənt",
+        "ukphone": "'vaɪbrənt"
+    },
+    {
+        "name": "vibrate",
+        "trans": [
+            "颤动， 振动"
+        ],
+        "usphone": "vaɪ'breɪt",
+        "ukphone": "'vaɪbreɪt"
+    },
+    {
+        "name": "vibration",
+        "trans": [
+            "振动， 颤动"
+        ],
+        "usphone": "vaɪ'breʃən",
+        "ukphone": "vaɪ'breɪʃn"
+    },
+    {
+        "name": "vice",
+        "trans": [
+            "恶行， 恶习； 副， 代理"
+        ],
+        "usphone": "vaɪs",
+        "ukphone": "vaɪs"
+    },
+    {
+        "name": "vicinity",
+        "trans": [
+            "邻近， 附近"
+        ],
+        "usphone": "və'sɪnəti",
+        "ukphone": "və'sɪnəti"
+    },
+    {
+        "name": "vicious",
+        "trans": [
+            "危险的， 罪恶的； 残酷的， 凶残的； 恶性的"
+        ],
+        "usphone": "'vɪʃəs",
+        "ukphone": "'vɪʃəs"
+    },
+    {
+        "name": "vigilance",
+        "trans": [
+            "警戒， 警惕"
+        ],
+        "usphone": "'vɪdʒələns",
+        "ukphone": "'vɪdʒɪləns"
+    },
+    {
+        "name": "vigor",
+        "trans": [
+            "活力， 精力"
+        ],
+        "usphone": "'vɪgɚ",
+        "ukphone": "'vɪgər"
+    },
+    {
+        "name": "violate",
+        "trans": [
+            "违反， 违背； 亵渎； 侵犯， 干扰"
+        ],
+        "usphone": "'vaɪəlet",
+        "ukphone": "'vaɪəleɪt"
+    },
+    {
+        "name": "violent",
+        "trans": [
+            "暴力的； 感情强烈的， 激情的； 强烈的， 激烈的"
+        ],
+        "usphone": "'vaɪələnt",
+        "ukphone": "'vaɪələnt"
+    },
+    {
+        "name": "viral",
+        "trans": [
+            "病毒的， 病毒引起的"
+        ],
+        "usphone": "'vaɪrəl",
+        "ukphone": "'vaɪrəl"
+    },
+    {
+        "name": "virtual",
+        "trans": [
+            "模拟的， 虚拟的； 实际上的， 事实上的"
+        ],
+        "usphone": "ˈvɝ​tʃʊəl",
+        "ukphone": "'vɜːrtʃuəl"
+    },
+    {
+        "name": "virtue",
+        "trans": [
+            "美德； 优点"
+        ],
+        "usphone": "'vɝtʃʊ",
+        "ukphone": "'vɜːrtʃuː"
+    },
+    {
+        "name": "virtuous",
+        "trans": [
+            "有道德的， 品行端正的， 品德高的； 〈贬〉自命清高的， 自以为是的"
+        ],
+        "usphone": "'vɝtʃuəs",
+        "ukphone": "'vɜːrtʃuəs"
+    },
+    {
+        "name": "virus",
+        "trans": [
+            "病毒； 病毒性疾病"
+        ],
+        "usphone": "'vaɪrəs",
+        "ukphone": "'vaɪrəs"
+    },
+    {
+        "name": "viscous",
+        "trans": [
+            "黏滞的， 黏性的"
+        ],
+        "usphone": "'vɪskəs",
+        "ukphone": "'vɪskəs"
+    },
+    {
+        "name": "visible",
+        "trans": [
+            "看得见的， 明显的"
+        ],
+        "usphone": "'vɪzəbl",
+        "ukphone": "'vɪzəb"
+    },
+    {
+        "name": "visual",
+        "trans": [
+            "视觉的"
+        ],
+        "usphone": "'vɪʒʊəl",
+        "ukphone": "'vɪʒuəl"
+    },
+    {
+        "name": "visualize",
+        "trans": [
+            "想象， 使形象化； 构思"
+        ],
+        "usphone": "'vɪʒuəlaɪz",
+        "ukphone": "'vɪʒuəlaɪz"
+    },
+    {
+        "name": "vital",
+        "trans": [
+            "生死攸关的； 至关重要的； 精力充沛的， 有活力的"
+        ],
+        "usphone": "'vaɪtl",
+        "ukphone": "'vaɪtl"
+    },
+    {
+        "name": "vivid",
+        "trans": [
+            "清晰的； 鲜明的； 生动的； 活泼的"
+        ],
+        "usphone": "'vɪvɪd",
+        "ukphone": "'vɪvɪd"
+    },
+    {
+        "name": "vivify",
+        "trans": [
+            "赋予生气； 使生动， 使活跃"
+        ],
+        "usphone": "'vɪvə,fai",
+        "ukphone": "'vɪvɪfaɪ"
+    },
+    {
+        "name": "vocal",
+        "trans": [
+            "声音的，嗓音的，发声的；直言不讳的"
+        ],
+        "usphone": "'vokl",
+        "ukphone": "'voukl"
+    },
+    {
+        "name": "vocalize",
+        "trans": [
+            "用言语表达； 说， 唱， 发声"
+        ],
+        "usphone": "'vokə'laɪz",
+        "ukphone": "'voukəlaɪz"
+    },
+    {
+        "name": "vocation",
+        "trans": [
+            "职业； 使命感； 圣召"
+        ],
+        "usphone": "vo'keʃən",
+        "ukphone": "vou'keɪʃn"
+    },
+    {
+        "name": "vogue",
+        "trans": [
+            "流行的， 时髦的",
+            "时尚，风气，流行"
+        ],
+        "usphone": "voɡ",
+        "ukphone": "voug"
+    },
+    {
+        "name": "volatile",
+        "trans": [
+            "挥发性的， 易挥发的； 不稳定的； 反复无常的"
+        ],
+        "usphone": "'vɑlətl",
+        "ukphone": "'vɑːlətl"
+    },
+    {
+        "name": "volcano",
+        "trans": [
+            "火山"
+        ],
+        "usphone": "vɑl'keno",
+        "ukphone": "vɑːl'keɪnou"
+    },
+    {
+        "name": "voltage",
+        "trans": [
+            "电压， 伏特数"
+        ],
+        "usphone": "'voltɪdʒ",
+        "ukphone": "'voultɪdʒ"
+    },
+    {
+        "name": "volume",
+        "trans": [
+            "体积， 容积， 容量； 音量； 卷， 册； 书"
+        ],
+        "usphone": "'vɑljum",
+        "ukphone": "'vɑːljuːm"
+    },
+    {
+        "name": "volunteer",
+        "trans": [
+            "自愿做",
+            "志愿的， 义务的",
+            "志愿者；志愿军"
+        ],
+        "usphone": ",vɑlən'tɪr",
+        "ukphone": "ˌvɑːlən'tɪr"
+    },
+    {
+        "name": "voracious",
+        "trans": [
+            "狼吞虎咽的， 贪婪的； 求知欲强的"
+        ],
+        "usphone": "və'reʃəs",
+        "ukphone": "və'reɪʃəs"
+    },
+    {
+        "name": "vow",
+        "trans": [
+            "发誓",
+            "誓约"
+        ],
+        "usphone": "vaʊ",
+        "ukphone": "vau"
+    },
+    {
+        "name": "voyage",
+        "trans": [
+            "旅行； 航程"
+        ],
+        "usphone": "'vɔɪɪdʒ",
+        "ukphone": "'vɔɪɪdʒ"
+    },
+    {
+        "name": "vulgar",
+        "trans": [
+            "下流的， 粗俗的； 普通的， 通俗的"
+        ],
+        "usphone": "'vʌlɡɚ",
+        "ukphone": "'vʌlgər"
+    },
+    {
+        "name": "vulnerable",
+        "trans": [
+            "易受攻击的， 易受伤的"
+        ],
+        "usphone": "'vʌlnərəbl",
+        "ukphone": "'vʌlnərəbl"
+    },
+    {
+        "name": "waggle",
+        "trans": [
+            "摆动"
+        ],
+        "usphone": "'wæɡl",
+        "ukphone": "'wægl"
+    },
+    {
+        "name": "wagon",
+        "trans": [
+            "四轮马车； 货车"
+        ],
+        "usphone": "'wægən",
+        "ukphone": "'wægən"
+    },
+    {
+        "name": "walnut",
+        "trans": [
+            "胡桃； 胡桃木"
+        ],
+        "usphone": "'wɔlnət",
+        "ukphone": "'wɔːlnʌt"
+    },
+    {
+        "name": "wan",
+        "trans": [
+            "苍白的， 无血色的； 憔悴的"
+        ],
+        "usphone": "wɑn",
+        "ukphone": "wæn"
+    },
+    {
+        "name": "wane",
+        "trans": [
+            "衰退，减弱；减少；亏，缺",
+            "月亏； 衰落"
+        ],
+        "usphone": "wen",
+        "ukphone": "weɪn"
+    },
+    {
+        "name": "wanna",
+        "trans": [
+            "想要"
+        ],
+        "usphone": "ˈwɑnə",
+        "ukphone": "'wɔːnə"
+    },
+    {
+        "name": "ware",
+        "trans": [
+            "陶器；器皿；"
+        ],
+        "usphone": "wer",
+        "ukphone": "wer"
+    },
+    {
+        "name": "warehouse",
+        "trans": [
+            "仓库， 货栈"
+        ],
+        "usphone": "'wɛrhaʊs",
+        "ukphone": "'werhaus"
+    },
+    {
+        "name": "warp",
+        "trans": [
+            "扭曲，弯曲，变形；"
+        ],
+        "usphone": "wɔrp",
+        "ukphone": "wɔːrp"
+    },
+    {
+        "name": "warrant",
+        "trans": [
+            "授权，批准；许可证；委任状，执行令",
+            "保证， 担保； 使正当"
+        ],
+        "usphone": "'wɔrənt",
+        "ukphone": "'wɔːrənt"
+    },
+    {
+        "name": "wary",
+        "trans": [
+            "小心翼翼的， 留神的， 警惕的"
+        ],
+        "usphone": "'wɛri",
+        "ukphone": "'weri"
+    },
+    {
+        "name": "wasp",
+        "trans": [
+            "黄蜂"
+        ],
+        "usphone": "wɑsp",
+        "ukphone": "wɑːsp"
+    },
+    {
+        "name": "waste",
+        "trans": [
+            "无用的，废弃的；荒芜的",
+            "浪费；废料，废弃物",
+            "浪费， 消耗"
+        ],
+        "usphone": "west",
+        "ukphone": "weɪst"
+    },
+    {
+        "name": "watercourse",
+        "trans": [
+            "水道， 河道"
+        ],
+        "usphone": "'wɔtɚkɔrs",
+        "ukphone": "'wɔːtərkɔːrs"
+    },
+    {
+        "name": "wax",
+        "trans": [
+            "给…打蜡；渐满",
+            "蜡； 蜡状物"
+        ],
+        "usphone": "waks",
+        "ukphone": "wæks"
+    },
+    {
+        "name": "wear",
+        "trans": [
+            "穿，戴；留；面露，面带；磨损，用旧",
+            "穿戴， 衣着； 服装， 穿戴物； 磨损， 损坏"
+        ],
+        "usphone": "wɛr",
+        "ukphone": "wer"
+    },
+    {
+        "name": "weathering",
+        "trans": [
+            "侵蚀， 风化"
+        ],
+        "usphone": "'wɛðərɪŋ",
+        "ukphone": "'weðərɪŋ"
+    },
+    {
+        "name": "weave",
+        "trans": [
+            "迂回行进；编织；编造，编纂",
+            "编法， 织法"
+        ],
+        "usphone": "wiv",
+        "ukphone": "wiːv"
+    },
+    {
+        "name": "wedge",
+        "trans": [
+            "楔子；楔形物",
+            "■入， 塞入"
+        ],
+        "usphone": "wɛdʒ",
+        "ukphone": "wedʒ"
+    },
+    {
+        "name": "wedge-shaped",
+        "trans": [
+            "楔形的"
+        ],
+        "usphone": "'wedʒʃeipt",
+        "ukphone": "'wedʒˌʃeɪpt"
+    },
+    {
+        "name": "weed",
+        "trans": [
+            "杂草； 水草"
+        ],
+        "usphone": "wid",
+        "ukphone": "wiːd"
+    },
+    {
+        "name": "weird",
+        "trans": [
+            "怪异的， 神秘的"
+        ],
+        "usphone": "wɪrd",
+        "ukphone": "wɪrd"
+    },
+    {
+        "name": "welfare",
+        "trans": [
+            "福利； 安宁， 幸福"
+        ],
+        "usphone": "'wɛl'fɛr",
+        "ukphone": "'welfer"
+    },
+    {
+        "name": "well-heeled",
+        "trans": [
+            "富有的， 有钱的"
+        ],
+        "usphone": "'wel'hi:ld",
+        "ukphone": "wel'hiːld"
+    },
+    {
+        "name": "whereby",
+        "trans": [
+            "借以， 凭"
+        ],
+        "usphone": "wɛr'bai",
+        "ukphone": "wer'baɪ"
+    },
+    {
+        "name": "whim",
+        "trans": [
+            "一时的兴致， 冲动； 怪念头， 奇想"
+        ],
+        "usphone": "wɪm",
+        "ukphone": "wɪm"
+    },
+    {
+        "name": "wholesome",
+        "trans": [
+            "健康的， 有利健康的； 有道德的"
+        ],
+        "usphone": "'holsəm",
+        "ukphone": "'houlsəm"
+    },
+    {
+        "name": "wick",
+        "trans": [
+            "蜡烛芯； 灯芯"
+        ],
+        "usphone": "wɪk",
+        "ukphone": "wɪk"
+    },
+    {
+        "name": "widespread",
+        "trans": [
+            "分布广泛的， 普遍的"
+        ],
+        "usphone": "ˈwʌɪdsprɛd",
+        "ukphone": "'waɪdspred"
+    },
+    {
+        "name": "wield",
+        "trans": [
+            "支配， 掌权， 行使"
+        ],
+        "usphone": "wild",
+        "ukphone": "wiːld"
+    },
+    {
+        "name": "willful",
+        "trans": [
+            "成心的， 有意的； 任性的"
+        ],
+        "usphone": "'wɪlfəl",
+        "ukphone": "'wɪlfl"
+    },
+    {
+        "name": "willow",
+        "trans": [
+            "柳， 柳树； 柳木制品"
+        ],
+        "usphone": "'wɪlo",
+        "ukphone": "'wɪlou"
+    },
+    {
+        "name": "wintry",
+        "trans": [
+            "冬天的； 寒冷的； 冷淡的"
+        ],
+        "usphone": "'wɪntri",
+        "ukphone": "'wɪntri"
+    },
+    {
+        "name": "wipe",
+        "trans": [
+            "擦， 揩， 抹"
+        ],
+        "usphone": "waɪp",
+        "ukphone": "waɪp"
+    },
+    {
+        "name": "wispy",
+        "trans": [
+            "成束的； 纤细的"
+        ],
+        "usphone": "'wispi",
+        "ukphone": "'wɪspi"
+    },
+    {
+        "name": "wit",
+        "trans": [
+            "智力， 才智； 风趣； 机智幽默的人"
+        ],
+        "usphone": "wɪt",
+        "ukphone": "wɪt"
+    },
+    {
+        "name": "withdraw",
+        "trans": [
+            "取消； 撤销； 提取； 撤退， 撤离"
+        ],
+        "usphone": "wɪð'drɔ",
+        "ukphone": "wɪð'drɔː"
+    },
+    {
+        "name": "wither",
+        "trans": [
+            "枯萎， 凋谢； 衰退； 萎缩； 破灭"
+        ],
+        "usphone": "'wɪðɚ",
+        "ukphone": "'wɪðər"
+    },
+    {
+        "name": "withhold",
+        "trans": [
+            "拒绝给， 不给； 抑制； 忍住"
+        ],
+        "usphone": "wɪð'hold",
+        "ukphone": "wɪð'hould"
+    },
+    {
+        "name": "withstand",
+        "trans": [
+            "经受住， 耐； 抵挡"
+        ],
+        "usphone": "wɪð'stænd",
+        "ukphone": "wɪð'stænd"
+    },
+    {
+        "name": "wonder",
+        "trans": [
+            "诧异；纳闷，想知道",
+            "惊奇， 惊异； 奇迹， 奇事"
+        ],
+        "usphone": "'wʌndɚ",
+        "ukphone": "'wʌndər"
+    },
+    {
+        "name": "worship",
+        "trans": [
+            "祭拜； 崇拜， 崇敬"
+        ],
+        "usphone": "'wɝʃɪp",
+        "ukphone": "'wɜːrʃɪp"
+    },
+    {
+        "name": "worth",
+        "trans": [
+            "值…的，价值…的，值得…的",
+            "价值； 财产"
+        ],
+        "usphone": "wɝθ",
+        "ukphone": "wɜːrθ"
+    },
+    {
+        "name": "wrap",
+        "trans": [
+            "包，裹",
+            "披肩， 围巾； 包装材料"
+        ],
+        "usphone": "ræp",
+        "ukphone": "ræp"
+    },
+    {
+        "name": "wreck",
+        "trans": [
+            "使失事；破坏",
+            "沉船； 失事"
+        ],
+        "usphone": "rɛk",
+        "ukphone": "rek"
+    },
+    {
+        "name": "wrench",
+        "trans": [
+            "扭伤；猛拉，猛扭；使痛苦",
+            "扭伤； 痛苦， 难受； 扳手"
+        ],
+        "usphone": "rɛntʃ",
+        "ukphone": "rentʃ"
+    },
+    {
+        "name": "wretch",
+        "trans": [
+            "不幸的人； 恶棍， 无赖"
+        ],
+        "usphone": "rɛtʃ",
+        "ukphone": "retʃ"
+    },
+    {
+        "name": "wrinkle",
+        "trans": [
+            "起皱纹",
+            "皱纹"
+        ],
+        "usphone": "'rɪŋkl",
+        "ukphone": "'rɪŋkl"
+    },
+    {
+        "name": "X-ray",
+        "trans": [
+            "X射线， X光； X光照片"
+        ],
+        "usphone": "'eksreɪ",
+        "ukphone": "'eks reɪ"
+    },
+    {
+        "name": "yarn",
+        "trans": [
+            "纱， 纱线； 故事"
+        ],
+        "usphone": "jɑn",
+        "ukphone": "jɑːrn"
+    },
+    {
+        "name": "yeast",
+        "trans": [
+            "酵母， 发酵粉"
+        ],
+        "usphone": "jist",
+        "ukphone": "jiːst"
+    },
+    {
+        "name": "yelp",
+        "trans": [
+            "尖叫",
+            "短而尖的叫声"
+        ],
+        "usphone": "jɛlp",
+        "ukphone": "jelp"
+    },
+    {
+        "name": "yield",
+        "trans": [
+            "生产，出产；屈服，顺从；让出，放弃；变形，弯曲",
+            "产量； 收益"
+        ],
+        "usphone": "jild",
+        "ukphone": "jiːld"
+    },
+    {
+        "name": "yogurt",
+        "trans": [
+            "酸奶"
+        ],
+        "usphone": "'joɡət",
+        "ukphone": "'jougərt"
+    },
+    {
+        "name": "yoke",
+        "trans": [
+            "裤腰；牛轭；奴役，束缚",
+            "使结合， 连接"
+        ],
+        "usphone": "jok",
+        "ukphone": "jouk"
+    },
+    {
+        "name": "yolk",
+        "trans": [
+            "蛋黄， 卵黄"
+        ],
+        "usphone": "jok",
+        "ukphone": "jouk"
+    },
+    {
+        "name": "zealous",
+        "trans": [
+            "狂热的， 热烈的， 充满激情的"
+        ],
+        "usphone": "'zɛləs",
+        "ukphone": "'zeləs"
+    },
+    {
+        "name": "zest",
+        "trans": [
+            "趣味； 热情， 狂热"
+        ],
+        "usphone": "zɛst",
+        "ukphone": "zest"
+    },
+    {
+        "name": "zigzag",
+        "trans": [
+            "曲折行进",
+            "之字形的，弯弯曲曲的",
+            "之字形"
+        ],
+        "usphone": "'zɪɡzæɡ",
+        "ukphone": "'zɪgzæg"
+    },
+    {
+        "name": "zinc",
+        "trans": [
+            "锌"
+        ],
+        "usphone": "zɪŋk",
+        "ukphone": "zɪŋk"
+    },
+    {
+        "name": "zone",
+        "trans": [
+            "将…划做特殊区域；分区，划分地带",
+            "地区， 地域， 地带； 气候带"
+        ],
+        "usphone": "zon",
+        "ukphone": "zoun"
+    }
+]

--- a/src/resources/dictionary.ts
+++ b/src/resources/dictionary.ts
@@ -1398,6 +1398,17 @@ const internationalExam: DictionaryResource[] = [
     languageCategory: 'en',
   },
   {
+    id: 'toefl-writing',
+    name: 'TOEFL 写作高频词',
+    description: '托福写作高频词：逻辑衔接、论证动词、评价形容词与常考话题词',
+    category: '国际考试',
+    tags: ['TOEFL'],
+    url: '/dicts/TOEFL_Writing_HighFreq.json',
+    length: 493,
+    language: 'en',
+    languageCategory: 'en',
+  },
+  {
     id: 'bec2',
     name: '商务英语',
     description: '商务英语常见词',

--- a/src/resources/dictionary.ts
+++ b/src/resources/dictionary.ts
@@ -1387,6 +1387,17 @@ const internationalExam: DictionaryResource[] = [
     languageCategory: 'en',
   },
   {
+    id: 'toefl-order',
+    name: 'TOEFL 正序版',
+    description: '托福考试常见词（按字母正序排列）',
+    category: '国际考试',
+    tags: ['TOEFL'],
+    url: '/dicts/TOEFL_order.json',
+    length: 4264,
+    language: 'en',
+    languageCategory: 'en',
+  },
+  {
     id: 'bec2',
     name: '商务英语',
     description: '商务英语常见词',


### PR DESCRIPTION
按 `docs/toBuildDict.md` 的流程加了两个 TOEFL 词典。

### TOEFL 正序版（4264 词）

现有的 `TOEFL_3_T.json` 是乱序的，这个是同样 4264 个词按字母重排了一遍，方便按字母段过词，跟 IELTS 已有的顺序版/乱序版组织方式一样。词条内容一条没动，只改了顺序。

排序用的是不区分大小写的规则，所以 `Babylonian` 落在 `axis` 和 `backhand` 之间。现有的 `IELTS_order.json` 用的是字节序，119 个首字母大写的词都堆在了 `abandon` 前面，我没有一并改，如果需要可以再补一个 commit。

### TOEFL 写作高频词（493 词）

托福写作里用得多的词，按主题分了 10 组：逻辑衔接、论证动词、分析评估、因果影响、评价形容词、性质形容词、抽象名词、论辩名词，再加教育科技、环境社会经济健康媒体两组话题词。

选词是人工整理的，没有对应的单一源词书。释义和音标没有自己写，全部取自仓库里已有的词库（`TOEFL_3_T`、`TOEFL_ZhangHongYan`、`IELTS_3_T`、`CET4_T` / `CET6_T`、2025 考研红宝书等）。我写了个脚本给 `public/dicts/` 下所有词典建索引，把这 493 个词的释义和美音英音逐条比对了一遍，都能在已有词典里找到原样的出处。如果这种来源不符合收录标准，这个词典可以撤掉，只留正序版。

### 检查

`length` 是 `scripts/update-dict-size.js` 跑出来的；两个词典都没有重复词、空释义或缺音标；`vite build` 通过，`tsc --noEmit` 相对 master 没有新增报错；本地 dev 起来看过，两个词典在列表里都能选中并正常打字。
