### PR TITLE
feat: add Beijing primary school dictionary with sentence examples

### DIFF
--- a/public/dicts/beijing_primary_english.json
+++ b/public/dicts/beijing_primary_english.json
@@ -1,0 +1,10106 @@
+[
+  {
+    "name": "a",
+    "trans": [
+      "art. 一个"
+    ],
+    "sentences": [
+      {
+        "english": "I have a book.",
+        "chinese": "我有一本书。"
+      }
+    ]
+  },
+  {
+    "name": "a bit",
+    "trans": [
+      "有一点"
+    ],
+    "sentences": [
+      {
+        "english": "I am a bit tired today.",
+        "chinese": "我今天有一点累。"
+      }
+    ]
+  },
+  {
+    "name": "a pair of",
+    "trans": [
+      "一双"
+    ],
+    "sentences": [
+      {
+        "english": "I need a pair of shoes.",
+        "chinese": "我需要一双鞋。"
+      }
+    ]
+  },
+  {
+    "name": "about",
+    "trans": [
+      "prep. 关于"
+    ],
+    "sentences": [
+      {
+        "english": "This book is about animals.",
+        "chinese": "这本书是关于动物的。"
+      }
+    ]
+  },
+  {
+    "name": "above",
+    "trans": [
+      "prep. 在上方"
+    ],
+    "sentences": [
+      {
+        "english": "The clock is above the door.",
+        "chinese": "钟在门的上方。"
+      }
+    ]
+  },
+  {
+    "name": "address",
+    "trans": [
+      "n. 地址"
+    ],
+    "sentences": [
+      {
+        "english": "What is your home address?",
+        "chinese": "你家的地址是什么?"
+      }
+    ]
+  },
+  {
+    "name": "after",
+    "trans": [
+      "prep. 在之后"
+    ],
+    "sentences": [
+      {
+        "english": "We play after class.",
+        "chinese": "我们下课后玩耍。"
+      }
+    ]
+  },
+  {
+    "name": "afternoon",
+    "trans": [
+      "n. 下午"
+    ],
+    "sentences": [
+      {
+        "english": "Good afternoon, Miss Li.",
+        "chinese": "下午好,李老师。"
+      }
+    ]
+  },
+  {
+    "name": "airport",
+    "trans": [
+      "n. 机场"
+    ],
+    "sentences": [
+      {
+        "english": "My father works at the airport.",
+        "chinese": "我父亲在机场工作。"
+      }
+    ]
+  },
+  {
+    "name": "album",
+    "trans": [
+      "n. 集邮册"
+    ],
+    "sentences": [
+      {
+        "english": "I keep my photos in this album.",
+        "chinese": "我把照片放在这本册子里。"
+      }
+    ]
+  },
+  {
+    "name": "all",
+    "trans": [
+      "adj. 全部的"
+    ],
+    "sentences": [
+      {
+        "english": "Hugh and all his friends came to the party.",
+        "chinese": "休和他所有的朋友都去了聚会。"
+      }
+    ]
+  },
+  {
+    "name": "all right",
+    "trans": [
+      "好吧"
+    ],
+    "sentences": [
+      {
+        "english": "`What's your new teacher like?' — `He's all right.'",
+        "chinese": "“你的新老师怎么样？”——“还不错。”"
+      }
+    ]
+  },
+  {
+    "name": "also",
+    "trans": [
+      "adv. 也"
+    ],
+    "sentences": [
+      {
+        "english": "The book also includes an index of all US presidents.",
+        "chinese": "这本书还附有美国历任总统索引。"
+      }
+    ]
+  },
+  {
+    "name": "always",
+    "trans": [
+      "adv. 总是"
+    ],
+    "sentences": [
+      {
+        "english": "She's always late for school.",
+        "chinese": "她总是上学迟到。"
+      }
+    ]
+  },
+  {
+    "name": "am",
+    "trans": [
+      "v. 是"
+    ],
+    "sentences": [
+      {
+        "english": "I am studying Chinese.",
+        "chinese": "我正在学中文。"
+      }
+    ]
+  },
+  {
+    "name": "amazing",
+    "trans": [
+      "adj. 令人惊讶的"
+    ],
+    "sentences": [
+      {
+        "english": "It's amazing what we can remember if we try.",
+        "chinese": "令人惊奇的是，只要我们努力回想，就能记起很多事情。"
+      }
+    ]
+  },
+  {
+    "name": "America",
+    "trans": [
+      "n. 美国"
+    ],
+    "sentences": [
+      {
+        "english": "But I also know how much I love America.",
+        "chinese": "但我知道我有多爱美国。"
+      }
+    ]
+  },
+  {
+    "name": "American",
+    "trans": [
+      "adj. 美国的"
+    ],
+    "sentences": [
+      {
+        "english": "He put on an American accent.",
+        "chinese": "他假操着一口美国腔。"
+      }
+    ]
+  },
+  {
+    "name": "an",
+    "trans": [
+      "art. 一个"
+    ],
+    "sentences": [
+      {
+        "english": "At a time of famine, it was an inflammatory statement.",
+        "chinese": "“在饥荒时期”，是一种煽动性的说法。"
+      }
+    ]
+  },
+  {
+    "name": "and",
+    "trans": [
+      "conj. 和"
+    ],
+    "sentences": [
+      {
+        "english": "She and Simon have already gone.",
+        "chinese": "她和西蒙已经走了。"
+      }
+    ]
+  },
+  {
+    "name": "angry",
+    "trans": [
+      "adj. 生气的"
+    ],
+    "sentences": [
+      {
+        "english": "We are very angry about the decision to close the school.",
+        "chinese": "关闭学校这一决定使我们非常愤怒。"
+      }
+    ]
+  },
+  {
+    "name": "animal",
+    "trans": [
+      "n. 动物"
+    ],
+    "sentences": [
+      {
+        "english": "I have an allergy to animal hair.",
+        "chinese": "我对动物毛过敏。"
+      }
+    ]
+  },
+  {
+    "name": "another",
+    "trans": [
+      "pron. 另一个"
+    ],
+    "sentences": [
+      {
+        "english": "These children are learning to help one another.",
+        "chinese": "这些孩子们正学着互相帮助。"
+      }
+    ]
+  },
+  {
+    "name": "answer",
+    "trans": [
+      "v. 回答"
+    ],
+    "sentences": [
+      {
+        "english": "I asked him but he didn't answer.",
+        "chinese": "我问了他，但他没有回答。"
+      }
+    ]
+  },
+  {
+    "name": "anything",
+    "trans": [
+      "pron. 任何东西"
+    ],
+    "sentences": [
+      {
+        "english": "He is young and ready for anything.",
+        "chinese": "他很年轻，什么事情都愿意尝试。"
+      }
+    ]
+  },
+  {
+    "name": "apple",
+    "trans": [
+      "n. 苹果"
+    ],
+    "sentences": [
+      {
+        "english": "I always have an apple in my packed lunch.",
+        "chinese": "我打包午餐时总是放上一个苹果。"
+      }
+    ]
+  },
+  {
+    "name": "April",
+    "trans": [
+      "n. 四月"
+    ],
+    "sentences": [
+      {
+        "english": "I'm getting married in April.",
+        "chinese": "我4月份就要结婚了。"
+      }
+    ]
+  },
+  {
+    "name": "are",
+    "trans": [
+      "v. 是"
+    ],
+    "sentences": [
+      {
+        "english": "This is happening everywhere in the country.",
+        "chinese": "全国各地都在发生这样的事情。"
+      }
+    ]
+  },
+  {
+    "name": "aren't",
+    "trans": [
+      "不是"
+    ],
+    "sentences": [
+      {
+        "english": "Our troubles aren't over yet.",
+        "chinese": "我们的麻烦还没有完呢。"
+      }
+    ]
+  },
+  {
+    "name": "argue",
+    "trans": [
+      "v. 争论"
+    ],
+    "sentences": [
+      {
+        "english": "He was arguing with his wife about money.",
+        "chinese": "他和妻子正因为钱的事情吵架。"
+      }
+    ]
+  },
+  {
+    "name": "around",
+    "trans": [
+      "adv. 朝相反方向"
+    ],
+    "sentences": [
+      {
+        "english": "She looked at the people around her.",
+        "chinese": "她看着周围的人。"
+      }
+    ]
+  },
+  {
+    "name": "arrive",
+    "trans": [
+      "v. 到达"
+    ],
+    "sentences": [
+      {
+        "english": "Their train arrived on time.",
+        "chinese": "他们的火车正点到达。"
+      }
+    ]
+  },
+  {
+    "name": "Art",
+    "trans": [
+      "n. 美术"
+    ],
+    "sentences": [
+      {
+        "english": "modern American art",
+        "chinese": "美国现代艺术作品"
+      }
+    ]
+  },
+  {
+    "name": "at",
+    "trans": [
+      "prep. 在"
+    ],
+    "sentences": [
+      {
+        "english": "They agreed to meet at a restaurant.",
+        "chinese": "他们同意在一家餐馆见面。"
+      }
+    ]
+  },
+  {
+    "name": "at all",
+    "trans": [
+      "根本"
+    ],
+    "sentences": [
+      {
+        "english": "Kay has no affectation at all.",
+        "chinese": "凯一点也不做作。"
+      }
+    ]
+  },
+  {
+    "name": "ate",
+    "trans": [
+      "v. 吃（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "What did you eat last night?",
+        "chinese": "你昨晚吃的什么？"
+      }
+    ]
+  },
+  {
+    "name": "Australia",
+    "trans": [
+      "n. 澳大利亚"
+    ],
+    "sentences": [
+      {
+        "english": "She's working out in Australia.",
+        "chinese": "她远在澳大利亚工作。"
+      }
+    ]
+  },
+  {
+    "name": "Australian",
+    "trans": [
+      "adj. 澳大利亚的"
+    ],
+    "sentences": [
+      {
+        "english": "She spoke with a strong Australian accent.",
+        "chinese": "她说话带有浓重的澳大利亚口音。"
+      }
+    ]
+  },
+  {
+    "name": "autumn",
+    "trans": [
+      "n. 秋天"
+    ],
+    "sentences": [
+      {
+        "english": "Autumn is my favourite season.",
+        "chinese": "秋季是我最喜欢的季节。"
+      }
+    ]
+  },
+  {
+    "name": "awake",
+    "trans": [
+      "adj. 醒的"
+    ],
+    "sentences": [
+      {
+        "english": "I stayed awake until midnight.",
+        "chinese": "我到半夜还没睡着。"
+      }
+    ]
+  },
+  {
+    "name": "away",
+    "trans": [
+      "adv. 离开"
+    ],
+    "sentences": [
+      {
+        "english": "Jason was working away from home for a while.",
+        "chinese": "贾森离家外出工作一阵子。"
+      }
+    ]
+  },
+  {
+    "name": "baby",
+    "trans": [
+      "n. 婴儿"
+    ],
+    "sentences": [
+      {
+        "english": "He bathed the baby and put her to bed.",
+        "chinese": "他给孩子洗了澡安顿上床。"
+      }
+    ]
+  },
+  {
+    "name": "back",
+    "trans": [
+      "adj. 后面的"
+    ],
+    "sentences": [
+      {
+        "english": "She stepped back from the door.",
+        "chinese": "她从门口退了回来。"
+      }
+    ]
+  },
+  {
+    "name": "bag",
+    "trans": [
+      "n. 包"
+    ],
+    "sentences": [
+      {
+        "english": "He ate a whole bag of sweets.",
+        "chinese": "他吃了整整一袋糖果。"
+      }
+    ]
+  },
+  {
+    "name": "ball",
+    "trans": [
+      "n. 球"
+    ],
+    "sentences": [
+      {
+        "english": "Two young boys were kicking a ball.",
+        "chinese": "两个小男孩儿在踢球。"
+      }
+    ]
+  },
+  {
+    "name": "balloon",
+    "trans": [
+      "n. 气球"
+    ],
+    "sentences": [
+      {
+        "english": "Large balloons floated above the crowd.",
+        "chinese": "巨大的气球飘在人群上方。"
+      }
+    ]
+  },
+  {
+    "name": "bamboo",
+    "trans": [
+      "n. 竹子"
+    ],
+    "sentences": [
+      {
+        "english": "We sat on big bamboo chairs with soft cushions.",
+        "chinese": "我们坐在垫着软垫的大竹椅上。"
+      }
+    ]
+  },
+  {
+    "name": "banana",
+    "trans": [
+      "n. 香蕉"
+    ],
+    "sentences": [
+      {
+        "english": "I bought milk, bread and a bunch of bananas.",
+        "chinese": "我买了牛奶、面包和一串香蕉。"
+      }
+    ]
+  },
+  {
+    "name": "baseball",
+    "trans": [
+      "n. 棒球"
+    ],
+    "sentences": [
+      {
+        "english": "My mind, which had been essentially empty to that point, filled with baseball statistics.",
+        "chinese": "我的头脑那时候象张白纸，写满了棒球比赛数据。"
+      }
+    ]
+  },
+  {
+    "name": "basketball",
+    "trans": [
+      "n. 篮球"
+    ],
+    "sentences": [
+      {
+        "english": "I enjoy playing basketball.",
+        "chinese": "我喜欢打篮球。"
+      }
+    ]
+  },
+  {
+    "name": "bear",
+    "trans": [
+      "n. 熊"
+    ],
+    "sentences": [
+      {
+        "english": "The loneliness was hard to bear.",
+        "chinese": "寂寞难耐。"
+      }
+    ]
+  },
+  {
+    "name": "beautiful",
+    "trans": [
+      "adj. 漂亮的"
+    ],
+    "sentences": [
+      {
+        "english": "Karen sings beautifully.",
+        "chinese": "卡伦唱歌很好听。"
+      }
+    ]
+  },
+  {
+    "name": "because",
+    "trans": [
+      "conj. 因为"
+    ],
+    "sentences": [
+      {
+        "english": "He is called Mitch because his name is Mitchell.",
+        "chinese": "人们叫他Mitch（米奇），因为他名叫Mitchell（米切尔）。"
+      }
+    ]
+  },
+  {
+    "name": "bed",
+    "trans": [
+      "n. 床"
+    ],
+    "sentences": [
+      {
+        "english": "We went to bed at about 10 p.m.",
+        "chinese": "我们晚上10点左右上床睡觉。"
+      }
+    ]
+  },
+  {
+    "name": "before",
+    "trans": [
+      "prep. 在之前"
+    ],
+    "sentences": [
+      {
+        "english": "Brush your teeth before you go to bed.",
+        "chinese": "你刷完牙再上床睡觉。"
+      }
+    ]
+  },
+  {
+    "name": "beside",
+    "trans": [
+      "prep. 在旁边"
+    ],
+    "sentences": [
+      {
+        "english": "Can I sit beside you?",
+        "chinese": "我能坐你边上吗？"
+      }
+    ]
+  },
+  {
+    "name": "best",
+    "trans": [
+      "adj. 最好的"
+    ],
+    "sentences": [
+      {
+        "english": "If you do your best, no one can criticize you.",
+        "chinese": "只要尽了力，谁也不能怪罪你。"
+      }
+    ]
+  },
+  {
+    "name": "between",
+    "trans": [
+      "prep. 在中间"
+    ],
+    "sentences": [
+      {
+        "english": "Nicole was standing between the two men.",
+        "chinese": "妮科尔站在两名男子中间。"
+      }
+    ]
+  },
+  {
+    "name": "bicycle",
+    "trans": [
+      "n. 自行车"
+    ],
+    "sentences": [
+      {
+        "english": "Oscar had a new bicycle.",
+        "chinese": "奥斯卡拥有一辆新的自行车。"
+      }
+    ]
+  },
+  {
+    "name": "big",
+    "trans": [
+      "adj. 大的"
+    ],
+    "sentences": [
+      {
+        "english": "Australia is a big country.",
+        "chinese": "澳大利亚面积很大。"
+      }
+    ]
+  },
+  {
+    "name": "bike",
+    "trans": [
+      "n. 自行车"
+    ],
+    "sentences": [
+      {
+        "english": "When you ride a bike, you exercise all your leg muscles.",
+        "chinese": "骑自行车时腿部肌肉都得到了锻炼。"
+      }
+    ]
+  },
+  {
+    "name": "bird",
+    "trans": [
+      "n. 鸟"
+    ],
+    "sentences": [
+      {
+        "english": "a bird's nest",
+        "chinese": "鸟窝"
+      }
+    ]
+  },
+  {
+    "name": "birthday",
+    "trans": [
+      "n. 生日"
+    ],
+    "sentences": [
+      {
+        "english": "Mum always sends David a present on his birthday.",
+        "chinese": "戴维过生日时妈妈总会送上一份礼物。"
+      }
+    ]
+  },
+  {
+    "name": "biscuit",
+    "trans": [
+      "n. 饼干"
+    ],
+    "sentences": [
+      {
+        "english": "The child was enjoying a chocolate biscuit, which he got from his fellows.",
+        "chinese": "翻译小孩从他的伙伴那弄到了一块巧克力饼干，正津津有味地吃着。"
+      }
+    ]
+  },
+  {
+    "name": "black",
+    "trans": [
+      "adj. 黑色的"
+    ],
+    "sentences": [
+      {
+        "english": "A cup of black coffee contains no calories.",
+        "chinese": "一杯黑咖啡不含热量。"
+      }
+    ]
+  },
+  {
+    "name": "blind",
+    "trans": [
+      "adj. 盲的"
+    ],
+    "sentences": [
+      {
+        "english": "My grandfather is going blind.",
+        "chinese": "我爷爷快失明了。"
+      }
+    ]
+  },
+  {
+    "name": "blue",
+    "trans": [
+      "adj. 蓝色的"
+    ],
+    "sentences": [
+      {
+        "english": "We looked up at the cloudless blue sky.",
+        "chinese": "我们仰望着没有一丝云彩的蓝天。"
+      }
+    ]
+  },
+  {
+    "name": "body",
+    "trans": [
+      "n. 身体"
+    ],
+    "sentences": [
+      {
+        "english": "Yoga creates a healthy mind in a healthy body.",
+        "chinese": "瑜伽促进身心健康。"
+      }
+    ]
+  },
+  {
+    "name": "book",
+    "trans": [
+      "n. 书"
+    ],
+    "sentences": [
+      {
+        "english": "Her second book was an immediate success.",
+        "chinese": "她的第二本书一出版便迅速蹿红。"
+      }
+    ]
+  },
+  {
+    "name": "bookshelf",
+    "trans": [
+      "n. 书架"
+    ],
+    "sentences": [
+      {
+        "english": "He stared at my bookshelf for a while, and say 'Ah, she likes reading!",
+        "chinese": "接着，他开始看我的书架，惊讶的发现书好多呀！"
+      }
+    ]
+  },
+  {
+    "name": "bored",
+    "trans": [
+      "adj. 无聊的"
+    ],
+    "sentences": [
+      {
+        "english": "I am getting very bored with this television programme.",
+        "chinese": "我逐渐对这个电视节目感到非常厌倦。"
+      }
+    ]
+  },
+  {
+    "name": "boring",
+    "trans": [
+      "adj. 无聊的"
+    ],
+    "sentences": [
+      {
+        "english": "Washing dishes is boring work.",
+        "chinese": "刷盘子这活儿很没劲。"
+      }
+    ]
+  },
+  {
+    "name": "borrow",
+    "trans": [
+      "v. 借"
+    ],
+    "sentences": [
+      {
+        "english": "He have taken advantage of her kindness to borrow money from her frequently.",
+        "chinese": "他利用她的善良，三番五次向她借钱。"
+      }
+    ]
+  },
+  {
+    "name": "both",
+    "trans": [
+      "pron. 都"
+    ],
+    "sentences": [
+      {
+        "english": "Stand up straight with both arms at your sides.",
+        "chinese": "站直身子，双臂垂在两侧。"
+      }
+    ]
+  },
+  {
+    "name": "bought",
+    "trans": [
+      "v. 买（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "Car buyers are more interested in safety than speed.",
+        "chinese": "购车者更关注安全，而不是速度。"
+      }
+    ]
+  },
+  {
+    "name": "box",
+    "trans": [
+      "n. 盒子"
+    ],
+    "sentences": [
+      {
+        "english": "He packed his books into the cardboard box beside him.",
+        "chinese": "他把书收拾进身旁的纸板箱里。"
+      }
+    ]
+  },
+  {
+    "name": "boy",
+    "trans": [
+      "n. 男孩"
+    ],
+    "sentences": [
+      {
+        "english": "He is a good boy.",
+        "chinese": "他是一个好男孩。"
+      }
+    ]
+  },
+  {
+    "name": "break",
+    "trans": [
+      "v. 弄坏"
+    ],
+    "sentences": [
+      {
+        "english": "The plane crashed into the trees and broke into three pieces.",
+        "chinese": "飞机撞树断成了三截。"
+      }
+    ]
+  },
+  {
+    "name": "bring",
+    "trans": [
+      "v. 带来"
+    ],
+    "sentences": [
+      {
+        "english": "Remember to bring an old shirt to wear when we paint.",
+        "chinese": "粉刷时记得带件旧衬衫穿上。"
+      }
+    ]
+  },
+  {
+    "name": "British",
+    "trans": [
+      "adj. 英国的"
+    ],
+    "sentences": [
+      {
+        "english": "We were still in British waters.",
+        "chinese": "我们仍在英国的领海上。"
+      }
+    ]
+  },
+  {
+    "name": "broken",
+    "trans": [
+      "adj. 坏掉的"
+    ],
+    "sentences": [
+      {
+        "english": "She was taken to hospital with a broken leg.",
+        "chinese": "她腿骨折了，被送进了医院。"
+      }
+    ]
+  },
+  {
+    "name": "brother",
+    "trans": [
+      "n. 兄弟"
+    ],
+    "sentences": [
+      {
+        "english": "His brother advised her to have nothing to do with it.",
+        "chinese": "他哥哥劝她不要管那件事。"
+      }
+    ]
+  },
+  {
+    "name": "brown",
+    "trans": [
+      "adj. 棕色的"
+    ],
+    "sentences": [
+      {
+        "english": "He looked into her brown eyes.",
+        "chinese": "他盯着她褐色的眼睛。"
+      }
+    ]
+  },
+  {
+    "name": "build",
+    "trans": [
+      "v. 建造"
+    ],
+    "sentences": [
+      {
+        "english": "They are going to build a hotel here.",
+        "chinese": "他们要在这儿建一座宾馆。"
+      }
+    ]
+  },
+  {
+    "name": "building",
+    "trans": [
+      "n. 建筑物"
+    ],
+    "sentences": [
+      {
+        "english": "They lived on the top floor of the building.",
+        "chinese": "他们住在大楼顶层。"
+      }
+    ]
+  },
+  {
+    "name": "bus",
+    "trans": [
+      "n. 公共汽车"
+    ],
+    "sentences": [
+      {
+        "english": "The bus came right on time.",
+        "chinese": "公共汽车正好准时到达。"
+      }
+    ]
+  },
+  {
+    "name": "bus driver",
+    "trans": [
+      "n. 公交车司机"
+    ],
+    "sentences": [
+      {
+        "english": "He's a bus driver.",
+        "chinese": "他是一名公共汽车司机。"
+      }
+    ]
+  },
+  {
+    "name": "busy",
+    "trans": [
+      "adj. 忙碌的"
+    ],
+    "sentences": [
+      {
+        "english": "They are busy preparing for a party on Saturday.",
+        "chinese": "他们忙着筹备星期六聚会。"
+      }
+    ]
+  },
+  {
+    "name": "but",
+    "trans": [
+      "conj. 但是"
+    ],
+    "sentences": [
+      {
+        "english": "I really enjoyed my holiday, but now it's time to get back to work.",
+        "chinese": "我假期过得特别快活，不过现在得回去上班了。"
+      }
+    ]
+  },
+  {
+    "name": "by",
+    "trans": [
+      "prep. 乘坐"
+    ],
+    "sentences": [
+      {
+        "english": "The dinner was served by his mother and sisters.",
+        "chinese": "晚餐是他母亲和姐妹们做的。"
+      }
+    ]
+  },
+  {
+    "name": "bye",
+    "trans": [
+      "int. 再见"
+    ],
+    "sentences": [
+      {
+        "english": "Really? All right. Bye-bye.",
+        "chinese": "是吗？行，再见。"
+      }
+    ]
+  },
+  {
+    "name": "cake",
+    "trans": [
+      "n. 蛋糕"
+    ],
+    "sentences": [
+      {
+        "english": "He ate a piece of chocolate cake.",
+        "chinese": "他吃了一块巧克力蛋糕。"
+      }
+    ]
+  },
+  {
+    "name": "came",
+    "trans": [
+      "v. 来（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "Two police officers came into the hall.",
+        "chinese": "两名警官来到大厅。"
+      }
+    ]
+  },
+  {
+    "name": "camera",
+    "trans": [
+      "n. 照相机"
+    ],
+    "sentences": [
+      {
+        "english": "He took out his camera and really wanted to get that picture.",
+        "chinese": "他拿出照相机，很想得到那张照片。"
+      }
+    ]
+  },
+  {
+    "name": "can",
+    "trans": [
+      "v. 能"
+    ],
+    "sentences": [
+      {
+        "english": "I can take care of myself.",
+        "chinese": "我能照顾自己。"
+      }
+    ]
+  },
+  {
+    "name": "Canada",
+    "trans": [
+      "n. 加拿大"
+    ],
+    "sentences": [
+      {
+        "english": "My aunt lives in Canada.",
+        "chinese": "我的姑母住在加拿大。"
+      }
+    ]
+  },
+  {
+    "name": "candy",
+    "trans": [
+      "n. 糖果"
+    ],
+    "sentences": [
+      {
+        "english": "I gave him a piece of candy.",
+        "chinese": "我给了他一块糖。"
+      }
+    ]
+  },
+  {
+    "name": "capital",
+    "trans": [
+      "n. 首都"
+    ],
+    "sentences": [
+      {
+        "english": "He wrote his name in capitals.",
+        "chinese": "他把名字用大写字母写出。"
+      }
+    ]
+  },
+  {
+    "name": "car",
+    "trans": [
+      "n. 汽车"
+    ],
+    "sentences": [
+      {
+        "english": "They arrived by car.",
+        "chinese": "他们是坐小汽车来的。"
+      }
+    ]
+  },
+  {
+    "name": "card",
+    "trans": [
+      "n. 卡片"
+    ],
+    "sentences": [
+      {
+        "english": "Please remember to bring your membership card.",
+        "chinese": "请记得带上您的会员卡。"
+      }
+    ]
+  },
+  {
+    "name": "careful",
+    "trans": [
+      "adj. 小心的"
+    ],
+    "sentences": [
+      {
+        "english": "Have a nice time, and drive carefully.",
+        "chinese": "玩得开心，小心开车。"
+      }
+    ]
+  },
+  {
+    "name": "carry",
+    "trans": [
+      "v. 提；抱"
+    ],
+    "sentences": [
+      {
+        "english": "You have to carry a passport.",
+        "chinese": "你得随身带着护照。"
+      }
+    ]
+  },
+  {
+    "name": "cartoon",
+    "trans": [
+      "n. 动画片"
+    ],
+    "sentences": [
+      {
+        "english": "cartoon characters",
+        "chinese": "漫画人物"
+      }
+    ]
+  },
+  {
+    "name": "cashier",
+    "trans": [
+      "n. 收银员"
+    ],
+    "sentences": [
+      {
+        "english": "Ari: (To the cashier) Two tickets, please. How much are they?",
+        "chinese": "（对收银员说）请买两张票。多少钱？"
+      }
+    ]
+  },
+  {
+    "name": "cat",
+    "trans": [
+      "n. 猫"
+    ],
+    "sentences": [
+      {
+        "english": "The cat sat on my lap, purring.",
+        "chinese": "这只猫坐在我的大腿上，发出呼噜声。"
+      }
+    ]
+  },
+  {
+    "name": "catch",
+    "trans": [
+      "v. 抓"
+    ],
+    "sentences": [
+      {
+        "english": "Police say they are confident of catching the man.",
+        "chinese": "警方说他们有信心抓到那名男子。"
+      }
+    ]
+  },
+  {
+    "name": "CD",
+    "trans": [
+      "n. 光盘"
+    ],
+    "sentences": [
+      {
+        "english": "How nice of him to give me a CD that will remind me.",
+        "chinese": "这家伙竟然送我一张CD让我想起。"
+      }
+    ]
+  },
+  {
+    "name": "CD-ROM",
+    "trans": [
+      "n. 光盘"
+    ],
+    "sentences": [
+      {
+        "english": "The encyclopedia is available on CD-ROM.",
+        "chinese": "百科全书光盘已上市。"
+      }
+    ]
+  },
+  {
+    "name": "cent",
+    "trans": [
+      "n. 美分"
+    ],
+    "sentences": [
+      {
+        "english": "The book cost six dollars and fifty cents.",
+        "chinese": "这本书6.5美元。"
+      }
+    ]
+  },
+  {
+    "name": "chair",
+    "trans": [
+      "n. 椅子"
+    ],
+    "sentences": [
+      {
+        "english": "He suddenly got up from his chair.",
+        "chinese": "他突然离开椅子站了起来。"
+      }
+    ]
+  },
+  {
+    "name": "cheap",
+    "trans": [
+      "adj. 便宜的"
+    ],
+    "sentences": [
+      {
+        "english": "You can deliver more food more cheaply by ship.",
+        "chinese": "走海路可以运更多的食品，且费用更便宜。"
+      }
+    ]
+  },
+  {
+    "name": "cheese",
+    "trans": [
+      "n. 奶酪"
+    ],
+    "sentences": [
+      {
+        "english": "We had bread and cheese for lunch.",
+        "chinese": "我们中午吃的面包配奶酪。"
+      }
+    ]
+  },
+  {
+    "name": "chicken",
+    "trans": [
+      "n. 鸡"
+    ],
+    "sentences": [
+      {
+        "english": "We had chicken sandwiches.",
+        "chinese": "我们吃了鸡肉三明治。"
+      }
+    ]
+  },
+  {
+    "name": "child",
+    "trans": [
+      "n. 小孩"
+    ],
+    "sentences": [
+      {
+        "english": "When I was a child I lived in a village.",
+        "chinese": "我小时候住在一个村庄里。"
+      }
+    ]
+  },
+  {
+    "name": "children",
+    "trans": [
+      "n. 孩子们"
+    ],
+    "sentences": [
+      {
+        "english": "When I was a child I lived in a village.",
+        "chinese": "我小时候住在一个村庄里。"
+      }
+    ]
+  },
+  {
+    "name": "Children's Day",
+    "trans": [
+      "n. 儿童节"
+    ],
+    "sentences": [
+      {
+        "english": "June 1st is Children's Day.",
+        "chinese": "六月一日是儿童节。"
+      }
+    ]
+  },
+  {
+    "name": "China",
+    "trans": [
+      "n. 中国"
+    ],
+    "sentences": [
+      {
+        "english": "He ate from a small bowl made of china.",
+        "chinese": "他用一个小瓷碗吃饭。"
+      }
+    ]
+  },
+  {
+    "name": "Chinatown",
+    "trans": [
+      "n. 唐人街"
+    ],
+    "sentences": [
+      {
+        "english": "How can I get to Chinatown?",
+        "chinese": "我该怎么去唐人街？"
+      }
+    ]
+  },
+  {
+    "name": "Chinese",
+    "trans": [
+      "n. 语文；汉语"
+    ],
+    "sentences": [
+      {
+        "english": "I am studying Chinese.",
+        "chinese": "我正在学中文。"
+      }
+    ]
+  },
+  {
+    "name": "chips",
+    "trans": [
+      "n. 薯条"
+    ],
+    "sentences": [
+      {
+        "english": "a computer chip",
+        "chinese": "电脑芯片"
+      }
+    ]
+  },
+  {
+    "name": "chocolate",
+    "trans": [
+      "n. 巧克力"
+    ],
+    "sentences": [
+      {
+        "english": "We shared a bar of chocolate.",
+        "chinese": "我们分吃了一块巧克力。"
+      }
+    ]
+  },
+  {
+    "name": "choose",
+    "trans": [
+      "v. 选择"
+    ],
+    "sentences": [
+      {
+        "english": "Each group will choose its own leader.",
+        "chinese": "每队要选出自己的队长。"
+      }
+    ]
+  },
+  {
+    "name": "chopsticks",
+    "trans": [
+      "n. 筷子"
+    ],
+    "sentences": [
+      {
+        "english": "She had no idea how to use chopsticks.",
+        "chinese": "她不会用筷子。"
+      }
+    ]
+  },
+  {
+    "name": "Christmas",
+    "trans": [
+      "n. 圣诞节"
+    ],
+    "sentences": [
+      {
+        "english": "`Merry Christmas!'",
+        "chinese": "“圣诞快乐！”"
+      }
+    ]
+  },
+  {
+    "name": "circle",
+    "trans": [
+      "n. 圆"
+    ],
+    "sentences": [
+      {
+        "english": "The Japanese flag is white, with a red circle in the centre.",
+        "chinese": "日本国旗是白底中央有一个红圈。。"
+      }
+    ]
+  },
+  {
+    "name": "city",
+    "trans": [
+      "n. 城市"
+    ],
+    "sentences": [
+      {
+        "english": "We visited the city of Los Angeles.",
+        "chinese": "我们访问了洛杉矶市。"
+      }
+    ]
+  },
+  {
+    "name": "clap",
+    "trans": [
+      "v. 鼓掌"
+    ],
+    "sentences": [
+      {
+        "english": "Margaret clapped her hands.",
+        "chinese": "玛格丽特鼓了几下掌。"
+      }
+    ]
+  },
+  {
+    "name": "class",
+    "trans": [
+      "n. 班级；课"
+    ],
+    "sentences": [
+      {
+        "english": "He spent six months in a class with younger students.",
+        "chinese": "他和比自己年纪小的学生在一个班里上了6个月的课。"
+      }
+    ]
+  },
+  {
+    "name": "classroom",
+    "trans": [
+      "n. 教室"
+    ],
+    "sentences": [
+      {
+        "english": "She'd sent him outside the classroom.",
+        "chinese": "她叫他到教室外面去。"
+      }
+    ]
+  },
+  {
+    "name": "clean",
+    "trans": [
+      "v. 打扫"
+    ],
+    "sentences": [
+      {
+        "english": "Make sure the children's hands are clean before they eat.",
+        "chinese": "要保证孩子们吃饭前洗干净手。"
+      }
+    ]
+  },
+  {
+    "name": "clever",
+    "trans": [
+      "adj. 聪明的"
+    ],
+    "sentences": [
+      {
+        "english": "The garden has been cleverly designed.",
+        "chinese": "这个花园设计得很巧妙。"
+      }
+    ]
+  },
+  {
+    "name": "click on",
+    "trans": [
+      "点击"
+    ],
+    "sentences": [
+      {
+        "english": "If you get stuck, click on Help.",
+        "chinese": "如果你碰到困难，请点击“帮助”。"
+      }
+    ]
+  },
+  {
+    "name": "climb",
+    "trans": [
+      "v. 爬"
+    ],
+    "sentences": [
+      {
+        "english": "It took half an hour to climb the hill.",
+        "chinese": "爬上这座山需要半个小时。"
+      }
+    ]
+  },
+  {
+    "name": "clock",
+    "trans": [
+      "n. 钟"
+    ],
+    "sentences": [
+      {
+        "english": "He could hear a clock ticking.",
+        "chinese": "他能听到时钟的滴答声。"
+      }
+    ]
+  },
+  {
+    "name": "clothes",
+    "trans": [
+      "n. 衣服"
+    ],
+    "sentences": [
+      {
+        "english": "Milly went upstairs to change her clothes.",
+        "chinese": "米利上楼去换衣服。"
+      }
+    ]
+  },
+  {
+    "name": "coat",
+    "trans": [
+      "n. 外套"
+    ],
+    "sentences": [
+      {
+        "english": "He put on his coat and walked out.",
+        "chinese": "他穿上外套走了出去。"
+      }
+    ]
+  },
+  {
+    "name": "coconut",
+    "trans": [
+      "n. 椰子"
+    ],
+    "sentences": [
+      {
+        "english": "Add two cups of grated coconut.",
+        "chinese": "加两杯椰蓉。"
+      }
+    ]
+  },
+  {
+    "name": "cola",
+    "trans": [
+      "n. 可乐"
+    ],
+    "sentences": [
+      {
+        "english": "Peter: And how much is the cola?",
+        "chinese": "彼得：可乐多少钱一听？。"
+      }
+    ]
+  },
+  {
+    "name": "cold",
+    "trans": [
+      "adj. 寒冷的"
+    ],
+    "sentences": [
+      {
+        "english": "Put on a jumper if you're cold.",
+        "chinese": "你要是觉得冷，就把针织衫穿上。"
+      }
+    ]
+  },
+  {
+    "name": "collect",
+    "trans": [
+      "v. 收集"
+    ],
+    "sentences": [
+      {
+        "english": "Computers can help with the collection of information.",
+        "chinese": "计算机有助于信息收集。"
+      }
+    ]
+  },
+  {
+    "name": "colour",
+    "trans": [
+      "n. 颜色"
+    ],
+    "sentences": [
+      {
+        "english": "`What colour is the car?' — `It's red.'",
+        "chinese": "“那辆车是什么颜色的？”——“红色。”"
+      }
+    ]
+  },
+  {
+    "name": "come",
+    "trans": [
+      "v. 来"
+    ],
+    "sentences": [
+      {
+        "english": "He came to a door.",
+        "chinese": "他来到一扇门前。"
+      }
+    ]
+  },
+  {
+    "name": "come on",
+    "trans": [
+      "加油"
+    ],
+    "sentences": [
+      {
+        "english": "Come on, it's time we left.",
+        "chinese": "快点，我们该走了。"
+      }
+    ]
+  },
+  {
+    "name": "computer game",
+    "trans": [
+      "n. 电子游戏"
+    ],
+    "sentences": [
+      {
+        "english": "pay How much did you pay for your new computer game?",
+        "chinese": "你的新电脑游戏花了多少钱？"
+      }
+    ]
+  },
+  {
+    "name": "concert",
+    "trans": [
+      "n. 音乐会"
+    ],
+    "sentences": [
+      {
+        "english": "We attended a concert by the great jazz pianist Harold Mabern.",
+        "chinese": "我们去听了哈罗德·马本这位伟大爵士钢琴家的音乐会。"
+      }
+    ]
+  },
+  {
+    "name": "cook",
+    "trans": [
+      "v. 烧菜"
+    ],
+    "sentences": [
+      {
+        "english": "Let the vegetables cook for about 10 minutes.",
+        "chinese": "让蔬菜炖上10分钟左右。"
+      }
+    ]
+  },
+  {
+    "name": "cool",
+    "trans": [
+      "adj. 凉爽的"
+    ],
+    "sentences": [
+      {
+        "english": "I felt the cool air on my neck.",
+        "chinese": "我脖子那里感到一阵凉风。"
+      }
+    ]
+  },
+  {
+    "name": "copy",
+    "trans": [
+      "v. 模仿"
+    ],
+    "sentences": [
+      {
+        "english": "I made a copy of Steve's letter.",
+        "chinese": "我复印了一份史蒂夫的信。"
+      }
+    ]
+  },
+  {
+    "name": "cost",
+    "trans": [
+      "v. 花费"
+    ],
+    "sentences": [
+      {
+        "english": "The cost of a loaf of bread has gone up.",
+        "chinese": "一条面包的价格上涨了。"
+      }
+    ]
+  },
+  {
+    "name": "cough",
+    "trans": [
+      "n. 咳嗽"
+    ],
+    "sentences": [
+      {
+        "english": "James began to cough violently.",
+        "chinese": "詹姆斯开始剧烈咳嗽。"
+      }
+    ]
+  },
+  {
+    "name": "count",
+    "trans": [
+      "v. 数"
+    ],
+    "sentences": [
+      {
+        "english": "Nancy counted slowly to five.",
+        "chinese": "南希慢慢数到了5."
+      }
+    ]
+  },
+  {
+    "name": "country",
+    "trans": [
+      "n. 国家"
+    ],
+    "sentences": [
+      {
+        "english": "This is the greatest country in the world.",
+        "chinese": "这是世界上最伟大的国家。"
+      }
+    ]
+  },
+  {
+    "name": "cousin",
+    "trans": [
+      "n. 表兄弟"
+    ],
+    "sentences": [
+      {
+        "english": "Do you know my cousin Alex?",
+        "chinese": "你认识我表兄亚历克斯吗？"
+      }
+    ]
+  },
+  {
+    "name": "cow",
+    "trans": [
+      "n. 奶牛"
+    ],
+    "sentences": [
+      {
+        "english": "A mature cow has horns.",
+        "chinese": "成年母牛头上长有角。"
+      }
+    ]
+  },
+  {
+    "name": "crayon",
+    "trans": [
+      "n. 蜡笔"
+    ],
+    "sentences": [
+      {
+        "english": "He colored the picture with crayon.",
+        "chinese": "他用蜡笔给画上色。"
+      }
+    ]
+  },
+  {
+    "name": "crisp",
+    "trans": [
+      "n. 薯片"
+    ],
+    "sentences": [
+      {
+        "english": "Bake the potatoes for 15 minutes, until they're nice and crisp.",
+        "chinese": "将土豆片烤15分钟，直至酥脆。"
+      }
+    ]
+  },
+  {
+    "name": "cry",
+    "trans": [
+      "v. 哭"
+    ],
+    "sentences": [
+      {
+        "english": "`Nancy Drew,' she cried, `you're under arrest!'",
+        "chinese": "“南希·德鲁，”她喊道，“你被捕了！”"
+      }
+    ]
+  },
+  {
+    "name": "cup",
+    "trans": [
+      "n. 奖杯"
+    ],
+    "sentences": [
+      {
+        "english": "Let's have a cup of coffee.",
+        "chinese": "咱们喝杯咖啡吧。"
+      }
+    ]
+  },
+  {
+    "name": "cut",
+    "trans": [
+      "v. 切"
+    ],
+    "sentences": [
+      {
+        "english": "Mrs Haines cut the ribbon.",
+        "chinese": "海恩斯夫人剪了彩。"
+      }
+    ]
+  },
+  {
+    "name": "cute",
+    "trans": [
+      "adj. 可爱的"
+    ],
+    "sentences": [
+      {
+        "english": "I thought that girl was really cute.",
+        "chinese": "我觉得那个女孩特别迷人。"
+      }
+    ]
+  },
+  {
+    "name": "dad",
+    "trans": [
+      "n. 爸爸"
+    ],
+    "sentences": [
+      {
+        "english": "Don't tell my mum and dad about this!",
+        "chinese": "这件事不要告诉我爸妈！"
+      }
+    ]
+  },
+  {
+    "name": "daddy",
+    "trans": [
+      "n. 爸爸"
+    ],
+    "sentences": [
+      {
+        "english": "My daddy always reads me stories and helps me with my homework.",
+        "chinese": "我爸爸经常给我读故事，辅导我做作业。"
+      }
+    ]
+  },
+  {
+    "name": "dance",
+    "trans": [
+      "v. 跳舞"
+    ],
+    "sentences": [
+      {
+        "english": "Let's go dancing tonight.",
+        "chinese": "咱们今晚去跳舞吧。"
+      }
+    ]
+  },
+  {
+    "name": "dancing",
+    "trans": [
+      "n. 舞蹈"
+    ],
+    "sentences": [
+      {
+        "english": "She turned on the radio and danced around the room.",
+        "chinese": "她打开收音机，在房间四处跳起舞来。"
+      }
+    ]
+  },
+  {
+    "name": "dangerous",
+    "trans": [
+      "adj. 危险的"
+    ],
+    "sentences": [
+      {
+        "english": "We are in a very dangerous situation.",
+        "chinese": "我们的情况非常危险。"
+      }
+    ]
+  },
+  {
+    "name": "day",
+    "trans": [
+      "n. 天"
+    ],
+    "sentences": [
+      {
+        "english": "They'll be back in three days.",
+        "chinese": "他们三天后回来。"
+      }
+    ]
+  },
+  {
+    "name": "deaf",
+    "trans": [
+      "adj. 聋的"
+    ],
+    "sentences": [
+      {
+        "english": "She is now totally deaf.",
+        "chinese": "她现在彻底失聪了。"
+      }
+    ]
+  },
+  {
+    "name": "dear",
+    "trans": [
+      "adj. 亲爱的"
+    ],
+    "sentences": [
+      {
+        "english": "Mrs Cavendish is a dear friend of mine.",
+        "chinese": "卡文迪什夫人是我的密友。"
+      }
+    ]
+  },
+  {
+    "name": "delicious",
+    "trans": [
+      "adj. 美味的"
+    ],
+    "sentences": [
+      {
+        "english": "This yogurt has a deliciously creamy flavour.",
+        "chinese": "这酸奶有一种香甜的奶油味。"
+      }
+    ]
+  },
+  {
+    "name": "desk",
+    "trans": [
+      "n. 书桌"
+    ],
+    "sentences": [
+      {
+        "english": "They asked for Miss Minton at the reception desk.",
+        "chinese": "他们问服务台的人找明顿小姐。"
+      }
+    ]
+  },
+  {
+    "name": "didn't",
+    "trans": [
+      "没有"
+    ],
+    "sentences": [
+      {
+        "english": "From his expression chaning, I knew he didn't want me to ask this question.",
+        "chinese": "从他表情的变化上，我看得出他不希望我问这个问题。"
+      }
+    ]
+  },
+  {
+    "name": "different",
+    "trans": [
+      "adj. 不同的"
+    ],
+    "sentences": [
+      {
+        "english": "Although they are twins, they are so different!",
+        "chinese": "他们是双胞胎，但差别很大！"
+      }
+    ]
+  },
+  {
+    "name": "difficult",
+    "trans": [
+      "adj. 困难的"
+    ],
+    "sentences": [
+      {
+        "english": "The homework was too difficult for us.",
+        "chinese": "这家庭作业对我们来说太难了。"
+      }
+    ]
+  },
+  {
+    "name": "dinner",
+    "trans": [
+      "n. 正餐"
+    ],
+    "sentences": [
+      {
+        "english": "She invited us for dinner.",
+        "chinese": "她请我们吃晚餐。"
+      }
+    ]
+  },
+  {
+    "name": "dirty",
+    "trans": [
+      "adj. 脏的"
+    ],
+    "sentences": [
+      {
+        "english": "She collected the dirty plates from the table.",
+        "chinese": "她收拾了桌上的脏盘子。"
+      }
+    ]
+  },
+  {
+    "name": "do",
+    "trans": [
+      "v. 做"
+    ],
+    "sentences": [
+      {
+        "english": "They don't work very hard.",
+        "chinese": "他们工作不怎么努力。"
+      }
+    ]
+  },
+  {
+    "name": "doctor",
+    "trans": [
+      "n. 医生"
+    ],
+    "sentences": [
+      {
+        "english": "I went to the doctor today.",
+        "chinese": "我今天去了诊所。"
+      }
+    ]
+  },
+  {
+    "name": "does",
+    "trans": [
+      "v. 助动词"
+    ],
+    "sentences": [
+      {
+        "english": "They don't work very hard.",
+        "chinese": "他们工作不怎么努力。"
+      }
+    ]
+  },
+  {
+    "name": "doesn't",
+    "trans": [
+      "不"
+    ],
+    "sentences": [
+      {
+        "english": "This line doesn't scan.",
+        "chinese": "这一行不合韵律。"
+      }
+    ]
+  },
+  {
+    "name": "dog",
+    "trans": [
+      "n. 狗"
+    ],
+    "sentences": [
+      {
+        "english": "He was walking his dog.",
+        "chinese": "他在遛狗。"
+      }
+    ]
+  },
+  {
+    "name": "doll",
+    "trans": [
+      "n. 娃娃"
+    ],
+    "sentences": [
+      {
+        "english": "It's a vinyl doll with movable arms and legs.",
+        "chinese": "这是个胳膊和腿都能活动的乙烯基塑料娃娃。"
+      }
+    ]
+  },
+  {
+    "name": "dollar",
+    "trans": [
+      "n. 美元"
+    ],
+    "sentences": [
+      {
+        "english": "She earns seven dollars an hour.",
+        "chinese": "她一个小时挣7美元。"
+      }
+    ]
+  },
+  {
+    "name": "don't",
+    "trans": [
+      "不"
+    ],
+    "sentences": [
+      {
+        "english": "Don't be so strict with him. After all, he is just a child.",
+        "chinese": "别对他太严厉。他毕竟只是个孩子。"
+      }
+    ]
+  },
+  {
+    "name": "door",
+    "trans": [
+      "n. 门"
+    ],
+    "sentences": [
+      {
+        "english": "I knocked at the front door, but there was no answer.",
+        "chinese": "我敲了敲前门，但没有回应。"
+      }
+    ]
+  },
+  {
+    "name": "down",
+    "trans": [
+      "adv. 向下"
+    ],
+    "sentences": [
+      {
+        "english": "He was halfway down the hill.",
+        "chinese": "他下到半山腰。"
+      }
+    ]
+  },
+  {
+    "name": "dragon boat",
+    "trans": [
+      "n. 龙舟"
+    ],
+    "sentences": [
+      {
+        "english": "Let's chase the dragon boat.",
+        "chinese": "我们一同去追逐龙舟吧。"
+      }
+    ]
+  },
+  {
+    "name": "dragon dance",
+    "trans": [
+      "n. 舞龙"
+    ],
+    "sentences": [
+      {
+        "english": "The Dragon Dance and Lion Dance are traditionally performed during the festival.",
+        "chinese": "耍龙灯和舞狮子是春节期间的传统项目。"
+      }
+    ]
+  },
+  {
+    "name": "draw",
+    "trans": [
+      "v. 画"
+    ],
+    "sentences": [
+      {
+        "english": "She was drawing with a pencil.",
+        "chinese": "她在用铅笔画画。"
+      }
+    ]
+  },
+  {
+    "name": "dress",
+    "trans": [
+      "n. 连衣裙"
+    ],
+    "sentences": [
+      {
+        "english": "She was wearing a short black dress.",
+        "chinese": "她穿着一条黑色连衣短裙。"
+      }
+    ]
+  },
+  {
+    "name": "drew",
+    "trans": [
+      "v. 画（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "I like dancing, singing, and drawing.",
+        "chinese": "我喜欢跳舞、唱歌、画画。"
+      }
+    ]
+  },
+  {
+    "name": "drink",
+    "trans": [
+      "v. 喝"
+    ],
+    "sentences": [
+      {
+        "english": "He drank his cup of coffee.",
+        "chinese": "他喝他杯子里的咖啡。"
+      }
+    ]
+  },
+  {
+    "name": "driver",
+    "trans": [
+      "n. 司机"
+    ],
+    "sentences": [
+      {
+        "english": "The driver got out of his truck.",
+        "chinese": "司机下了卡车。"
+      }
+    ]
+  },
+  {
+    "name": "drove",
+    "trans": [
+      "v. 驾驶（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "a driving instructor",
+        "chinese": "驾驶教练"
+      }
+    ]
+  },
+  {
+    "name": "dry",
+    "trans": [
+      "adj. 干的"
+    ],
+    "sentences": [
+      {
+        "english": "The Sahara is one of the driest places in Africa.",
+        "chinese": "撒哈拉沙漠是非洲最干旱的地区之一。"
+      }
+    ]
+  },
+  {
+    "name": "duck",
+    "trans": [
+      "n. 鸭子"
+    ],
+    "sentences": [
+      {
+        "english": "A few ducks were swimming around in the shallow water.",
+        "chinese": "几只鸭子在浅浅的水中游来游去。"
+      }
+    ]
+  },
+  {
+    "name": "each",
+    "trans": [
+      "pron. 各自"
+    ],
+    "sentences": [
+      {
+        "english": "The library buys 2,000 new books each year.",
+        "chinese": "图书馆每年购入2,000本新书。"
+      }
+    ]
+  },
+  {
+    "name": "ear",
+    "trans": [
+      "n. 耳朵"
+    ],
+    "sentences": [
+      {
+        "english": "He tweaked Guy's ear roughly.",
+        "chinese": "他粗暴地扯盖伊的耳朵。"
+      }
+    ]
+  },
+  {
+    "name": "east",
+    "trans": [
+      "n. 东方"
+    ],
+    "sentences": [
+      {
+        "english": "The city lies to the east of the river.",
+        "chinese": "这座城市位于河东。"
+      }
+    ]
+  },
+  {
+    "name": "easy",
+    "trans": [
+      "adj. 容易的"
+    ],
+    "sentences": [
+      {
+        "english": "Most students found jobs easily at the end of the course.",
+        "chinese": "课程结束后多数学生轻松找到工作。"
+      }
+    ]
+  },
+  {
+    "name": "eat",
+    "trans": [
+      "v. 吃"
+    ],
+    "sentences": [
+      {
+        "english": "What did you eat last night?",
+        "chinese": "你昨晚吃的什么？"
+      }
+    ]
+  },
+  {
+    "name": "egg",
+    "trans": [
+      "n. 鸡蛋"
+    ],
+    "sentences": [
+      {
+        "english": "Break the eggs into a bowl.",
+        "chinese": "把鸡蛋打到碗里。"
+      }
+    ]
+  },
+  {
+    "name": "eight",
+    "trans": [
+      "num. 八"
+    ],
+    "sentences": [
+      {
+        "english": "Inside, the eight security guards assigned to the front door began to worry.",
+        "chinese": "在商场里面，八个被派至前门的保安人员开始担忧起来。"
+      }
+    ]
+  },
+  {
+    "name": "eighteen",
+    "trans": [
+      "num. 十八"
+    ],
+    "sentences": [
+      {
+        "english": "My classmate is eighteen.",
+        "chinese": "我的同学十八岁。"
+      }
+    ]
+  },
+  {
+    "name": "eighty",
+    "trans": [
+      "num. 八十"
+    ],
+    "sentences": [
+      {
+        "english": "Nineteen Eighty-Four is often described, mainly by conservatives, as an attack against socialism.",
+        "chinese": "人们，主要是保守派，经常把《一九八四》描述为一部抨击社会主义的作品。"
+      }
+    ]
+  },
+  {
+    "name": "elephant",
+    "trans": [
+      "n. 大象"
+    ],
+    "sentences": [
+      {
+        "english": "Aquarius elephant back in mosaic clock, behind the engraved produced in London.",
+        "chinese": "水瓶座大象回到马赛克时钟，背后刻在伦敦生产。"
+      }
+    ]
+  },
+  {
+    "name": "eleven",
+    "trans": [
+      "num. 十一"
+    ],
+    "sentences": [
+      {
+        "english": "Charles I ruled for eleven years.",
+        "chinese": "查理一世统治了十一年。"
+      }
+    ]
+  },
+  {
+    "name": "email",
+    "trans": [
+      "n. 电子邮件"
+    ],
+    "sentences": [
+      {
+        "english": "You can contact us by email.",
+        "chinese": "你可以通过电子邮件联系我们。"
+      }
+    ]
+  },
+  {
+    "name": "end",
+    "trans": [
+      "n. 结束"
+    ],
+    "sentences": [
+      {
+        "english": "Work will start before the end of the year.",
+        "chinese": "年底前开工。"
+      }
+    ]
+  },
+  {
+    "name": "England",
+    "trans": [
+      "n. 英国"
+    ],
+    "sentences": [
+      {
+        "english": "Scotland thrashed England 5–1.",
+        "chinese": "苏格兰队以5:1大胜英格兰队。"
+      }
+    ]
+  },
+  {
+    "name": "English",
+    "trans": [
+      "n. 英语"
+    ],
+    "sentences": [
+      {
+        "english": "Do you speak English?",
+        "chinese": "你说英语吗？"
+      }
+    ]
+  },
+  {
+    "name": "enjoy",
+    "trans": [
+      "v. 享受"
+    ],
+    "sentences": [
+      {
+        "english": "You're going to enjoy this.",
+        "chinese": "你会喜欢这个的。"
+      }
+    ]
+  },
+  {
+    "name": "eraser",
+    "trans": [
+      "n. 橡皮"
+    ],
+    "sentences": [
+      {
+        "english": "How much is the eraser?",
+        "chinese": "这块橡皮擦多少钱？"
+      }
+    ]
+  },
+  {
+    "name": "everyone",
+    "trans": [
+      "pron. 每人"
+    ],
+    "sentences": [
+      {
+        "english": "Not everyone thinks that the government is acting fairly.",
+        "chinese": "不是每个人都觉得政府办事公道。"
+      }
+    ]
+  },
+  {
+    "name": "everything",
+    "trans": [
+      "pron. 每件事"
+    ],
+    "sentences": [
+      {
+        "english": "Everything in his life has changed.",
+        "chinese": "他生活中的一切都变了。"
+      }
+    ]
+  },
+  {
+    "name": "everywhere",
+    "trans": [
+      "adv. 到处"
+    ],
+    "sentences": [
+      {
+        "english": "People everywhere want the same things.",
+        "chinese": "各地的人都想要相同的东西。"
+      }
+    ]
+  },
+  {
+    "name": "excited",
+    "trans": [
+      "adj. 兴奋的"
+    ],
+    "sentences": [
+      {
+        "english": "I was excited about playing football again.",
+        "chinese": "我对再次玩足球感到兴奋。"
+      }
+    ]
+  },
+  {
+    "name": "excuse me",
+    "trans": [
+      "打扰一下"
+    ],
+    "sentences": [
+      {
+        "english": "Daniel: Excuse me. How much is the beef?",
+        "chinese": "丹尼尔：请问，这个牛肉怎么卖？"
+      }
+    ]
+  },
+  {
+    "name": "expensive",
+    "trans": [
+      "adj. 昂贵的"
+    ],
+    "sentences": [
+      {
+        "english": "People thought that healthy food was more expensive than fast food.",
+        "chinese": "人们觉得健康食品比快餐贵。"
+      }
+    ]
+  },
+  {
+    "name": "eye",
+    "trans": [
+      "n. 眼睛"
+    ],
+    "sentences": [
+      {
+        "english": "Mrs Brooke was a tall lady with dark brown eyes.",
+        "chinese": "布鲁克太太个子高高的，双眼深褐色。"
+      }
+    ]
+  },
+  {
+    "name": "face",
+    "trans": [
+      "n. 脸"
+    ],
+    "sentences": [
+      {
+        "english": "the south face of Mount Qomolangma",
+        "chinese": "珠穆朗玛峰南坡面"
+      }
+    ]
+  },
+  {
+    "name": "factory",
+    "trans": [
+      "n. 工厂"
+    ],
+    "sentences": [
+      {
+        "english": "A strike has shut the factory.",
+        "chinese": "罢工使工厂停业。"
+      }
+    ]
+  },
+  {
+    "name": "fall",
+    "trans": [
+      "v. 落下"
+    ],
+    "sentences": [
+      {
+        "english": "Tyler fell from his horse and broke his arm.",
+        "chinese": "泰勒坠马摔伤了胳膊。"
+      }
+    ]
+  },
+  {
+    "name": "fall over",
+    "trans": [
+      "摔倒"
+    ],
+    "sentences": [
+      {
+        "english": "Their legs lock in place so they don't fall over.",
+        "chinese": "它们的腿固定在原地，这样它们就不会摔倒。"
+      }
+    ]
+  },
+  {
+    "name": "fantastic",
+    "trans": [
+      "adj. 极好的"
+    ],
+    "sentences": [
+      {
+        "english": "Sarah has a fantastic social life — she's always out.",
+        "chinese": "萨拉的社交生活很精彩——她总不在家待着。"
+      }
+    ]
+  },
+  {
+    "name": "far",
+    "trans": [
+      "adv. 远"
+    ],
+    "sentences": [
+      {
+        "english": "We've gone too far to go back now.",
+        "chinese": "我们走得太远了，现在已经回不去了。"
+      }
+    ]
+  },
+  {
+    "name": "farm",
+    "trans": [
+      "n. 农场"
+    ],
+    "sentences": [
+      {
+        "english": "Both boys like to work on the farm.",
+        "chinese": "两个男孩都喜欢在农场工作。"
+      }
+    ]
+  },
+  {
+    "name": "fast",
+    "trans": [
+      "adv. 快"
+    ],
+    "sentences": [
+      {
+        "english": "Jane has always loved fast cars.",
+        "chinese": "简一向喜欢快车。"
+      }
+    ]
+  },
+  {
+    "name": "fast food",
+    "trans": [
+      "n. 快餐"
+    ],
+    "sentences": [
+      {
+        "english": "He likes fast food like hamburgers, pizzas and hot dogs.",
+        "chinese": "他喜欢吃像汉堡、比萨和热狗这样的快餐。"
+      }
+    ]
+  },
+  {
+    "name": "fat",
+    "trans": [
+      "adj. 胖的"
+    ],
+    "sentences": [
+      {
+        "english": "Emily picked up a fat book and handed it to me.",
+        "chinese": "埃米莉拿起一本非常厚的书递给了我。"
+      }
+    ]
+  },
+  {
+    "name": "father",
+    "trans": [
+      "n. 父亲"
+    ],
+    "sentences": [
+      {
+        "english": "His father was an artist.",
+        "chinese": "他父亲是个艺术家。"
+      }
+    ]
+  },
+  {
+    "name": "Father's Day",
+    "trans": [
+      "n. 父亲节"
+    ],
+    "sentences": [
+      {
+        "english": "After all, that's what Father's Day is all about.",
+        "chinese": "毕竟，那就是关于父亲节的一切了。"
+      }
+    ]
+  },
+  {
+    "name": "favourite",
+    "trans": [
+      "adj. 最喜爱的"
+    ],
+    "sentences": [
+      {
+        "english": "What is your favourite film?",
+        "chinese": "你最喜欢哪部电影？"
+      }
+    ]
+  },
+  {
+    "name": "feed",
+    "trans": [
+      "v. 喂"
+    ],
+    "sentences": [
+      {
+        "english": "It's time to feed the baby.",
+        "chinese": "该喂孩子了。"
+      }
+    ]
+  },
+  {
+    "name": "feet",
+    "trans": [
+      "n. 脚（复数）"
+    ],
+    "sentences": [
+      {
+        "english": "We danced until our feet were sore.",
+        "chinese": "我们跳舞跳到脚痛。"
+      }
+    ]
+  },
+  {
+    "name": "fell",
+    "trans": [
+      "v. 摔倒（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "Tyler fell from his horse and broke his arm.",
+        "chinese": "泰勒坠马摔伤了胳膊。"
+      }
+    ]
+  },
+  {
+    "name": "fever",
+    "trans": [
+      "n. 发烧"
+    ],
+    "sentences": [
+      {
+        "english": "Jim had a high fever.",
+        "chinese": "吉姆发高烧了。"
+      }
+    ]
+  },
+  {
+    "name": "field",
+    "trans": [
+      "n. 田地"
+    ],
+    "sentences": [
+      {
+        "english": "We drove past fields of sunflowers.",
+        "chinese": "我们驱车经过向日葵田。"
+      }
+    ]
+  },
+  {
+    "name": "fifteen",
+    "trans": [
+      "num. 十五"
+    ],
+    "sentences": [
+      {
+        "english": "Three fives are fifteen.",
+        "chinese": "三个五等于十五。"
+      }
+    ]
+  },
+  {
+    "name": "fifty",
+    "trans": [
+      "num. 五十"
+    ],
+    "sentences": [
+      {
+        "english": "Fifty is the new forty.",
+        "chinese": "四十尚未老，五十正当年。"
+      }
+    ]
+  },
+  {
+    "name": "film",
+    "trans": [
+      "n. 电影"
+    ],
+    "sentences": [
+      {
+        "english": "I'm going to see a film tonight.",
+        "chinese": "我今晚要去看场电影。"
+      }
+    ]
+  },
+  {
+    "name": "find",
+    "trans": [
+      "v. 找到"
+    ],
+    "sentences": [
+      {
+        "english": "The police searched the house and found a gun.",
+        "chinese": "警察搜查这间房子，找到一把枪。"
+      }
+    ]
+  },
+  {
+    "name": "fine",
+    "trans": [
+      "adj. 很好的"
+    ],
+    "sentences": [
+      {
+        "english": "Linda is fine and sends you her love.",
+        "chinese": "琳达安好，让我转达她对你的爱。"
+      }
+    ]
+  },
+  {
+    "name": "finger",
+    "trans": [
+      "n. 手指"
+    ],
+    "sentences": [
+      {
+        "english": "Amber had a huge diamond ring on her finger.",
+        "chinese": "安伯手指上戴着一枚大钻戒。"
+      }
+    ]
+  },
+  {
+    "name": "finish",
+    "trans": [
+      "v. 完成"
+    ],
+    "sentences": [
+      {
+        "english": "Dad finished eating, and left the room.",
+        "chinese": "爸爸吃完离开了房间。"
+      }
+    ]
+  },
+  {
+    "name": "fire",
+    "trans": [
+      "n. 火"
+    ],
+    "sentences": [
+      {
+        "english": "We learned how to make fire and hunt for fish.",
+        "chinese": "我们学会了生火、打鱼。"
+      }
+    ]
+  },
+  {
+    "name": "first",
+    "trans": [
+      "num. 第一"
+    ],
+    "sentences": [
+      {
+        "english": "January is the first month of the year.",
+        "chinese": "一月是一年中的第一个月。"
+      }
+    ]
+  },
+  {
+    "name": "fish",
+    "trans": [
+      "n. 鱼"
+    ],
+    "sentences": [
+      {
+        "english": "Brian learned to fish in the Colorado River.",
+        "chinese": "布赖恩在科罗拉多河学会钓鱼。"
+      }
+    ]
+  },
+  {
+    "name": "five",
+    "trans": [
+      "num. 五"
+    ],
+    "sentences": [
+      {
+        "english": "She brought up five children.",
+        "chinese": "她抚育了五个孩子。"
+      }
+    ]
+  },
+  {
+    "name": "fix",
+    "trans": [
+      "v. 修理"
+    ],
+    "sentences": [
+      {
+        "english": "This morning, a man came to fix my washing machine.",
+        "chinese": "今早来了一个男人帮我修洗衣机。"
+      }
+    ]
+  },
+  {
+    "name": "flag",
+    "trans": [
+      "n. 旗"
+    ],
+    "sentences": [
+      {
+        "english": "The crowd was shouting and waving American flags.",
+        "chinese": "人群呼喊着，挥舞着美国国旗。"
+      }
+    ]
+  },
+  {
+    "name": "Flag Day",
+    "trans": [
+      "n. 国旗日"
+    ],
+    "sentences": [
+      {
+        "english": "Wednesday also marked Flag Day observances nationwide.",
+        "chinese": "周三也标志着全国性的国旗日惯例。"
+      }
+    ]
+  },
+  {
+    "name": "floor",
+    "trans": [
+      "n. 楼层"
+    ],
+    "sentences": [
+      {
+        "english": "There were no seats, so we sat on the floor.",
+        "chinese": "没有座位，我们就坐在了地板上。"
+      }
+    ]
+  },
+  {
+    "name": "flower",
+    "trans": [
+      "n. 花"
+    ],
+    "sentences": [
+      {
+        "english": "Dad gave Mum a huge bunch of flowers.",
+        "chinese": "爸爸送给妈妈一大束花。"
+      }
+    ]
+  },
+  {
+    "name": "flute",
+    "trans": [
+      "n. 长笛"
+    ],
+    "sentences": [
+      {
+        "english": "There was a little wooden flute in there. I tootled on it and passed it around.",
+        "chinese": "这有个小木笛，我拨弄了一会儿然后给了别人。"
+      }
+    ]
+  },
+  {
+    "name": "fly",
+    "trans": [
+      "v. 放飞"
+    ],
+    "sentences": [
+      {
+        "english": "Jerry flew to Los Angeles this morning.",
+        "chinese": "杰里今早乘飞机飞往洛杉矶。"
+      }
+    ]
+  },
+  {
+    "name": "food",
+    "trans": [
+      "n. 食物"
+    ],
+    "sentences": [
+      {
+        "english": "The waitress brought our meal and said, `Enjoy your food!'",
+        "chinese": "女服务员端上饭来，说“请享用您的美食！”"
+      }
+    ]
+  },
+  {
+    "name": "foot",
+    "trans": [
+      "n. 脚"
+    ],
+    "sentences": [
+      {
+        "english": "We danced until our feet were sore.",
+        "chinese": "我们跳舞跳到脚痛。"
+      }
+    ]
+  },
+  {
+    "name": "football",
+    "trans": [
+      "n. 足球"
+    ],
+    "sentences": [
+      {
+        "english": "Paul loves playing football.",
+        "chinese": "保罗喜欢踢足球。"
+      }
+    ]
+  },
+  {
+    "name": "for",
+    "trans": [
+      "prep. 为"
+    ],
+    "sentences": [
+      {
+        "english": "These flowers are for you.",
+        "chinese": "这些花是给你的。"
+      }
+    ]
+  },
+  {
+    "name": "foreign",
+    "trans": [
+      "adj. 外国的"
+    ],
+    "sentences": [
+      {
+        "english": "It's good to learn a foreign language.",
+        "chinese": "学一门外语很好。"
+      }
+    ]
+  },
+  {
+    "name": "fork",
+    "trans": [
+      "n. 叉"
+    ],
+    "sentences": [
+      {
+        "english": "Please use your knife and fork.",
+        "chinese": "请使用你的刀叉。"
+      }
+    ]
+  },
+  {
+    "name": "forty",
+    "trans": [
+      "num. 四十"
+    ],
+    "sentences": [
+      {
+        "english": "Fifty is the new forty.",
+        "chinese": "四十尚未老，五十正当年。"
+      }
+    ]
+  },
+  {
+    "name": "four",
+    "trans": [
+      "num. 四"
+    ],
+    "sentences": [
+      {
+        "english": "She bid four hearts.",
+        "chinese": "她叫四红桃。"
+      }
+    ]
+  },
+  {
+    "name": "fourteen",
+    "trans": [
+      "num. 十四"
+    ],
+    "sentences": [
+      {
+        "english": "\"Fourteen minutes,\" Chris said, taking a peep at his watch.",
+        "chinese": "“十四分钟，”克里斯瞥了一眼手表说道。"
+      }
+    ]
+  },
+  {
+    "name": "fox",
+    "trans": [
+      "n. 狐狸"
+    ],
+    "sentences": [
+      {
+        "english": "He was as cunning as a fox.",
+        "chinese": "他像狐狸一样狡猾。"
+      }
+    ]
+  },
+  {
+    "name": "Friday",
+    "trans": [
+      "n. 星期五"
+    ],
+    "sentences": [
+      {
+        "english": "He is going home on Friday.",
+        "chinese": "他周五回家。"
+      }
+    ]
+  },
+  {
+    "name": "friend",
+    "trans": [
+      "n. 朋友"
+    ],
+    "sentences": [
+      {
+        "english": "She's my best friend.",
+        "chinese": "她是我最好的朋友。"
+      }
+    ]
+  },
+  {
+    "name": "from",
+    "trans": [
+      "prep. 来自"
+    ],
+    "sentences": [
+      {
+        "english": "I received a letter from Mary yesterday.",
+        "chinese": "昨天我收到了玛丽的来信。"
+      }
+    ]
+  },
+  {
+    "name": "fruit",
+    "trans": [
+      "n. 水果"
+    ],
+    "sentences": [
+      {
+        "english": "Clarence Berry was one of these men. He was a fruit farmer from California.",
+        "chinese": "克拉伦斯.百瑞就是这些人中的一个，他是加州的果农。"
+      }
+    ]
+  },
+  {
+    "name": "fun",
+    "trans": [
+      "n. 有趣"
+    ],
+    "sentences": [
+      {
+        "english": "Liz was always so much fun.",
+        "chinese": "利兹总是很有趣。"
+      }
+    ]
+  },
+  {
+    "name": "funny",
+    "trans": [
+      "adj. 好笑的"
+    ],
+    "sentences": [
+      {
+        "english": "Children get some very funny ideas sometimes!",
+        "chinese": "小孩子的想法有时候真是稀奇古怪！"
+      }
+    ]
+  },
+  {
+    "name": "future",
+    "trans": [
+      "n. 将来"
+    ],
+    "sentences": [
+      {
+        "english": "His future depends on the result of the election.",
+        "chinese": "他的前途取决于这次选举结果。"
+      }
+    ]
+  },
+  {
+    "name": "game",
+    "trans": [
+      "n. 游戏"
+    ],
+    "sentences": [
+      {
+        "english": "Football is a popular game.",
+        "chinese": "足球是一项很受欢迎的运动。"
+      }
+    ]
+  },
+  {
+    "name": "Geography",
+    "trans": [
+      "n. 地理"
+    ],
+    "sentences": [
+      {
+        "english": "I'm revising Geography today.",
+        "chinese": "我今天复习地理。"
+      }
+    ]
+  },
+  {
+    "name": "get",
+    "trans": [
+      "v. 收到"
+    ],
+    "sentences": [
+      {
+        "english": "He got arrested for possession of drugs.",
+        "chinese": "他因持有毒品而被捕。"
+      }
+    ]
+  },
+  {
+    "name": "get out",
+    "trans": [
+      "离开"
+    ],
+    "sentences": [
+      {
+        "english": "Let's get out of here, huh?",
+        "chinese": "我们离开这里吧，嗯？"
+      }
+    ]
+  },
+  {
+    "name": "get up",
+    "trans": [
+      "起床"
+    ],
+    "sentences": [
+      {
+        "english": "I generally get up at six.",
+        "chinese": "我一般六点钟起床。"
+      }
+    ]
+  },
+  {
+    "name": "ginger",
+    "trans": [
+      "n. 姜"
+    ],
+    "sentences": [
+      {
+        "english": "Please add some ginger to the soup.",
+        "chinese": "请在汤里加一些姜。"
+      }
+    ]
+  },
+  {
+    "name": "giraffe",
+    "trans": [
+      "n. 长颈鹿"
+    ],
+    "sentences": [
+      {
+        "english": "A giraffe cannot cough.",
+        "chinese": "长颈鹿没办法咳嗽。"
+      }
+    ]
+  },
+  {
+    "name": "girl",
+    "trans": [
+      "n. 女孩"
+    ],
+    "sentences": [
+      {
+        "english": "She is a lovely girl.",
+        "chinese": "她是一个可爱的女孩。"
+      }
+    ]
+  },
+  {
+    "name": "glasses",
+    "trans": [
+      "n. 眼镜"
+    ],
+    "sentences": [
+      {
+        "english": "He took off his glasses.",
+        "chinese": "他摘下眼镜。"
+      }
+    ]
+  },
+  {
+    "name": "go",
+    "trans": [
+      "v. 去"
+    ],
+    "sentences": [
+      {
+        "english": "We went to Rome on holiday.",
+        "chinese": "我们假期去了罗马。"
+      }
+    ]
+  },
+  {
+    "name": "go home",
+    "trans": [
+      "回家"
+    ],
+    "sentences": [
+      {
+        "english": "Come on, it's time to go home.",
+        "chinese": "快点，该回家了。"
+      }
+    ]
+  },
+  {
+    "name": "go shopping",
+    "trans": [
+      "去购物"
+    ],
+    "sentences": [
+      {
+        "english": "He asked me whether I would go shopping with him the next day.",
+        "chinese": "他问我第二天是否会和他一起去购物。"
+      }
+    ]
+  },
+  {
+    "name": "go straight on",
+    "trans": [
+      "直着走"
+    ],
+    "sentences": [
+      {
+        "english": "Go straight on and turn right, and the bank is on your left.",
+        "chinese": "一直走再向右拐，银行就在你的左边"
+      }
+    ]
+  },
+  {
+    "name": "go swimming",
+    "trans": [
+      "去游泳"
+    ],
+    "sentences": [
+      {
+        "english": "I shall be only too pleased to go swimming with you.",
+        "chinese": "我就是很高兴能和你一起去游泳。"
+      }
+    ]
+  },
+  {
+    "name": "go to bed",
+    "trans": [
+      "上床睡觉"
+    ],
+    "sentences": [
+      {
+        "english": "She was the last to go to bed.",
+        "chinese": "她是最后一个睡觉的人。"
+      }
+    ]
+  },
+  {
+    "name": "go to school",
+    "trans": [
+      "上学"
+    ],
+    "sentences": [
+      {
+        "english": "She will have to go to school.",
+        "chinese": "她将不得不去上学。"
+      }
+    ]
+  },
+  {
+    "name": "go to work",
+    "trans": [
+      "上班"
+    ],
+    "sentences": [
+      {
+        "english": "I go to work at 8 o'clock.",
+        "chinese": "我8点钟去上班。"
+      }
+    ]
+  },
+  {
+    "name": "goal",
+    "trans": [
+      "n. 进球"
+    ],
+    "sentences": [
+      {
+        "english": "The ball went straight into the goal.",
+        "chinese": "球直接入门。"
+      }
+    ]
+  },
+  {
+    "name": "gold",
+    "trans": [
+      "n. 金子"
+    ],
+    "sentences": [
+      {
+        "english": "He wore a black and gold shirt.",
+        "chinese": "他穿了一件黑黄相间的衬衣。"
+      }
+    ]
+  },
+  {
+    "name": "good",
+    "trans": [
+      "adj. 好的"
+    ],
+    "sentences": [
+      {
+        "english": "We had a really good time.",
+        "chinese": "我们玩得非常开心。"
+      }
+    ]
+  },
+  {
+    "name": "good at",
+    "trans": [
+      "擅长"
+    ],
+    "sentences": [
+      {
+        "english": "She was good at repartee.",
+        "chinese": "她善于机智地应答。"
+      }
+    ]
+  },
+  {
+    "name": "goodbye",
+    "trans": [
+      "int. 再见"
+    ],
+    "sentences": [
+      {
+        "english": "As she receded he waved goodbye.",
+        "chinese": "当她离去时，他挥手告别。"
+      }
+    ]
+  },
+  {
+    "name": "granddad",
+    "trans": [
+      "n. 祖父"
+    ],
+    "sentences": [
+      {
+        "english": "They wanted to call me granddad.",
+        "chinese": "他们想叫我爷爷。"
+      }
+    ]
+  },
+  {
+    "name": "grandma",
+    "trans": [
+      "n. 奶奶；外婆"
+    ],
+    "sentences": [
+      {
+        "english": "My grandma lives with us.",
+        "chinese": "我的奶奶和我们住在一起。"
+      }
+    ]
+  },
+  {
+    "name": "grandpa",
+    "trans": [
+      "n. 爷爷；外公"
+    ],
+    "sentences": [
+      {
+        "english": "We'll buy Grandpa a new one.",
+        "chinese": "我们会给爷爷买一个新的。"
+      }
+    ]
+  },
+  {
+    "name": "grandparent",
+    "trans": [
+      "n. 祖父母"
+    ],
+    "sentences": [
+      {
+        "english": "Almost every grandparent wants to be with his or her grandchildren and is willing to make sacrifices.",
+        "chinese": "几乎每个祖父母都想和孙辈在一起，并愿意为他们做出牺牲。"
+      }
+    ]
+  },
+  {
+    "name": "grass",
+    "trans": [
+      "n. 草地"
+    ],
+    "sentences": [
+      {
+        "english": "We sat on the grass and ate our picnic.",
+        "chinese": "我们坐在草地上吃野餐。"
+      }
+    ]
+  },
+  {
+    "name": "great",
+    "trans": [
+      "adj. 太好了"
+    ],
+    "sentences": [
+      {
+        "english": "She had a great big smile on her face.",
+        "chinese": "她脸上露出灿烂的笑容。"
+      }
+    ]
+  },
+  {
+    "name": "green",
+    "trans": [
+      "adj. 绿色的"
+    ],
+    "sentences": [
+      {
+        "english": "She wore a green dress.",
+        "chinese": "她穿着一件绿裙子。"
+      }
+    ]
+  },
+  {
+    "name": "ground",
+    "trans": [
+      "n. 地面"
+    ],
+    "sentences": [
+      {
+        "english": "He fell to the ground.",
+        "chinese": "他摔到地上。"
+      }
+    ]
+  },
+  {
+    "name": "guitar",
+    "trans": [
+      "n. 吉他"
+    ],
+    "sentences": [
+      {
+        "english": "There was a time when he was able to sing, while playing his guitar.",
+        "chinese": "曾有一段时间他能边弹吉他，边唱歌。"
+      }
+    ]
+  },
+  {
+    "name": "had",
+    "trans": [
+      "v. 度过（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "Alex hasn't left yet.",
+        "chinese": "亚历克斯还没有离开。"
+      }
+    ]
+  },
+  {
+    "name": "hair",
+    "trans": [
+      "n. 头发"
+    ],
+    "sentences": [
+      {
+        "english": "Most men have hair on their chest.",
+        "chinese": "大多数男人长着胸毛。"
+      }
+    ]
+  },
+  {
+    "name": "half",
+    "trans": [
+      "n. 一半"
+    ],
+    "sentences": [
+      {
+        "english": "More than half of all U.S. houses are heated with gas.",
+        "chinese": "美国的所有住宅中有一半以上采用天然气供暖。"
+      }
+    ]
+  },
+  {
+    "name": "hamburger",
+    "trans": [
+      "n. 汉堡包"
+    ],
+    "sentences": [
+      {
+        "english": "A pound of hamburger, please.",
+        "chinese": "请给我一磅汉堡。"
+      }
+    ]
+  },
+  {
+    "name": "hand",
+    "trans": [
+      "n. 手"
+    ],
+    "sentences": [
+      {
+        "english": "I put my hand into my pocket and took out the letter.",
+        "chinese": "我把手伸进口袋里，拿出了那封信。"
+      }
+    ]
+  },
+  {
+    "name": "happen",
+    "trans": [
+      "v. 发生"
+    ],
+    "sentences": [
+      {
+        "english": "We don't know what will happen.",
+        "chinese": "我们不知道将会发生什么。"
+      }
+    ]
+  },
+  {
+    "name": "happy",
+    "trans": [
+      "adj. 快乐的"
+    ],
+    "sentences": [
+      {
+        "english": "The children played happily together all day.",
+        "chinese": "孩子们在一起快乐地玩耍。"
+      }
+    ]
+  },
+  {
+    "name": "hard",
+    "trans": [
+      "adj. 困难的；努力地"
+    ],
+    "sentences": [
+      {
+        "english": "The glass hit the hard wooden floor.",
+        "chinese": "玻璃撞到了坚硬的木地板上。"
+      }
+    ]
+  },
+  {
+    "name": "hat",
+    "trans": [
+      "n. 帽子"
+    ],
+    "sentences": [
+      {
+        "english": "Look for a woman in a red hat.",
+        "chinese": "找一个戴红帽子的女士。"
+      }
+    ]
+  },
+  {
+    "name": "have",
+    "trans": [
+      "v. 有"
+    ],
+    "sentences": [
+      {
+        "english": "Alex hasn't left yet.",
+        "chinese": "亚历克斯还没有离开。"
+      }
+    ]
+  },
+  {
+    "name": "have a rest",
+    "trans": [
+      "休息一下"
+    ],
+    "sentences": [
+      {
+        "english": "You'd better have a rest.",
+        "chinese": "你最好休息一下。"
+      }
+    ]
+  },
+  {
+    "name": "have breakfast",
+    "trans": [
+      "吃早餐"
+    ],
+    "sentences": [
+      {
+        "english": "It is time for her to have breakfast.",
+        "chinese": "她该吃早饭的时间到了。"
+      }
+    ]
+  },
+  {
+    "name": "have lunch",
+    "trans": [
+      "吃午餐"
+    ],
+    "sentences": [
+      {
+        "english": "Let's have lunch out on the patio.",
+        "chinese": "咱们在外面平台上吃午饭吧。"
+      }
+    ]
+  },
+  {
+    "name": "he",
+    "trans": [
+      "pron. 他"
+    ],
+    "sentences": [
+      {
+        "english": "John was my boss, but he couldn't remember my name.",
+        "chinese": "约翰是我的老板，但他记不住我的名字。"
+      }
+    ]
+  },
+  {
+    "name": "he's",
+    "trans": [
+      "他是"
+    ],
+    "sentences": [
+      {
+        "english": "He's feeling absolutely terrible, and he thinks he might have the flu.",
+        "chinese": "他感觉非常得不好，觉得自己得了流感。"
+      }
+    ]
+  },
+  {
+    "name": "head",
+    "trans": [
+      "n. 头"
+    ],
+    "sentences": [
+      {
+        "english": "My head hurts.",
+        "chinese": "我的头疼。"
+      }
+    ]
+  },
+  {
+    "name": "headache",
+    "trans": [
+      "n. 头疼"
+    ],
+    "sentences": [
+      {
+        "english": "I have a terrible headache.",
+        "chinese": "我头痛得厉害。"
+      }
+    ]
+  },
+  {
+    "name": "hear",
+    "trans": [
+      "v. 听见"
+    ],
+    "sentences": [
+      {
+        "english": "She could hear music in the distance.",
+        "chinese": "她能听见远处的音乐。"
+      }
+    ]
+  },
+  {
+    "name": "heavy",
+    "trans": [
+      "adj. 重的"
+    ],
+    "sentences": [
+      {
+        "english": "This bag is very heavy. What's in it?",
+        "chinese": "这个袋子很重，里面有什么？"
+      }
+    ]
+  },
+  {
+    "name": "hello",
+    "trans": [
+      "int. 你好"
+    ],
+    "sentences": [
+      {
+        "english": "Hello, Trish. How are you?",
+        "chinese": "喂，特里什，你好吗？"
+      }
+    ]
+  },
+  {
+    "name": "help",
+    "trans": [
+      "v. 帮助"
+    ],
+    "sentences": [
+      {
+        "english": "Can somebody help me, please?",
+        "chinese": "请问有人能帮我吗？"
+      }
+    ]
+  },
+  {
+    "name": "helpful",
+    "trans": [
+      "adj. 有帮助的"
+    ],
+    "sentences": [
+      {
+        "english": "The staff in the hotel are very helpful.",
+        "chinese": "旅馆的工作人员非常乐于助人。"
+      }
+    ]
+  },
+  {
+    "name": "her",
+    "trans": [
+      "pron. 她的"
+    ],
+    "sentences": [
+      {
+        "english": "I told her that dinner was ready.",
+        "chinese": "我告诉她饭做好了。"
+      }
+    ]
+  },
+  {
+    "name": "here",
+    "trans": [
+      "adv. 这里"
+    ],
+    "sentences": [
+      {
+        "english": "I can't stay here all day.",
+        "chinese": "我不能一整天都待在这儿。"
+      }
+    ]
+  },
+  {
+    "name": "Here you are",
+    "trans": [
+      "给你"
+    ],
+    "sentences": [
+      {
+        "english": "Here you are, then how much should I pay?",
+        "chinese": "给你，那么我需要交多少钱？"
+      }
+    ]
+  },
+  {
+    "name": "here's",
+    "trans": [
+      "这是"
+    ],
+    "sentences": [
+      {
+        "english": "Here's a pop factoid for you.",
+        "chinese": "告诉你一个广为流传的趣闻。"
+      }
+    ]
+  },
+  {
+    "name": "hers",
+    "trans": [
+      "pron. 她的"
+    ],
+    "sentences": [
+      {
+        "english": "She admitted that the bag was hers.",
+        "chinese": "她承认包是她的。"
+      }
+    ]
+  },
+  {
+    "name": "hi",
+    "trans": [
+      "int. 嗨；你好"
+    ],
+    "sentences": [
+      {
+        "english": "`Hi, Liz,' she said.",
+        "chinese": "“你好，利兹。”她说道。"
+      }
+    ]
+  },
+  {
+    "name": "hide",
+    "trans": [
+      "v. 隐藏"
+    ],
+    "sentences": [
+      {
+        "english": "He hid the bicycle behind the wall.",
+        "chinese": "他把自行车藏在墙后面。"
+      }
+    ]
+  },
+  {
+    "name": "high",
+    "trans": [
+      "adj. 高的"
+    ],
+    "sentences": [
+      {
+        "english": "They lived in a house with a high wall around it.",
+        "chinese": "他们住在四周有高墙的一栋房子内。"
+      }
+    ]
+  },
+  {
+    "name": "high jump",
+    "trans": [
+      "n. 跳高"
+    ],
+    "sentences": [
+      {
+        "english": "He took first place in the high jump.",
+        "chinese": "他跳高得了第一。"
+      }
+    ]
+  },
+  {
+    "name": "hill",
+    "trans": [
+      "n. 小山"
+    ],
+    "sentences": [
+      {
+        "english": "The castle is on a hill above the old town.",
+        "chinese": "城堡在老城上方的一座小山上。"
+      }
+    ]
+  },
+  {
+    "name": "him",
+    "trans": [
+      "pron. 他（宾格）"
+    ],
+    "sentences": [
+      {
+        "english": "Elaine met him at the railway station.",
+        "chinese": "伊莱恩在火车站遇到了他。"
+      }
+    ]
+  },
+  {
+    "name": "his",
+    "trans": [
+      "pron. 他的"
+    ],
+    "sentences": [
+      {
+        "english": "He spent part of his career in Hollywood.",
+        "chinese": "他在好莱坞度过了他职业生涯的一部分。"
+      }
+    ]
+  },
+  {
+    "name": "history",
+    "trans": [
+      "n. 历史"
+    ],
+    "sentences": [
+      {
+        "english": "The film showed great moments in football history.",
+        "chinese": "这部电影展示了足球史上的伟大时刻。"
+      }
+    ]
+  },
+  {
+    "name": "hobby",
+    "trans": [
+      "n. 爱好"
+    ],
+    "sentences": [
+      {
+        "english": "My hobbies are music and tennis.",
+        "chinese": "我的业余爱好是音乐和网球。"
+      }
+    ]
+  },
+  {
+    "name": "hold",
+    "trans": [
+      "v. 拿着"
+    ],
+    "sentences": [
+      {
+        "english": "She held his hand tightly.",
+        "chinese": "她紧紧地握着他的手。"
+      }
+    ]
+  },
+  {
+    "name": "holiday",
+    "trans": [
+      "n. 假期"
+    ],
+    "sentences": [
+      {
+        "english": "I can't wait for the summer holidays.",
+        "chinese": "我等暑假都等不及了。"
+      }
+    ]
+  },
+  {
+    "name": "home",
+    "trans": [
+      "n. 家"
+    ],
+    "sentences": [
+      {
+        "english": "He died from a fall at his home in London.",
+        "chinese": "他在伦敦的家中摔死。"
+      }
+    ]
+  },
+  {
+    "name": "homework",
+    "trans": [
+      "n. 家庭作业"
+    ],
+    "sentences": [
+      {
+        "english": "How much homework do you get?",
+        "chinese": "你有多少家庭作业？"
+      }
+    ]
+  },
+  {
+    "name": "Hong Kong",
+    "trans": [
+      "n. 香港"
+    ],
+    "sentences": [
+      {
+        "english": "We flew direct to Hong Kong.",
+        "chinese": "我们直飞香港。"
+      }
+    ]
+  },
+  {
+    "name": "Hooray",
+    "trans": [
+      "int. 万岁"
+    ],
+    "sentences": [
+      {
+        "english": "You are the country's Baby, I wish the Children's Day Hooray!",
+        "chinese": "你们是国家的宝贝，祝儿童节万岁！"
+      }
+    ]
+  },
+  {
+    "name": "hope",
+    "trans": [
+      "v. 希望"
+    ],
+    "sentences": [
+      {
+        "english": "The team are hoping to win a medal.",
+        "chinese": "该队希望赢得一块奖牌。"
+      }
+    ]
+  },
+  {
+    "name": "horse",
+    "trans": [
+      "n. 马"
+    ],
+    "sentences": [
+      {
+        "english": "Have you ever ridden a horse?",
+        "chinese": "你骑过马吗？"
+      }
+    ]
+  },
+  {
+    "name": "hospital",
+    "trans": [
+      "n. 医院"
+    ],
+    "sentences": [
+      {
+        "english": "The two men were taken to hospital after the car crash.",
+        "chinese": "车祸发生后那两个男人被送往医院了。"
+      }
+    ]
+  },
+  {
+    "name": "hot",
+    "trans": [
+      "adj. 热的"
+    ],
+    "sentences": [
+      {
+        "english": "Have some hot coffee. That will warm you up.",
+        "chinese": "喝些热咖啡，那会让你暖和起来。"
+      }
+    ]
+  },
+  {
+    "name": "hot dog",
+    "trans": [
+      "n. 热狗"
+    ],
+    "sentences": [
+      {
+        "english": "The children ate hot dogs and ice cream at Melissa's birthday party.",
+        "chinese": "孩子们在梅利莎的生日晚会上吃了热狗和冰激凌。"
+      }
+    ]
+  },
+  {
+    "name": "house",
+    "trans": [
+      "n. 房屋"
+    ],
+    "sentences": [
+      {
+        "english": "Amy's invited me to her house for dinner.",
+        "chinese": "埃米邀请我去她家吃晚饭。"
+      }
+    ]
+  },
+  {
+    "name": "how",
+    "trans": [
+      "adv. 怎样"
+    ],
+    "sentences": [
+      {
+        "english": "How do you spell his name?",
+        "chinese": "你怎么拼写他的名字？"
+      }
+    ]
+  },
+  {
+    "name": "how many",
+    "trans": [
+      "多少"
+    ],
+    "sentences": [
+      {
+        "english": "How many people were there?",
+        "chinese": "有多少人？"
+      }
+    ]
+  },
+  {
+    "name": "how old",
+    "trans": [
+      "多大"
+    ],
+    "sentences": [
+      {
+        "english": "How old is this building?",
+        "chinese": "这座建筑已有多少年了？"
+      }
+    ]
+  },
+  {
+    "name": "hundred",
+    "trans": [
+      "num. 一百"
+    ],
+    "sentences": [
+      {
+        "english": "The bank's hundredth anniversary is in December.",
+        "chinese": "这家银行的百年纪念日在十二月。"
+      }
+    ]
+  },
+  {
+    "name": "hungry",
+    "trans": [
+      "adj. 饿的"
+    ],
+    "sentences": [
+      {
+        "english": "My friend was hungry, so we drove to a supermarket to get some food.",
+        "chinese": "我的朋友饿了，于是我们开车去一家超市买些食物。"
+      }
+    ]
+  },
+  {
+    "name": "hurry up",
+    "trans": [
+      "赶快"
+    ],
+    "sentences": [
+      {
+        "english": "Hurry up! The train is about to leave.",
+        "chinese": "快点！火车马上要开了。"
+      }
+    ]
+  },
+  {
+    "name": "hurt",
+    "trans": [
+      "v. 使受伤"
+    ],
+    "sentences": [
+      {
+        "english": "Yasin hurt himself while he was playing football.",
+        "chinese": "亚辛在踢足球的时候弄伤了自己。"
+      }
+    ]
+  },
+  {
+    "name": "I",
+    "trans": [
+      "pron. 我"
+    ],
+    "sentences": [
+      {
+        "english": "I live in Arizona.",
+        "chinese": "我住在亚利桑那州。"
+      }
+    ]
+  },
+  {
+    "name": "I'm",
+    "trans": [
+      "我是"
+    ],
+    "sentences": [
+      {
+        "english": "I'm tired—I'm going to bed.",
+        "chinese": "我累了—我要睡觉了。"
+      }
+    ]
+  },
+  {
+    "name": "ice cream",
+    "trans": [
+      "n. 冰激凌"
+    ],
+    "sentences": [
+      {
+        "english": "Serve the pie warm with vanilla ice cream.",
+        "chinese": "趁热把馅饼端上桌，配上香草冰激凌。"
+      }
+    ]
+  },
+  {
+    "name": "ice-skating",
+    "trans": [
+      "n. 滑冰"
+    ],
+    "sentences": [
+      {
+        "english": "I love watching ice-skating on television.",
+        "chinese": "我喜欢在电视上看滑冰。"
+      }
+    ]
+  },
+  {
+    "name": "idea",
+    "trans": [
+      "n. 主意"
+    ],
+    "sentences": [
+      {
+        "english": "These people have a lot of great ideas.",
+        "chinese": "这些人有很多好点子。"
+      }
+    ]
+  },
+  {
+    "name": "ill",
+    "trans": [
+      "adj. 生病的"
+    ],
+    "sentences": [
+      {
+        "english": "He is seriously ill with cancer.",
+        "chinese": "他癌症病得很重。"
+      }
+    ]
+  },
+  {
+    "name": "important",
+    "trans": [
+      "adj. 重要的"
+    ],
+    "sentences": [
+      {
+        "english": "The teacher stressed the importance of doing our homework.",
+        "chinese": "老师强调了做家庭作业的重要性。"
+      }
+    ]
+  },
+  {
+    "name": "in",
+    "trans": [
+      "prep. 在里面"
+    ],
+    "sentences": [
+      {
+        "english": "My brother was playing in the garden.",
+        "chinese": "我弟弟在花园里玩。"
+      }
+    ]
+  },
+  {
+    "name": "in front of",
+    "trans": [
+      "在前面"
+    ],
+    "sentences": [
+      {
+        "english": "He was dozing in front of the TV.",
+        "chinese": "他在电视机前打瞌睡。"
+      }
+    ]
+  },
+  {
+    "name": "inside",
+    "trans": [
+      "prep. 在里面"
+    ],
+    "sentences": [
+      {
+        "english": "Inside the envelope was a photograph.",
+        "chinese": "信封里面是一张照片。"
+      }
+    ]
+  },
+  {
+    "name": "instead",
+    "trans": [
+      "adv. 代替"
+    ],
+    "sentences": [
+      {
+        "english": "Robert didn't want to go bowling. He went to the cinema instead.",
+        "chinese": "罗伯特不想打保龄球。他想去看电影。"
+      }
+    ]
+  },
+  {
+    "name": "interested",
+    "trans": [
+      "adj. 感兴趣的"
+    ],
+    "sentences": [
+      {
+        "english": "I thought you might be interested in this article in the newspaper.",
+        "chinese": "我觉得你可能对报上这篇文章感兴趣。"
+      }
+    ]
+  },
+  {
+    "name": "into",
+    "trans": [
+      "prep. 到…里"
+    ],
+    "sentences": [
+      {
+        "english": "Put the apples into a dish.",
+        "chinese": "把苹果放在盘子里。"
+      }
+    ]
+  },
+  {
+    "name": "invent",
+    "trans": [
+      "v. 发明"
+    ],
+    "sentences": [
+      {
+        "english": "Who was the inventor of the telephone?",
+        "chinese": "电话是谁发明的？"
+      }
+    ]
+  },
+  {
+    "name": "invitation",
+    "trans": [
+      "n. 请柬"
+    ],
+    "sentences": [
+      {
+        "english": "I accepted Sarah's invitation to her birthday party.",
+        "chinese": "我接受了萨拉参加她生日派对的邀请。"
+      }
+    ]
+  },
+  {
+    "name": "is",
+    "trans": [
+      "v. 是"
+    ],
+    "sentences": [
+      {
+        "english": "This is happening everywhere in the country.",
+        "chinese": "全国各地都在发生这样的事情。"
+      }
+    ]
+  },
+  {
+    "name": "isn't",
+    "trans": [
+      "不是"
+    ],
+    "sentences": [
+      {
+        "english": "Money isn't everything.",
+        "chinese": "金钱不是最重要的。"
+      }
+    ]
+  },
+  {
+    "name": "it",
+    "trans": [
+      "pron. 它"
+    ],
+    "sentences": [
+      {
+        "english": "They live in a beautiful cottage. Here's a photo of it.",
+        "chinese": "他们住着一座漂亮的别墅。这儿有一张别墅的照片。"
+      }
+    ]
+  },
+  {
+    "name": "it's",
+    "trans": [
+      "它是"
+    ],
+    "sentences": [
+      {
+        "english": "It's not rubbish—it's true!",
+        "chinese": "这不是瞎说—是真的！"
+      }
+    ]
+  },
+  {
+    "name": "jacket",
+    "trans": [
+      "n. 夹克"
+    ],
+    "sentences": [
+      {
+        "english": "He wore a black leather jacket.",
+        "chinese": "他身穿一件黑色皮夹克。"
+      }
+    ]
+  },
+  {
+    "name": "jigsaw",
+    "trans": [
+      "n. 拼图"
+    ],
+    "sentences": [
+      {
+        "english": "The children put the last pieces in the jigsaw puzzle.",
+        "chinese": "孩子们把拼图的最后几块放了进去。"
+      }
+    ]
+  },
+  {
+    "name": "jigsaw puzzle",
+    "trans": [
+      "n. 拼图"
+    ],
+    "sentences": [
+      {
+        "english": "This process is akin to piecing together a jigsaw puzzle.",
+        "chinese": "这过程类似于拼七巧板。"
+      }
+    ]
+  },
+  {
+    "name": "jump",
+    "trans": [
+      "v. 跳"
+    ],
+    "sentences": [
+      {
+        "english": "She set a world record for the longest jump by a woman.",
+        "chinese": "她创造了女子跳远的世界纪录。"
+      }
+    ]
+  },
+  {
+    "name": "kangaroo",
+    "trans": [
+      "n. 袋鼠"
+    ],
+    "sentences": [
+      {
+        "english": "Kangaroo is usually the main social, and sometimes up to hundreds.",
+        "chinese": "袋鼠通常以群居为主，有时可多达上百只。"
+      }
+    ]
+  },
+  {
+    "name": "kilometre",
+    "trans": [
+      "n. 千米"
+    ],
+    "sentences": [
+      {
+        "english": "About a kilometre out of the city, the train began to pick up speed.",
+        "chinese": "出城约一公里后，火车开始加速。"
+      }
+    ]
+  },
+  {
+    "name": "kind",
+    "trans": [
+      "adj. 友善的"
+    ],
+    "sentences": [
+      {
+        "english": "What kind of car do you drive?",
+        "chinese": "你开哪种车？"
+      }
+    ]
+  },
+  {
+    "name": "kite",
+    "trans": [
+      "n. 风筝"
+    ],
+    "sentences": [
+      {
+        "english": "We went to the beach to fly kites.",
+        "chinese": "我们去海滩放风筝。"
+      }
+    ]
+  },
+  {
+    "name": "knee",
+    "trans": [
+      "n. 膝盖"
+    ],
+    "sentences": [
+      {
+        "english": "Lie down and bring your knees up toward your chest.",
+        "chinese": "躺平后膝关节向胸部靠拢。"
+      }
+    ]
+  },
+  {
+    "name": "knife",
+    "trans": [
+      "n. 刀"
+    ],
+    "sentences": [
+      {
+        "english": "I stopped eating and put down my knife and fork.",
+        "chinese": "我停止吃东西，放下了刀叉。"
+      }
+    ]
+  },
+  {
+    "name": "know",
+    "trans": [
+      "v. 知道"
+    ],
+    "sentences": [
+      {
+        "english": "You should know the answer to that question.",
+        "chinese": "你应该知道那道题的答案。"
+      }
+    ]
+  },
+  {
+    "name": "lady",
+    "trans": [
+      "n. 女士"
+    ],
+    "sentences": [
+      {
+        "english": "He said she was a lady with a clear mind.",
+        "chinese": "他说她是一位思想敏锐的女士。"
+      }
+    ]
+  },
+  {
+    "name": "lake",
+    "trans": [
+      "n. 湖"
+    ],
+    "sentences": [
+      {
+        "english": "They went fishing in the lake.",
+        "chinese": "他们去湖里钓鱼。"
+      }
+    ]
+  },
+  {
+    "name": "language",
+    "trans": [
+      "n. 语言"
+    ],
+    "sentences": [
+      {
+        "english": "The English language has over 500,000 words.",
+        "chinese": "英语有50多万个单词。"
+      }
+    ]
+  },
+  {
+    "name": "last",
+    "trans": [
+      "adj. 上一个"
+    ],
+    "sentences": [
+      {
+        "english": "He didn't come home last night.",
+        "chinese": "他昨晚没有回家。"
+      }
+    ]
+  },
+  {
+    "name": "late",
+    "trans": [
+      "adj. 迟的"
+    ],
+    "sentences": [
+      {
+        "english": "He married late in life.",
+        "chinese": "他结婚很晚。"
+      }
+    ]
+  },
+  {
+    "name": "later",
+    "trans": [
+      "adv. 后来"
+    ],
+    "sentences": [
+      {
+        "english": "He joined the company straight from school and left his job ten years later.",
+        "chinese": "他从学校一毕业就加入了这家公司，十年后就辞职了。"
+      }
+    ]
+  },
+  {
+    "name": "laugh",
+    "trans": [
+      "v. 笑"
+    ],
+    "sentences": [
+      {
+        "english": "When I saw what he was wearing, I started to laugh.",
+        "chinese": "当看到他穿的衣服时，我笑了起来。"
+      }
+    ]
+  },
+  {
+    "name": "learn",
+    "trans": [
+      "v. 学习"
+    ],
+    "sentences": [
+      {
+        "english": "Clint is a quick learner; he's one of my smarter students.",
+        "chinese": "克林特学东西很快，他是我最聪明的学生之一。"
+      }
+    ]
+  },
+  {
+    "name": "learnt",
+    "trans": [
+      "v. 学习（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "Clint is a quick learner; he's one of my smarter students.",
+        "chinese": "克林特学东西很快，他是我最聪明的学生之一。"
+      }
+    ]
+  },
+  {
+    "name": "leave",
+    "trans": [
+      "v. 离开"
+    ],
+    "sentences": [
+      {
+        "english": "He left the country yesterday.",
+        "chinese": "他昨天离开了这个国家。"
+      }
+    ]
+  },
+  {
+    "name": "leaves",
+    "trans": [
+      "n. 树叶（复数）"
+    ],
+    "sentences": [
+      {
+        "english": "A brown, dry oak leaf fell into the water.",
+        "chinese": "一片褐色的干橡树叶掉进水里。"
+      }
+    ]
+  },
+  {
+    "name": "left",
+    "trans": [
+      "adv. 向左"
+    ],
+    "sentences": [
+      {
+        "english": "Is there any milk left?",
+        "chinese": "还有牛奶吗?"
+      }
+    ]
+  },
+  {
+    "name": "leg",
+    "trans": [
+      "n. 腿"
+    ],
+    "sentences": [
+      {
+        "english": "He broke his right leg in a motorcycle accident.",
+        "chinese": "他在一次摩托车事故中摔断了右腿。"
+      }
+    ]
+  },
+  {
+    "name": "lesson",
+    "trans": [
+      "n. 教训；一节课"
+    ],
+    "sentences": [
+      {
+        "english": "Johanna has started taking piano lessons.",
+        "chinese": "约翰娜开始上钢琴课。"
+      }
+    ]
+  },
+  {
+    "name": "let's",
+    "trans": [
+      "让我们"
+    ],
+    "sentences": [
+      {
+        "english": "Let's think positive.",
+        "chinese": "咱们往好的方面想吧。"
+      }
+    ]
+  },
+  {
+    "name": "letter",
+    "trans": [
+      "n. 信"
+    ],
+    "sentences": [
+      {
+        "english": "I received a letter from a friend.",
+        "chinese": "我收到一封朋友的来信。"
+      }
+    ]
+  },
+  {
+    "name": "library",
+    "trans": [
+      "n. 图书馆"
+    ],
+    "sentences": [
+      {
+        "english": "I found the book I needed at the local library.",
+        "chinese": "我在当地图书馆找到了我需要的那本书。"
+      }
+    ]
+  },
+  {
+    "name": "lie",
+    "trans": [
+      "n. 谎言"
+    ],
+    "sentences": [
+      {
+        "english": "There was a man lying on the ground.",
+        "chinese": "有一个人躺在地上。"
+      }
+    ]
+  },
+  {
+    "name": "lift",
+    "trans": [
+      "v. 抬"
+    ],
+    "sentences": [
+      {
+        "english": "He lifted the bag onto his shoulder.",
+        "chinese": "他把包扛在肩上。"
+      }
+    ]
+  },
+  {
+    "name": "light",
+    "trans": [
+      "adj. 轻的"
+    ],
+    "sentences": [
+      {
+        "english": "He opened the curtains, and suddenly the room was filled with light.",
+        "chinese": "他拉开窗帘，突然房间里充满了光。"
+      }
+    ]
+  },
+  {
+    "name": "like",
+    "trans": [
+      "v. 喜欢"
+    ],
+    "sentences": [
+      {
+        "english": "He looks like my uncle.",
+        "chinese": "他长得像我的叔叔。"
+      }
+    ]
+  },
+  {
+    "name": "line",
+    "trans": [
+      "n. 排；线"
+    ],
+    "sentences": [
+      {
+        "english": "Draw a line at the bottom of the page.",
+        "chinese": "在这一页的底部画一条线。"
+      }
+    ]
+  },
+  {
+    "name": "lion",
+    "trans": [
+      "n. 狮子"
+    ],
+    "sentences": [
+      {
+        "english": "the lion, is fear of him not in the least.",
+        "chinese": "从此农民立即看不起狮子了，至少不再怕它了。"
+      }
+    ]
+  },
+  {
+    "name": "list",
+    "trans": [
+      "n. 清单"
+    ],
+    "sentences": [
+      {
+        "english": "I added coffee to my shopping list.",
+        "chinese": "我在购物单上加了咖啡。"
+      }
+    ]
+  },
+  {
+    "name": "listen",
+    "trans": [
+      "v. 听"
+    ],
+    "sentences": [
+      {
+        "english": "He spends his time listening to the radio.",
+        "chinese": "他把时间花在听收音机上。"
+      }
+    ]
+  },
+  {
+    "name": "little",
+    "trans": [
+      "adj. 小的"
+    ],
+    "sentences": [
+      {
+        "english": "We all sat at a little table.",
+        "chinese": "我们都坐在一张小桌旁。"
+      }
+    ]
+  },
+  {
+    "name": "live",
+    "trans": [
+      "v. 居住"
+    ],
+    "sentences": [
+      {
+        "english": "She lived in New York for 10 years.",
+        "chinese": "她在纽约住了10年。"
+      }
+    ]
+  },
+  {
+    "name": "London",
+    "trans": [
+      "n. 伦敦"
+    ],
+    "sentences": [
+      {
+        "english": "The play took London by storm.",
+        "chinese": "这部剧很快就风靡伦敦。"
+      }
+    ]
+  },
+  {
+    "name": "long",
+    "trans": [
+      "adj. 长的"
+    ],
+    "sentences": [
+      {
+        "english": "Cleaning up didn't take too long.",
+        "chinese": "清理工作没花多长时间。"
+      }
+    ]
+  },
+  {
+    "name": "long jump",
+    "trans": [
+      "n. 跳远"
+    ],
+    "sentences": [
+      {
+        "english": "He is ready for the long jump.",
+        "chinese": "他为跳远做好准备了。"
+      }
+    ]
+  },
+  {
+    "name": "look",
+    "trans": [
+      "v. 看"
+    ],
+    "sentences": [
+      {
+        "english": "I looked out of the window.",
+        "chinese": "我向窗外望去。"
+      }
+    ]
+  },
+  {
+    "name": "look after",
+    "trans": [
+      "照顾"
+    ],
+    "sentences": [
+      {
+        "english": "I know the Lord will look after him.",
+        "chinese": "我知道上帝会照顾他的。"
+      }
+    ]
+  },
+  {
+    "name": "look at",
+    "trans": [
+      "看"
+    ],
+    "sentences": [
+      {
+        "english": "I didn't dare look at him.",
+        "chinese": "我不敢看他。"
+      }
+    ]
+  },
+  {
+    "name": "lots of",
+    "trans": [
+      "许多"
+    ],
+    "sentences": [
+      {
+        "english": "We took lots of measurements.",
+        "chinese": "我们得到了许多测量的结果。"
+      }
+    ]
+  },
+  {
+    "name": "loud",
+    "trans": [
+      "adj. 吵闹的"
+    ],
+    "sentences": [
+      {
+        "english": "The cat rolled onto its back, purring loudly.",
+        "chinese": "猫翻了个身，呼噜呼噜地大声叫着。"
+      }
+    ]
+  },
+  {
+    "name": "love",
+    "trans": [
+      "v. 爱"
+    ],
+    "sentences": [
+      {
+        "english": "You will love your baby from the moment she is born.",
+        "chinese": "你会爱你的孩子，从她出生的那一刻起。"
+      }
+    ]
+  },
+  {
+    "name": "lovely",
+    "trans": [
+      "adj. 可爱的"
+    ],
+    "sentences": [
+      {
+        "english": "Sam has a lovely voice.",
+        "chinese": "萨姆有一副好嗓子。"
+      }
+    ]
+  },
+  {
+    "name": "lunch",
+    "trans": [
+      "n. 午餐"
+    ],
+    "sentences": [
+      {
+        "english": "Are you free for lunch?",
+        "chinese": "你有空吃午饭吗?"
+      }
+    ]
+  },
+  {
+    "name": "machine",
+    "trans": [
+      "n. 机器"
+    ],
+    "sentences": [
+      {
+        "english": "I put the coin in the coffee machine.",
+        "chinese": "我把硬币投进咖啡机里。"
+      }
+    ]
+  },
+  {
+    "name": "made",
+    "trans": [
+      "v. 制作（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "The president made him a general. His mother named him Tommy.",
+        "chinese": "总统任命他为将官。"
+      }
+    ]
+  },
+  {
+    "name": "make",
+    "trans": [
+      "v. 制作"
+    ],
+    "sentences": [
+      {
+        "english": "She makes all her own clothes.",
+        "chinese": "她的衣服都是自己做的。"
+      }
+    ]
+  },
+  {
+    "name": "man",
+    "trans": [
+      "n. 男人"
+    ],
+    "sentences": [
+      {
+        "english": "A handsome man walked into the room.",
+        "chinese": "一位英俊的男士走进屋里。"
+      }
+    ]
+  },
+  {
+    "name": "many",
+    "trans": [
+      "adj. 许多的"
+    ],
+    "sentences": [
+      {
+        "english": "He made a list of his friends. There weren't many.",
+        "chinese": "他罗列了一下朋友名字。不多。"
+      }
+    ]
+  },
+  {
+    "name": "map",
+    "trans": [
+      "n. 地图"
+    ],
+    "sentences": [
+      {
+        "english": "The detailed map helps tourists find their way around the city.",
+        "chinese": "详图引导游客在城中游览。"
+      }
+    ]
+  },
+  {
+    "name": "Maths",
+    "trans": [
+      "n. 数学"
+    ],
+    "sentences": [
+      {
+        "english": "SIMON: That's the thing. He said he was bad at maths.",
+        "chinese": "西蒙：是这样的，他说他不擅长数学。"
+      }
+    ]
+  },
+  {
+    "name": "matter",
+    "trans": [
+      "n. 麻烦事"
+    ],
+    "sentences": [
+      {
+        "english": "She wanted to discuss a private matter with me.",
+        "chinese": "她想和我谈一件私事儿。"
+      }
+    ]
+  },
+  {
+    "name": "maybe",
+    "trans": [
+      "adv. 也许"
+    ],
+    "sentences": [
+      {
+        "english": "Maybe we can go to the cinema or something.",
+        "chinese": "或许我们可以看场电影什么的。"
+      }
+    ]
+  },
+  {
+    "name": "me",
+    "trans": [
+      "pron. 我（宾格）"
+    ],
+    "sentences": [
+      {
+        "english": "The way he treats me really burns me up.",
+        "chinese": "他这样对待我真使我恼火。"
+      }
+    ]
+  },
+  {
+    "name": "meat",
+    "trans": [
+      "n. 肉"
+    ],
+    "sentences": [
+      {
+        "english": "I don't eat meat or fish.",
+        "chinese": "我不吃肉，也不吃鱼。"
+      }
+    ]
+  },
+  {
+    "name": "medicine",
+    "trans": [
+      "n. 药"
+    ],
+    "sentences": [
+      {
+        "english": "He decided on a career in medicine.",
+        "chinese": "他决定从医。"
+      }
+    ]
+  },
+  {
+    "name": "meet",
+    "trans": [
+      "v. 见面"
+    ],
+    "sentences": [
+      {
+        "english": "I met Shona in town today.",
+        "chinese": "我今天在城里碰到了肖纳。"
+      }
+    ]
+  },
+  {
+    "name": "men",
+    "trans": [
+      "n. 男人们"
+    ],
+    "sentences": [
+      {
+        "english": "A handsome man walked into the room.",
+        "chinese": "一位英俊的男士走进屋里。"
+      }
+    ]
+  },
+  {
+    "name": "message",
+    "trans": [
+      "n. 信息"
+    ],
+    "sentences": [
+      {
+        "english": "I'm getting emails and messages from friends all over the world.",
+        "chinese": "我收到世界各地朋友们的电邮和信息。"
+      }
+    ]
+  },
+  {
+    "name": "met",
+    "trans": [
+      "v. 遇见（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "I met Shona in town today.",
+        "chinese": "我今天在城里碰到了肖纳。"
+      }
+    ]
+  },
+  {
+    "name": "middle school",
+    "trans": [
+      "n. 中学"
+    ],
+    "sentences": [
+      {
+        "english": "I'm a middle school teacher.",
+        "chinese": "我是一个中学教师。"
+      }
+    ]
+  },
+  {
+    "name": "might",
+    "trans": [
+      "v. 可能"
+    ],
+    "sentences": [
+      {
+        "english": "I might go to study in England.",
+        "chinese": "我也许去英格兰念书。"
+      }
+    ]
+  },
+  {
+    "name": "milk",
+    "trans": [
+      "n. 牛奶"
+    ],
+    "sentences": [
+      {
+        "english": "He went out to buy a pint of milk.",
+        "chinese": "他出去买一品脱奶。"
+      }
+    ]
+  },
+  {
+    "name": "milkshake",
+    "trans": [
+      "n. 奶昔"
+    ],
+    "sentences": [
+      {
+        "english": "I want a strawberry milkshake.",
+        "chinese": "我想要杯草莓奶昔。"
+      }
+    ]
+  },
+  {
+    "name": "million",
+    "trans": [
+      "num. 百万"
+    ],
+    "sentences": [
+      {
+        "english": "A million people visit the county each year.",
+        "chinese": "每年有百万人到访该郡。"
+      }
+    ]
+  },
+  {
+    "name": "mine",
+    "trans": [
+      "pron. 我的"
+    ],
+    "sentences": [
+      {
+        "english": "The company owns gold and silver mines.",
+        "chinese": "公司拥有金银矿。"
+      }
+    ]
+  },
+  {
+    "name": "minute",
+    "trans": [
+      "n. 分钟"
+    ],
+    "sentences": [
+      {
+        "english": "The doctor will be with you in a minute.",
+        "chinese": "大夫一会儿就来。"
+      }
+    ]
+  },
+  {
+    "name": "miss",
+    "trans": [
+      "v. 想念"
+    ],
+    "sentences": [
+      {
+        "english": "His first shot missed the goal completely.",
+        "chinese": "他第一次射门偏出球门老远。"
+      }
+    ]
+  },
+  {
+    "name": "mistake",
+    "trans": [
+      "n. 错误"
+    ],
+    "sentences": [
+      {
+        "english": "Tony made three spelling mistakes in the letter.",
+        "chinese": "托尼信里有三处拼写错误。"
+      }
+    ]
+  },
+  {
+    "name": "model",
+    "trans": [
+      "n. 模型"
+    ],
+    "sentences": [
+      {
+        "english": "At school, the children are making a model of the solar system.",
+        "chinese": "学校里，孩子们正在做太阳系模型。"
+      }
+    ]
+  },
+  {
+    "name": "Monday",
+    "trans": [
+      "n. 星期一"
+    ],
+    "sentences": [
+      {
+        "english": "The first meeting was last Monday.",
+        "chinese": "第一次会面是上周一。"
+      }
+    ]
+  },
+  {
+    "name": "monkey",
+    "trans": [
+      "n. 猴子"
+    ],
+    "sentences": [
+      {
+        "english": "They're trying to make a monkey out of me.",
+        "chinese": "他们试图拿我做笑料。"
+      }
+    ]
+  },
+  {
+    "name": "monster",
+    "trans": [
+      "n. 怪物"
+    ],
+    "sentences": [
+      {
+        "english": "The film is about a monster in the wardrobe.",
+        "chinese": "影片刻画了一只衣橱怪兽。"
+      }
+    ]
+  },
+  {
+    "name": "month",
+    "trans": [
+      "n. 月份"
+    ],
+    "sentences": [
+      {
+        "english": "September is the ninth month of the year.",
+        "chinese": "九月是一年中第九个月。"
+      }
+    ]
+  },
+  {
+    "name": "moon",
+    "trans": [
+      "n. 月亮"
+    ],
+    "sentences": [
+      {
+        "english": "The first man on the moon was an American, Neil Armstrong.",
+        "chinese": "登月第一人是美国人尼尔·阿姆斯特朗。"
+      }
+    ]
+  },
+  {
+    "name": "more",
+    "trans": [
+      "adj. 更多的"
+    ],
+    "sentences": [
+      {
+        "english": "More people are surviving heart attacks than ever before.",
+        "chinese": "现在心脏病患者比以往任何时候的存活率都高。"
+      }
+    ]
+  },
+  {
+    "name": "more than",
+    "trans": [
+      "超过"
+    ],
+    "sentences": [
+      {
+        "english": "He loves me more than you do.",
+        "chinese": "他比你更爱我。"
+      }
+    ]
+  },
+  {
+    "name": "morning",
+    "trans": [
+      "n. 早晨；上午"
+    ],
+    "sentences": [
+      {
+        "english": "Tomorrow morning we will take a walk around the city.",
+        "chinese": "明早我们在城里走一走。"
+      }
+    ]
+  },
+  {
+    "name": "morning exercises",
+    "trans": [
+      "n. 早操"
+    ],
+    "sentences": [
+      {
+        "english": "I've began to get up early to do some morning exercises for a change.",
+        "chinese": "我这些天已经开始早起做早操给自己做个改变。"
+      }
+    ]
+  },
+  {
+    "name": "mother",
+    "trans": [
+      "n. 母亲"
+    ],
+    "sentences": [
+      {
+        "english": "She's a mother of two children.",
+        "chinese": "她是两个孩子的母亲。"
+      }
+    ]
+  },
+  {
+    "name": "Mother's Day",
+    "trans": [
+      "n. 母亲节"
+    ],
+    "sentences": [
+      {
+        "english": "Tomorrow is Mother's Day!",
+        "chinese": "明天就是母亲节！"
+      }
+    ]
+  },
+  {
+    "name": "mountain",
+    "trans": [
+      "n. 山"
+    ],
+    "sentences": [
+      {
+        "english": "Denali is the highest mountain in North America.",
+        "chinese": "迪纳利山是北美洲第一高山。"
+      }
+    ]
+  },
+  {
+    "name": "mouse",
+    "trans": [
+      "n. 老鼠"
+    ],
+    "sentences": [
+      {
+        "english": "I clicked the mouse and the message appeared on the screen.",
+        "chinese": "我点击鼠标，消息出现在了屏幕上。"
+      }
+    ]
+  },
+  {
+    "name": "mouth",
+    "trans": [
+      "n. 嘴"
+    ],
+    "sentences": [
+      {
+        "english": "When you cough, please cover your mouth.",
+        "chinese": "咳嗽时请捂住嘴。"
+      }
+    ]
+  },
+  {
+    "name": "Mr",
+    "trans": [
+      "n. 先生"
+    ],
+    "sentences": [
+      {
+        "english": "Could I please speak to Mr Johnson?",
+        "chinese": "请找一下约翰逊先生好吗？"
+      }
+    ]
+  },
+  {
+    "name": "Ms",
+    "trans": [
+      "n. 女士"
+    ],
+    "sentences": [
+      {
+        "english": "Ms Kennedy refused to speak to reporters after the meeting.",
+        "chinese": "肯尼迪女士会后拒绝接受记者采访。"
+      }
+    ]
+  },
+  {
+    "name": "much",
+    "trans": [
+      "adv. 非常"
+    ],
+    "sentences": [
+      {
+        "english": "These plants do not need much water.",
+        "chinese": "这些植物不怎么需要水。"
+      }
+    ]
+  },
+  {
+    "name": "mum",
+    "trans": [
+      "n. 妈妈"
+    ],
+    "sentences": [
+      {
+        "english": "We waited for my mum and dad to get home.",
+        "chinese": "我们等爸爸妈妈回家。"
+      }
+    ]
+  },
+  {
+    "name": "museum",
+    "trans": [
+      "n. 博物馆"
+    ],
+    "sentences": [
+      {
+        "english": "Hundreds of people came to the museum to see the exhibition.",
+        "chinese": "数百人来博物馆看这个展览。"
+      }
+    ]
+  },
+  {
+    "name": "Music",
+    "trans": [
+      "n. 音乐"
+    ],
+    "sentences": [
+      {
+        "english": "Diane is studying classical music.",
+        "chinese": "黛安娜在学习古典乐。"
+      }
+    ]
+  },
+  {
+    "name": "my",
+    "trans": [
+      "pron. 我的"
+    ],
+    "sentences": [
+      {
+        "english": "We can eat at my house tonight.",
+        "chinese": "今晚我们可以在我家吃饭。"
+      }
+    ]
+  },
+  {
+    "name": "name",
+    "trans": [
+      "n. 名字"
+    ],
+    "sentences": [
+      {
+        "english": "`What's his name?' — `Peter.'",
+        "chinese": "“他叫什么名字？”——“彼得。”"
+      }
+    ]
+  },
+  {
+    "name": "National Day",
+    "trans": [
+      "n. 国庆节"
+    ],
+    "sentences": [
+      {
+        "english": "Yesterday was National Day.",
+        "chinese": "昨天是国庆节。"
+      }
+    ]
+  },
+  {
+    "name": "naughty",
+    "trans": [
+      "adj. 淘气的"
+    ],
+    "sentences": [
+      {
+        "english": "When I'm very naughty, my mum sends me to bed early.",
+        "chinese": "我很调皮的时候，我妈妈就让我早点上床睡觉。"
+      }
+    ]
+  },
+  {
+    "name": "nearly",
+    "trans": [
+      "adv. 几乎"
+    ],
+    "sentences": [
+      {
+        "english": "He has worked for the company for nearly 20 years.",
+        "chinese": "他在这家公司工作了近20年。"
+      }
+    ]
+  },
+  {
+    "name": "need",
+    "trans": [
+      "v. 需要"
+    ],
+    "sentences": [
+      {
+        "english": "There is a need for more schools in the area.",
+        "chinese": "这个地区需要更多学校。"
+      }
+    ]
+  },
+  {
+    "name": "nervous",
+    "trans": [
+      "adj. 紧张的"
+    ],
+    "sentences": [
+      {
+        "english": "Beth stood up nervously when the teacher came into the room.",
+        "chinese": "老师走进教室时，贝丝紧张地站了起来。"
+      }
+    ]
+  },
+  {
+    "name": "new",
+    "trans": [
+      "adj. 新的"
+    ],
+    "sentences": [
+      {
+        "english": "They've just opened a new hotel.",
+        "chinese": "他们刚刚建成了一家新酒店。"
+      }
+    ]
+  },
+  {
+    "name": "New Year",
+    "trans": [
+      "n. 新年"
+    ],
+    "sentences": [
+      {
+        "english": "I'll see you in the new year.",
+        "chinese": "新的一年里再见。"
+      }
+    ]
+  },
+  {
+    "name": "newspaper",
+    "trans": [
+      "n. 报纸"
+    ],
+    "sentences": [
+      {
+        "english": "They read about it in the newspaper.",
+        "chinese": "他们在报纸上看到了这个。"
+      }
+    ]
+  },
+  {
+    "name": "next to",
+    "trans": [
+      "在旁边"
+    ],
+    "sentences": [
+      {
+        "english": "The commons is next to the gym.",
+        "chinese": "学生公共食堂在体育馆的旁边。"
+      }
+    ]
+  },
+  {
+    "name": "nice",
+    "trans": [
+      "adj. 好的"
+    ],
+    "sentences": [
+      {
+        "english": "The book is nicely illustrated.",
+        "chinese": "这本书的插图精美。"
+      }
+    ]
+  },
+  {
+    "name": "Nice to meet you",
+    "trans": [
+      "见到你真高兴"
+    ],
+    "sentences": [
+      {
+        "english": "Hello- nice to meet you. Take a lott- I'll be down in a minute.",
+        "chinese": "你好，很快活认识你。请坐，我马高上去。"
+      }
+    ]
+  },
+  {
+    "name": "night",
+    "trans": [
+      "n. 夜晚"
+    ],
+    "sentences": [
+      {
+        "english": "The rain continued all night.",
+        "chinese": "雨下了一整晚。"
+      }
+    ]
+  },
+  {
+    "name": "nine",
+    "trans": [
+      "num. 九"
+    ],
+    "sentences": [
+      {
+        "english": "Forty-nine women testified against him in the first case of its kind.",
+        "chinese": "49名妇女当庭指证马特威尔。这是首起此类案件。"
+      }
+    ]
+  },
+  {
+    "name": "nineteen",
+    "trans": [
+      "num. 十九"
+    ],
+    "sentences": [
+      {
+        "english": "Nineteen sixty-eight was one of the most tumultuous and heartbreaking years in American history.",
+        "chinese": "1968年是美国历史上最为混乱和令人悲伤的岁月中的一年。"
+      }
+    ]
+  },
+  {
+    "name": "ninety",
+    "trans": [
+      "num. 九十"
+    ],
+    "sentences": [
+      {
+        "english": "Her weight was under ninety pounds.",
+        "chinese": "她的体重不足90磅。"
+      }
+    ]
+  },
+  {
+    "name": "no",
+    "trans": [
+      "int. 不"
+    ],
+    "sentences": [
+      {
+        "english": "`Are you having any problems?' — `No, I'm OK.'",
+        "chinese": "“你有什么问题吗？”——“没有，我挺好的。”"
+      }
+    ]
+  },
+  {
+    "name": "no one",
+    "trans": [
+      "没有人"
+    ],
+    "sentences": [
+      {
+        "english": "We asked everyone in the room, but no one wanted to help.",
+        "chinese": "我们求助了屋里所有的人，但是没有人想帮忙。"
+      }
+    ]
+  },
+  {
+    "name": "noise",
+    "trans": [
+      "n. 噪音"
+    ],
+    "sentences": [
+      {
+        "english": "Don't make so much noise!",
+        "chinese": "不要制造这么多噪音！"
+      }
+    ]
+  },
+  {
+    "name": "noodles",
+    "trans": [
+      "n. 面条"
+    ],
+    "sentences": [
+      {
+        "english": "Would you prefer rice or noodles?",
+        "chinese": "你喜欢吃米饭还是面条？"
+      }
+    ]
+  },
+  {
+    "name": "north",
+    "trans": [
+      "n. 北方"
+    ],
+    "sentences": [
+      {
+        "english": "In the north, snow and ice cover the ground.",
+        "chinese": "在北方，冰雪覆盖大地。"
+      }
+    ]
+  },
+  {
+    "name": "nose",
+    "trans": [
+      "n. 鼻子"
+    ],
+    "sentences": [
+      {
+        "english": "His eyes and his mouth were quiet small, but his nose was very big.",
+        "chinese": "他的眼睛和嘴都是很小的，但他的鼻子很大…"
+      }
+    ]
+  },
+  {
+    "name": "not",
+    "trans": [
+      "adv. 不"
+    ],
+    "sentences": [
+      {
+        "english": "Their plan was not working.",
+        "chinese": "他们的计划没起到作用。"
+      }
+    ]
+  },
+  {
+    "name": "nothing",
+    "trans": [
+      "pron. 没什么"
+    ],
+    "sentences": [
+      {
+        "english": "There was nothing in the fridge except some butter.",
+        "chinese": "冰箱里除了黄油什么都没有。"
+      }
+    ]
+  },
+  {
+    "name": "now",
+    "trans": [
+      "adv. 现在"
+    ],
+    "sentences": [
+      {
+        "english": "I must go now.",
+        "chinese": "我现在必须走了。"
+      }
+    ]
+  },
+  {
+    "name": "nurse",
+    "trans": [
+      "n. 护士"
+    ],
+    "sentences": [
+      {
+        "english": "She thanked the nurses who cared for her.",
+        "chinese": "她感谢了照顾她的护士。"
+      }
+    ]
+  },
+  {
+    "name": "o'clock",
+    "trans": [
+      "n. 点钟"
+    ],
+    "sentences": [
+      {
+        "english": "I went to bed at ten o'clock last night.",
+        "chinese": "我昨晚十点钟上床睡觉。"
+      }
+    ]
+  },
+  {
+    "name": "of",
+    "trans": [
+      "prep. …的"
+    ],
+    "sentences": [
+      {
+        "english": "Police searched the homes of the criminals.",
+        "chinese": "警察搜查了罪犯的家。"
+      }
+    ]
+  },
+  {
+    "name": "of course",
+    "trans": [
+      "当然"
+    ],
+    "sentences": [
+      {
+        "english": "Of course there were lots of interesting things to see.",
+        "chinese": "当然有很多有趣的事情要看。"
+      }
+    ]
+  },
+  {
+    "name": "office",
+    "trans": [
+      "n. 办公室"
+    ],
+    "sentences": [
+      {
+        "english": "I work in an office with about 25 people.",
+        "chinese": "我在一间约有25人的办公室工作。"
+      }
+    ]
+  },
+  {
+    "name": "often",
+    "trans": [
+      "adv. 经常"
+    ],
+    "sentences": [
+      {
+        "english": "They often spend the weekend together.",
+        "chinese": "他们经常一起过周末。"
+      }
+    ]
+  },
+  {
+    "name": "OK",
+    "trans": [
+      "adj. 好的"
+    ],
+    "sentences": [
+      {
+        "english": "OK, let me show you around the rest of the office.",
+        "chinese": "你要带我去看看这公司的大楼，那太好了。"
+      }
+    ]
+  },
+  {
+    "name": "old",
+    "trans": [
+      "adj. 老的；古老的"
+    ],
+    "sentences": [
+      {
+        "english": "Mr Kaufmann was a small old man with a beard.",
+        "chinese": "考夫曼先生是一位留着胡子的老人。"
+      }
+    ]
+  },
+  {
+    "name": "on",
+    "trans": [
+      "prep. 在上面"
+    ],
+    "sentences": [
+      {
+        "english": "He was sitting on the sofa.",
+        "chinese": "他坐在沙发上。"
+      }
+    ]
+  },
+  {
+    "name": "on holiday",
+    "trans": [
+      "度假"
+    ],
+    "sentences": [
+      {
+        "english": "They met while on holiday in Greece.",
+        "chinese": "他们是在希腊度假时认识的。"
+      }
+    ]
+  },
+  {
+    "name": "once upon a time",
+    "trans": [
+      "从前"
+    ],
+    "sentences": [
+      {
+        "english": "Once upon a time there was a princess...",
+        "chinese": "从前有一位公主…"
+      }
+    ]
+  },
+  {
+    "name": "one",
+    "trans": [
+      "num. 一"
+    ],
+    "sentences": [
+      {
+        "english": "`Which dress do you prefer?' — `I like the red one.'",
+        "chinese": "“你喜欢哪一条裙子？”——“我喜欢红色的那条。”"
+      }
+    ]
+  },
+  {
+    "name": "onion",
+    "trans": [
+      "n. 洋葱"
+    ],
+    "sentences": [
+      {
+        "english": "I sliced up an onion.",
+        "chinese": "我把洋葱切成了片。"
+      }
+    ]
+  },
+  {
+    "name": "only",
+    "trans": [
+      "adv. 只"
+    ],
+    "sentences": [
+      {
+        "english": "She's the only girl in the class.",
+        "chinese": "她是班上唯一的女孩。"
+      }
+    ]
+  },
+  {
+    "name": "open",
+    "trans": [
+      "v. 打开"
+    ],
+    "sentences": [
+      {
+        "english": "He opened the window.",
+        "chinese": "他打开了窗户。"
+      }
+    ]
+  },
+  {
+    "name": "or",
+    "trans": [
+      "conj. 或者"
+    ],
+    "sentences": [
+      {
+        "english": "`Do you want tea or coffee?' John asked.",
+        "chinese": "“你想喝茶还是咖啡？”约翰问。"
+      }
+    ]
+  },
+  {
+    "name": "orange",
+    "trans": [
+      "adj. 橙色的"
+    ],
+    "sentences": [
+      {
+        "english": "His supporters were dressed in orange.",
+        "chinese": "他的支持者穿着橘色的衣服。"
+      }
+    ]
+  },
+  {
+    "name": "other",
+    "trans": [
+      "adj. 其他的"
+    ],
+    "sentences": [
+      {
+        "english": "Mr Johnson and the other teachers are very worried.",
+        "chinese": "约翰逊先生和其他老师都非常担心。"
+      }
+    ]
+  },
+  {
+    "name": "our",
+    "trans": [
+      "pron. 我们的"
+    ],
+    "sentences": [
+      {
+        "english": "The result of our investigation said the damage was caused sometime in transit.",
+        "chinese": "我们调查的结果是，货物是在运输途中的某个时候受损的。"
+      }
+    ]
+  },
+  {
+    "name": "over there",
+    "trans": [
+      "在那边"
+    ],
+    "sentences": [
+      {
+        "english": "That's Peter over there.",
+        "chinese": "那边那个人是彼得。"
+      }
+    ]
+  },
+  {
+    "name": "paint",
+    "trans": [
+      "v. 绘画"
+    ],
+    "sentences": [
+      {
+        "english": "We'll need about three cans of red paint.",
+        "chinese": "我们需要大概三罐红色颜料。"
+      }
+    ]
+  },
+  {
+    "name": "pair",
+    "trans": [
+      "n. 一双"
+    ],
+    "sentences": [
+      {
+        "english": "She wore a pair of plain black shoes.",
+        "chinese": "她穿了一双朴素的黑鞋子。"
+      }
+    ]
+  },
+  {
+    "name": "panda",
+    "trans": [
+      "n. 熊猫"
+    ],
+    "sentences": [
+      {
+        "english": "The lesser panda grovelled at his feet when he shout at it.",
+        "chinese": "他一吼，那小熊猫就趴在他的脚下。"
+      }
+    ]
+  },
+  {
+    "name": "paper",
+    "trans": [
+      "n. 纸"
+    ],
+    "sentences": [
+      {
+        "english": "He wrote his name down on a piece of paper.",
+        "chinese": "他在一张纸上写下自己的名字。"
+      }
+    ]
+  },
+  {
+    "name": "parent",
+    "trans": [
+      "n. 父母"
+    ],
+    "sentences": [
+      {
+        "english": "A happy parent makes for a happy child.",
+        "chinese": "幸福的家长造就幸福的孩子。"
+      }
+    ]
+  },
+  {
+    "name": "park",
+    "trans": [
+      "n. 公园"
+    ],
+    "sentences": [
+      {
+        "english": "I took a walk with the dog around the park.",
+        "chinese": "我带着狗绕公园散步。"
+      }
+    ]
+  },
+  {
+    "name": "party",
+    "trans": [
+      "n. 聚会"
+    ],
+    "sentences": [
+      {
+        "english": "We organized a huge birthday party.",
+        "chinese": "我们举办了盛大的生日聚会。"
+      }
+    ]
+  },
+  {
+    "name": "past",
+    "trans": [
+      "prep. 晚于"
+    ],
+    "sentences": [
+      {
+        "english": "In the past, most babies with the disease died.",
+        "chinese": "过去，患这种病的宝宝大部分都夭折了。"
+      }
+    ]
+  },
+  {
+    "name": "PE",
+    "trans": [
+      "n. 体育课"
+    ],
+    "sentences": [
+      {
+        "english": "You'll do better in PE.",
+        "chinese": "你将在体育方面做得更好。"
+      }
+    ]
+  },
+  {
+    "name": "peace",
+    "trans": [
+      "n. 和平"
+    ],
+    "sentences": [
+      {
+        "english": "The new rulers brought peace to the country.",
+        "chinese": "新上任的统治者给这个国家带来了和平。"
+      }
+    ]
+  },
+  {
+    "name": "peach",
+    "trans": [
+      "n. 桃子"
+    ],
+    "sentences": [
+      {
+        "english": "The room was decorated in peach.",
+        "chinese": "这个房间装修为桃红色调。"
+      }
+    ]
+  },
+  {
+    "name": "pear",
+    "trans": [
+      "n. 梨"
+    ],
+    "sentences": [
+      {
+        "english": "In gardens, cankers are most prominent on apples and pear trees.",
+        "chinese": "花园树木中患溃疡病最多的是苹果树和梨树。"
+      }
+    ]
+  },
+  {
+    "name": "pen",
+    "trans": [
+      "n. 钢笔"
+    ],
+    "sentences": [
+      {
+        "english": "Can I borrow a pen please?",
+        "chinese": "我可以借支笔吗？"
+      }
+    ]
+  },
+  {
+    "name": "pen friend",
+    "trans": [
+      "n. 笔友"
+    ],
+    "sentences": [
+      {
+        "english": "Linda heard from her pen friend in England yesterday.",
+        "chinese": "琳达昨天收到了她的英国笔友的来信。"
+      }
+    ]
+  },
+  {
+    "name": "pen pal",
+    "trans": [
+      "n. 笔友"
+    ],
+    "sentences": [
+      {
+        "english": "Maybe you should find a pen pal.",
+        "chinese": "也许你应该找个笔友。"
+      }
+    ]
+  },
+  {
+    "name": "pencil",
+    "trans": [
+      "n. 铅笔"
+    ],
+    "sentences": [
+      {
+        "english": "She used a pencil and some blank paper to draw the picture.",
+        "chinese": "她用铅笔和白纸画画。"
+      }
+    ]
+  },
+  {
+    "name": "pencil box",
+    "trans": [
+      "n. 铅笔盒"
+    ],
+    "sentences": [
+      {
+        "english": "Put away your pencil box!",
+        "chinese": "把你的铅笔盒收起来！"
+      }
+    ]
+  },
+  {
+    "name": "pencil case",
+    "trans": [
+      "n. 铅笔盒"
+    ],
+    "sentences": [
+      {
+        "english": "Your eraser is in my pencil case. You can take it out.",
+        "chinese": "你的橡皮擦在我的文具盒里，你可以拿出来。"
+      }
+    ]
+  },
+  {
+    "name": "people",
+    "trans": [
+      "n. 人们"
+    ],
+    "sentences": [
+      {
+        "english": "He's reading a book about the people of Angola.",
+        "chinese": "他在读一本有关安哥拉人民的书。"
+      }
+    ]
+  },
+  {
+    "name": "perfect",
+    "trans": [
+      "adj. 完美的"
+    ],
+    "sentences": [
+      {
+        "english": "The system worked perfectly.",
+        "chinese": "该系统运行完美。"
+      }
+    ]
+  },
+  {
+    "name": "pet",
+    "trans": [
+      "n. 宠物"
+    ],
+    "sentences": [
+      {
+        "english": "Do you have any pets?",
+        "chinese": "你养的有宠物吗？"
+      }
+    ]
+  },
+  {
+    "name": "phone",
+    "trans": [
+      "n. 电话"
+    ],
+    "sentences": [
+      {
+        "english": "He phoned Laura to see if she was better.",
+        "chinese": "他给劳拉打电话问她是否好点了。"
+      }
+    ]
+  },
+  {
+    "name": "photo",
+    "trans": [
+      "n. 照片"
+    ],
+    "sentences": [
+      {
+        "english": "The photo wasn't very clear.",
+        "chinese": "这张照片不太清晰。"
+      }
+    ]
+  },
+  {
+    "name": "picnic",
+    "trans": [
+      "n. 野餐"
+    ],
+    "sentences": [
+      {
+        "english": "Afterwards, we picnicked by the river.",
+        "chinese": "之后，我们在河边野餐。"
+      }
+    ]
+  },
+  {
+    "name": "picture",
+    "trans": [
+      "n. 图画"
+    ],
+    "sentences": [
+      {
+        "english": "She drew a picture with coloured chalk.",
+        "chinese": "她用彩色粉笔画了幅图。"
+      }
+    ]
+  },
+  {
+    "name": "piece",
+    "trans": [
+      "n. 张；片"
+    ],
+    "sentences": [
+      {
+        "english": "You must only take one piece of cake.",
+        "chinese": "你只能吃一块蛋糕。"
+      }
+    ]
+  },
+  {
+    "name": "pig",
+    "trans": [
+      "n. 猪"
+    ],
+    "sentences": [
+      {
+        "english": "Children can help feed the pigs.",
+        "chinese": "孩子们能帮着喂猪。"
+      }
+    ]
+  },
+  {
+    "name": "ping-pong",
+    "trans": [
+      "n. 乒乓球"
+    ],
+    "sentences": [
+      {
+        "english": "Christine: You know what? I think you take ping-pong a little too seriously.",
+        "chinese": "克莉丝汀：你知道吗？我想你把兵乓球看得太严重了点。"
+      }
+    ]
+  },
+  {
+    "name": "pink",
+    "trans": [
+      "adj. 粉色的"
+    ],
+    "sentences": [
+      {
+        "english": "She wore pink lipstick.",
+        "chinese": "她涂着粉红色的唇膏。"
+      }
+    ]
+  },
+  {
+    "name": "place",
+    "trans": [
+      "n. 地方"
+    ],
+    "sentences": [
+      {
+        "english": "Keep your dog on a lead in public places.",
+        "chinese": "在公共场合狗要栓绳。"
+      }
+    ]
+  },
+  {
+    "name": "plan",
+    "trans": [
+      "n. 计划"
+    ],
+    "sentences": [
+      {
+        "english": "They are meeting to discuss the peace plan.",
+        "chinese": "他们会面商讨和平方案。"
+      }
+    ]
+  },
+  {
+    "name": "plane",
+    "trans": [
+      "n. 飞机"
+    ],
+    "sentences": [
+      {
+        "english": "The plane landed at Geneva.",
+        "chinese": "飞机在日内瓦降落。"
+      }
+    ]
+  },
+  {
+    "name": "planet",
+    "trans": [
+      "n. 行星"
+    ],
+    "sentences": [
+      {
+        "english": "We study the planets in the solar system.",
+        "chinese": "我们研究太阳系中的行星。"
+      }
+    ]
+  },
+  {
+    "name": "plant",
+    "trans": [
+      "n. 植物"
+    ],
+    "sentences": [
+      {
+        "english": "Water each plant daily.",
+        "chinese": "每天给所有的植物浇水。"
+      }
+    ]
+  },
+  {
+    "name": "play",
+    "trans": [
+      "v. 玩"
+    ],
+    "sentences": [
+      {
+        "english": "Polly was playing with her dolls.",
+        "chinese": "波莉正在玩她的洋娃娃。"
+      }
+    ]
+  },
+  {
+    "name": "player",
+    "trans": [
+      "n. 演奏者"
+    ],
+    "sentences": [
+      {
+        "english": "She was a good tennis player.",
+        "chinese": "她网球打得很好。"
+      }
+    ]
+  },
+  {
+    "name": "playground",
+    "trans": [
+      "n. 操场"
+    ],
+    "sentences": [
+      {
+        "english": "The park has playground equipment made of wood.",
+        "chinese": "这个公园有木制的儿童游乐设施。"
+      }
+    ]
+  },
+  {
+    "name": "playtime",
+    "trans": [
+      "n. 游戏时间"
+    ],
+    "sentences": [
+      {
+        "english": "Friends in different classes can meet up at playtime.",
+        "chinese": "不在一个班的朋友可在课间休息时间见面。"
+      }
+    ]
+  },
+  {
+    "name": "please",
+    "trans": [
+      "int. 请"
+    ],
+    "sentences": [
+      {
+        "english": "Can you help us, please?",
+        "chinese": "请问您能帮帮我们吗？"
+      }
+    ]
+  },
+  {
+    "name": "pleased",
+    "trans": [
+      "adj. 高兴的"
+    ],
+    "sentences": [
+      {
+        "english": "I'm so pleased that we solved the problem.",
+        "chinese": "我们解决了那个问题，我特别高兴。"
+      }
+    ]
+  },
+  {
+    "name": "plus",
+    "trans": [
+      "prep. 加"
+    ],
+    "sentences": [
+      {
+        "english": "Two plus two equals four.",
+        "chinese": "*2加2等于4。"
+      }
+    ]
+  },
+  {
+    "name": "pm",
+    "trans": [
+      "n. 下午"
+    ],
+    "sentences": [
+      {
+        "english": "He said he would be back about 2 pm.",
+        "chinese": "他说他将于下午二时回来。"
+      }
+    ]
+  },
+  {
+    "name": "poem",
+    "trans": [
+      "n. 诗"
+    ],
+    "sentences": [
+      {
+        "english": "He read to her from a book of love poems.",
+        "chinese": "他读一本爱情诗集给她听。"
+      }
+    ]
+  },
+  {
+    "name": "point",
+    "trans": [
+      "v. 指"
+    ],
+    "sentences": [
+      {
+        "english": "We disagreed with every point she made.",
+        "chinese": "她提出的观点我们一个都不同意。"
+      }
+    ]
+  },
+  {
+    "name": "policeman",
+    "trans": [
+      "n. 警察"
+    ],
+    "sentences": [
+      {
+        "english": "An injured policeman was led away by colleagues.",
+        "chinese": "一位受伤的警察被同事们带走了。"
+      }
+    ]
+  },
+  {
+    "name": "postcard",
+    "trans": [
+      "n. 明信片"
+    ],
+    "sentences": [
+      {
+        "english": "How much for a postcard?",
+        "chinese": "一张明信片多少钱？"
+      }
+    ]
+  },
+  {
+    "name": "poster",
+    "trans": [
+      "n. 海报"
+    ],
+    "sentences": [
+      {
+        "english": "I saw a poster for the jazz festival in Monterey.",
+        "chinese": "我在蒙特雷看到了爵士音乐节的海报。"
+      }
+    ]
+  },
+  {
+    "name": "potato",
+    "trans": [
+      "n. 土豆"
+    ],
+    "sentences": [
+      {
+        "english": "How much time do you spend online? Are your turning into a mouse potato?",
+        "chinese": "你把多少时间花在网上？你准备变成网虫吗？"
+      }
+    ]
+  },
+  {
+    "name": "practice",
+    "trans": [
+      "n. 练习"
+    ],
+    "sentences": [
+      {
+        "english": "They campaign against the practice of using animals for experiments.",
+        "chinese": "他们发起运动，反对用动物做实验的惯例。"
+      }
+    ]
+  },
+  {
+    "name": "present",
+    "trans": [
+      "n. 礼物"
+    ],
+    "sentences": [
+      {
+        "english": "Nine people were present at the meeting.",
+        "chinese": "*9人出席了会议。"
+      }
+    ]
+  },
+  {
+    "name": "pretty",
+    "trans": [
+      "adj. 漂亮的"
+    ],
+    "sentences": [
+      {
+        "english": "She's a very charming and pretty girl.",
+        "chinese": "她是个非常迷人的美女。"
+      }
+    ]
+  },
+  {
+    "name": "print",
+    "trans": [
+      "v. 印刷"
+    ],
+    "sentences": [
+      {
+        "english": "The publishers have printed 40,000 copies of the novel.",
+        "chinese": "这部小说出版商已经印刷了4万册。"
+      }
+    ]
+  },
+  {
+    "name": "printing",
+    "trans": [
+      "n. 印刷术"
+    ],
+    "sentences": [
+      {
+        "english": "The publishers have printed 40,000 copies of the novel.",
+        "chinese": "这部小说出版商已经印刷了4万册。"
+      }
+    ]
+  },
+  {
+    "name": "programme",
+    "trans": [
+      "n. 节目"
+    ],
+    "sentences": [
+      {
+        "english": "The art gallery's education programme includes art classes for all ages.",
+        "chinese": "美术馆的教育规划涵盖各年龄段的美术课程。"
+      }
+    ]
+  },
+  {
+    "name": "proud",
+    "trans": [
+      "adj. 自豪的"
+    ],
+    "sentences": [
+      {
+        "english": "Nick wears his police uniform proudly.",
+        "chinese": "尼克骄傲地穿着警服。"
+      }
+    ]
+  },
+  {
+    "name": "pupil",
+    "trans": [
+      "n. 小学生"
+    ],
+    "sentences": [
+      {
+        "english": "Around 270 pupils attend this school.",
+        "chinese": "约270名学生在该校就读。"
+      }
+    ]
+  },
+  {
+    "name": "put",
+    "trans": [
+      "v. 放"
+    ],
+    "sentences": [
+      {
+        "english": "Steven put the photograph on the desk.",
+        "chinese": "史蒂文把照片放到桌上。"
+      }
+    ]
+  },
+  {
+    "name": "put on",
+    "trans": [
+      "穿上"
+    ],
+    "sentences": [
+      {
+        "english": "No matter how much water you put on it, it will never get soaked.",
+        "chinese": "不论你对它倒多少水，它永远不会湿透。"
+      }
+    ]
+  },
+  {
+    "name": "question",
+    "trans": [
+      "n. 问题"
+    ],
+    "sentences": [
+      {
+        "english": "They asked a lot of questions about her health.",
+        "chinese": "他们问了很多关于她健康的问题。"
+      }
+    ]
+  },
+  {
+    "name": "quickly",
+    "trans": [
+      "adv. 很快地"
+    ],
+    "sentences": [
+      {
+        "english": "The room was filling quickly.",
+        "chinese": "房间很快就挤满了人。"
+      }
+    ]
+  },
+  {
+    "name": "quiet",
+    "trans": [
+      "adj. 安静的"
+    ],
+    "sentences": [
+      {
+        "english": "She spoke so quietly that we couldn't understand what she said.",
+        "chinese": "她说话那么轻，我们听不懂她在说什么。"
+      }
+    ]
+  },
+  {
+    "name": "quite",
+    "trans": [
+      "adv. 相当"
+    ],
+    "sentences": [
+      {
+        "english": "I felt quite bad about it at the time.",
+        "chinese": "当时我因那件事而觉得很难过。"
+      }
+    ]
+  },
+  {
+    "name": "race",
+    "trans": [
+      "n. 赛跑"
+    ],
+    "sentences": [
+      {
+        "english": "Mark easily won the race.",
+        "chinese": "马克轻松地赢得了比赛。"
+      }
+    ]
+  },
+  {
+    "name": "radio",
+    "trans": [
+      "n. 收音机"
+    ],
+    "sentences": [
+      {
+        "english": "He turned on the radio.",
+        "chinese": "他打开了收音机。"
+      }
+    ]
+  },
+  {
+    "name": "rain",
+    "trans": [
+      "v. 下雨"
+    ],
+    "sentences": [
+      {
+        "english": "We got very wet in the rain.",
+        "chinese": "我们在雨中淋湿了。"
+      }
+    ]
+  },
+  {
+    "name": "ran",
+    "trans": [
+      "v. 跑（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "He goes running every morning.",
+        "chinese": "他每天早上去跑步。"
+      }
+    ]
+  },
+  {
+    "name": "read",
+    "trans": [
+      "v. 阅读"
+    ],
+    "sentences": [
+      {
+        "english": "She spends all her time reading.",
+        "chinese": "她把所有的时间都花在阅读上。"
+      }
+    ]
+  },
+  {
+    "name": "really",
+    "trans": [
+      "adv. 非常"
+    ],
+    "sentences": [
+      {
+        "english": "You're not really leaving, are you?",
+        "chinese": "你不是真的要走吧?"
+      }
+    ]
+  },
+  {
+    "name": "red",
+    "trans": [
+      "adj. 红色的"
+    ],
+    "sentences": [
+      {
+        "english": "a bunch of red roses",
+        "chinese": "一束红玫瑰"
+      }
+    ]
+  },
+  {
+    "name": "reply",
+    "trans": [
+      "v. 回复"
+    ],
+    "sentences": [
+      {
+        "english": "`That's a nice dress,' said Michael. `Thanks,' she replied.",
+        "chinese": "“这条裙子真漂亮。”迈克尔说。“谢谢。”她答道。"
+      }
+    ]
+  },
+  {
+    "name": "report",
+    "trans": [
+      "n. 报道"
+    ],
+    "sentences": [
+      {
+        "english": "I reported the crime to the police.",
+        "chinese": "我向警方报案了。"
+      }
+    ]
+  },
+  {
+    "name": "rest",
+    "trans": [
+      "n. 休息"
+    ],
+    "sentences": [
+      {
+        "english": "He's tired, and the doctor advised him to rest.",
+        "chinese": "他累了，医生建议他休息。"
+      }
+    ]
+  },
+  {
+    "name": "restaurant",
+    "trans": [
+      "n. 餐馆"
+    ],
+    "sentences": [
+      {
+        "english": "We ate at an Italian restaurant.",
+        "chinese": "我们在一家意大利餐馆吃饭。"
+      }
+    ]
+  },
+  {
+    "name": "return",
+    "trans": [
+      "v. 归还"
+    ],
+    "sentences": [
+      {
+        "english": "He will return to Moscow tomorrow.",
+        "chinese": "他明天将返回莫斯科。"
+      }
+    ]
+  },
+  {
+    "name": "rice",
+    "trans": [
+      "n. 米饭"
+    ],
+    "sentences": [
+      {
+        "english": "The meal consisted of chicken, rice and vegetables.",
+        "chinese": "这顿饭包括鸡肉、米饭和蔬菜。"
+      }
+    ]
+  },
+  {
+    "name": "ride",
+    "trans": [
+      "v. 骑"
+    ],
+    "sentences": [
+      {
+        "english": "We passed three men riding on motorcycles.",
+        "chinese": "我们经过三个骑摩托车的人。"
+      }
+    ]
+  },
+  {
+    "name": "right",
+    "trans": [
+      "adv. 向右"
+    ],
+    "sentences": [
+      {
+        "english": "Ron was right about the result of the election.",
+        "chinese": "关于选举结果，罗恩是对的。"
+      }
+    ]
+  },
+  {
+    "name": "ring",
+    "trans": [
+      "n. 环"
+    ],
+    "sentences": [
+      {
+        "english": "The school bell rang.",
+        "chinese": "学校的铃响了。"
+      }
+    ]
+  },
+  {
+    "name": "river",
+    "trans": [
+      "n. 河流"
+    ],
+    "sentences": [
+      {
+        "english": "We had a fine company of these river-inspectors along, this trip.",
+        "chinese": "本航次，我们有一群河流巡视员随船同行。"
+      }
+    ]
+  },
+  {
+    "name": "room",
+    "trans": [
+      "n. 房间"
+    ],
+    "sentences": [
+      {
+        "english": "A minute later he left the room.",
+        "chinese": "一分钟后他离开了房间。"
+      }
+    ]
+  },
+  {
+    "name": "round",
+    "trans": [
+      "adj. 圆的"
+    ],
+    "sentences": [
+      {
+        "english": "She has a round face.",
+        "chinese": "她有一张圆脸。"
+      }
+    ]
+  },
+  {
+    "name": "row",
+    "trans": [
+      "v. 划船"
+    ],
+    "sentences": [
+      {
+        "english": "They drove past a row of pretty little houses.",
+        "chinese": "他们开车经过一排漂亮的小房子。"
+      }
+    ]
+  },
+  {
+    "name": "rule",
+    "trans": [
+      "n. 规则"
+    ],
+    "sentences": [
+      {
+        "english": "I need a book that explains the rules of basketball.",
+        "chinese": "我需要一本解释篮球规则的书。"
+      }
+    ]
+  },
+  {
+    "name": "ruler",
+    "trans": [
+      "n. 尺子"
+    ],
+    "sentences": [
+      {
+        "english": "He was the ruler of France at that time.",
+        "chinese": "他当时是法国的统治者。"
+      }
+    ]
+  },
+  {
+    "name": "run",
+    "trans": [
+      "v. 跑"
+    ],
+    "sentences": [
+      {
+        "english": "He goes running every morning.",
+        "chinese": "他每天早上去跑步。"
+      }
+    ]
+  },
+  {
+    "name": "run a race",
+    "trans": [
+      "参加赛跑"
+    ],
+    "sentences": [
+      {
+        "english": "I run a race with the wind. Hula, I always run ahead of wind.",
+        "chinese": "我和风赛跑。呼啦，我。"
+      }
+    ]
+  },
+  {
+    "name": "run away",
+    "trans": [
+      "逃跑"
+    ],
+    "sentences": [
+      {
+        "english": "His first instinct was to run away.",
+        "chinese": "他的本能反应就是逃跑。"
+      }
+    ]
+  },
+  {
+    "name": "sad",
+    "trans": [
+      "adj. 伤心的"
+    ],
+    "sentences": [
+      {
+        "english": "`My girlfriend is moving away', he said sadly.",
+        "chinese": "“我女朋友要搬走了。”他伤心地说。"
+      }
+    ]
+  },
+  {
+    "name": "safe",
+    "trans": [
+      "adj. 安全的"
+    ],
+    "sentences": [
+      {
+        "english": "We must try to make our roads safer.",
+        "chinese": "我们必须要尽力使我们的道路十二分安全。"
+      }
+    ]
+  },
+  {
+    "name": "said",
+    "trans": [
+      "v. 说（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "She said that they were very pleased.",
+        "chinese": "她说他们很高兴。"
+      }
+    ]
+  },
+  {
+    "name": "sandwich",
+    "trans": [
+      "n. 三明治"
+    ],
+    "sentences": [
+      {
+        "english": "She ordered an egg sandwich.",
+        "chinese": "她点了一份鸡蛋汉堡包。"
+      }
+    ]
+  },
+  {
+    "name": "Saturday",
+    "trans": [
+      "n. 星期六"
+    ],
+    "sentences": [
+      {
+        "english": "He called her on Saturday morning.",
+        "chinese": "他周六早上给她打了电话。"
+      }
+    ]
+  },
+  {
+    "name": "sausage",
+    "trans": [
+      "n. 香肠"
+    ],
+    "sentences": [
+      {
+        "english": "They ate sausages for breakfast.",
+        "chinese": "他们早饭吃了香肠。"
+      }
+    ]
+  },
+  {
+    "name": "saw",
+    "trans": [
+      "v. 看见（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "He escaped by sawing through the bars of his jail cell.",
+        "chinese": "他锯断牢房的窗栅栏逃跑了。"
+      }
+    ]
+  },
+  {
+    "name": "say",
+    "trans": [
+      "v. 说"
+    ],
+    "sentences": [
+      {
+        "english": "She said that they were very pleased.",
+        "chinese": "她说他们很高兴。"
+      }
+    ]
+  },
+  {
+    "name": "scared",
+    "trans": [
+      "adj. 害怕的"
+    ],
+    "sentences": [
+      {
+        "english": "I'm not scared of him.",
+        "chinese": "我不怕他。"
+      }
+    ]
+  },
+  {
+    "name": "scary",
+    "trans": [
+      "adj. 可怕的"
+    ],
+    "sentences": [
+      {
+        "english": "The film is too scary for children.",
+        "chinese": "这部电影太吓人，不适合儿童观看。"
+      }
+    ]
+  },
+  {
+    "name": "school",
+    "trans": [
+      "n. 学校"
+    ],
+    "sentences": [
+      {
+        "english": "The school was built in the 1960s.",
+        "chinese": "这所学校建于20世纪60年代。"
+      }
+    ]
+  },
+  {
+    "name": "schoolbag",
+    "trans": [
+      "n. 书包"
+    ],
+    "sentences": [
+      {
+        "english": "He sat down and took out his book from his schoolbag.",
+        "chinese": "他坐下来并把书从书包里拿出来。"
+      }
+    ]
+  },
+  {
+    "name": "Science",
+    "trans": [
+      "n. 科学"
+    ],
+    "sentences": [
+      {
+        "english": "He studied plant science at university.",
+        "chinese": "他在大学读植物学专业。"
+      }
+    ]
+  },
+  {
+    "name": "scissors",
+    "trans": [
+      "n. 剪刀"
+    ],
+    "sentences": [
+      {
+        "english": "Cut the card using scissors.",
+        "chinese": "用剪刀剪卡片。"
+      }
+    ]
+  },
+  {
+    "name": "sea",
+    "trans": [
+      "n. 大海"
+    ],
+    "sentences": [
+      {
+        "english": "They swam in the warm Caribbean Sea.",
+        "chinese": "他们在温暖的加勒比海里游泳。"
+      }
+    ]
+  },
+  {
+    "name": "season",
+    "trans": [
+      "n. 季节"
+    ],
+    "sentences": [
+      {
+        "english": "The football season begins again soon.",
+        "chinese": "足球赛季马上又要开始了。"
+      }
+    ]
+  },
+  {
+    "name": "seat",
+    "trans": [
+      "n. 座位"
+    ],
+    "sentences": [
+      {
+        "english": "We had front-row seats at the concert.",
+        "chinese": "我们坐在音乐会的前排位置。"
+      }
+    ]
+  },
+  {
+    "name": "second",
+    "trans": [
+      "num. 第二"
+    ],
+    "sentences": [
+      {
+        "english": "For a few seconds nobody spoke.",
+        "chinese": "有几秒钟大家都沉默不语。"
+      }
+    ]
+  },
+  {
+    "name": "secret",
+    "trans": [
+      "n. 秘密"
+    ],
+    "sentences": [
+      {
+        "english": "They tried to keep their marriage secret.",
+        "chinese": "他们打算隐婚。"
+      }
+    ]
+  },
+  {
+    "name": "see",
+    "trans": [
+      "v. 看见"
+    ],
+    "sentences": [
+      {
+        "english": "The fog was so thick we couldn't see anything.",
+        "chinese": "浓雾弥漫，我们什么也看不见。"
+      }
+    ]
+  },
+  {
+    "name": "seek",
+    "trans": [
+      "v. 寻找"
+    ],
+    "sentences": [
+      {
+        "english": "They are seeking work in hotels and bars.",
+        "chinese": "他们在找旅馆和酒吧的工作。"
+      }
+    ]
+  },
+  {
+    "name": "sell",
+    "trans": [
+      "v. 卖"
+    ],
+    "sentences": [
+      {
+        "english": "Emily sold the paintings to an art gallery.",
+        "chinese": "埃米莉把画卖给了一家艺术画廊。"
+      }
+    ]
+  },
+  {
+    "name": "send",
+    "trans": [
+      "v. 寄"
+    ],
+    "sentences": [
+      {
+        "english": "I sent her an email this morning.",
+        "chinese": "我今早给她发了一封邮件。"
+      }
+    ]
+  },
+  {
+    "name": "sent",
+    "trans": [
+      "v. 寄（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "I sent her an email this morning.",
+        "chinese": "我今早给她发了一封邮件。"
+      }
+    ]
+  },
+  {
+    "name": "seven",
+    "trans": [
+      "num. 七"
+    ],
+    "sentences": [
+      {
+        "english": "We started German in year seven.",
+        "chinese": "我们在七年级开始学习德语。"
+      }
+    ]
+  },
+  {
+    "name": "seventeen",
+    "trans": [
+      "num. 十七"
+    ],
+    "sentences": [
+      {
+        "english": "But when she was seventeen, she began to go out with a young man.",
+        "chinese": "但是当她是十七的时候，她开始和一个年轻的男人出去。"
+      }
+    ]
+  },
+  {
+    "name": "seventy",
+    "trans": [
+      "num. 七十"
+    ],
+    "sentences": [
+      {
+        "english": "How old is she—seventy odd?",
+        "chinese": "她多大年纪？七十出头？"
+      }
+    ]
+  },
+  {
+    "name": "she",
+    "trans": [
+      "pron. 她"
+    ],
+    "sentences": [
+      {
+        "english": "She's seventeen years old.",
+        "chinese": "她17岁。"
+      }
+    ]
+  },
+  {
+    "name": "she's",
+    "trans": [
+      "她是"
+    ],
+    "sentences": [
+      {
+        "english": "She's so superficial!",
+        "chinese": "她太肤浅了！"
+      }
+    ]
+  },
+  {
+    "name": "sheep",
+    "trans": [
+      "n. 绵羊"
+    ],
+    "sentences": [
+      {
+        "english": "Sheep were grazing in the fields.",
+        "chinese": "羊在野地里吃草。"
+      }
+    ]
+  },
+  {
+    "name": "shine",
+    "trans": [
+      "v. 发光"
+    ],
+    "sentences": [
+      {
+        "english": "Today it's warm and the sun is shining.",
+        "chinese": "今天很暖和，阳光灿烂。"
+      }
+    ]
+  },
+  {
+    "name": "ship",
+    "trans": [
+      "n. 船"
+    ],
+    "sentences": [
+      {
+        "english": "The ship was ready to sail.",
+        "chinese": "轮船准备起航了。"
+      }
+    ]
+  },
+  {
+    "name": "shirt",
+    "trans": [
+      "n. 衬衫"
+    ],
+    "sentences": [
+      {
+        "english": "He peeled off his shirt.",
+        "chinese": "他脱下了衬衣。"
+      }
+    ]
+  },
+  {
+    "name": "shoe",
+    "trans": [
+      "n. 鞋子"
+    ],
+    "sentences": [
+      {
+        "english": "I need a new pair of shoes.",
+        "chinese": "我需要一双新鞋。"
+      }
+    ]
+  },
+  {
+    "name": "shop",
+    "trans": [
+      "n. 商店"
+    ],
+    "sentences": [
+      {
+        "english": "Paul and his wife run a flower shop.",
+        "chinese": "保罗和他妻子开了一家花店。"
+      }
+    ]
+  },
+  {
+    "name": "short",
+    "trans": [
+      "adj. 矮的；短的"
+    ],
+    "sentences": [
+      {
+        "english": "Last year we all went to Brighton for a short holiday.",
+        "chinese": "去年我们都去布赖顿度了个短假。"
+      }
+    ]
+  },
+  {
+    "name": "shorts",
+    "trans": [
+      "n. 短裤"
+    ],
+    "sentences": [
+      {
+        "english": "She was wearing pink shorts and a black T-shirt.",
+        "chinese": "她穿着粉色短裤，黑色T恤。"
+      }
+    ]
+  },
+  {
+    "name": "should",
+    "trans": [
+      "v. 应该"
+    ],
+    "sentences": [
+      {
+        "english": "You shouldn't stay up so late.",
+        "chinese": "你不应该这么晚才睡。"
+      }
+    ]
+  },
+  {
+    "name": "shoulder",
+    "trans": [
+      "n. 肩膀"
+    ],
+    "sentences": [
+      {
+        "english": "She put her arm round his shoulders.",
+        "chinese": "她搂着他的肩膀。"
+      }
+    ]
+  },
+  {
+    "name": "shout",
+    "trans": [
+      "v. 呼喊"
+    ],
+    "sentences": [
+      {
+        "english": "`She's alive!' he shouted.",
+        "chinese": "“她还活着！”他大声叫道。"
+      }
+    ]
+  },
+  {
+    "name": "shy",
+    "trans": [
+      "adj. 害羞的"
+    ],
+    "sentences": [
+      {
+        "english": "His shyness made it difficult for him to make friends.",
+        "chinese": "他很害羞，很难交到朋友。"
+      }
+    ]
+  },
+  {
+    "name": "silence",
+    "trans": [
+      "n. 安静"
+    ],
+    "sentences": [
+      {
+        "english": "There was a long silence before Sarah replied.",
+        "chinese": "萨拉沉默了良久才回应。"
+      }
+    ]
+  },
+  {
+    "name": "sing",
+    "trans": [
+      "v. 唱歌"
+    ],
+    "sentences": [
+      {
+        "english": "I love singing.",
+        "chinese": "我喜欢唱歌。"
+      }
+    ]
+  },
+  {
+    "name": "sir",
+    "trans": [
+      "n. 先生"
+    ],
+    "sentences": [
+      {
+        "english": "Excuse me sir, is this your car?",
+        "chinese": "先生，请问这是您的车吗？"
+      }
+    ]
+  },
+  {
+    "name": "sister",
+    "trans": [
+      "n. 姐妹"
+    ],
+    "sentences": [
+      {
+        "english": "This is my sister Sarah.",
+        "chinese": "这是我妹妹萨拉。"
+      }
+    ]
+  },
+  {
+    "name": "sit",
+    "trans": [
+      "v. 坐"
+    ],
+    "sentences": [
+      {
+        "english": "They sat watching television all evening.",
+        "chinese": "他们坐着看了一晚上电视。"
+      }
+    ]
+  },
+  {
+    "name": "six",
+    "trans": [
+      "num. 六"
+    ],
+    "sentences": [
+      {
+        "english": "She's six months pregnant.",
+        "chinese": "她怀孕六个月了。"
+      }
+    ]
+  },
+  {
+    "name": "sixteen",
+    "trans": [
+      "num. 十六"
+    ],
+    "sentences": [
+      {
+        "english": "He had become a midshipman at age sixteen.",
+        "chinese": "他16岁就已经成了一名海军学校学生。"
+      }
+    ]
+  },
+  {
+    "name": "sixty",
+    "trans": [
+      "num. 六十"
+    ],
+    "sentences": [
+      {
+        "english": "She is close on sixty.",
+        "chinese": "她快满六十岁了。"
+      }
+    ]
+  },
+  {
+    "name": "skate",
+    "trans": [
+      "v. 滑冰"
+    ],
+    "sentences": [
+      {
+        "english": "The ice-rink was full of skaters.",
+        "chinese": "冰场里满是滑冰的人。"
+      }
+    ]
+  },
+  {
+    "name": "skip",
+    "trans": [
+      "v. 跳绳"
+    ],
+    "sentences": [
+      {
+        "english": "We skipped down the street, talking and laughing.",
+        "chinese": "我们沿着街蹦蹦跳跳地走，谈笑风生。"
+      }
+    ]
+  },
+  {
+    "name": "skirt",
+    "trans": [
+      "n. 短裙"
+    ],
+    "sentences": [
+      {
+        "english": "how much is our skirt?",
+        "chinese": "你的裙子多少钱？"
+      }
+    ]
+  },
+  {
+    "name": "sky",
+    "trans": [
+      "n. 天空"
+    ],
+    "sentences": [
+      {
+        "english": "The sun was shining in the sky.",
+        "chinese": "太阳在空中闪耀。"
+      }
+    ]
+  },
+  {
+    "name": "sleep",
+    "trans": [
+      "v. 睡觉"
+    ],
+    "sentences": [
+      {
+        "english": "You should try to get as much sleep as possible.",
+        "chinese": "你应该尽可能多睡会儿。"
+      }
+    ]
+  },
+  {
+    "name": "small",
+    "trans": [
+      "adj. 小的"
+    ],
+    "sentences": [
+      {
+        "english": "My daughter is small for her age.",
+        "chinese": "我女儿要比同龄人个头小。"
+      }
+    ]
+  },
+  {
+    "name": "smile",
+    "trans": [
+      "v. 微笑"
+    ],
+    "sentences": [
+      {
+        "english": "When he saw me, he smiled.",
+        "chinese": "看到我时，他笑了。"
+      }
+    ]
+  },
+  {
+    "name": "snake",
+    "trans": [
+      "n. 蛇"
+    ],
+    "sentences": [
+      {
+        "english": "The snake slowly uncoiled.",
+        "chinese": "蛇慢慢地展开了盘着的身体。"
+      }
+    ]
+  },
+  {
+    "name": "snow",
+    "trans": [
+      "v. 下雪"
+    ],
+    "sentences": [
+      {
+        "english": "Six inches of snow fell.",
+        "chinese": "雪下了6英寸厚。"
+      }
+    ]
+  },
+  {
+    "name": "so",
+    "trans": [
+      "adv. 这么；那么"
+    ],
+    "sentences": [
+      {
+        "english": "`Do you think they will stay together?' — `I hope so.'",
+        "chinese": "“你觉得他们会在一起吗？”——“我希望如此。”"
+      }
+    ]
+  },
+  {
+    "name": "sock",
+    "trans": [
+      "n. 短袜"
+    ],
+    "sentences": [
+      {
+        "english": "a pair of red socks",
+        "chinese": "一双红色短袜"
+      }
+    ]
+  },
+  {
+    "name": "solve",
+    "trans": [
+      "v. 解决"
+    ],
+    "sentences": [
+      {
+        "english": "They have not solved the problem of unemployment.",
+        "chinese": "他们还没有解决失业问题。"
+      }
+    ]
+  },
+  {
+    "name": "some",
+    "trans": [
+      "pron. 一些"
+    ],
+    "sentences": [
+      {
+        "english": "Would you like some orange juice?",
+        "chinese": "你要来些橙汁吗？"
+      }
+    ]
+  },
+  {
+    "name": "someday",
+    "trans": [
+      "adv. 将来某一天"
+    ],
+    "sentences": [
+      {
+        "english": "Someday I hope to become a pilot.",
+        "chinese": "我希望自己有朝一日成为飞行员。"
+      }
+    ]
+  },
+  {
+    "name": "sometimes",
+    "trans": [
+      "adv. 有时"
+    ],
+    "sentences": [
+      {
+        "english": "I sometimes sit out in the garden and read.",
+        "chinese": "我有时会坐在花园里看书。"
+      }
+    ]
+  },
+  {
+    "name": "song",
+    "trans": [
+      "n. 歌曲"
+    ],
+    "sentences": [
+      {
+        "english": "She sang a Spanish song.",
+        "chinese": "她唱了一首西班牙歌曲。"
+      }
+    ]
+  },
+  {
+    "name": "soon",
+    "trans": [
+      "adv. 不久"
+    ],
+    "sentences": [
+      {
+        "english": "I'll call you soon.",
+        "chinese": "我很快就会给你打电话的。"
+      }
+    ]
+  },
+  {
+    "name": "sorry",
+    "trans": [
+      "adj. 对不起的"
+    ],
+    "sentences": [
+      {
+        "english": "I felt sorry for him because nobody listened to him.",
+        "chinese": "我很同情他，因为没有人听他讲话。"
+      }
+    ]
+  },
+  {
+    "name": "south",
+    "trans": [
+      "n. 南方"
+    ],
+    "sentences": [
+      {
+        "english": "The town lies ten miles to the south.",
+        "chinese": "那个小镇离南部有10英里远。"
+      }
+    ]
+  },
+  {
+    "name": "space",
+    "trans": [
+      "n. 太空"
+    ],
+    "sentences": [
+      {
+        "english": "They cut down trees to make space for houses.",
+        "chinese": "他们把树砍了以留出空地建房子。"
+      }
+    ]
+  },
+  {
+    "name": "spaceship",
+    "trans": [
+      "n. 宇宙飞船"
+    ],
+    "sentences": [
+      {
+        "english": "It's like a spaceship landed.",
+        "chinese": "它像一艘降落的宇宙飞船。"
+      }
+    ]
+  },
+  {
+    "name": "speak",
+    "trans": [
+      "v. 说"
+    ],
+    "sentences": [
+      {
+        "english": "They took tests in written and spoken English.",
+        "chinese": "他们参加了英语测试的笔试和口试。"
+      }
+    ]
+  },
+  {
+    "name": "special",
+    "trans": [
+      "adj. 特别的"
+    ],
+    "sentences": [
+      {
+        "english": "You're very special to me.",
+        "chinese": "你对我来说非同寻常。"
+      }
+    ]
+  },
+  {
+    "name": "spend",
+    "trans": [
+      "v. 度过"
+    ],
+    "sentences": [
+      {
+        "english": "I have spent all my money.",
+        "chinese": "我花光了我所有的钱。"
+      }
+    ]
+  },
+  {
+    "name": "sport",
+    "trans": [
+      "n. 运动"
+    ],
+    "sentences": [
+      {
+        "english": "Basketball is my favourite sport.",
+        "chinese": "篮球是我最喜欢的体育运动。"
+      }
+    ]
+  },
+  {
+    "name": "Sports Day",
+    "trans": [
+      "n. 运动会"
+    ],
+    "sentences": [
+      {
+        "english": "What are the children doing? They're practising for Sports Day.",
+        "chinese": "孩子们正在干什么？他们在为运动会做准备。"
+      }
+    ]
+  },
+  {
+    "name": "spring",
+    "trans": [
+      "n. 春天"
+    ],
+    "sentences": [
+      {
+        "english": "They are getting married next spring.",
+        "chinese": "他们将在下一个春天结婚。"
+      }
+    ]
+  },
+  {
+    "name": "stairs",
+    "trans": [
+      "n. 楼梯"
+    ],
+    "sentences": [
+      {
+        "english": "We walked up the stairs to the second floor.",
+        "chinese": "我们走楼梯上了二楼。"
+      }
+    ]
+  },
+  {
+    "name": "stamp",
+    "trans": [
+      "n. 邮票"
+    ],
+    "sentences": [
+      {
+        "english": "She put a stamp on the corner of the envelope.",
+        "chinese": "她在信封角上贴了一枚邮票。"
+      }
+    ]
+  },
+  {
+    "name": "stand",
+    "trans": [
+      "v. 站"
+    ],
+    "sentences": [
+      {
+        "english": "She was standing beside my bed.",
+        "chinese": "她站在我床边。"
+      }
+    ]
+  },
+  {
+    "name": "station",
+    "trans": [
+      "n. 车站"
+    ],
+    "sentences": [
+      {
+        "english": "Ingrid went with him to the train station.",
+        "chinese": "英格丽德陪他去了火车站。"
+      }
+    ]
+  },
+  {
+    "name": "stay",
+    "trans": [
+      "v. 停留"
+    ],
+    "sentences": [
+      {
+        "english": "`Stay here', Trish said. `I'll bring the car to you.'",
+        "chinese": "“待那儿别动。”特里希说，“我把车给你开过来。”"
+      }
+    ]
+  },
+  {
+    "name": "stick",
+    "trans": [
+      "v. 粘贴"
+    ],
+    "sentences": [
+      {
+        "english": "She put some dry sticks on the fire.",
+        "chinese": "她给火添了些干树枝。"
+      }
+    ]
+  },
+  {
+    "name": "still",
+    "trans": [
+      "adv. 仍然"
+    ],
+    "sentences": [
+      {
+        "english": "Do you still live in Newcastle?",
+        "chinese": "你还住在纽卡斯尔吗？"
+      }
+    ]
+  },
+  {
+    "name": "stomach ache",
+    "trans": [
+      "n. 胃痛"
+    ],
+    "sentences": [
+      {
+        "english": "Generally speaking, stomach ache is not a big deal.",
+        "chinese": "一般来说胃疼没什么大事。"
+      }
+    ]
+  },
+  {
+    "name": "stone",
+    "trans": [
+      "n. 石头"
+    ],
+    "sentences": [
+      {
+        "english": "a stone floor",
+        "chinese": "石头地面"
+      }
+    ]
+  },
+  {
+    "name": "stop",
+    "trans": [
+      "v. 停止"
+    ],
+    "sentences": [
+      {
+        "english": "She stopped eating and started to laugh.",
+        "chinese": "她收住嘴 ，大笑起来。"
+      }
+    ]
+  },
+  {
+    "name": "strong",
+    "trans": [
+      "adj. 强壮的"
+    ],
+    "sentences": [
+      {
+        "english": "You have to be strong and do what you believe is right.",
+        "chinese": "你得坚决，认准的事就去做。"
+      }
+    ]
+  },
+  {
+    "name": "student",
+    "trans": [
+      "n. 学生"
+    ],
+    "sentences": [
+      {
+        "english": "I am a student.",
+        "chinese": "我是一名学生。"
+      }
+    ]
+  },
+  {
+    "name": "study",
+    "trans": [
+      "v. 学习"
+    ],
+    "sentences": [
+      {
+        "english": "She spends most of her time studying.",
+        "chinese": "她大部分时间用在学习上。"
+      }
+    ]
+  },
+  {
+    "name": "summer",
+    "trans": [
+      "n. 夏天"
+    ],
+    "sentences": [
+      {
+        "english": "I went to France this summer.",
+        "chinese": "我今年夏天去了法国。"
+      }
+    ]
+  },
+  {
+    "name": "sun",
+    "trans": [
+      "n. 太阳"
+    ],
+    "sentences": [
+      {
+        "english": "The sun was now high in the sky.",
+        "chinese": "太阳此刻高挂在天上。"
+      }
+    ]
+  },
+  {
+    "name": "Sunday",
+    "trans": [
+      "n. 星期日"
+    ],
+    "sentences": [
+      {
+        "english": "We went for a walk on Sunday.",
+        "chinese": "我们周日出门散了个步。"
+      }
+    ]
+  },
+  {
+    "name": "sunny",
+    "trans": [
+      "adj. 晴朗的"
+    ],
+    "sentences": [
+      {
+        "english": "The weather was warm and sunny.",
+        "chinese": "天气暖暖的，阳光明媚。"
+      }
+    ]
+  },
+  {
+    "name": "supermarket",
+    "trans": [
+      "n. 超市"
+    ],
+    "sentences": [
+      {
+        "english": "We mostly do our food shopping in the supermarket.",
+        "chinese": "我们大多数时候上超市采购食品。"
+      }
+    ]
+  },
+  {
+    "name": "surprise",
+    "trans": [
+      "n. 惊喜"
+    ],
+    "sentences": [
+      {
+        "english": "I have a surprise for you: we are moving to Switzerland!",
+        "chinese": "我有个惊喜告诉你：我们要移民瑞士了！"
+      }
+    ]
+  },
+  {
+    "name": "sweater",
+    "trans": [
+      "n. 毛线衫"
+    ],
+    "sentences": [
+      {
+        "english": "How much did the sweater cost you?",
+        "chinese": "你花了多少钱买这件毛衣？"
+      }
+    ]
+  },
+  {
+    "name": "sweets",
+    "trans": [
+      "n. 糖果"
+    ],
+    "sentences": [
+      {
+        "english": "a cup of sweet tea",
+        "chinese": "一杯甜茶"
+      }
+    ]
+  },
+  {
+    "name": "swim",
+    "trans": [
+      "v. 游泳"
+    ],
+    "sentences": [
+      {
+        "english": "She learned to swim when she was 10.",
+        "chinese": "她10岁学会了游泳。"
+      }
+    ]
+  },
+  {
+    "name": "swimming",
+    "trans": [
+      "n. 游泳"
+    ],
+    "sentences": [
+      {
+        "english": "Swimming is a great form of exercise.",
+        "chinese": "游泳是一种很好的锻炼方式。"
+      }
+    ]
+  },
+  {
+    "name": "T-shirt",
+    "trans": [
+      "n. T恤衫"
+    ],
+    "sentences": [
+      {
+        "english": "She wore an olive-green T-shirt.",
+        "chinese": "她穿了一件橄榄绿的T恤衫。"
+      }
+    ]
+  },
+  {
+    "name": "table",
+    "trans": [
+      "n. 桌子"
+    ],
+    "sentences": [
+      {
+        "english": "Mum was sitting at the kitchen table.",
+        "chinese": "妈妈坐在餐桌旁。"
+      }
+    ]
+  },
+  {
+    "name": "take",
+    "trans": [
+      "v. 带；拿"
+    ],
+    "sentences": [
+      {
+        "english": "Let me take your coat.",
+        "chinese": "我来帮你拿大衣。"
+      }
+    ]
+  },
+  {
+    "name": "talk",
+    "trans": [
+      "v. 谈话"
+    ],
+    "sentences": [
+      {
+        "english": "After the fight, Mark was too upset to talk.",
+        "chinese": "争辩过后，马克心烦意乱，闭口不言。"
+      }
+    ]
+  },
+  {
+    "name": "tall",
+    "trans": [
+      "adj. 高的"
+    ],
+    "sentences": [
+      {
+        "english": "John is very tall.",
+        "chinese": "约翰个子很高。"
+      }
+    ]
+  },
+  {
+    "name": "taxi driver",
+    "trans": [
+      "n. 出租车司机"
+    ],
+    "sentences": [
+      {
+        "english": "How much did the taxi driver charge for you?",
+        "chinese": "出租车司机收了你多少钱？"
+      }
+    ]
+  },
+  {
+    "name": "teacher",
+    "trans": [
+      "n. 老师"
+    ],
+    "sentences": [
+      {
+        "english": "She did not admit lying to her teacher.",
+        "chinese": "她不承认向老师撒谎"
+      }
+    ]
+  },
+  {
+    "name": "team",
+    "trans": [
+      "n. 球队"
+    ],
+    "sentences": [
+      {
+        "english": "Kate was in the school hockey team.",
+        "chinese": "凯特在校曲棍球队。"
+      }
+    ]
+  },
+  {
+    "name": "tell",
+    "trans": [
+      "v. 告诉"
+    ],
+    "sentences": [
+      {
+        "english": "I told Rachel I got the job.",
+        "chinese": "我告诉蕾切尔我找到工作了。"
+      }
+    ]
+  },
+  {
+    "name": "ten",
+    "trans": [
+      "num. 十"
+    ],
+    "sentences": [
+      {
+        "english": "My highest card is ten.",
+        "chinese": "我最大的牌是十。"
+      }
+    ]
+  },
+  {
+    "name": "test",
+    "trans": [
+      "n. 考试"
+    ],
+    "sentences": [
+      {
+        "english": "Test the temperature of the water with your wrist before you put your baby in the bath.",
+        "chinese": "给婴儿洗澡前要先用你的手腕测试水温。"
+      }
+    ]
+  },
+  {
+    "name": "thank",
+    "trans": [
+      "v. 感谢"
+    ],
+    "sentences": [
+      {
+        "english": "I thanked them for all their kindness to me.",
+        "chinese": "我对他们的一番好意表示感谢。"
+      }
+    ]
+  },
+  {
+    "name": "Thanksgiving",
+    "trans": [
+      "n. 感恩节"
+    ],
+    "sentences": [
+      {
+        "english": "The natural world like this Thanksgiving, more people should have the heart of Thanksgiving.",
+        "chinese": "自然界尚且如此感恩，人更应该具有感恩之心。"
+      }
+    ]
+  },
+  {
+    "name": "that",
+    "trans": [
+      "pron. 那个"
+    ],
+    "sentences": [
+      {
+        "english": "Well, actually, it's not that expensive.",
+        "chinese": "啊，其实也不是那么贵。"
+      }
+    ]
+  },
+  {
+    "name": "the",
+    "trans": [
+      "art. 这个；那个"
+    ],
+    "sentences": [
+      {
+        "english": "The office staff here are all British.",
+        "chinese": "这里的办公室职员全都是英国人。"
+      }
+    ]
+  },
+  {
+    "name": "the Great Wall",
+    "trans": [
+      "n. 长城"
+    ],
+    "sentences": [
+      {
+        "english": "He talked about the Great Wall as if he had been there before.",
+        "chinese": "他说起长城来似乎他以前去过那里。"
+      }
+    ]
+  },
+  {
+    "name": "theatre",
+    "trans": [
+      "n. 剧院"
+    ],
+    "sentences": [
+      {
+        "english": "Last night, we went to the theatre to see a play by Chekhov.",
+        "chinese": "我们昨晚去剧院看了一出契诃夫的戏剧。"
+      }
+    ]
+  },
+  {
+    "name": "their",
+    "trans": [
+      "pron. 他们的"
+    ],
+    "sentences": [
+      {
+        "english": "They took off their coats.",
+        "chinese": "他们脱下了大衣。"
+      }
+    ]
+  },
+  {
+    "name": "them",
+    "trans": [
+      "pron. 他们（宾格）"
+    ],
+    "sentences": [
+      {
+        "english": "I've lost my keys. Have you seen them?",
+        "chinese": "我找不到我的钥匙了。你见到了吗？"
+      }
+    ]
+  },
+  {
+    "name": "then",
+    "trans": [
+      "adv. 然后"
+    ],
+    "sentences": [
+      {
+        "english": "I bought this flat two years ago. Since then, house prices have fallen.",
+        "chinese": "我两年前买的这间公寓。那之后，房价就跌了。"
+      }
+    ]
+  },
+  {
+    "name": "there",
+    "trans": [
+      "adv. 在那里"
+    ],
+    "sentences": [
+      {
+        "english": "There is a swimming pool in the garden.",
+        "chinese": "花园里有一个游泳池。"
+      }
+    ]
+  },
+  {
+    "name": "there are",
+    "trans": [
+      "有"
+    ],
+    "sentences": [
+      {
+        "english": "There are six sailings a day.",
+        "chinese": "每天有六个船运航班。"
+      }
+    ]
+  },
+  {
+    "name": "there is",
+    "trans": [
+      "有"
+    ],
+    "sentences": [
+      {
+        "english": "There is no viable alternative.",
+        "chinese": "没有其他可行的措施。"
+      }
+    ]
+  },
+  {
+    "name": "these",
+    "trans": [
+      "pron. 这些"
+    ],
+    "sentences": [
+      {
+        "english": "These scissors are heavy.",
+        "chinese": "这些剪刀很沉。"
+      }
+    ]
+  },
+  {
+    "name": "they",
+    "trans": [
+      "pron. 他们"
+    ],
+    "sentences": [
+      {
+        "english": "She said goodbye to the children as they left for school.",
+        "chinese": "孩子们离开去上学时，她向他们道别。"
+      }
+    ]
+  },
+  {
+    "name": "they're",
+    "trans": [
+      "他们是"
+    ],
+    "sentences": [
+      {
+        "english": "I talk to CIOs and ask them how much they're spending on plumbing.",
+        "chinese": "我跟CIO们谈谈，问问他们花了多少钱在这上。"
+      }
+    ]
+  },
+  {
+    "name": "thin",
+    "trans": [
+      "adj. 瘦的"
+    ],
+    "sentences": [
+      {
+        "english": "The book is printed on very thin paper.",
+        "chinese": "这书就印在很薄的纸张上。"
+      }
+    ]
+  },
+  {
+    "name": "thing",
+    "trans": [
+      "n. 东西"
+    ],
+    "sentences": [
+      {
+        "english": "What's that thing in the middle of the road?",
+        "chinese": "路中间那个是什么东西？"
+      }
+    ]
+  },
+  {
+    "name": "thirsty",
+    "trans": [
+      "adj. 口渴的"
+    ],
+    "sentences": [
+      {
+        "english": "Drink some water whenever you feel thirsty.",
+        "chinese": "无论何时感到口渴就喝些水。"
+      }
+    ]
+  },
+  {
+    "name": "thirteen",
+    "trans": [
+      "num. 十三"
+    ],
+    "sentences": [
+      {
+        "english": "\"Thirteen?\" he guessed wildly.",
+        "chinese": "“十三？”他胡乱猜道。"
+      }
+    ]
+  },
+  {
+    "name": "thirty",
+    "trans": [
+      "num. 三十"
+    ],
+    "sentences": [
+      {
+        "english": "By this time he was thirty.",
+        "chinese": "到这时他30岁了。"
+      }
+    ]
+  },
+  {
+    "name": "thirty-six",
+    "trans": [
+      "num. 三十六"
+    ],
+    "sentences": [
+      {
+        "english": "She's in her mid-thirties—thirty-six to be exact.",
+        "chinese": "她三十五岁左右—确切地说是三十六岁。"
+      }
+    ]
+  },
+  {
+    "name": "this",
+    "trans": [
+      "pron. 这个"
+    ],
+    "sentences": [
+      {
+        "english": "How can we solve this problem?",
+        "chinese": "我们如何能解决这个问题呢？"
+      }
+    ]
+  },
+  {
+    "name": "thought",
+    "trans": [
+      "v. 想（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "The thought of Nick made her sad.",
+        "chinese": "一想到尼克，她就伤心。"
+      }
+    ]
+  },
+  {
+    "name": "thousand",
+    "trans": [
+      "num. 一千"
+    ],
+    "sentences": [
+      {
+        "english": "Over five thousand people attended the conference.",
+        "chinese": "超过五千人出席了此次大会。"
+      }
+    ]
+  },
+  {
+    "name": "three",
+    "trans": [
+      "num. 三"
+    ],
+    "sentences": [
+      {
+        "english": "We waited three months before going back.",
+        "chinese": "我们等了3个月才回去。"
+      }
+    ]
+  },
+  {
+    "name": "Thursday",
+    "trans": [
+      "n. 星期四"
+    ],
+    "sentences": [
+      {
+        "english": "On Thursday Barbara invited me to her house for lunch.",
+        "chinese": "芭芭拉邀请我周四去她家吃午饭。"
+      }
+    ]
+  },
+  {
+    "name": "ticket",
+    "trans": [
+      "n. 票"
+    ],
+    "sentences": [
+      {
+        "english": "Where are the tickets for tonight's game?",
+        "chinese": "今晚比赛的门票在哪里？"
+      }
+    ]
+  },
+  {
+    "name": "tidy",
+    "trans": [
+      "v. 整理"
+    ],
+    "sentences": [
+      {
+        "english": "I'm not a very tidy person.",
+        "chinese": "我不是个特别爱整洁的人。"
+      }
+    ]
+  },
+  {
+    "name": "tiger",
+    "trans": [
+      "n. 老虎"
+    ],
+    "sentences": [
+      {
+        "english": "The tiger is native to India.",
+        "chinese": "这种虎产于印度。"
+      }
+    ]
+  },
+  {
+    "name": "time",
+    "trans": [
+      "n. 时间"
+    ],
+    "sentences": [
+      {
+        "english": "Time passed, and still Mary did not come back.",
+        "chinese": "时间一点点流逝，玛丽仍然没有回来。"
+      }
+    ]
+  },
+  {
+    "name": "tired",
+    "trans": [
+      "adj. 累的"
+    ],
+    "sentences": [
+      {
+        "english": "Michael is tired after his long flight.",
+        "chinese": "在长途飞行后，迈克尔感到很累。"
+      }
+    ]
+  },
+  {
+    "name": "to",
+    "trans": [
+      "prep. 到；向"
+    ],
+    "sentences": [
+      {
+        "english": "Two friends and I drove to Wales.",
+        "chinese": "两个朋友和我开车去威尔士。"
+      }
+    ]
+  },
+  {
+    "name": "to go",
+    "trans": [
+      "剩余"
+    ],
+    "sentences": [
+      {
+        "english": "Right, we're ready to go.",
+        "chinese": "对，我们准备好了，可以走了。"
+      }
+    ]
+  },
+  {
+    "name": "today",
+    "trans": [
+      "n. 今天"
+    ],
+    "sentences": [
+      {
+        "english": "More people have cars today.",
+        "chinese": "如今越来越多的人们有车。"
+      }
+    ]
+  },
+  {
+    "name": "together",
+    "trans": [
+      "adv. 一起"
+    ],
+    "sentences": [
+      {
+        "english": "We went on long walks together.",
+        "chinese": "我们一起长距离散步。"
+      }
+    ]
+  },
+  {
+    "name": "tomato",
+    "trans": [
+      "n. 西红柿"
+    ],
+    "sentences": [
+      {
+        "english": "The tomato hit the wall with a splat.",
+        "chinese": "西红柿啪的一声打在墙上。"
+      }
+    ]
+  },
+  {
+    "name": "tomorrow",
+    "trans": [
+      "n. 明天"
+    ],
+    "sentences": [
+      {
+        "english": "If I were to see her tomorrow, I would tell her about your decisions.",
+        "chinese": "我明天如见到她，就把你的决定告诉她。"
+      }
+    ]
+  },
+  {
+    "name": "too",
+    "trans": [
+      "adv. 也"
+    ],
+    "sentences": [
+      {
+        "english": "I like swimming and tennis too.",
+        "chinese": "我喜欢游泳，也喜欢网球。"
+      }
+    ]
+  },
+  {
+    "name": "took",
+    "trans": [
+      "v. 拿（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "Let me take your coat.",
+        "chinese": "我来帮你拿大衣。"
+      }
+    ]
+  },
+  {
+    "name": "toothache",
+    "trans": [
+      "n. 牙疼"
+    ],
+    "sentences": [
+      {
+        "english": "His mother took him to the dentist's because he had a toothache.",
+        "chinese": "由于他的牙疼，他的妈妈带他到牙医诊所。"
+      }
+    ]
+  },
+  {
+    "name": "toothbrush",
+    "trans": [
+      "n. 牙刷"
+    ],
+    "sentences": [
+      {
+        "english": "The company is promoting its new sort of toothbrush on television.",
+        "chinese": "该公司正在电视上推销他们的新牙刷。"
+      }
+    ]
+  },
+  {
+    "name": "top",
+    "trans": [
+      "n. 顶部"
+    ],
+    "sentences": [
+      {
+        "english": "We climbed the path up to the top of the hill.",
+        "chinese": "我们沿着小路爬上山顶。"
+      }
+    ]
+  },
+  {
+    "name": "touch",
+    "trans": [
+      "v. 触摸"
+    ],
+    "sentences": [
+      {
+        "english": "Her little hands gently touched my face.",
+        "chinese": "她的小手轻轻触摸我的脸庞。"
+      }
+    ]
+  },
+  {
+    "name": "toy",
+    "trans": [
+      "n. 玩具"
+    ],
+    "sentences": [
+      {
+        "english": "Sophie went to sleep holding her favourite toy.",
+        "chinese": "索菲抱着最喜欢的玩具睡着了。"
+      }
+    ]
+  },
+  {
+    "name": "train",
+    "trans": [
+      "n. 火车"
+    ],
+    "sentences": [
+      {
+        "english": "We caught the early-morning train.",
+        "chinese": "我们赶上了凌晨的火车。"
+      }
+    ]
+  },
+  {
+    "name": "train driver",
+    "trans": [
+      "n. 火车司机"
+    ],
+    "sentences": [
+      {
+        "english": "A train driver?",
+        "chinese": "火车司机？"
+      }
+    ]
+  },
+  {
+    "name": "travel",
+    "trans": [
+      "v. 旅行"
+    ],
+    "sentences": [
+      {
+        "english": "People often travel hundreds of miles to get here.",
+        "chinese": "人们常常赶数百里路来到这里。"
+      }
+    ]
+  },
+  {
+    "name": "tree",
+    "trans": [
+      "n. 树"
+    ],
+    "sentences": [
+      {
+        "english": "The car smashed into a tree.",
+        "chinese": "汽车猛地撞到了树上。"
+      }
+    ]
+  },
+  {
+    "name": "trip",
+    "trans": [
+      "n. 旅行"
+    ],
+    "sentences": [
+      {
+        "english": "She has just returned from a trip to Switzerland.",
+        "chinese": "她去瑞士旅行刚回来。"
+      }
+    ]
+  },
+  {
+    "name": "trousers",
+    "trans": [
+      "n. 裤子"
+    ],
+    "sentences": [
+      {
+        "english": "Read is henpecked by his wife. Mrs. Read wears the trousers in that family.",
+        "chinese": "里德先生怕老婆，在家里里德夫人是一家之主。"
+      }
+    ]
+  },
+  {
+    "name": "true",
+    "trans": [
+      "adj. 真实的"
+    ],
+    "sentences": [
+      {
+        "english": "Everything she said was true.",
+        "chinese": "她说的都是真的。"
+      }
+    ]
+  },
+  {
+    "name": "try",
+    "trans": [
+      "v. 尝试"
+    ],
+    "sentences": [
+      {
+        "english": "He tried to help her at work.",
+        "chinese": "他试图在工作上帮助她。"
+      }
+    ]
+  },
+  {
+    "name": "Tuesday",
+    "trans": [
+      "n. 星期二"
+    ],
+    "sentences": [
+      {
+        "english": "He phoned on Tuesday, just before you arrived.",
+        "chinese": "他星期二来电话了，就在你来之前。"
+      }
+    ]
+  },
+  {
+    "name": "turn",
+    "trans": [
+      "v. 转向"
+    ],
+    "sentences": [
+      {
+        "english": "He turned and walked away.",
+        "chinese": "他转身走开了。"
+      }
+    ]
+  },
+  {
+    "name": "twelve",
+    "trans": [
+      "num. 十二"
+    ],
+    "sentences": [
+      {
+        "english": "It's ten past twelve.",
+        "chinese": "现在十二点十分。"
+      }
+    ]
+  },
+  {
+    "name": "twenty",
+    "trans": [
+      "num. 二十"
+    ],
+    "sentences": [
+      {
+        "english": "Twenty-eight is divisible by seven.",
+        "chinese": "二十八可以被七整除。"
+      }
+    ]
+  },
+  {
+    "name": "two",
+    "trans": [
+      "num. 二"
+    ],
+    "sentences": [
+      {
+        "english": "Two lamps burned dimly.",
+        "chinese": "两盏油灯昏暗地燃烧着。"
+      }
+    ]
+  },
+  {
+    "name": "under",
+    "trans": [
+      "prep. 在下面"
+    ],
+    "sentences": [
+      {
+        "english": "There are hundreds of tunnels under the ground.",
+        "chinese": "地下有上百条隧道。"
+      }
+    ]
+  },
+  {
+    "name": "up",
+    "trans": [
+      "adv. 向上"
+    ],
+    "sentences": [
+      {
+        "english": "A dark blue lorry came up the road.",
+        "chinese": "一辆深蓝色的卡车沿路驶来。"
+      }
+    ]
+  },
+  {
+    "name": "us",
+    "trans": [
+      "pron. 我们（宾格）"
+    ],
+    "sentences": [
+      {
+        "english": "William's girlfriend has invited us for lunch.",
+        "chinese": "威廉的女友邀请我们去吃午餐。"
+      }
+    ]
+  },
+  {
+    "name": "use",
+    "trans": [
+      "v. 使用"
+    ],
+    "sentences": [
+      {
+        "english": "They wouldn't let him use the phone.",
+        "chinese": "他们不会让他用电话的。"
+      }
+    ]
+  },
+  {
+    "name": "useful",
+    "trans": [
+      "adj. 有用的"
+    ],
+    "sentences": [
+      {
+        "english": "The students used their extra time usefully, doing homework or playing sports.",
+        "chinese": "学生们充分利用了课余时间，不是做作业，就是做运动。"
+      }
+    ]
+  },
+  {
+    "name": "usually",
+    "trans": [
+      "adv. 通常"
+    ],
+    "sentences": [
+      {
+        "english": "We usually eat in the kitchen.",
+        "chinese": "我们通常在厨房吃饭。"
+      }
+    ]
+  },
+  {
+    "name": "vegetable",
+    "trans": [
+      "n. 蔬菜"
+    ],
+    "sentences": [
+      {
+        "english": "As a general rule vegetable oils are better for you than animal fats.",
+        "chinese": "一般来说，植物油比动物脂肪对人较有好处。"
+      }
+    ]
+  },
+  {
+    "name": "very",
+    "trans": [
+      "adv. 非常"
+    ],
+    "sentences": [
+      {
+        "english": "The answer is very simple.",
+        "chinese": "答案很简单。"
+      }
+    ]
+  },
+  {
+    "name": "video",
+    "trans": [
+      "n. 录像"
+    ],
+    "sentences": [
+      {
+        "english": "We watched a video of my first birthday party.",
+        "chinese": "我们看了我第一次生日聚会的录像。"
+      }
+    ]
+  },
+  {
+    "name": "village",
+    "trans": [
+      "n. 村庄"
+    ],
+    "sentences": [
+      {
+        "english": "No doubt Tom would live out his days in the same village.",
+        "chinese": "毫无疑问，汤姆会在同一个村庄里度过他的一生。"
+      }
+    ]
+  },
+  {
+    "name": "violin",
+    "trans": [
+      "n. 小提琴"
+    ],
+    "sentences": [
+      {
+        "english": "Lizzie plays the violin.",
+        "chinese": "莉齐拉小提琴。"
+      }
+    ]
+  },
+  {
+    "name": "visit",
+    "trans": [
+      "v. 参观"
+    ],
+    "sentences": [
+      {
+        "english": "He wanted to visit his brother.",
+        "chinese": "他想去看望他的哥哥。"
+      }
+    ]
+  },
+  {
+    "name": "wait",
+    "trans": [
+      "v. 等待"
+    ],
+    "sentences": [
+      {
+        "english": "I walked to the street corner and waited for the school bus.",
+        "chinese": "我走到街道拐角处，等候校车。"
+      }
+    ]
+  },
+  {
+    "name": "waitress",
+    "trans": [
+      "n. 女服务员"
+    ],
+    "sentences": [
+      {
+        "english": "A few minutes later, the waitress came running up the dark street behind us.",
+        "chinese": "几分钟后，服务小姐从黑暗的街道里跑着追上了我们。"
+      }
+    ]
+  },
+  {
+    "name": "walk",
+    "trans": [
+      "v. 步行"
+    ],
+    "sentences": [
+      {
+        "english": "She walked two miles to school every day.",
+        "chinese": "她每天步行两英里去上学。"
+      }
+    ]
+  },
+  {
+    "name": "want",
+    "trans": [
+      "v. 想要"
+    ],
+    "sentences": [
+      {
+        "english": "People wanted to know who she was.",
+        "chinese": "人们想知道她是谁。"
+      }
+    ]
+  },
+  {
+    "name": "warm",
+    "trans": [
+      "adj. 温暖的"
+    ],
+    "sentences": [
+      {
+        "english": "On warm summer days, she would sit outside.",
+        "chinese": "在温暖的夏天，她会坐在外面。"
+      }
+    ]
+  },
+  {
+    "name": "wash",
+    "trans": [
+      "v. 洗"
+    ],
+    "sentences": [
+      {
+        "english": "She finished her dinner and washed the dishes.",
+        "chinese": "她吃完晚饭，洗了碗。"
+      }
+    ]
+  },
+  {
+    "name": "watch",
+    "trans": [
+      "v. 观看"
+    ],
+    "sentences": [
+      {
+        "english": "A man stood in the doorway, watching me.",
+        "chinese": "一个男人站在门口，注视着我。"
+      }
+    ]
+  },
+  {
+    "name": "watch TV",
+    "trans": [
+      "看电视"
+    ],
+    "sentences": [
+      {
+        "english": "His mother does not allow him to watch TV before he finishes his homework.",
+        "chinese": "不完成作业，他的母亲不允许他看电视。"
+      }
+    ]
+  },
+  {
+    "name": "water",
+    "trans": [
+      "n. 水"
+    ],
+    "sentences": [
+      {
+        "english": "Could I have a glass of water, please?",
+        "chinese": "请给我一杯水好吗?"
+      }
+    ]
+  },
+  {
+    "name": "watermelon",
+    "trans": [
+      "n. 西瓜"
+    ],
+    "sentences": [
+      {
+        "english": "He said he had found out a man selling watermelon.",
+        "chinese": "他说，他找到了一个卖西瓜的人。"
+      }
+    ]
+  },
+  {
+    "name": "way",
+    "trans": [
+      "n. 方法"
+    ],
+    "sentences": [
+      {
+        "english": "One way of making friends is to go to an evening class.",
+        "chinese": "交朋友的一种方法是去上夜校。"
+      }
+    ]
+  },
+  {
+    "name": "we",
+    "trans": [
+      "pron. 我们"
+    ],
+    "sentences": [
+      {
+        "english": "We said we would be friends for ever.",
+        "chinese": "我们说我们将永远是朋友。"
+      }
+    ]
+  },
+  {
+    "name": "wear",
+    "trans": [
+      "v. 穿"
+    ],
+    "sentences": [
+      {
+        "english": "He was wearing a brown shirt.",
+        "chinese": "他穿着一件棕色的衬衫。"
+      }
+    ]
+  },
+  {
+    "name": "weather",
+    "trans": [
+      "n. 天气"
+    ],
+    "sentences": [
+      {
+        "english": "Have you heard the weather forecast this morning?",
+        "chinese": "你今天早上听天气预报了吗?"
+      }
+    ]
+  },
+  {
+    "name": "Wednesday",
+    "trans": [
+      "n. 星期三"
+    ],
+    "sentences": [
+      {
+        "english": "Come and have supper with us on Wednesday.",
+        "chinese": "星期三来和我们一起吃晚饭吧。"
+      }
+    ]
+  },
+  {
+    "name": "week",
+    "trans": [
+      "n. 星期"
+    ],
+    "sentences": [
+      {
+        "english": "I thought about it all week.",
+        "chinese": "这件事我想了整整一个星期。"
+      }
+    ]
+  },
+  {
+    "name": "weekend",
+    "trans": [
+      "n. 周末"
+    ],
+    "sentences": [
+      {
+        "english": "I had dinner with Tim last weekend.",
+        "chinese": "上周末我和蒂姆共进晚餐。"
+      }
+    ]
+  },
+  {
+    "name": "welcome",
+    "trans": [
+      "v. 欢迎"
+    ],
+    "sentences": [
+      {
+        "english": "She was there to welcome him home.",
+        "chinese": "她在那儿欢迎他回家。"
+      }
+    ]
+  },
+  {
+    "name": "well",
+    "trans": [
+      "adv. 详细地"
+    ],
+    "sentences": [
+      {
+        "english": "Well, I didn't expect to see you here!",
+        "chinese": "哎呀，我没想到会在这儿见到你!"
+      }
+    ]
+  },
+  {
+    "name": "went",
+    "trans": [
+      "v. 去（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "We went to Rome on holiday.",
+        "chinese": "我们假期去了罗马。"
+      }
+    ]
+  },
+  {
+    "name": "west",
+    "trans": [
+      "n. 西方"
+    ],
+    "sentences": [
+      {
+        "english": "relations between Japan and the West",
+        "chinese": "日本与西方国家的关系"
+      }
+    ]
+  },
+  {
+    "name": "wet",
+    "trans": [
+      "adj. 湿的"
+    ],
+    "sentences": [
+      {
+        "english": "He dried his wet hair with a towel.",
+        "chinese": "他用毛巾把湿头发擦干。"
+      }
+    ]
+  },
+  {
+    "name": "what",
+    "trans": [
+      "pron. 什么"
+    ],
+    "sentences": [
+      {
+        "english": "`Has something happened?' — `Yes.' — `What?'",
+        "chinese": "“发生什么事情了吗?”——“是的。”——“什么事情?”"
+      }
+    ]
+  },
+  {
+    "name": "what's",
+    "trans": [
+      "是什么"
+    ],
+    "sentences": [
+      {
+        "english": "How cold your hands feel! What's the matter with you?",
+        "chinese": "你的手怎么这样冰冷！你怎么啦！"
+      }
+    ]
+  },
+  {
+    "name": "when",
+    "trans": [
+      "conj. 什么时候"
+    ],
+    "sentences": [
+      {
+        "english": "When I met Jill, I was living on my own.",
+        "chinese": "当我遇到吉尔时，我正独自生活。"
+      }
+    ]
+  },
+  {
+    "name": "where",
+    "trans": [
+      "adv. 哪里"
+    ],
+    "sentences": [
+      {
+        "english": "People were looking to see where the noise was coming from.",
+        "chinese": "人们都在看噪音是从哪里来的。"
+      }
+    ]
+  },
+  {
+    "name": "where's",
+    "trans": [
+      "在哪里"
+    ],
+    "sentences": [
+      {
+        "english": "Where's all my stuff?",
+        "chinese": "我那些东西都哪儿去了？"
+      }
+    ]
+  },
+  {
+    "name": "white",
+    "trans": [
+      "adj. 白色的"
+    ],
+    "sentences": [
+      {
+        "english": "He had nice white teeth.",
+        "chinese": "他长着漂亮的白牙齿。"
+      }
+    ]
+  },
+  {
+    "name": "who",
+    "trans": [
+      "pron. 谁"
+    ],
+    "sentences": [
+      {
+        "english": "Who is the strongest man around here?",
+        "chinese": "谁是这附近最强壮的人?"
+      }
+    ]
+  },
+  {
+    "name": "whose",
+    "trans": [
+      "pron. 谁的"
+    ],
+    "sentences": [
+      {
+        "english": "`Whose is this?' — `It's mine.'",
+        "chinese": "“这是谁的?”——“是我的。”"
+      }
+    ]
+  },
+  {
+    "name": "why",
+    "trans": [
+      "adv. 为什么"
+    ],
+    "sentences": [
+      {
+        "english": "`Would you like to spend the afternoon with me?' — `Why not?'",
+        "chinese": "“你愿意和我一起度过下午吗?”——“为什么不呢?”"
+      }
+    ]
+  },
+  {
+    "name": "wide",
+    "trans": [
+      "adj. 宽的"
+    ],
+    "sentences": [
+      {
+        "english": "The bed is too wide for this room.",
+        "chinese": "这张床对这个房间来说太宽了。"
+      }
+    ]
+  },
+  {
+    "name": "win",
+    "trans": [
+      "v. 赢"
+    ],
+    "sentences": [
+      {
+        "english": "He does not have a chance of winning the fight.",
+        "chinese": "他没有机会赢得这场战斗。"
+      }
+    ]
+  },
+  {
+    "name": "window",
+    "trans": [
+      "n. 窗户"
+    ],
+    "sentences": [
+      {
+        "english": "He looked out of the window.",
+        "chinese": "他向窗外望去。"
+      }
+    ]
+  },
+  {
+    "name": "windy",
+    "trans": [
+      "adj. 有风的"
+    ],
+    "sentences": [
+      {
+        "english": "It was a wet and windy day.",
+        "chinese": "这是一个多雨多风的日子。"
+      }
+    ]
+  },
+  {
+    "name": "winner",
+    "trans": [
+      "n. 胜利者"
+    ],
+    "sentences": [
+      {
+        "english": "She will present the prizes to the winners.",
+        "chinese": "她将把奖品颁发给获胜者。"
+      }
+    ]
+  },
+  {
+    "name": "winter",
+    "trans": [
+      "n. 冬天"
+    ],
+    "sentences": [
+      {
+        "english": "It had been a hard winter.",
+        "chinese": "那年冬天特别冷。"
+      }
+    ]
+  },
+  {
+    "name": "with",
+    "trans": [
+      "prep. 用；和"
+    ],
+    "sentences": [
+      {
+        "english": "Her son and daughter were with her.",
+        "chinese": "她的儿子和女儿和她在一起。"
+      }
+    ]
+  },
+  {
+    "name": "wolf",
+    "trans": [
+      "n. 狼"
+    ],
+    "sentences": [
+      {
+        "english": "The Rams held on to defeat the Nevada Wolf Pack in Reno, 32-28.",
+        "chinese": "公羊队坚忍不拔，在雷诺市以32比28的比分击败了内华达狼群队。"
+      }
+    ]
+  },
+  {
+    "name": "woman",
+    "trans": [
+      "n. 女人"
+    ],
+    "sentences": [
+      {
+        "english": "She was a tall, dark woman, with an unusual face.",
+        "chinese": "她是个身材高大、皮肤黝黑的女人，长着一张不同寻常的脸。"
+      }
+    ]
+  },
+  {
+    "name": "women",
+    "trans": [
+      "n. 女人们"
+    ],
+    "sentences": [
+      {
+        "english": "She was a tall, dark woman, with an unusual face.",
+        "chinese": "她是个身材高大、皮肤黝黑的女人，长着一张不同寻常的脸。"
+      }
+    ]
+  },
+  {
+    "name": "won",
+    "trans": [
+      "v. 赢（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "He does not have a chance of winning the fight.",
+        "chinese": "他没有机会赢得这场战斗。"
+      }
+    ]
+  },
+  {
+    "name": "wore",
+    "trans": [
+      "v. 穿（过去式）"
+    ],
+    "sentences": [
+      {
+        "english": "He was wearing a brown shirt.",
+        "chinese": "他穿着一件棕色的衬衫。"
+      }
+    ]
+  },
+  {
+    "name": "work",
+    "trans": [
+      "n. 工作"
+    ],
+    "sentences": [
+      {
+        "english": "He worked as a teacher for 40 years.",
+        "chinese": "他当教师40年了。"
+      }
+    ]
+  },
+  {
+    "name": "world",
+    "trans": [
+      "n. 世界"
+    ],
+    "sentences": [
+      {
+        "english": "Scotland is a beautiful part of the world.",
+        "chinese": "苏格兰是世界上一个美丽的地方。"
+      }
+    ]
+  },
+  {
+    "name": "worry",
+    "trans": [
+      "v. 担心"
+    ],
+    "sentences": [
+      {
+        "english": "Don't worry, I'm sure he'll be fine.",
+        "chinese": "别担心，我相信他会没事的。"
+      }
+    ]
+  },
+  {
+    "name": "wouldn't",
+    "trans": [
+      "将不"
+    ],
+    "sentences": [
+      {
+        "english": "B That wouldn't be a problem. How much would you take out?",
+        "chinese": "没有问题，你想提多少钱呢？"
+      }
+    ]
+  },
+  {
+    "name": "write",
+    "trans": [
+      "v. 写"
+    ],
+    "sentences": [
+      {
+        "english": "Write your name and address on a postcard and send it to us.",
+        "chinese": "把你的名字和地址写在明信片上寄给我们。"
+      }
+    ]
+  },
+  {
+    "name": "writer",
+    "trans": [
+      "n. 作家"
+    ],
+    "sentences": [
+      {
+        "english": "She enjoys reading detective stories by American writers.",
+        "chinese": "她喜欢读美国作家写的侦探小说。"
+      }
+    ]
+  },
+  {
+    "name": "year",
+    "trans": [
+      "n. 年"
+    ],
+    "sentences": [
+      {
+        "english": "The castle has more than 650,000 visitors a year.",
+        "chinese": "这座城堡一年的游客量超过65万人次。"
+      }
+    ]
+  },
+  {
+    "name": "yellow",
+    "trans": [
+      "adj. 黄色的"
+    ],
+    "sentences": [
+      {
+        "english": "She was wearing a yellow dress.",
+        "chinese": "她穿着一条黄裙子。"
+      }
+    ]
+  },
+  {
+    "name": "yes",
+    "trans": [
+      "int. 是的"
+    ],
+    "sentences": [
+      {
+        "english": "`Are you a friend of Nick's?' — `Yes.'",
+        "chinese": "“你是尼克的朋友吗？”——“是的。”"
+      }
+    ]
+  },
+  {
+    "name": "yesterday",
+    "trans": [
+      "n. 昨天"
+    ],
+    "sentences": [
+      {
+        "english": "In yesterday's game, the Cowboys were the winners.",
+        "chinese": "在昨天的比赛中，牛仔队获胜了。"
+      }
+    ]
+  },
+  {
+    "name": "you",
+    "trans": [
+      "pron. 你"
+    ],
+    "sentences": [
+      {
+        "english": "Hurry up! You are really late.",
+        "chinese": "快一点！你真的迟到了。"
+      }
+    ]
+  },
+  {
+    "name": "you're",
+    "trans": [
+      "你是"
+    ],
+    "sentences": [
+      {
+        "english": "Just because you're unhappy doesn't mean you can take it out on me.",
+        "chinese": "你心里不舒服，并不表示你可以拿我出气。你只有一张嘴。"
+      }
+    ]
+  },
+  {
+    "name": "young",
+    "trans": [
+      "adj. 年轻的"
+    ],
+    "sentences": [
+      {
+        "english": "There is plenty of information on this for young people.",
+        "chinese": "对于年轻人来说，这方面的信息很多。"
+      }
+    ]
+  },
+  {
+    "name": "yours",
+    "trans": [
+      "pron. 你的"
+    ],
+    "sentences": [
+      {
+        "english": "I believe Paul is a friend of yours.",
+        "chinese": "我认为保罗是你的朋友。"
+      }
+    ]
+  },
+  {
+    "name": "zoo",
+    "trans": [
+      "n. 动物园"
+    ],
+    "sentences": [
+      {
+        "english": "He took his son to the zoo.",
+        "chinese": "他带着儿子去了动物园。"
+      }
+    ]
+  }
+]

--- a/scripts/fetch-sentences-bing.js
+++ b/scripts/fetch-sentences-bing.js
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * scripts/fetch-sentences-bing.js
+ *
+ * Bing Dict 例句抓取。仅为 sentences 为空的词补齐。
+ *
+ * Usage:
+ *   node scripts/fetch-sentences-bing.js public/dicts/beijing_primary_english.json
+ *
+ * Env:
+ *   INTERVAL_MS=400
+ *   MAX_PER_WORD=1
+ */
+
+const fs = require('fs')
+const path = require('path')
+const https = require('https')
+
+const INTERVAL_MS = Number(process.env.INTERVAL_MS || 400)
+const MAX_PER_WORD = Number(process.env.MAX_PER_WORD || 1)
+
+const target = process.argv[2]
+if (!target) {
+  console.error('Usage: node scripts/fetch-sentences-bing.js <dict-json-path>')
+  process.exit(1)
+}
+const absPath = path.resolve(target)
+const words = JSON.parse(fs.readFileSync(absPath, 'utf8'))
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+function httpGet(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(
+        url,
+        {
+          headers: {
+            'User-Agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
+            'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+          },
+        },
+        (res) => {
+          if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            return resolve(httpGet(res.headers.location))
+          }
+          const chunks = []
+          res.on('data', (c) => chunks.push(c))
+          res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+        },
+      )
+      .on('error', reject)
+  })
+}
+
+function decodeEntities(s) {
+  return s
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+}
+
+function stripTags(html) {
+  return decodeEntities(html.replace(/<[^>]+>/g, ''))
+    .replace(/\s+([,.!?;:])/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function extractBlocks(html, className) {
+  const results = []
+  const marker = `class="${className}`
+  let idx = 0
+  while ((idx = html.indexOf(marker, idx)) !== -1) {
+    const gtIdx = html.indexOf('>', idx)
+    if (gtIdx < 0) break
+    let depth = 1
+    let i = gtIdx + 1
+    let out = ''
+    while (i < html.length && depth > 0) {
+      if (html.startsWith('</div>', i)) {
+        depth--
+        i += 6
+        if (depth === 0) break
+        out += '</div>'
+      } else if (html.startsWith('<div', i)) {
+        depth++
+        const end = html.indexOf('>', i)
+        out += html.slice(i, end + 1)
+        i = end + 1
+      } else {
+        out += html[i]
+        i++
+      }
+    }
+    results.push(out)
+    idx = i
+    if (results.length > MAX_PER_WORD * 3) break
+  }
+  return results
+}
+
+const BLOCKED_KEYWORDS =
+  /\b(sex|drug|kill|gun|murder|arrest|police|marijuana|alcohol|whisky|beer|violence|bomb|weapon|virgin|breast|nude|adult|porn|dead|corpse|burglarized|apartheid|racism|terror|weapon)/i
+
+function containsTarget(english, target) {
+  const t = target.trim().toLowerCase()
+  if (!t) return false
+  const escaped = t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const re = new RegExp(`(^|[^A-Za-z0-9'])${escaped}([^A-Za-z0-9']|$)`, 'i')
+  return re.test(english)
+}
+
+function passQualityFilter(english, chinese) {
+  if (/["`""]/.test(english)) return false
+  if (/[""]/.test(chinese)) return false
+  if (/[!?]{2,}/.test(english)) return false
+  if (BLOCKED_KEYWORDS.test(english)) return false
+  const words = english.split(/\s+/)
+  if (words.length > 14) return false
+  if (english.length > 100) return false
+  if (chinese.length > 35) return false
+  const shouty = words.filter((w) => /^[A-Z]{3,}$/.test(w))
+  if (shouty.length > 1) return false
+  return true
+}
+
+function parseBing(html, target) {
+  const results = []
+  const enBlocks = extractBlocks(html, 'sen_en b_regtxt')
+  const cnBlocks = extractBlocks(html, 'sen_cn b_regtxt')
+  const n = Math.min(enBlocks.length, cnBlocks.length)
+  const candidates = []
+  for (let i = 0; i < n; i++) {
+    const english = stripTags(enBlocks[i])
+    const chinese = stripTags(cnBlocks[i])
+    if (!english || !chinese) continue
+    if (!/[A-Za-z]/.test(english) || !/[\u4e00-\u9fa5]/.test(chinese)) continue
+    if (!passQualityFilter(english, chinese)) continue
+    if (target && !containsTarget(english, target)) continue
+    candidates.push({ english, chinese, len: english.length })
+  }
+  candidates.sort((a, b) => a.len - b.len)
+  for (const c of candidates) {
+    if (results.length >= MAX_PER_WORD) break
+    results.push({ english: c.english, chinese: c.chinese })
+  }
+  return results
+}
+
+async function fetchSentences(word) {
+  const url = `https://cn.bing.com/dict/search?q=${encodeURIComponent(word)}`
+  const html = await httpGet(url)
+  return parseBing(html, word)
+}
+
+;(async () => {
+  const missing = []
+  let filled = 0
+  let scanned = 0
+  const started = Date.now()
+
+  for (let i = 0; i < words.length; i++) {
+    const w = words[i]
+    if (Array.isArray(w.sentences) && w.sentences.length > 0) continue
+    scanned++
+    try {
+      const s = await fetchSentences(w.name)
+      if (s.length > 0) {
+        w.sentences = s
+        filled++
+      } else {
+        missing.push(w.name)
+      }
+    } catch (e) {
+      missing.push(w.name)
+      console.error(`[${i + 1}] ${w.name} ERROR:`, e.message)
+    }
+    if (scanned % 15 === 0) {
+      fs.writeFileSync(absPath, JSON.stringify(words, null, 2), 'utf8')
+      const elapsed = ((Date.now() - started) / 1000).toFixed(1)
+      console.log(`[progress] scanned=${scanned}  filled=${filled}  missing=${missing.length}  ${elapsed}s`)
+    }
+    await sleep(INTERVAL_MS)
+  }
+
+  fs.writeFileSync(absPath, JSON.stringify(words, null, 2), 'utf8')
+  console.log(`\nDONE. scanned=${scanned}  filled=${filled}  missing=${missing.length}`)
+  if (missing.length > 0) {
+    const outPath = path.resolve(process.cwd(), 'scripts/missing-sentences.txt')
+    fs.writeFileSync(outPath, missing.join('\n') + '\n', 'utf8')
+    console.log(`Missing list saved to ${outPath}`)
+  }
+})()

--- a/scripts/fetch-sentences-bing.js
+++ b/scripts/fetch-sentences-bing.js
@@ -14,7 +14,7 @@
 
 const fs = require('fs')
 const path = require('path')
-const https = require('https')
+const httpGet = require('./http-get')
 
 const INTERVAL_MS = Number(process.env.INTERVAL_MS || 400)
 const MAX_PER_WORD = Number(process.env.MAX_PER_WORD || 1)
@@ -28,31 +28,6 @@ const absPath = path.resolve(target)
 const words = JSON.parse(fs.readFileSync(absPath, 'utf8'))
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
-
-function httpGet(url) {
-  return new Promise((resolve, reject) => {
-    https
-      .get(
-        url,
-        {
-          headers: {
-            'User-Agent':
-              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
-            'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
-          },
-        },
-        (res) => {
-          if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-            return resolve(httpGet(res.headers.location))
-          }
-          const chunks = []
-          res.on('data', (c) => chunks.push(c))
-          res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
-        },
-      )
-      .on('error', reject)
-  })
-}
 
 function decodeEntities(s) {
   return s

--- a/scripts/fetch-sentences-youdao-blng.js
+++ b/scripts/fetch-sentences-youdao-blng.js
@@ -6,7 +6,7 @@
  */
 const fs = require('fs')
 const path = require('path')
-const https = require('https')
+const httpGet = require('./http-get')
 
 const INTERVAL_MS = Number(process.env.INTERVAL_MS || 350)
 const MAX_PER_WORD = Number(process.env.MAX_PER_WORD || 1)
@@ -23,31 +23,6 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
 
 const BLOCKED_KEYWORDS =
   /\b(sex|drug|kill|murder|arrest|marijuana|whisky|violence|bomb|virgin|breast|nude|porn|corpse|apartheid|racism|terror)/i
-
-function httpGet(url) {
-  return new Promise((resolve, reject) => {
-    https
-      .get(
-        url,
-        {
-          headers: {
-            'User-Agent':
-              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
-            'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
-          },
-        },
-        (res) => {
-          if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-            return resolve(httpGet(res.headers.location))
-          }
-          const chunks = []
-          res.on('data', (c) => chunks.push(c))
-          res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
-        },
-      )
-      .on('error', reject)
-  })
-}
 
 function decodeJsString(s) {
   return s

--- a/scripts/fetch-sentences-youdao-blng.js
+++ b/scripts/fetch-sentences-youdao-blng.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * scripts/fetch-sentences-youdao-blng.js
+ *
+ * 从有道 blng_sents_part（双语例句）字段抓取例句，仅为 sentences 为空的词补齐。
+ */
+const fs = require('fs')
+const path = require('path')
+const https = require('https')
+
+const INTERVAL_MS = Number(process.env.INTERVAL_MS || 350)
+const MAX_PER_WORD = Number(process.env.MAX_PER_WORD || 1)
+
+const target = process.argv[2]
+if (!target) {
+  console.error('Usage: node scripts/fetch-sentences-youdao-blng.js <dict-json-path>')
+  process.exit(1)
+}
+const absPath = path.resolve(target)
+const words = JSON.parse(fs.readFileSync(absPath, 'utf8'))
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+const BLOCKED_KEYWORDS =
+  /\b(sex|drug|kill|murder|arrest|marijuana|whisky|violence|bomb|virgin|breast|nude|porn|corpse|apartheid|racism|terror)/i
+
+function httpGet(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(
+        url,
+        {
+          headers: {
+            'User-Agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
+            'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+          },
+        },
+        (res) => {
+          if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            return resolve(httpGet(res.headers.location))
+          }
+          const chunks = []
+          res.on('data', (c) => chunks.push(c))
+          res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+        },
+      )
+      .on('error', reject)
+  })
+}
+
+function decodeJsString(s) {
+  return s
+    .replace(/\\u([0-9a-fA-F]{4})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+    .replace(/\\n/g, ' ')
+    .replace(/\\"/g, '"')
+    .replace(/\\'/g, "'")
+    .replace(/\\\\/g, '\\')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function containsTarget(english, target) {
+  const t = target.trim().toLowerCase()
+  if (!t) return false
+  const escaped = t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const re = new RegExp(`(^|[^A-Za-z0-9'])${escaped}([^A-Za-z0-9']|$)`, 'i')
+  return re.test(english)
+}
+
+function passQualityFilter(english, chinese) {
+  if (/[""]/.test(chinese)) return false
+  if (/[!?]{2,}/.test(english)) return false
+  if (BLOCKED_KEYWORDS.test(english)) return false
+  const words = english.split(/\s+/)
+  if (words.length > 14) return false
+  if (english.length > 100) return false
+  if (chinese.length > 35) return false
+  return true
+}
+
+function parseYoudaoBlng(html, target) {
+  const idx = html.indexOf('blng_sents_part:{')
+  if (idx < 0) return []
+  const region = html.slice(idx, idx + 40000)
+  const pairRe = /\{sentence:"((?:[^"\\]|\\.)*)"[^{}]*?"sentence-translation":"((?:[^"\\]|\\.)*)"/g
+  const candidates = []
+  let m
+  while ((m = pairRe.exec(region)) !== null) {
+    const english = decodeJsString(m[1])
+    const chinese = decodeJsString(m[2])
+    if (!english || !chinese) continue
+    if (!/[A-Za-z]/.test(english) || !/[\u4e00-\u9fa5]/.test(chinese)) continue
+    if (target && !containsTarget(english, target)) continue
+    if (!passQualityFilter(english, chinese)) continue
+    candidates.push({ english, chinese, len: english.length })
+  }
+  candidates.sort((a, b) => a.len - b.len)
+  return candidates.slice(0, MAX_PER_WORD).map((c) => ({ english: c.english, chinese: c.chinese }))
+}
+
+async function fetchSentences(word) {
+  const url = `https://www.youdao.com/result?word=${encodeURIComponent(word)}&lang=en`
+  const html = await httpGet(url)
+  return parseYoudaoBlng(html, word)
+}
+
+;(async () => {
+  const missing = []
+  let filled = 0
+  let scanned = 0
+  const started = Date.now()
+  for (let i = 0; i < words.length; i++) {
+    const w = words[i]
+    if (Array.isArray(w.sentences) && w.sentences.length > 0) continue
+    scanned++
+    try {
+      const s = await fetchSentences(w.name)
+      if (s.length > 0) {
+        w.sentences = s
+        filled++
+      } else {
+        missing.push(w.name)
+      }
+    } catch (e) {
+      missing.push(w.name)
+      console.error(`[${i + 1}] ${w.name} ERROR:`, e.message)
+    }
+    if (scanned % 15 === 0) {
+      fs.writeFileSync(absPath, JSON.stringify(words, null, 2), 'utf8')
+      const elapsed = ((Date.now() - started) / 1000).toFixed(1)
+      console.log(`[progress] scanned=${scanned}  filled=${filled}  missing=${missing.length}  ${elapsed}s`)
+    }
+    await sleep(INTERVAL_MS)
+  }
+
+  fs.writeFileSync(absPath, JSON.stringify(words, null, 2), 'utf8')
+  console.log(`\nDONE. scanned=${scanned}  filled=${filled}  missing=${missing.length}`)
+  if (missing.length > 0) {
+    fs.writeFileSync(path.resolve(process.cwd(), 'scripts/missing-sentences.txt'), missing.join('\n') + '\n', 'utf8')
+    console.log('Missing list saved to scripts/missing-sentences.txt')
+  }
+})()

--- a/scripts/fetch-sentences.js
+++ b/scripts/fetch-sentences.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * scripts/fetch-sentences.js
+ *
+ * 从有道词典公开网页抓取例句，为 public/dicts/<dict>.json 中每个词补齐 sentences 字段。
+ *
+ * Usage:
+ *   node scripts/fetch-sentences.js public/dicts/beijing_primary_english.json
+ *
+ * Options via env:
+ *   INTERVAL_MS=300   请求间隔
+ *   MAX_PER_WORD=1    每词保留几条例句
+ *   RESUME=1          已存在 sentences 的词跳过
+ */
+
+const fs = require('fs')
+const path = require('path')
+const https = require('https')
+
+const INTERVAL_MS = Number(process.env.INTERVAL_MS || 300)
+const MAX_PER_WORD = Number(process.env.MAX_PER_WORD || 1)
+const RESUME = process.env.RESUME !== '0'
+
+const target = process.argv[2]
+if (!target) {
+  console.error('Usage: node scripts/fetch-sentences.js <dict-json-path>')
+  process.exit(1)
+}
+
+const absPath = path.resolve(target)
+const raw = fs.readFileSync(absPath, 'utf8')
+const words = JSON.parse(raw)
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+function httpGet(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(
+        url,
+        {
+          headers: {
+            'User-Agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
+            'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+          },
+        },
+        (res) => {
+          if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            return resolve(httpGet(res.headers.location))
+          }
+          const chunks = []
+          res.on('data', (c) => chunks.push(c))
+          res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+        },
+      )
+      .on('error', reject)
+  })
+}
+
+function parseYoudao(html) {
+  const result = []
+  const idx = html.indexOf('examples:[')
+  if (idx < 0) return result
+
+  const region = html.slice(idx, idx + 20000)
+  const itemRe = /\{sense:\{[^{}]*word:"((?:[^"\\]|\\.)*)"\}[^{}]*example:"((?:[^"\\]|\\.)*)"\}/g
+  let m
+  while ((m = itemRe.exec(region)) !== null) {
+    const chinese = decodeJsString(m[1])
+    const english = decodeJsString(m[2])
+    if (!/[A-Za-z]/.test(english) || !/[\u4e00-\u9fa5]/.test(chinese)) continue
+    result.push({ english, chinese })
+    if (result.length >= MAX_PER_WORD) break
+  }
+  return result
+}
+
+function decodeJsString(s) {
+  return s
+    .replace(/\\u([0-9a-fA-F]{4})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+    .replace(/\\n/g, ' ')
+    .replace(/\\"/g, '"')
+    .replace(/\\'/g, "'")
+    .replace(/\\\\/g, '\\')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+async function fetchSentences(word) {
+  const url = `https://www.youdao.com/result?word=${encodeURIComponent(word)}&lang=en`
+  const html = await httpGet(url)
+  return parseYoudao(html)
+}
+
+;(async () => {
+  const missing = []
+  let done = 0
+  const started = Date.now()
+  for (let i = 0; i < words.length; i++) {
+    const w = words[i]
+    if (RESUME && Array.isArray(w.sentences) && w.sentences.length > 0) continue
+
+    try {
+      const s = await fetchSentences(w.name)
+      if (s.length > 0) {
+        w.sentences = s
+        done++
+      } else {
+        missing.push(w.name)
+      }
+    } catch (e) {
+      missing.push(w.name)
+      console.error(`[${i + 1}/${words.length}] ${w.name} ERROR:`, e.message)
+    }
+
+    if ((i + 1) % 20 === 0) {
+      fs.writeFileSync(absPath, JSON.stringify(words, null, 2), 'utf8')
+      const elapsed = ((Date.now() - started) / 1000).toFixed(1)
+      console.log(`[progress] ${i + 1}/${words.length}  ok=${done}  miss=${missing.length}  ${elapsed}s`)
+    }
+    await sleep(INTERVAL_MS)
+  }
+
+  fs.writeFileSync(absPath, JSON.stringify(words, null, 2), 'utf8')
+  console.log(`\nDONE. ok=${done}, miss=${missing.length}`)
+  if (missing.length > 0) {
+    const outPath = path.resolve(process.cwd(), 'scripts/missing-sentences.txt')
+    fs.writeFileSync(outPath, missing.join('\n') + '\n', 'utf8')
+    console.log(`Missing list saved to ${outPath}`)
+  }
+})()

--- a/scripts/fetch-sentences.js
+++ b/scripts/fetch-sentences.js
@@ -15,7 +15,7 @@
 
 const fs = require('fs')
 const path = require('path')
-const https = require('https')
+const httpGet = require('./http-get')
 
 const INTERVAL_MS = Number(process.env.INTERVAL_MS || 300)
 const MAX_PER_WORD = Number(process.env.MAX_PER_WORD || 1)
@@ -32,31 +32,6 @@ const raw = fs.readFileSync(absPath, 'utf8')
 const words = JSON.parse(raw)
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
-
-function httpGet(url) {
-  return new Promise((resolve, reject) => {
-    https
-      .get(
-        url,
-        {
-          headers: {
-            'User-Agent':
-              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
-            'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
-          },
-        },
-        (res) => {
-          if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-            return resolve(httpGet(res.headers.location))
-          }
-          const chunks = []
-          res.on('data', (c) => chunks.push(c))
-          res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
-        },
-      )
-      .on('error', reject)
-  })
-}
 
 function parseYoudao(html) {
   const result = []

--- a/scripts/http-get.js
+++ b/scripts/http-get.js
@@ -1,0 +1,45 @@
+const https = require('https')
+
+const MAX_REDIRECTS = 5
+
+function httpGet(url, redirectCount = 0) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(
+      url,
+      {
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
+          'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+        },
+      },
+      (res) => {
+        const statusCode = res.statusCode ?? 0
+        const location = res.headers.location
+
+        if (statusCode >= 300 && statusCode < 400 && location) {
+          res.resume()
+          if (redirectCount >= MAX_REDIRECTS) {
+            reject(new Error(`Too many redirects while fetching ${url}`))
+            return
+          }
+          resolve(httpGet(new URL(location, url).toString(), redirectCount + 1))
+          return
+        }
+
+        if (statusCode < 200 || statusCode >= 300) {
+          res.resume()
+          reject(new Error(`HTTP ${statusCode} while fetching ${url}`))
+          return
+        }
+
+        const chunks = []
+        res.on('data', (chunk) => chunks.push(chunk))
+        res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+        res.on('error', reject)
+      },
+    )
+    request.on('error', reject)
+  })
+}
+
+module.exports = httpGet

--- a/src/components/WordPronunciationIcon/index.tsx
+++ b/src/components/WordPronunciationIcon/index.tsx
@@ -1,7 +1,9 @@
 import { SoundIcon } from './SoundIcon'
 import usePronunciationSound from '@/hooks/usePronunciation'
+import { wordPronunciationEndSignalAtom } from '@/store'
 import type { Word } from '@/typings'
-import { useCallback, useEffect, useImperativeHandle } from 'react'
+import { useSetAtom } from 'jotai'
+import { useCallback, useEffect, useImperativeHandle, useRef } from 'react'
 import React from 'react'
 
 export const WordPronunciationIcon = React.forwardRef<
@@ -31,6 +33,15 @@ export const WordPronunciationIcon = React.forwardRef<
   useEffect(() => {
     return stop
   }, [word, stop])
+
+  const setPronunciationEndSignal = useSetAtom(wordPronunciationEndSignalAtom)
+  const prevIsPlayingRef = useRef(false)
+  useEffect(() => {
+    if (prevIsPlayingRef.current && !isPlaying) {
+      setPronunciationEndSignal((v) => v + 1)
+    }
+    prevIsPlayingRef.current = isPlaying
+  }, [isPlaying, setPronunciationEndSignal])
 
   useImperativeHandle(
     ref,

--- a/src/components/WordPronunciationIcon/index.tsx
+++ b/src/components/WordPronunciationIcon/index.tsx
@@ -3,7 +3,7 @@ import usePronunciationSound from '@/hooks/usePronunciation'
 import { wordPronunciationEndSignalAtom } from '@/store'
 import type { Word } from '@/typings'
 import { useSetAtom } from 'jotai'
-import { useCallback, useEffect, useImperativeHandle, useRef } from 'react'
+import { useCallback, useEffect, useImperativeHandle } from 'react'
 import React from 'react'
 
 export const WordPronunciationIcon = React.forwardRef<
@@ -23,7 +23,11 @@ export const WordPronunciationIcon = React.forwardRef<
       return word.name
     }
   }
-  const { play, stop, isPlaying } = usePronunciationSound(currentWord())
+  const setPronunciationEndSignal = useSetAtom(wordPronunciationEndSignalAtom)
+  const handlePronunciationEnd = useCallback(() => {
+    setPronunciationEndSignal((v) => v + 1)
+  }, [setPronunciationEndSignal])
+  const { play, stop, isPlaying } = usePronunciationSound(currentWord(), undefined, handlePronunciationEnd)
 
   const playSound = useCallback(() => {
     stop()
@@ -33,15 +37,6 @@ export const WordPronunciationIcon = React.forwardRef<
   useEffect(() => {
     return stop
   }, [word, stop])
-
-  const setPronunciationEndSignal = useSetAtom(wordPronunciationEndSignalAtom)
-  const prevIsPlayingRef = useRef(false)
-  useEffect(() => {
-    if (prevIsPlayingRef.current && !isPlaying) {
-      setPronunciationEndSignal((v) => v + 1)
-    }
-    prevIsPlayingRef.current = isPlaying
-  }, [isPlaying, setPronunciationEndSignal])
 
   useImperativeHandle(
     ref,

--- a/src/hooks/useMicrosoftSpeech.ts
+++ b/src/hooks/useMicrosoftSpeech.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+export type UseMicrosoftSpeechOptions = {
+  lang?: string
+  volume?: number
+  rate?: number
+  pitch?: number
+  preferredVoiceNames?: string[]
+}
+
+export type UseMicrosoftSpeechResult = {
+  speak: (abort?: boolean) => void
+  cancel: () => void
+  speaking: boolean
+  isSupported: boolean
+}
+
+const DEFAULT_MICROSOFT_VOICES = [
+  'Microsoft Aria Online (Natural)',
+  'Microsoft Guy Online (Natural)',
+  'Microsoft Jenny Online (Natural)',
+  'Microsoft Aria',
+  'Microsoft Zira',
+  'Microsoft David',
+  'Google US English',
+]
+
+function pickVoice(voices: SpeechSynthesisVoice[], lang: string, preferred: string[]): SpeechSynthesisVoice | null {
+  const sameLang = voices.filter((v) => v.lang.toLowerCase().startsWith(lang.slice(0, 2).toLowerCase()))
+  const pool = sameLang.length > 0 ? sameLang : voices
+
+  for (const name of preferred) {
+    const hit = pool.find((v) => v.name === name)
+    if (hit) return hit
+  }
+  const microsoft = pool.find((v) => /microsoft/i.test(v.name))
+  if (microsoft) return microsoft
+  return pool[0] ?? null
+}
+
+export default function useMicrosoftSpeech(text: string, option: UseMicrosoftSpeechOptions = {}): UseMicrosoftSpeechResult {
+  const { lang = 'en-US', volume = 1, rate = 1, pitch = 1, preferredVoiceNames = DEFAULT_MICROSOFT_VOICES } = option
+
+  const isSupported = typeof window !== 'undefined' && !!window.speechSynthesis && typeof SpeechSynthesisUtterance !== 'undefined'
+
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([])
+  const [speaking, setSpeaking] = useState(false)
+  const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null)
+
+  useEffect(() => {
+    if (!isSupported) return
+    const synth = window.speechSynthesis
+    const loadVoices = () => setVoices(synth.getVoices())
+    loadVoices()
+    synth.addEventListener('voiceschanged', loadVoices)
+    return () => synth.removeEventListener('voiceschanged', loadVoices)
+  }, [isSupported])
+
+  const voice = useMemo(() => {
+    if (voices.length === 0) return null
+    return pickVoice(voices, lang, preferredVoiceNames)
+  }, [voices, lang, preferredVoiceNames])
+
+  const speak = useCallback(
+    (abort = false) => {
+      if (!isSupported || !text) return
+      const synth = window.speechSynthesis
+      if (abort && synth.speaking) synth.cancel()
+
+      const utter = new SpeechSynthesisUtterance(text)
+      utter.lang = lang
+      utter.volume = volume
+      utter.rate = rate
+      utter.pitch = pitch
+      if (voice) utter.voice = voice
+
+      utter.addEventListener('end', () => setSpeaking(false))
+      utter.addEventListener('error', () => setSpeaking(false))
+
+      utteranceRef.current = utter
+      setSpeaking(true)
+      synth.speak(utter)
+    },
+    [isSupported, text, lang, volume, rate, pitch, voice],
+  )
+
+  const cancel = useCallback(() => {
+    if (!isSupported) return
+    window.speechSynthesis.cancel()
+    setSpeaking(false)
+  }, [isSupported])
+
+  useEffect(() => {
+    return () => {
+      if (isSupported) window.speechSynthesis.cancel()
+    }
+  }, [isSupported])
+
+  return { speak, cancel, speaking, isSupported }
+}

--- a/src/hooks/usePronunciation.ts
+++ b/src/hooks/usePronunciation.ts
@@ -34,7 +34,7 @@ export function generateWordSoundSrc(word: string, pronunciation: Exclude<Pronun
   }
 }
 
-export default function usePronunciationSound(word: string, isLoop?: boolean) {
+export default function usePronunciationSound(word: string, isLoop?: boolean, onEnd?: () => void) {
   const pronunciationConfig = useAtomValue(pronunciationConfigAtom)
   const loop = useMemo(() => (typeof isLoop === 'boolean' ? isLoop : pronunciationConfig.isLoop), [isLoop, pronunciationConfig.isLoop])
   const [isPlaying, setIsPlaying] = useState(false)
@@ -58,7 +58,12 @@ export default function usePronunciationSound(word: string, isLoop?: boolean) {
     const unListens: Array<() => void> = []
 
     unListens.push(addHowlListener(sound, 'play', () => setIsPlaying(true)))
-    unListens.push(addHowlListener(sound, 'end', () => setIsPlaying(false)))
+    unListens.push(
+      addHowlListener(sound, 'end', () => {
+        setIsPlaying(false)
+        onEnd?.()
+      }),
+    )
     unListens.push(addHowlListener(sound, 'pause', () => setIsPlaying(false)))
     unListens.push(addHowlListener(sound, 'playerror', () => setIsPlaying(false)))
 
@@ -67,7 +72,7 @@ export default function usePronunciationSound(word: string, isLoop?: boolean) {
       unListens.forEach((unListen) => unListen())
       ;(sound as Howl).unload()
     }
-  }, [sound])
+  }, [onEnd, sound])
 
   return { play, stop, isPlaying }
 }

--- a/src/pages/Typing/components/WordPanel/components/Sentence/index.tsx
+++ b/src/pages/Typing/components/WordPanel/components/Sentence/index.tsx
@@ -1,0 +1,143 @@
+import Tooltip from '@/components/Tooltip'
+import { SoundIcon } from '@/components/WordPronunciationIcon/SoundIcon'
+import useMicrosoftSpeech from '@/hooks/useMicrosoftSpeech'
+import {
+  fontSizeConfigAtom,
+  isTextSelectableAtom,
+  pronunciationConfigAtom,
+  wordDictationConfigAtom,
+  wordPronunciationEndSignalAtom,
+} from '@/store'
+import type { Sentence as SentenceType } from '@/typings'
+import { useAtomValue } from 'jotai'
+import { Fragment, useCallback, useEffect, useMemo, useRef } from 'react'
+
+export type SentenceProps = {
+  sentence: SentenceType
+  wordName?: string
+  showTrans?: boolean
+  autoPlay?: boolean
+}
+
+function escapeRegExp(input: string) {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function isWordChar(ch: string | undefined) {
+  return !!ch && /[A-Za-z0-9']/.test(ch)
+}
+
+type Segment = { text: string; matched: boolean }
+
+function highlightSegments(text: string, target: string): Segment[] {
+  if (!target.trim()) return [{ text, matched: false }]
+
+  const pattern = new RegExp(escapeRegExp(target.trim()), 'gi')
+  const segments: Segment[] = []
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = pattern.exec(text)) !== null) {
+    const start = match.index
+    const end = start + match[0].length
+    const before = text[start - 1]
+    const after = text[end]
+
+    if (isWordChar(before) || isWordChar(after)) continue
+
+    if (start > lastIndex) segments.push({ text: text.slice(lastIndex, start), matched: false })
+    segments.push({ text: match[0], matched: true })
+    lastIndex = end
+  }
+  if (lastIndex < text.length) segments.push({ text: text.slice(lastIndex), matched: false })
+
+  return segments.length > 0 ? segments : [{ text, matched: false }]
+}
+
+export default function Sentence({ sentence, wordName, showTrans = true, autoPlay = false }: SentenceProps) {
+  const pronunciationConfig = useAtomValue(pronunciationConfigAtom)
+  const fontSizeConfig = useAtomValue(fontSizeConfigAtom)
+  const isTextSelectable = useAtomValue(isTextSelectableAtom)
+  const wordEndSignal = useAtomValue(wordPronunciationEndSignalAtom)
+  const wordDictationConfig = useAtomValue(wordDictationConfigAtom)
+
+  const speechLang = pronunciationConfig.type === 'uk' ? 'en-GB' : 'en-US'
+  const speechOptions = useMemo(
+    () => ({ lang: speechLang, volume: pronunciationConfig.volume, rate: pronunciationConfig.rate }),
+    [speechLang, pronunciationConfig.volume, pronunciationConfig.rate],
+  )
+  const { speak, speaking, isSupported } = useMicrosoftSpeech(sentence.english, speechOptions)
+
+  const handleClickSoundIcon = useCallback(() => {
+    speak(true)
+  }, [speak])
+
+  const speakRef = useRef(speak)
+  useEffect(() => {
+    speakRef.current = speak
+  }, [speak])
+
+  const initialSignalRef = useRef(wordEndSignal)
+  useEffect(() => {
+    if (!autoPlay || !isSupported) return
+    if (wordEndSignal === initialSignalRef.current) return
+    const timer = window.setTimeout(() => {
+      speakRef.current(true)
+    }, 1000)
+    return () => window.clearTimeout(timer)
+  }, [wordEndSignal, autoPlay, isSupported])
+
+  const sentenceFontSize = Math.max(14, Math.round(fontSizeConfig.translateFont * 0.85))
+  const chineseFontSize = Math.max(12, Math.round(fontSizeConfig.translateFont * 0.75))
+
+  const englishSegments = useMemo(
+    () => (wordName ? highlightSegments(sentence.english, wordName) : [{ text: sentence.english, matched: false }]),
+    [sentence.english, wordName],
+  )
+
+  return (
+    <div className="mt-2 flex w-full max-w-4xl flex-col items-center gap-1 px-4">
+      <div className="flex w-full items-center justify-center gap-2">
+        <span
+          className={`text-center italic text-gray-700 transition-colors duration-300 dark:text-white dark:text-opacity-70 ${
+            isTextSelectable ? 'select-text' : ''
+          }`}
+          style={{ fontSize: `${sentenceFontSize}px` }}
+        >
+          {englishSegments.map((segment, idx) => (
+            <Fragment key={idx}>
+              {segment.matched ? (
+                wordDictationConfig.isOpen ? (
+                  <span className="mx-0.5 inline-block rounded bg-gray-200 px-1 font-semibold not-italic tracking-widest text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+                    {'_'.repeat(segment.text.length)}
+                  </span>
+                ) : (
+                  <span className="font-semibold not-italic text-indigo-500 underline decoration-indigo-300 decoration-2 underline-offset-4 dark:text-indigo-300 dark:decoration-indigo-500">
+                    {segment.text}
+                  </span>
+                )
+              ) : (
+                segment.text
+              )}
+            </Fragment>
+          ))}
+        </span>
+        {isSupported && (
+          <Tooltip content="朗读例句（Microsoft TTS）" className="h-5 w-5 shrink-0 cursor-pointer leading-none">
+            <SoundIcon animated={speaking} onClick={handleClickSoundIcon} className="h-5 w-5" />
+          </Tooltip>
+        )}
+      </div>
+      {showTrans && sentence.chinese && (
+        <span
+          className={`text-center text-gray-500 transition-colors duration-300 dark:text-white dark:text-opacity-50 ${
+            isTextSelectable ? 'select-text' : ''
+          }`}
+          style={{ fontSize: `${chineseFontSize}px` }}
+        >
+          {sentence.chinese}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Typing/components/WordPanel/components/Sentence/index.tsx
+++ b/src/pages/Typing/components/WordPanel/components/Sentence/index.tsx
@@ -79,8 +79,13 @@ export default function Sentence({ sentence, wordName, showTrans = true, autoPla
 
   const initialSignalRef = useRef(wordEndSignal)
   useEffect(() => {
-    if (!autoPlay || !isSupported) return
+    if (!autoPlay || !isSupported) {
+      // Do not replay a pronunciation that ended while the sentence was hidden.
+      initialSignalRef.current = wordEndSignal
+      return
+    }
     if (wordEndSignal === initialSignalRef.current) return
+    initialSignalRef.current = wordEndSignal
     const timer = window.setTimeout(() => {
       speakRef.current(true)
     }, 1000)
@@ -123,7 +128,7 @@ export default function Sentence({ sentence, wordName, showTrans = true, autoPla
           ))}
         </span>
         {isSupported && (
-          <Tooltip content="朗读例句（Microsoft TTS）" className="h-5 w-5 shrink-0 cursor-pointer leading-none">
+          <Tooltip content="朗读例句（浏览器语音）" className="h-5 w-5 shrink-0 cursor-pointer leading-none">
             <SoundIcon animated={speaking} onClick={handleClickSoundIcon} className="h-5 w-5" />
           </Tooltip>
         )}

--- a/src/pages/Typing/components/WordPanel/index.tsx
+++ b/src/pages/Typing/components/WordPanel/index.tsx
@@ -3,6 +3,7 @@ import type { TypingState } from '../../store/type'
 import PrevAndNextWord from '../PrevAndNextWord'
 import Progress from '../Progress'
 import Phonetic from './components/Phonetic'
+import Sentence from './components/Sentence'
 import Translation from './components/Translation'
 import WordComponent from './components/Word'
 import { usePrefetchPronunciationSound } from '@/hooks/usePronunciation'
@@ -179,6 +180,19 @@ export default function WordPanel() {
                 onMouseEnter={() => handleShowTranslation(true)}
                 onMouseLeave={() => handleShowTranslation(false)}
               />
+              {currentWord.sentences && currentWord.sentences.length > 0 && (
+                <div className={`flex flex-col items-center gap-2 pb-2 ${shouldShowTranslation ? '' : 'invisible'}`}>
+                  {currentWord.sentences.map((sentence, idx) => (
+                    <Sentence
+                      key={`${currentWord.name}-${idx}`}
+                      sentence={sentence}
+                      wordName={currentWord.name}
+                      showTrans={shouldShowTranslation}
+                      autoPlay={idx === 0}
+                    />
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/src/pages/Typing/components/WordPanel/index.tsx
+++ b/src/pages/Typing/components/WordPanel/index.tsx
@@ -188,7 +188,7 @@ export default function WordPanel() {
                       sentence={sentence}
                       wordName={currentWord.name}
                       showTrans={shouldShowTranslation}
-                      autoPlay={idx === 0}
+                      autoPlay={idx === 0 && shouldShowTranslation}
                     />
                   ))}
                 </div>

--- a/src/resources/dictionary.ts
+++ b/src/resources/dictionary.ts
@@ -4160,6 +4160,17 @@ const indonesianDicts: DictionaryResource[] = [
  * Why arrays? Because it keeps the order across browsers.
  */
 export const dictionaryResources: DictionaryResource[] = [
+  {
+    id: 'BJPrimary',
+    name: '北京小学',
+    description: '北京小学英语',
+    category: '青少年英语',
+    tags: ['其他'],
+    url: '/dicts/beijing_primary_english.json',
+    length: 842,
+    language: 'en',
+    languageCategory: 'en',
+  },
   ...chinaExam,
   ...internationalExam,
   ...childrenEnglish,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -66,6 +66,8 @@ export const pronunciationIsOpenAtom = atom((get) => get(pronunciationConfigAtom
 
 export const pronunciationIsTransReadAtom = atom((get) => get(pronunciationConfigAtom).isTransRead)
 
+export const wordPronunciationEndSignalAtom = atom(0)
+
 export const randomConfigAtom = atomForConfig('randomConfig', {
   isOpen: false,
 })

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -19,12 +19,18 @@ export const PRONUNCIATION_PHONETIC_MAP: Pronunciation2PhoneticMap = {
   id: 'id',
 }
 
+export type Sentence = {
+  english: string
+  chinese: string
+}
+
 export type Word = {
   name: string
   trans: string[]
   usphone: string
   ukphone: string
   notation?: string
+  sentences?: Sentence[]
 }
 
 export type WordWithIndex = Word & {

--- a/tests/e2e/practice.spec.ts
+++ b/tests/e2e/practice.spec.ts
@@ -119,3 +119,31 @@ test.describe('Practice', () => {
     await expect(await page.getByText('第 2 章').first().isVisible()).toBeTruthy()
   })
 })
+
+test.describe('Practice sentence examples', () => {
+  test('shows examples and hides the target word in dictation mode', async ({ page }) => {
+    await page.route('**/dicts/CET4_T.json', async (route) => {
+      const response = await route.fetch()
+      const words = await response.json()
+      words[20] = {
+        ...words[20],
+        sentences: [{ english: `${words[20].name} is useful.`, chinese: '这是一个例句。' }],
+      }
+      await route.fulfill({ response, json: words })
+    })
+    await page.addInitScript(() => {
+      localStorage.setItem('currentChapter', '1')
+      localStorage.setItem('wordDictationConfig', JSON.stringify({ isOpen: true, openBy: 'user', type: 'hideAll' }))
+    })
+
+    await page.goto('/')
+    await page.getByLabel('关闭提示').click()
+    await expect(page.getByText('第 2 章').first()).toBeVisible()
+
+    await page.keyboard.press('Enter')
+    await page.keyboard.press('Control+Shift+V')
+
+    await expect(page.getByText('这是一个例句。')).toBeVisible()
+    await expect(page.getByText('_______', { exact: true })).toBeVisible()
+  })
+})


### PR DESCRIPTION
- Add 842-word Beijing primary school English dictionary with sentence coverage
- Extend Word type to support sentence examples (english/chinese pairs)
- Add Sentence component with TTS playback and target word highlighting
- Hide target word in sentences during dictation mode
- Auto-play sentence 1 second after word pronunciation ends via jotai signal
- Add scripts for fetching example sentences from Youdao/Bing dictionaries